### PR TITLE
Coalesced WBQ: do not accidentally remove entries added while StoreWorker is running (#15060)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
@@ -91,6 +91,11 @@ class CoalescedWriteBehindQueue implements WriteBehindQueue<DelayedEntry> {
             return false;
         }
 
+        if (current.getSequence() > incoming.getSequence()) {
+            // current is newer than incoming: do not remove
+            return false;
+        }
+
         Object currentValue = current.getValue();
         if (incomingValue == null && currentValue == null
                 || incomingValue != null && currentValue != null && incomingValue.equals(currentValue)) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueueTest.java
@@ -30,8 +30,10 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
+import static com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntries.createDefault;
 import static com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntries.createWithoutValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -65,6 +67,17 @@ public class CoalescedWriteBehindQueueTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void test_removeFirstOccurrence_whenSequenceNumberLower() throws Exception {
+        DelayedEntry<Data, Object> entry = newEntry(1, 10);
+        entry.setSequence(1);
+        queue.addLast(entry);
+        DelayedEntry<Data, Object> entry2 = newEntry(1, 10); // sequence is 0
+        assertFalse(queue.removeFirstOccurrence(entry2));
+
+        assertEquals(1, queue.size());
+    }
+
+    @Test
     public void test_contains() throws Exception {
         DelayedEntry<Data, Object> entry = newEntry(1);
         queue.addLast(entry);
@@ -93,5 +106,9 @@ public class CoalescedWriteBehindQueueTest extends HazelcastTestSupport {
 
     private DelayedEntry<Data, Object> newEntry(Object key) {
         return createWithoutValue(serializationService.toData(key));
+    }
+
+    private DelayedEntry<Data, Object> newEntry(Object key, Object value) {
+        return createDefault(serializationService.toData(key), serializationService.toData(value), 0L, 0);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueueTest.java
@@ -109,6 +109,6 @@ public class CoalescedWriteBehindQueueTest extends HazelcastTestSupport {
     }
 
     private DelayedEntry<Data, Object> newEntry(Object key, Object value) {
-        return createDefault(serializationService.toData(key), serializationService.toData(value), 0L, 0);
+        return createDefault(serializationService.toData(key), value, 0L, 0);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorkerConcurrentUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorkerConcurrentUpdateTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.mapstore.writebehind;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapStore;
+import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class StoreWorkerConcurrentUpdateTest extends HazelcastTestSupport {
+
+    /**
+     * Reproducer for https://github.com/hazelcast/hazelcast/issues/15060
+     */
+    @Test
+    public void testCoalescedWBQ_noUpdatesLost_whenEqualEntryAddedConcurrently() {
+        doTestAddEqualEntryConcurrently(true);
+    }
+
+    @Test
+    public void testBoundedWBQ_noUpdatesLost_whenEqualEntryAddedConcurrently() {
+        doTestAddEqualEntryConcurrently(false);
+    }
+
+    private void doTestAddEqualEntryConcurrently(boolean coalesced) {
+        String mapName = randomName();
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        final NewVersionConcurrentInsertMapStore mapStore = new NewVersionConcurrentInsertMapStore();
+        mapStoreConfig.setImplementation(mapStore).setWriteDelaySeconds(1).setWriteCoalescing(coalesced);
+
+        Config config = getConfig();
+        config.getMapConfig(mapName).setBackupCount(0).setMapStoreConfig(mapStoreConfig);
+        HazelcastInstance instance = createHazelcastInstance(config);
+
+        IMap<Integer, Entry> map = instance.getMap(mapName);
+        map.addInterceptor(new DummyMapInterceptor());
+        mapStore.setMap(map);
+
+        final int entryCount = 100;
+        for (int i = 0; i < entryCount; i++) {
+            map.put(i, new Entry(i, 1));
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(entryCount, mapStore.versionOne.size());
+                assertEquals(entryCount, mapStore.versionTwo.size());
+            }
+        });
+    }
+
+    private static final class Entry implements Serializable {
+
+        private int id;
+        private int version;
+
+        public Entry() {
+            // serialization
+        }
+
+        public Entry(int id, int version) {
+            this.id = id;
+            this.version = version;
+        }
+
+        public Entry newVersion() {
+            return new Entry(id, version + 1);
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Entry)) {
+                return false;
+            }
+            // different versions are considered equal
+            return id == ((Entry) o).id;
+        }
+    }
+
+    private static final class DummyMapInterceptor implements MapInterceptor {
+
+        @Override
+        public Object interceptGet(Object value) {
+            return null;
+        }
+
+        @Override
+        public void afterGet(Object value) {
+        }
+
+        @Override
+        public Object interceptPut(Object oldValue, Object newValue) {
+            /* Return non-null to make sure a plain object (rather than the
+               serialized version) will be stored in the write behind queue. */
+            return newValue;
+        }
+
+        @Override
+        public void afterPut(Object value) {
+        }
+
+        @Override
+        public Object interceptRemove(Object removedValue) {
+            return null;
+        }
+
+        @Override
+        public void afterRemove(Object oldValue) {
+        }
+    }
+
+    /**
+     * Simulates a concurrent addition of a new Entry version to the write
+     * behind queue right after {@link StoreWorker} selects entries to store.
+     */
+    private static final class NewVersionConcurrentInsertMapStore implements MapStore<Integer, Entry> {
+
+        private IMap<Integer, Entry> map;
+        private Set<Entry> versionOne = new HashSet<Entry>();
+        private Set<Entry> versionTwo = new HashSet<Entry>();
+
+        private void setMap(IMap<Integer, Entry> map) {
+            this.map = map;
+        }
+
+        @Override
+        public void store(Integer key, Entry value) {
+            if (value.version == 1) {
+                versionOne.add(value);
+                // add version 2 of the entry to the write behind queue
+                map.put(key, value.newVersion());
+            } else {
+                versionTwo.add(value);
+            }
+        }
+
+        @Override
+        public void storeAll(Map<Integer, Entry> map) {
+            for (Map.Entry<Integer, Entry> e : map.entrySet()) {
+                store(e.getKey(), e.getValue());
+            }
+        }
+
+        @Override
+        public void delete(Integer key) {
+        }
+
+        @Override
+        public void deleteAll(Collection<Integer> keys) {
+        }
+
+        @Override
+        public Entry load(Integer key) {
+            return null;
+        }
+
+        @Override
+        public Map<Integer, Entry> loadAll(Collection<Integer> keys) {
+            return null;
+        }
+
+        @Override
+        public Iterable<Integer> loadAllKeys() {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
`CoalescedWriteBehindQueue.removeFirstOccurence(e)` now
does not remove the existing entry if its sequence number is
higher than `e`'s. This means that the current entry was inserted
into the map after e and therefore
`StoreWorker.removeFinishedStoreOperationsFromQueues()`
should not remove it.

Fixes https://github.com/hazelcast/hazelcast/issues/15060