### PR TITLE
Fixed FencedLockFailureTest NPE

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockFailureTest.java
@@ -178,7 +178,7 @@ public class FencedLockFailureTest extends HazelcastRaftTestSupport {
             RaftLockRegistry registry = service.getRegistryOrNull(groupId);
             boolean[] verified = new boolean[1];
             CountDownLatch latch = new CountDownLatch(1);
-            OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+            OperationServiceImpl operationService = nodeEngine.getOperationService();
             operationService.execute(new PartitionSpecificRunnable() {
                 @Override
                 public int getPartitionId() {
@@ -359,14 +359,18 @@ public class FencedLockFailureTest extends HazelcastRaftTestSupport {
 
         assertTrueEventually(() -> {
             RaftLockService service = getNodeEngineImpl(lockInstance).getService(RaftLockService.SERVICE_NAME);
-            assertFalse(service.getRegistryOrNull(groupId).getWaitTimeouts().isEmpty());
+            RaftLockRegistry registry = service.getRegistryOrNull(groupId);
+            assertNotNull(registry);
+            assertFalse(registry.getWaitTimeouts().isEmpty());
         });
 
         unlockLatch.countDown();
 
         assertTrueEventually(() -> {
             RaftLockService service = getNodeEngineImpl(lockInstance).getService(RaftLockService.SERVICE_NAME);
-            assertTrue(service.getRegistryOrNull(groupId).getWaitTimeouts().isEmpty());
+            RaftLockRegistry registry = service.getRegistryOrNull(groupId);
+            assertNotNull(registry);
+            assertTrue(registry.getWaitTimeouts().isEmpty());
             assertTrue(lock.isLocked());
         });
 
@@ -540,6 +544,7 @@ public class FencedLockFailureTest extends HazelcastRaftTestSupport {
 
         assertTrueEventually(() -> {
             RaftLockRegistry registry = service.getRegistryOrNull(groupId);
+            assertNotNull(registry);
             Map<Tuple2<String, UUID>, Tuple2<Long, Long>> waitTimeouts = registry.getWaitTimeouts();
             assertEquals(1, waitTimeouts.size());
             lockWaitTimeoutKeyRef[0] = waitTimeouts.keySet().iterator().next();
@@ -553,7 +558,7 @@ public class FencedLockFailureTest extends HazelcastRaftTestSupport {
             RaftLockRegistry registry = service.getRegistryOrNull(groupId);
             boolean[] verified = new boolean[1];
             CountDownLatch latch = new CountDownLatch(1);
-            OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+            OperationServiceImpl operationService = nodeEngine.getOperationService();
             operationService.execute(new PartitionSpecificRunnable() {
                 @Override
                 public int getPartitionId() {


### PR DESCRIPTION
See http://jenkins.hazelcast.com/job/Hazelcast-pr-builder/1748/testReport/junit/com.hazelcast.cp.internal.datastructures.lock/FencedLockFailureTest/testPendingLockAcquireRetry/

```
java.lang.NullPointerException
	at com.hazelcast.cp.internal.datastructures.lock.FencedLockFailureTest.lambda$testPendingLockAcquireRetry$11(FencedLockFailureTest.java:362)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:1303)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:1405)
	at com.hazelcast.cp.internal.datastructures.lock.FencedLockFailureTest.testPendingLockAcquireRetry(FencedLockFailureTest.java:360)
```