### PR TITLE
Execute Operation.call() while running operations directly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
@@ -27,14 +27,15 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
-import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 import com.hazelcast.spi.impl.operationservice.TargetAware;
+import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 
 import java.io.IOException;
 import java.util.Collection;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
+import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createErrorLoggingResponseHandler;
 import static com.hazelcast.util.Preconditions.checkNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -80,9 +81,7 @@ public class OnJoinOp
                 }
                 try {
                     // not running via OperationService since we don't want any restrictions like cluster state check etc.
-                    op.beforeRun();
-                    op.run();
-                    op.afterRun();
+                    runDirect(op);
                 } catch (Exception e) {
                     getLogger().warning("Error while running post-join operation: " + op, e);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -19,22 +19,22 @@ package com.hazelcast.internal.partition.operation;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.ReplicaFragmentMigrationState;
-import com.hazelcast.internal.partition.impl.MigrationInterceptor.MigrationParticipant;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.partition.impl.MigrationInterceptor.MigrationParticipant;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.partition.MigrationAwareService;
-import com.hazelcast.spi.partition.PartitionMigrationEvent;
+import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
-import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.operationservice.TargetAware;
+import com.hazelcast.spi.partition.MigrationAwareService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
+import com.hazelcast.spi.partition.PartitionMigrationEvent;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
+
+import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
 
 /**
  * Migration operation used by Hazelcast version 3.9
@@ -123,9 +125,7 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
 
     private void runMigrationOperation(Operation op) throws Exception {
         prepareOperation(op);
-        op.beforeRun();
-        op.run();
-        op.afterRun();
+        runDirect(op);
     }
 
     protected void prepareOperation(Operation op) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -30,16 +30,16 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.impl.operationservice.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.BackupOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
-import com.hazelcast.spi.ServiceNamespace;
-import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
-import com.hazelcast.spi.exception.WrongTargetException;
-import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.TargetAware;
+import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -49,6 +49,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableCollection;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableCollection;
+import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createErrorLoggingResponseHandler;
 
 /**
@@ -156,9 +157,7 @@ public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
             for (Operation op : operations) {
                 prepareOperation(op);
                 try {
-                    op.beforeRun();
-                    op.run();
-                    op.afterRun();
+                    runDirect(op);
                 } catch (Throwable e) {
                     onOperationFailure(op, e);
                     logException(op, e);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
+
 public class TxnCommitBackupOperation extends AbstractKeyBasedMultiMapOperation implements BackupOperation {
 
     private List<Operation> opList;
@@ -47,9 +49,7 @@ public class TxnCommitBackupOperation extends AbstractKeyBasedMultiMapOperation 
     public void run() throws Exception {
         for (Operation op : opList) {
             op.setNodeEngine(getNodeEngine()).setServiceName(getServiceName()).setPartitionId(getPartitionId());
-            op.beforeRun();
-            op.run();
-            op.afterRun();
+            runDirect(op);
         }
         // changed to forceUnlock because replica-sync of lock causes problems, same as IMap
         // real solution is to make 'lock-and-get' backup-aware

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
+
 public class TxnCommitOperation extends AbstractBackupAwareMultiMapOperation implements Notifier {
 
     private List<Operation> opList;
@@ -51,9 +53,7 @@ public class TxnCommitOperation extends AbstractBackupAwareMultiMapOperation imp
             op.setNodeEngine(getNodeEngine())
                     .setServiceName(getServiceName())
                     .setPartitionId(getPartitionId());
-            op.beforeRun();
-            op.run();
-            op.afterRun();
+            runDirect(op);
         }
         getOrCreateContainer().unlock(dataKey, getCallerUuid(), threadId, getCallId());
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
@@ -17,8 +17,8 @@
 package com.hazelcast.spi.impl.operationexecutor;
 
 import com.hazelcast.nio.Packet;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 /**
  * The OperationRunner is responsible for the actual running of operations.
@@ -131,5 +131,23 @@ public abstract class OperationRunner {
      */
     public final int getPartitionId() {
         return partitionId;
+    }
+
+    /**
+     * Runs operation directly without checking any conditions;
+     * node state, partition ownership, timeouts etc.
+     * <p>
+     * {@link Operation#beforeRun()}, {@link Operation#call()}
+     * and {@link Operation#afterRun()} phases are executed sequentially.
+     * <p>
+     * Operation responses and backups are ignored.
+     *
+     * @param operation operation to run
+     * @throws Exception when one of the operation phases fails with an exception
+     */
+    public static void runDirect(Operation operation) throws Exception {
+        operation.beforeRun();
+        operation.call();
+        operation.afterRun();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -27,13 +27,13 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.operationservice.BackupOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.spi.impl.operationservice.BackupOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -41,6 +41,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.spi.partition.IPartition.MAX_BACKUP_COUNT;
 
@@ -154,10 +155,7 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
         }
 
         ensureBackupOperationInitialized();
-
-        backupOp.beforeRun();
-        backupOp.run();
-        backupOp.afterRun();
+        runDirect(backupOp);
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         PartitionReplicaVersionManager versionManager = nodeEngine.getPartitionService().getPartitionReplicaVersionManager();
@@ -172,7 +170,7 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         long callId = getCallId();
-        OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+        OperationServiceImpl operationService = nodeEngine.getOperationService();
 
         if (nodeEngine.getThisAddress().equals(originalCaller)) {
             operationService.getBackupHandler().notifyBackupComplete(callId);


### PR DESCRIPTION
`Operation.call()` should be used instead of `Operation.run()` while
executing operations without using operation service executor mechanism.

This is needed because, when `Operation.call()` is overridden, it's not used
when `Operation.run()` is called.
By default `Operation.call()` method calls `Operation.run()` internally.