### PR TITLE
WAN publisher SPI cleanup, part 2

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -985,7 +985,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         WanPublisherConfig publisherConfig = wcfg.getWanPublisherConfigs().get(0);
         assertEquals("tokyo", publisherConfig.getGroupName());
         assertEquals("tokyoPublisherId", publisherConfig.getPublisherId());
-        assertEquals("com.hazelcast.enterprise.wan.replication.WanBatchReplication", publisherConfig.getClassName());
+        assertEquals("com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication", publisherConfig.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
         assertEquals(1000, publisherConfig.getQueueCapacity());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -48,7 +48,7 @@
             <hz:wan-replication name="testWan">
                 <hz:wan-publisher group-name="tokyo"
                                   publisher-id="tokyoPublisherId"
-                                  class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
+                                  class-name="com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication">
                     <hz:queue-full-behavior>THROW_EXCEPTION</hz:queue-full-behavior>
                     <hz:queue-capacity>1000</hz:queue-capacity>
                     <hz:initial-publisher-state>STOPPED</hz:initial-publisher-state>
@@ -100,7 +100,7 @@
                         <hz:property name="maxEndpoints">2</hz:property>
                     </hz:properties>
                 </hz:wan-publisher>
-                <hz:wan-publisher group-name="ankara" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
+                <hz:wan-publisher group-name="ankara" class-name="com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication">
                     <hz:queue-capacity>${wan.queue.capacity}</hz:queue-capacity>
                 </hz:wan-publisher>
                 <hz:wan-consumer class-name="com.hazelcast.wan.custom.WanConsumer"

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -60,7 +60,7 @@
             <hz:wan-replication name="testWan">
                 <hz:wan-publisher group-name="tokyo"
                                   publisher-id="tokyoPublisherId"
-                                  class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
+                                  class-name="com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication">
                     <hz:queue-full-behavior>THROW_EXCEPTION</hz:queue-full-behavior>
                     <hz:queue-capacity>1000</hz:queue-capacity>
                     <hz:initial-publisher-state>STOPPED</hz:initial-publisher-state>
@@ -127,7 +127,7 @@
                         <hz:property name="maxEndpoints">2</hz:property>
                     </hz:properties>
                 </hz:wan-publisher>
-                <hz:wan-publisher group-name="ankara" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
+                <hz:wan-publisher group-name="ankara" class-name="com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication">
                     <hz:queue-capacity>${wan.queue.capacity}</hz:queue-capacity>
                 </hz:wan-publisher>
                 <hz:wan-consumer class-name="com.hazelcast.wan.custom.WanConsumer"

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -61,7 +61,7 @@ import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.ServiceLoader;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.cache.CacheException;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherState.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherState.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.wan.impl.WanReplicationService;
+
 /**
  * Defines the state in which a WAN publisher can be in if it is not shutting
  * down.
@@ -54,7 +56,7 @@ public enum WanPublisherState {
      * it will become available. Once it becomes available, you can then switch
      * the publisher state to REPLICATING to begin replicating to that cluster.
      *
-     * @see com.hazelcast.wan.WanReplicationService#clearQueues(String, String)
+     * @see WanReplicationService#clearQueues(String, String)
      */
     STOPPED((byte) 2, false, false);
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -95,7 +95,7 @@ import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 
 import java.util.Collections;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -36,8 +36,8 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.JsonUtil;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.version.Version;
-import com.hazelcast.wan.AddWanConfigResult;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.AddWanConfigResult;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -26,7 +26,7 @@ import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.io.File;
 import java.net.URL;

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.jmx;
 
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.monitor.LocalWanStats;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -69,7 +69,7 @@ import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.management.operation;
 import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.spi.impl.operationservice.AbstractLocalOperation;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 /**
  * Stop, pause or resume WAN replication for the given {@code wanReplicationName} and {@code targetGroupName}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ClearWanQueuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ClearWanQueuesOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.management.operation;
 
 import com.hazelcast.spi.impl.operationservice.AbstractLocalOperation;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 /**
  * Clear WAN replication queues for the given wan replication schema and publisher

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/WanCheckConsistencyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/WanCheckConsistencyOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.management.operation;
 
 import com.hazelcast.spi.impl.operationservice.AbstractLocalOperation;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 /**
  * Checking consistency of the given map for the given wan replication

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -57,7 +57,7 @@ import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.MemoryInfoAccessor;
 import com.hazelcast.util.RuntimeMemoryInfoAccessor;
 import com.hazelcast.wan.WanReplicationPublisher;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.wan.WanReplicationEvent;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters;
+import com.hazelcast.wan.DistributedServiceWanEventCounters;
 
 import java.util.concurrent.Future;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MerkleTreeNodeEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MerkleTreeNodeEntries.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.wan.merkletree.MerkleTree;
+import com.hazelcast.wan.impl.merkletree.MerkleTree;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.wan.ReplicationEventObject;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters;
+import com.hazelcast.wan.DistributedServiceWanEventCounters;
 import com.hazelcast.wan.impl.WanDataSerializerHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.wan.ReplicationEventObject;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters;
+import com.hazelcast.wan.DistributedServiceWanEventCounters;
 import com.hazelcast.wan.impl.WanDataSerializerHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -19,9 +19,10 @@ package com.hazelcast.monitor;
 
 import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.internal.management.JsonSerializable;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
+import com.hazelcast.wan.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
 import com.hazelcast.wan.WanSyncStats;
-import com.hazelcast.wan.merkletree.ConsistencyCheckResult;
+import com.hazelcast.wan.ConsistencyCheckResult;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.util.Map;
 
@@ -62,8 +63,8 @@ public interface LocalWanPublisherStats extends JsonSerializable {
     /**
      * Returns the current {@link WanPublisherState} of this publisher.
      *
-     * @see com.hazelcast.wan.WanReplicationService#pause(String, String)
-     * @see com.hazelcast.wan.WanReplicationService#stop(String, String)
+     * @see WanReplicationService#pause(String, String)
+     * @see WanReplicationService#stop(String, String)
      */
     WanPublisherState getPublisherState();
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/WanSyncState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/WanSyncState.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.monitor;
 
-import com.hazelcast.wan.WanSyncStatus;
+import com.hazelcast.wan.impl.WanSyncStatus;
 
 /**
  * Local WAN sync statistics to be used by {@link MemberState} implementations.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
@@ -20,9 +20,9 @@ package com.hazelcast.monitor.impl;
 import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.monitor.LocalWanPublisherStats;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
+import com.hazelcast.wan.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
 import com.hazelcast.wan.WanSyncStats;
-import com.hazelcast.wan.merkletree.ConsistencyCheckResult;
+import com.hazelcast.wan.ConsistencyCheckResult;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/WanSyncStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/WanSyncStateImpl.java
@@ -19,7 +19,7 @@ package com.hazelcast.monitor.impl;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.util.Clock;
-import com.hazelcast.wan.WanSyncStatus;
+import com.hazelcast.wan.impl.WanSyncStatus;
 
 public class WanSyncStateImpl implements WanSyncState {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.version.MemberVersion;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.util.Collection;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -73,7 +73,7 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.version.MemberVersion;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -65,7 +65,7 @@ import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.util.ServiceLoader;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.lang.reflect.Constructor;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/wan/ConsistencyCheckResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/ConsistencyCheckResult.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan;
 
 /**
  * Result of the last WAN consistency check result

--- a/hazelcast/src/main/java/com/hazelcast/wan/DistributedServiceWanEventCounters.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/DistributedServiceWanEventCounters.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.impl;
+package com.hazelcast.wan;
 
 import com.hazelcast.util.ConstructorFunction;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/ReplicationEventObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/ReplicationEventObject.java
@@ -17,7 +17,6 @@
 package com.hazelcast.wan;
 
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters;
 
 /**
  * Interface for all WAN replication messages

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/AddWanConfigResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/AddWanConfigResult.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.wan.impl;
 
 import com.hazelcast.util.Preconditions;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventCounters.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventCounters.java
@@ -19,6 +19,7 @@ package com.hazelcast.wan.impl;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.wan.DistributedServiceWanEventCounters;
 
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.wan.impl;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.WanReplicationConfig;
@@ -22,7 +22,8 @@ import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.spi.CoreService;
 import com.hazelcast.spi.StatisticsAwareService;
-import com.hazelcast.wan.impl.DistributedServiceWanEventCounters;
+import com.hazelcast.wan.WanReplicationPublisher;
+import com.hazelcast.wan.DistributedServiceWanEventCounters;
 
 /**
  * This is the WAN replications service API core interface. The

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -26,10 +26,9 @@ import com.hazelcast.internal.management.events.WanSyncIgnoredEvent;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.wan.AddWanConfigResult;
+import com.hazelcast.wan.DistributedServiceWanEventCounters;
 import com.hazelcast.wan.WanReplicationEndpoint;
 import com.hazelcast.wan.WanReplicationPublisher;
-import com.hazelcast.wan.WanReplicationService;
 
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,7 @@ import static com.hazelcast.nio.ClassLoaderUtil.getOrCreate;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 
 /**
- * Open source implementation of the {@link com.hazelcast.wan.WanReplicationService}
+ * Open source implementation of the {@link WanReplicationService}
  */
 public class WanReplicationServiceImpl implements WanReplicationService {
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanSyncStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanSyncStatus.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.wan.impl;
 
 /**
  * {@code WanSyncStatus} shows the current status of WAN sync.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/AbstractMerkleTreeView.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/AbstractMerkleTreeView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 /**
  * Base class for the {@link MerkleTreeView} implementations

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/ArrayMerkleTree.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/ArrayMerkleTree.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import com.hazelcast.util.collection.OAHashSet;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTree.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTree.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import java.util.function.Consumer;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTreeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTreeUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import com.hazelcast.util.QuickMath;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTreeView.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTreeView.java
@@ -14,7 +14,24 @@
  * limitations under the License.
  */
 
+package com.hazelcast.wan.impl.merkletree;
+
 /**
- * This package contains Merkle tree based anti-entropy implementation
+ * Readonly view of a Merkle tree
  */
-package com.hazelcast.wan.merkletree;
+interface MerkleTreeView {
+    /**
+     * Returns the hash for the node with the given {@code nodeOrder}
+     *
+     * @param nodeOrder The order of the node
+     * @return the hash of the node
+     */
+    int getNodeHash(int nodeOrder);
+
+    /**
+     * Returns the depth of the tree
+     *
+     * @return the depth of the tree
+     */
+    int depth();
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/RemoteMerkleTreeView.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/RemoteMerkleTreeView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import static com.hazelcast.util.Preconditions.checkTrue;
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/package-info.java
@@ -14,24 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
-
 /**
- * Readonly view of a Merkle tree
+ * This package contains Merkle tree based anti-entropy implementation
  */
-interface MerkleTreeView {
-    /**
-     * Returns the hash for the node with the given {@code nodeOrder}
-     *
-     * @param nodeOrder The order of the node
-     * @return the hash of the node
-     */
-    int getNodeHash(int nodeOrder);
-
-    /**
-     * Returns the depth of the tree
-     *
-     * @return the depth of the tree
-     */
-    int depth();
-}
+package com.hazelcast.wan.impl.merkletree;

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -2384,7 +2384,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Fully qualified class name of WAN Replication implementation implementing WanReplicationEndpoint.
-                        Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.replication.WanBatchReplication:
+                        Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication:
                         Waits until a batch size is reached or a delay time is passed.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -149,7 +149,7 @@
         The <wan-replication> element has the following sub-elements:
         * <wan-publisher>:
             Fully qualified class name of WAN Replication implementation implementing WanReplicationEndpoint.
-            Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.replication.WanBatchReplication:
+            Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication:
             Waits until a batch size is reached or a delay time is passed.
             Please see the `batch.size and batch.max.delay.millis configuration descriptions below.
         * <wan-consumer>:
@@ -277,7 +277,7 @@
     -->
     <wan-replication name="my-wan-cluster-batch">
         <wan-publisher group-name="nyc" publisher-id="nycPublisherId">
-            <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
+            <class-name>com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication</class-name>
             <queue-capacity>15000</queue-capacity>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
             <initial-publisher-state>REPLICATING</initial-publisher-state>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -139,7 +139,7 @@ hazelcast:
   # The "wan-replication" element has the following sub-elements:
   # * "wan-publisher":
   #     Fully qualified class name of WAN Replication implementation implementing WanReplicationEndpoint.
-  #     Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.replication.WanBatchReplication:
+  #     Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication:
   #     Waits until a batch size is reached or a delay time is passed.
   #     Please see the `batch.size and batch.max.delay.millis configuration descriptions below.
   # * "wan-consumer":
@@ -269,7 +269,7 @@ hazelcast:
       wan-publisher:
         nycPublisherId:
           group-name: nyc
-          class-name: com.hazelcast.enterprise.wan.replication.WanBatchReplication
+          class-name: com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication
           queue-capacity: 15000
           queue-full-behavior: DISCARD_AFTER_MUTATION
           initial-publisher-state: REPLICATING

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -29,7 +29,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.EndpointManager;
 import com.hazelcast.nio.NetworkingService;
 import com.hazelcast.version.Version;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.wan.impl.WanReplicationService;
 import org.mockito.ArgumentMatchers;
 
 import java.net.UnknownHostException;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -38,7 +38,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
-import com.hazelcast.wan.WanSyncStatus;
+import com.hazelcast.wan.impl.WanSyncStatus;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.wan.impl.WanReplicationService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeContext.java
@@ -19,6 +19,7 @@ package com.hazelcast.wan;
 import com.hazelcast.instance.impl.DefaultNodeContext;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeExtension;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 public class WanServiceMockingNodeContext extends DefaultNodeContext {
     private final WanReplicationService wanReplicationService;

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeExtension.java
@@ -18,6 +18,7 @@ package com.hazelcast.wan;
 
 import com.hazelcast.instance.impl.DefaultNodeExtension;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.wan.impl.WanReplicationService;
 
 class WanServiceMockingNodeExtension extends DefaultNodeExtension {
     private final WanReplicationService wanReplicationService;

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanSyncStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanSyncStatusTest.java
@@ -20,13 +20,14 @@ import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.wan.impl.WanSyncStatus;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.wan.WanSyncStatus.FAILED;
-import static com.hazelcast.wan.WanSyncStatus.IN_PROGRESS;
-import static com.hazelcast.wan.WanSyncStatus.READY;
+import static com.hazelcast.wan.impl.WanSyncStatus.FAILED;
+import static com.hazelcast.wan.impl.WanSyncStatus.IN_PROGRESS;
+import static com.hazelcast.wan.impl.WanSyncStatus.READY;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
@@ -46,7 +46,6 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.wan.WanReplicationEvent;
-import com.hazelcast.wan.WanReplicationService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/ArrayMerkleTreeBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/ArrayMerkleTreeBenchmark.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/ArrayMerkleTreeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/ArrayMerkleTreeTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/MerkleTreeUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/MerkleTreeUtilTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/RemoteMerkleTreeViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/merkletree/RemoteMerkleTreeViewTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.merkletree;
+package com.hazelcast.wan.impl.merkletree;
 
 import org.junit.Test;
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -62,7 +62,7 @@
     </properties>
     <wan-replication name="my-wan-cluster">
         <wan-publisher group-name="tokyo" publisher-id="tokyoPublisherId">
-            <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
+            <class-name>com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication</class-name>
             <queue-capacity>1000</queue-capacity>
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
             <initial-publisher-state>REPLICATING</initial-publisher-state>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -59,7 +59,7 @@ hazelcast:
 
         tokyoPublisherId:
           group-name: tokyo
-          class-name: com.hazelcast.enterprise.wan.replication.WanBatchReplication
+          class-name: com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication
           queue-capacity: 1000
           queue-full-behavior: THROW_EXCEPTION
           initial-publisher-state: REPLICATING


### PR DESCRIPTION
This change separates private and public WAN API so it's mostly import
changes. After the API is separated, we can more easily detect leaking
internals (e.g. the EWRMigrationContainer parameter in
WanReplicationEndpoint.collectReplicationData). This will help us fix
any methods that leak internals and finally to join the OS and EE
WAN SPI into one.

**Note to reviewers**: you can use `git show | grep -E "^[-+][^-+]+" | grep -v "[-+]import"` on the command line to list all of the changes that were not import changes. You'll have to correlate them to the exact file by either searching the "Files changed" in GitHub or by searching `git show`.

The public WAN packages and classes (in OS and EE):
```
com.hazelcast.cache.wan:
	CacheWanEventFilter
com.hazelcast.map.wan:
	MapWanEventFilter
com.hazelcast.enterprise.wan:
	EnterpriseReplicationEventObject
	WanConsistencyCheckEvent
	WanEventQueueMigrationListener
	WanFilterEventType
	WanReplicationConsumer
	WanReplicationEndpoint
	WanSyncEvent
	WanSyncType
com.hazelcast.wan:
	ConsistencyCheckResult
	DistributedServiceWanEventCounters
	ReplicationEventObject
	WanReplicationEndpoint
	WanReplicationEvent
	WanReplicationPublisher
	WANReplicationQueueFullException
	WanSyncStats
```

Also moved ICache operations to `impl` package (some of them were WAN operations).

Remaining cases to inspect and fix:
- whether `com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication` should remain private or public (since the user needs to list it in the configuration). Alternatively, we can add an alias (or make it the default) so the user doesn't need to list the whole class name.
- whether to move ReplicationSupportingService out of SPI since we are
closing off custom service SPI
- usage of EWRMigrationContainer in
WanReplicationEndpoint#collectReplicationData
- need to expose both sync and consistency check methods instead of
current WanReplicationEndpoint#publishSyncEvent
- all mentioning of "queue" in the SPI/API
- simplify various putBackup, publishReplicationEvent,
publishReplicationEventBackup, publishReplicationEvent methods
- rename checkWanReplicationQueues, WANQueueFullBehavior,
WANReplicationQueueFullException to avoid mentioning queue
- join ReplicationEventObject and EnterpriseReplicationEventObject
- join WanReplicationEndpoint from OS and EE

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2168
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3048