### PR TITLE
Convert custom query attribute abstract classes to functional interfaces

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
@@ -40,7 +40,7 @@ import static com.hazelcast.internal.serialization.impl.PortableUtils.getPortabl
 /**
  * Can't be accessed concurrently.
  */
-public class DefaultPortableReader extends ValueReader implements PortableReader {
+public class DefaultPortableReader implements ValueReader, PortableReader {
 
     private static final MultiResult NULL_EMPTY_TARGET_MULTIRESULT;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ArgumentParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ArgumentParser.java
@@ -28,7 +28,8 @@ package com.hazelcast.query.extractor;
  * @param <I> type of the unparsed argument object (input)
  * @param <O> type of the parsed argument object (output)
  */
-public abstract class ArgumentParser<I, O> {
+@FunctionalInterface
+public interface ArgumentParser<I, O> {
 
     /**
      * This method takes the unparsed argument object as an input and returns
@@ -37,6 +38,6 @@ public abstract class ArgumentParser<I, O> {
      * @param input extraction argument in the specified format
      * @return parsed argument object that will be passed to the {@link ValueExtractor}
      */
-    public abstract O parse(I input);
+    O parse(I input);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCallback.java
@@ -21,13 +21,14 @@ package com.hazelcast.query.extractor;
  *
  * @param <T> type of the extracted value
  */
-public abstract class ValueCallback<T> {
+@FunctionalInterface
+public interface ValueCallback<T> {
 
     /**
      * Notifies about a value passed as an argument
      *
      * @param value value to be notified about
      */
-    public abstract void onResult(T value);
+    void onResult(T value);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCollector.java
@@ -21,13 +21,14 @@ package com.hazelcast.query.extractor;
  *
  * @param <T> type of the collected value
  */
-public abstract class ValueCollector<T> {
+@FunctionalInterface
+public interface ValueCollector<T> {
 
     /**
      * Collects a value passed as an argument
      *
      * @param value value to be collected
      */
-    public abstract void addObject(T value);
+    void addObject(T value);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueExtractor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueExtractor.java
@@ -71,7 +71,8 @@ import com.hazelcast.nio.serialization.Portable;
  * @param <T> type of the target object to extract the value from
  * @param <A> type of the extraction argument object passed to the extract() method
  */
-public abstract class ValueExtractor<T, A> {
+@FunctionalInterface
+public interface ValueExtractor<T, A> {
 
     /**
      * Extracts a value from the given target object.
@@ -115,6 +116,6 @@ public abstract class ValueExtractor<T, A> {
      * @param collector collector of the extracted value(s)
      * @see ValueCollector
      */
-    public abstract void extract(T target, A argument, ValueCollector collector);
+    void extract(T target, A argument, ValueCollector collector);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReader.java
@@ -32,7 +32,7 @@ package com.hazelcast.query.extractor;
  * <p>The wildcard quantifier may be used multiple times, like "person.leg[any].finger[any]" which returns all fingers
  * from all legs.
  */
-public abstract class ValueReader {
+public interface ValueReader {
 
     /**
      * Read the value of the attribute specified by the path and returns the result via the callback.
@@ -43,7 +43,7 @@ public abstract class ValueReader {
      * @throws ValueReadingException in case of any reading errors. If an exception occurs the callback won't
      *                               be called at all
      */
-    public abstract <T> void read(String path, ValueCallback<T> callback) throws ValueReadingException;
+    <T> void read(String path, ValueCallback<T> callback) throws ValueReadingException;
 
     /**
      * Read the value of the attribute specified by the path and returns the result directly to the collector.
@@ -54,6 +54,6 @@ public abstract class ValueReader {
      * @throws ValueReadingException in case of any reading errors. If an exception occurs the collector won't
      *                               be called at all
      */
-    public abstract <T> void read(String path, ValueCollector<T> collector) throws ValueReadingException;
+    <T> void read(String path, ValueCollector<T> collector) throws ValueReadingException;
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultArgumentParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultArgumentParser.java
@@ -23,7 +23,7 @@ import com.hazelcast.query.extractor.ArgumentParser;
  *
  * @see ArgumentParser
  */
-public class DefaultArgumentParser extends ArgumentParser<Object, Object> {
+public class DefaultArgumentParser implements ArgumentParser<Object, Object> {
 
     @Override
     public Object parse(Object input) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultValueCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultValueCollector.java
@@ -22,7 +22,7 @@ import com.hazelcast.query.impl.getters.MultiResult;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DefaultValueCollector extends ValueCollector {
+public class DefaultValueCollector implements ValueCollector {
 
     private Object value;
     private List<Object> values;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ExtractorsAndIndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ExtractorsAndIndexesTest.java
@@ -89,7 +89,7 @@ public class ExtractorsAndIndexesTest extends HazelcastTestSupport {
         public String last;
     }
 
-    public static class Extractor extends ValueExtractor<Person, Void> {
+    public static class Extractor implements ValueExtractor<Person, Void> {
         @SuppressWarnings("unchecked")
         @Override
         public void extract(Person person, Void aVoid, ValueCollector valueCollector) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
@@ -233,7 +233,7 @@ public class QueryCacheTest extends AbstractQueryCacheTestSupport {
         assertQueryCacheSizeEventually(50, queryCache);
     }
 
-    public static class EvenNumberEmployeeValueExtractor extends ValueExtractor<Employee, Integer> {
+    public static class EvenNumberEmployeeValueExtractor implements ValueExtractor<Employee, Integer> {
         @Override
         public void extract(Employee target, Integer argument, ValueCollector collector) {
             collector.addObject(target.getId() % 2 == 0);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryPerformanceBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryPerformanceBenchmark.java
@@ -209,28 +209,28 @@ public class QueryPerformanceBenchmark extends HazelcastTestSupport {
         new Runner(opt).run();
     }
 
-    public static class NameExtractor extends ValueExtractor<Person, Object> {
+    public static class NameExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object argument, ValueCollector collector) {
             collector.addObject(target.getName());
         }
     }
 
-    public static class LimbNameExtractor extends ValueExtractor<Person, Object> {
+    public static class LimbNameExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object argument, ValueCollector collector) {
             collector.addObject(target.getFirstLimb().getName());
         }
     }
 
-    public static class PortableNameExtractor extends ValueExtractor<ValueReader, Object> {
+    public static class PortableNameExtractor implements ValueExtractor<ValueReader, Object> {
         @Override
         public void extract(ValueReader target, Object argument, ValueCollector collector) {
             target.read("name", collector);
         }
     }
 
-    public static class PortableLimbNameExtractor extends ValueExtractor<ValueReader, Object> {
+    public static class PortableLimbNameExtractor implements ValueExtractor<ValueReader, Object> {
         @Override
         public void extract(ValueReader target, Object argument, ValueCollector collector) {
             target.read("firstLimb.name", collector);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
@@ -89,21 +89,21 @@ public class CollectionAllPredicatesExtractorTest extends CollectionAllPredicate
         };
     }
 
-    public static class IndexOneLimbPowerExtractor extends ValueExtractor<Person, Object> {
+    public static class IndexOneLimbPowerExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object arguments, ValueCollector collector) {
             collector.addObject(target.limbs_list.get(1).power);
         }
     }
 
-    public static class IndexOneLimbNameExtractor extends ValueExtractor<Person, Object> {
+    public static class IndexOneLimbNameExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object arguments, ValueCollector collector) {
             collector.addObject(target.limbs_list.get(1).name);
         }
     }
 
-    public static class ReducedLimbPowerExtractor extends ValueExtractor<Person, Object> {
+    public static class ReducedLimbPowerExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object arguments, ValueCollector collector) {
             for (Limb limb : target.limbs_list) {
@@ -112,7 +112,7 @@ public class CollectionAllPredicatesExtractorTest extends CollectionAllPredicate
         }
     }
 
-    public static class ReducedLimbNameExtractor extends ValueExtractor<Person, Object> {
+    public static class ReducedLimbNameExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object arguments, ValueCollector collector) {
             for (Limb limb : target.limbs_list) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
@@ -76,14 +76,14 @@ public class SingleValueAllPredicatesExtractorTest extends SingleValueAllPredica
         };
     }
 
-    public static class IqExtractor extends ValueExtractor<Person, Object> {
+    public static class IqExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object arguments, ValueCollector collector) {
             collector.addObject(target.brain.iq);
         }
     }
 
-    public static class NameExtractor extends ValueExtractor<Person, Object> {
+    public static class NameExtractor implements ValueExtractor<Person, Object> {
         @Override
         public void extract(Person target, Object arguments, ValueCollector collector) {
             collector.addObject(target.brain.name);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionWithExtractorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionWithExtractorsSpecTest.java
@@ -190,7 +190,7 @@ public class ExtractionWithExtractorsSpecTest extends AbstractExtractionTest {
     }
 
     @SuppressWarnings("unchecked")
-    public static class LimbTattoosCountExtractor extends ValueExtractor {
+    public static class LimbTattoosCountExtractor implements ValueExtractor {
         @Override
         public void extract(Object target, Object arguments, final ValueCollector collector) {
             Integer parsedId = Integer.parseInt((String) arguments);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
@@ -278,7 +278,7 @@ public class ExtractorHelperTest {
     public abstract class InitExceptionExtractor extends NameExtractor {
     }
 
-    public static final class IqExtractor extends ValueExtractor<Object, Object> {
+    public static final class IqExtractor implements ValueExtractor<Object, Object> {
 
         @Override
         public void extract(Object target, Object arguments, ValueCollector collector) {
@@ -291,7 +291,7 @@ public class ExtractorHelperTest {
         }
     }
 
-    public static class NameExtractor extends ValueExtractor<Object, Object> {
+    public static class NameExtractor implements ValueExtractor<Object, Object> {
 
         @Override
         public void extract(Object target, Object arguments, ValueCollector collector) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -164,7 +164,7 @@ public class ExtractorsTest {
         int power = 550;
     }
 
-    public static class PowerExtractor extends ValueExtractor<Bond, Object> {
+    public static class PowerExtractor implements ValueExtractor<Bond, Object> {
         @Override
         public void extract(Bond target, Object arguments, ValueCollector collector) {
             collector.addObject(target.car.power);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
@@ -191,7 +191,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         assertEquals(2, limbExtractorExecutions);
     }
 
-    public static class BodyNameExtractor extends ValueExtractor<Body, Object> {
+    public static class BodyNameExtractor implements ValueExtractor<Body, Object> {
 
         @Override
         public void extract(Body target, Object arguments, ValueCollector collector) {
@@ -200,7 +200,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         }
     }
 
-    public static class LimbNameExtractor extends ValueExtractor<Body, Object> {
+    public static class LimbNameExtractor implements ValueExtractor<Body, Object> {
 
         @Override
         public void extract(Body target, Object arguments, ValueCollector collector) {

--- a/hazelcast/src/test/java/usercodedeployment/CapitalizatingFirstnameExtractor.java
+++ b/hazelcast/src/test/java/usercodedeployment/CapitalizatingFirstnameExtractor.java
@@ -19,7 +19,7 @@ package usercodedeployment;
 import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
 
-public class CapitalizatingFirstnameExtractor extends ValueExtractor<Person, Object> {
+public class CapitalizatingFirstnameExtractor implements ValueExtractor<Person, Object> {
     @Override
     public void extract(Person target, Object argument, ValueCollector collector) {
         collector.addObject(target.getName().toUpperCase());


### PR DESCRIPTION
ArgumentParser, ValueCallback, ValueCollector, ValueReader and
ValueExtractor can all be  interfaces instead of abstract classes. Since
some have only a single method, these become functional interfaces so
it's more lambda-friendly.