### PR TITLE
Fix quorum tests instance lifecycle and improve resource usage

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumTest.java
@@ -18,6 +18,9 @@ package com.hazelcast.quorum;
 
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cardinality.CardinalityEstimator;
+import com.hazelcast.collection.IList;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.ISet;
 import com.hazelcast.config.AtomicLongConfig;
 import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -38,22 +41,18 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SemaphoreConfig;
 import com.hazelcast.config.SetConfig;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.IFunction;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.cp.ICountDownLatch;
-import com.hazelcast.core.IExecutorService;
-import com.hazelcast.core.IFunction;
-import com.hazelcast.collection.IList;
-import com.hazelcast.cp.lock.ILock;
-import com.hazelcast.map.IMap;
-import com.hazelcast.collection.IQueue;
 import com.hazelcast.cp.ISemaphore;
-import com.hazelcast.collection.ISet;
-import com.hazelcast.multimap.MultiMap;
-import com.hazelcast.replicatedmap.ReplicatedMap;
+import com.hazelcast.cp.lock.ILock;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.durableexecutor.DurableExecutorService;
-import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.map.IMap;
+import com.hazelcast.multimap.MultiMap;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -99,13 +98,20 @@ public abstract class AbstractQuorumTest {
     protected static final String PN_COUNTER_NAME = "quorum" + randomString();
 
     protected static PartitionedCluster cluster;
+    protected static TestHazelcastInstanceFactory factory;
 
-    protected static void initTestEnvironment(Config config, TestHazelcastInstanceFactory factory) {
+    protected static void initTestEnvironment(Config config,
+                                              TestHazelcastInstanceFactory factory) {
+        if (AbstractQuorumTest.factory != null) {
+            throw new IllegalStateException("Already initialised!");
+        }
+        AbstractQuorumTest.factory = factory;
         initCluster(PartitionedCluster.createClusterConfig(config), factory, READ, WRITE, READ_WRITE);
     }
 
     protected static void shutdownTestEnvironment() {
-        HazelcastInstanceFactory.terminateAll();
+        factory.terminateAll();
+        factory = null;
         cluster = null;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.atomic;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
@@ -58,7 +58,7 @@ public class AtomicLongQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.atomic;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -39,6 +38,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
@@ -60,7 +60,7 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.atomic;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -38,6 +37,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.AbstractQuorumTest.QuorumTestClass.object;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
@@ -59,7 +59,7 @@ public class AtomicReferenceQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.atomic;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -40,6 +39,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import static com.hazelcast.quorum.AbstractQuorumTest.QuorumTestClass.object;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
@@ -61,7 +61,7 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumReadTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.quorum.cache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -40,6 +39,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -60,7 +60,7 @@ public class CacheQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumWriteTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.quorum.cache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -48,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -70,7 +70,7 @@ public class CacheQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumReadTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.quorum.cardinality;
 
 import com.hazelcast.cardinality.CardinalityEstimator;
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
@@ -58,7 +58,7 @@ public class CardinalityEstimatorQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumWriteTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.quorum.cardinality;
 
 import com.hazelcast.cardinality.CardinalityEstimator;
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -39,6 +38,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
@@ -60,7 +60,7 @@ public class CardinalityEstimatorQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.countdownlatch;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -54,7 +54,7 @@ public class CountDownLatchQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.countdownlatch;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -54,7 +54,7 @@ public class CountDownLatchQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.durableexecutor;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.quorum.AbstractQuorumTest;
@@ -41,6 +40,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
@@ -62,7 +62,7 @@ public class DurableExecutorQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.durableexecutor;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.quorum.AbstractQuorumTest;
@@ -49,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.quorum.durableexecutor.DurableExecutorQuorumWriteTest.ExecRunnable.callable;
 import static com.hazelcast.quorum.durableexecutor.DurableExecutorQuorumWriteTest.ExecRunnable.runnable;
 import static com.hazelcast.test.HazelcastTestSupport.generateKeyOwnedBy;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
@@ -70,7 +70,7 @@ public class DurableExecutorQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.executor;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
@@ -38,6 +37,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -58,7 +58,7 @@ public class ExecutorQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
@@ -16,11 +16,10 @@
 
 package com.hazelcast.quorum.executor;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.IExecutorService;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberSelector;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -62,6 +61,7 @@ import static com.hazelcast.quorum.executor.ExecutorQuorumWriteTest.Selector.sel
 import static com.hazelcast.test.HazelcastTestSupport.generateKeyOwnedBy;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
@@ -85,7 +85,7 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.list;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -35,6 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -52,7 +52,7 @@ public class ListQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.list;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -54,7 +54,7 @@ public class ListQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumReadTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.list;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalList;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -75,7 +75,7 @@ public class TransactionalListQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumWriteTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.list;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalList;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -75,7 +75,7 @@ public class TransactionalListQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.lock;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.lock.ILock;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -57,7 +57,7 @@ public class LockQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.lock;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.lock.ILock;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -41,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -61,7 +61,7 @@ public class LockQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumReadTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.quorum.map;
 
 import com.hazelcast.aggregation.Aggregators;
-import com.hazelcast.config.Config;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.quorum.AbstractQuorumTest;
@@ -41,6 +40,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.HashSet;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
@@ -62,7 +62,7 @@ public class MapQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.map;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.TestLoggingEntryProcessor;
 import com.hazelcast.quorum.AbstractQuorumTest;
@@ -42,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -59,7 +59,7 @@ public class MapQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.map;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
@@ -43,6 +42,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -76,7 +76,7 @@ public class TransactionalMapQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumWriteTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.map;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalMap;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -76,7 +76,7 @@ public class TransactionalMapQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.multimap;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -35,6 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -52,7 +52,7 @@ public class MultiMapQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.multimap;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
@@ -41,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -58,7 +58,7 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumReadTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.multimap;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalMultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalMultiMap;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -75,7 +75,7 @@ public class TransactionalMultiMapQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumWriteTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.multimap;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalMultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalMultiMap;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -75,7 +75,7 @@ public class TransactionalMultiMapQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/pncounter/PNCounterQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/pncounter/PNCounterQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.pncounter;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -35,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -55,7 +55,7 @@ public class PNCounterQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/pncounter/PNCounterQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/pncounter/PNCounterQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.pncounter;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -54,7 +54,7 @@ public class PNCounterQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.queue;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -57,7 +57,7 @@ public class QueueQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.queue;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -39,6 +38,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -59,7 +59,7 @@ public class QueueQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumReadTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.queue;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.quorum.QuorumType.READ;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -76,7 +76,7 @@ public class TransactionalQueueQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumWriteTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.queue;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -76,7 +76,7 @@ public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumReadTest.java
@@ -16,11 +16,10 @@
 
 package com.hazelcast.quorum.replicatedmap;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Comparator;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -54,7 +54,7 @@ public class ReplicatedMapQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumWriteTest.java
@@ -16,12 +16,11 @@
 
 package com.hazelcast.quorum.replicatedmap;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryAdapter;
-import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -58,7 +58,7 @@ public class ReplicatedMapQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.ringbuffer;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -38,6 +37,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -58,7 +58,7 @@ public class RingbufferQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
@@ -61,7 +62,7 @@ public class RingbufferQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.ringbuffer;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.scheduledexecutor;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -57,7 +57,7 @@ public class ScheduledExecutorQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.quorum.scheduledexecutor;
 
 import com.hazelcast.cluster.Member;
-import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
@@ -50,6 +50,7 @@ import static com.hazelcast.quorum.scheduledexecutor.ScheduledExecutorQuorumWrit
 import static com.hazelcast.quorum.scheduledexecutor.ScheduledExecutorQuorumWriteTest.ExecRunnable.runnable;
 import static com.hazelcast.test.HazelcastTestSupport.generateKeyOwnedBy;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -74,7 +75,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.semaphore;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.ISemaphore;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -35,6 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -52,7 +52,7 @@ public class SemaphoreQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.semaphore;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cp.ISemaphore;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -37,6 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -54,7 +54,7 @@ public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.set;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -35,6 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -52,7 +52,7 @@ public class SetQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumWriteTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.quorum.set;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
@@ -35,6 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -52,7 +52,7 @@ public class SetQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumReadTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.set;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalSet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -27,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalSet;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -75,7 +75,7 @@ public class TransactionalSetQuorumReadTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumWriteTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.quorum.set;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.transaction.TransactionalSet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -26,6 +24,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalSet;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,6 +40,7 @@ import java.util.Collection;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -74,7 +74,7 @@ public class TransactionalSetQuorumWriteTest extends AbstractQuorumTest {
 
     @BeforeClass
     public static void setUp() {
-        initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
+        initTestEnvironment(smallInstanceConfig(), new TestHazelcastInstanceFactory());
     }
 
     @AfterClass


### PR DESCRIPTION
Quorum tests were starting instances from TestHazelcastInstanceFactory
but were terminating instances from HazelcastInstanceFactory which was
then leaking instances. Fixed this by retaining a reference to the
factory and using it during cleanup.

Also, reduced resource usage by using small instance config.