### PR TITLE
Return correct TransactionType from getById

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionCreateMessageTask.java
@@ -43,7 +43,7 @@ public class TransactionCreateMessageTask
         TransactionOptions options = new TransactionOptions();
         options.setDurability(parameters.durability);
         options.setTimeout(parameters.timeout, TimeUnit.MILLISECONDS);
-        options.setTransactionType(TransactionOptions.TransactionType.getByValue(parameters.transactionType));
+        options.setTransactionType(TransactionOptions.TransactionType.getById(parameters.transactionType));
 
         TransactionManagerServiceImpl transactionManager =
                 (TransactionManagerServiceImpl) clientEngine.getTransactionManagerService();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -165,14 +165,14 @@ public final class TransactionOptions implements DataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(timeoutMillis);
         out.writeInt(durability);
-        out.writeInt(transactionType.value);
+        out.writeInt(transactionType.id);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         timeoutMillis = in.readLong();
         durability = in.readInt();
-        transactionType = TransactionType.getByValue(in.readInt());
+        transactionType = TransactionType.getById(in.readInt());
     }
 
 
@@ -215,24 +215,24 @@ public final class TransactionOptions implements DataSerializable {
          */
         TWO_PHASE(2);
 
-        private final int value;
+        private final int id;
 
-        TransactionType(int value) {
-            this.value = value;
+        TransactionType(int id) {
+            this.id = id;
         }
 
         public int id() {
-            return value;
+            return id;
         }
 
-        public static TransactionType getByValue(int value) {
-            switch (value) {
+        public static TransactionType getById(int id) {
+            switch (id) {
                 case 1:
-                    return TWO_PHASE;
-                case 2:
                     return ONE_PHASE;
+                case 2:
+                    return TWO_PHASE;
                 default:
-                    throw new IllegalArgumentException("Unrecognized value:" + value);
+                    throw new IllegalArgumentException("Unrecognized id:" + id);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionTypeTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionOptions;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class TransactionTypeTest {
+
+    @Test
+    public void getById_returns_matching_transactionType() {
+        for (TransactionOptions.TransactionType transactionType
+                : TransactionOptions.TransactionType.values()) {
+            assertEquals(transactionType,
+                    TransactionOptions.TransactionType.getById(transactionType.id()));
+        }
+    }
+}


### PR DESCRIPTION
fixes an issue of merged PR: https://github.com/hazelcast/hazelcast/pull/15183

- also renamed `getByValue` as `getById`
