### PR TITLE
[FORWARDPORT] Respect multi-value attributes in range optimizer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
@@ -87,7 +87,7 @@ public class RangeVisitor extends AbstractVisitor {
 
         if (predicate instanceof FalsePredicate) {
             return Ranges.UNSATISFIABLE;
-        } else if (!(predicate instanceof RangePredicate)) {
+        } else if (!isSupportedPredicate(predicate)) {
             return ranges;
         }
 
@@ -108,6 +108,16 @@ public class RangeVisitor extends AbstractVisitor {
         ranges.addRange(attribute, range, existingRange, predicateIndex);
 
         return ranges;
+    }
+
+    private static boolean isSupportedPredicate(Predicate predicate) {
+        if (!(predicate instanceof RangePredicate)) {
+            return false;
+        }
+
+        RangePredicate rangePredicate = (RangePredicate) predicate;
+        // we are unable to reason about multi-value attributes currently
+        return !rangePredicate.getAttribute().contains("[any]");
     }
 
     private static Range intersect(RangePredicate predicate, Range range, Indexes indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/RangeVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/RangeVisitorTest.java
@@ -54,6 +54,8 @@ public class RangeVisitorTest extends VisitorTestSupport {
         when(indexes.getConverter("age")).thenReturn(INTEGER_CONVERTER);
         when(indexes.getConverter("name")).thenReturn(STRING_CONVERTER);
         when(indexes.getConverter("noConverter")).thenReturn(null);
+        when(indexes.getConverter("collection[any]")).thenReturn(INTEGER_CONVERTER);
+        when(indexes.getConverter("collection[0]")).thenReturn(INTEGER_CONVERTER);
 
         visitor = new RangeVisitor();
     }
@@ -69,6 +71,8 @@ public class RangeVisitorTest extends VisitorTestSupport {
         check(same(), equal("age", 0), equal("name", "Alice"));
         check(same(), equal("age", 0), equal("name", "Alice"), greaterEqual("unindexed", true));
         check(same(), between("name", "Alice", "Bob"));
+        check(same(), equal("collection[any]", 0));
+        check(same(), equal("collection[any]", 0), equal("collection[any]", 1));
     }
 
     @Test
@@ -84,6 +88,7 @@ public class RangeVisitorTest extends VisitorTestSupport {
         check(alwaysFalse(), greaterEqual("age", "10"), lessThan("age", 10.0));
         check(alwaysFalse(), greaterThan("age", "10"), lessThan("age", 0));
         check(alwaysFalse(), equal("name", "Alice"), equal("name", "Bob"), greaterEqual("age", "10"), equal("age", 9));
+        check(alwaysFalse(), equal("collection[0]", 0), equal("collection[0]", 1));
     }
 
     @Test
@@ -107,6 +112,8 @@ public class RangeVisitorTest extends VisitorTestSupport {
         check(and(ref(0), equal("age", 1)), new CustomPredicate(), equal("age", 1), equal("age", "1"));
         check(and(ref(0), ref(1), equal("age", 1)), new CustomPredicate(), equal("unindexed", true), equal("age", 1),
                 equal("age", "1"));
+
+        check(equal("collection[0]", 1), equal("collection[0]", 1), equal("collection[0]", "1"));
     }
 
     @Test


### PR DESCRIPTION
(cherry-picked from e9ea3f3746bbf905d89e5fc788eee1ff739b52c7)

Fixes: https://github.com/hazelcast/hazelcast/issues/15138