### PR TITLE
Add null checks and annotations to IList, ISet, ITopic and MultiMap

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -43,12 +43,12 @@ import com.hazelcast.client.impl.protocol.codec.ListSubCodec;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
-import com.hazelcast.collection.impl.common.DataAwareItemEvent;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.collection.IList;
 import com.hazelcast.collection.ItemEvent;
-import com.hazelcast.core.ItemEventType;
 import com.hazelcast.collection.ItemListener;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.collection.impl.common.DataAwareItemEvent;
+import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 
@@ -60,7 +60,6 @@ import java.util.ListIterator;
 
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
  * Proxy implementation of {@link IList}.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -74,8 +74,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean addAll(int index, Collection<? extends E> c) {
-        checkNotNull(c);
+    public boolean addAll(int index, @Nonnull Collection<? extends E> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = ListAddAllWithIndexCodec.encodeRequest(name, index, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -93,8 +93,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public E set(int index, E element) {
-        checkNotNull(element);
+    public E set(int index, @Nonnull E element) {
+        checkNotNull(element, "Null item is not allowed");
         Data value = toData(element);
         ClientMessage request = ListSetCodec.encodeRequest(name, index, value);
         ClientMessage response = invokeOnPartition(request);
@@ -103,8 +103,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public void add(int index, E element) {
-        checkNotNull(element);
+    public void add(int index, @Nonnull E element) {
+        checkNotNull(element, "Null item is not allowed");
         Data value = toData(element);
         ClientMessage request = ListAddWithIndexCodec.encodeRequest(name, index, value);
         invokeOnPartition(request);
@@ -135,8 +135,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean contains(Object o) {
-        checkNotNull(o);
+    public boolean contains(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
         Data value = toData(o);
         ClientMessage request = ListContainsCodec.encodeRequest(name, value);
         ClientMessage response = invokeOnPartition(request);
@@ -159,13 +159,14 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public <T> T[] toArray(T[] a) {
+    public <T> T[] toArray(@Nonnull T[] a) {
+        checkNotNull(a, "Null array parameter is not allowed!");
         return getAll().toArray(a);
     }
 
     @Override
-    public boolean add(E e) {
-        checkNotNull(e);
+    public boolean add(@Nonnull E e) {
+        checkNotNull(e, "Null item is not allowed");
         Data element = toData(e);
         ClientMessage request = ListAddCodec.encodeRequest(name, element);
         ClientMessage response = invokeOnPartition(request);
@@ -174,8 +175,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean remove(Object o) {
-        checkNotNull(o);
+    public boolean remove(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
         Data value = toData(o);
         ClientMessage request = ListRemoveCodec.encodeRequest(name, value);
         ClientMessage response = invokeOnPartition(request);
@@ -184,8 +185,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean containsAll(Collection<?> c) {
-        checkNotNull(c);
+    public boolean containsAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = ListContainsAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -194,8 +195,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean addAll(Collection<? extends E> c) {
-        checkNotNull(c);
+    public boolean addAll(@Nonnull Collection<? extends E> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = ListAddAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -204,8 +205,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
-        checkNotNull(c);
+    public boolean removeAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = ListCompareAndRemoveAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -215,8 +216,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
-        checkNotNull(c);
+    public boolean retainAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = ListCompareAndRetainAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -234,7 +235,7 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     @Nonnull
     @Override
     public String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue) {
-        isNotNull(listener, "listener");
+        checkNotNull(listener, "Null listener is not allowed!");
         EventHandler<ClientMessage> eventHandler = new ItemEventHandler(listener);
         return registerListener(createItemListenerCodec(includeValue), eventHandler);
     }
@@ -276,8 +277,8 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public int lastIndexOf(Object o) {
-        checkNotNull(o);
+    public int lastIndexOf(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
         Data value = toData(o);
         ClientMessage request = ListLastIndexOfCodec.encodeRequest(name, value);
         ClientMessage response = invokeOnPartition(request);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -44,20 +44,22 @@ import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.map.IMapEvent;
 import com.hazelcast.map.MapEvent;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.monitor.LocalMultiMapStats;
+import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.util.ThreadUtil;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashSet;
@@ -68,7 +70,6 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
-import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.lang.Thread.currentThread;
 
 /**
@@ -82,6 +83,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
+    protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
 
     private ClientLockReferenceIdGenerator lockReferenceIdGenerator;
 
@@ -90,7 +92,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean put(K key, V value) {
+    public boolean put(@Nonnull K key, @Nonnull V value) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
@@ -103,7 +105,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public Collection<V> get(K key) {
+    public Collection<V> get(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         Data keyData = toData(key);
@@ -114,7 +116,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean remove(Object key, Object value) {
+    public boolean remove(@Nonnull Object key, @Nonnull Object value) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
@@ -127,7 +129,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public Collection<V> remove(Object key) {
+    public Collection<V> remove(@Nonnull Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         Data keyData = toData(key);
@@ -137,7 +139,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
         return new UnmodifiableLazyList<V>(resultParameters.response, getSerializationService());
     }
 
-    public void delete(Object key) {
+    public void delete(@Nonnull Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         Data keyData = toData(key);
         ClientMessage request = MultiMapDeleteCodec.encodeRequest(name, keyData, ThreadUtil.getThreadId());
@@ -187,7 +189,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean containsKey(K key) {
+    public boolean containsKey(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         Data keyData = toData(key);
@@ -198,7 +200,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean containsValue(Object value) {
+    public boolean containsValue(@Nonnull Object value) {
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data keyValue = toData(value);
@@ -209,7 +211,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean containsEntry(K key, V value) {
+    public boolean containsEntry(@Nonnull K key, @Nonnull V value) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
@@ -236,7 +238,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public int valueCount(K key) {
+    public int valueCount(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         Data keyData = toData(key);
@@ -247,13 +249,13 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public String addLocalEntryListener(EntryListener<K, V> listener) {
+    public String addLocalEntryListener(@Nonnull EntryListener<K, V> listener) {
         throw new UnsupportedOperationException("Locality for client is ambiguous");
     }
 
     @Override
-    public String addEntryListener(EntryListener<K, V> listener, final boolean includeValue) {
-        isNotNull(listener, "listener");
+    public String addEntryListener(@Nonnull EntryListener<K, V> listener, final boolean includeValue) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         EventHandler<ClientMessage> handler = createHandler(listener);
         return registerListener(createEntryListenerCodec(includeValue), handler);
     }
@@ -283,13 +285,15 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean removeEntryListener(String registrationId) {
+    public boolean removeEntryListener(@Nonnull String registrationId) {
+        checkNotNull(registrationId, "Registration ID should not be null!");
         return deregisterListener(registrationId);
     }
 
     @Override
-    public String addEntryListener(EntryListener<K, V> listener, K key, final boolean includeValue) {
-        isNotNull(listener, "listener");
+    public String addEntryListener(@Nonnull EntryListener<K, V> listener, @Nonnull K key, final boolean includeValue) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
         EventHandler<ClientMessage> handler = createHandler(listener);
         return registerListener(createEntryListenerToKeyCodec(includeValue, keyData), handler);
@@ -320,7 +324,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public void lock(K key) {
+    public void lock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         final Data keyData = toData(key);
@@ -330,8 +334,9 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public void lock(K key, long leaseTime, TimeUnit timeUnit) {
+    public void lock(@Nonnull K key, long leaseTime, @Nonnull TimeUnit timeUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(timeUnit, "Null timeUnit is not allowed!");
         checkPositive(leaseTime, "leaseTime should be positive");
 
         final Data keyData = toData(key);
@@ -342,7 +347,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean isLocked(K key) {
+    public boolean isLocked(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         final Data keyData = toData(key);
@@ -353,7 +358,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean tryLock(K key) {
+    public boolean tryLock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         try {
@@ -365,12 +370,14 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
+    public boolean tryLock(@Nonnull K key, long time, @Nullable TimeUnit timeunit) throws InterruptedException {
         return tryLock(key, time, timeunit, Long.MAX_VALUE, null);
     }
 
     @Override
-    public boolean tryLock(K key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseUnit) throws InterruptedException {
+    public boolean tryLock(@Nonnull K key,
+                           long time, @Nullable TimeUnit timeunit,
+                           long leaseTime, @Nullable TimeUnit leaseUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         final Data keyData = toData(key);
@@ -386,7 +393,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public void unlock(K key) {
+    public void unlock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         final Data keyData = toData(key);
@@ -396,7 +403,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     @Override
-    public void forceUnlock(K key) {
+    public void forceUnlock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         final Data keyData = toData(key);
@@ -445,7 +452,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
         @Override
         public void handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue,
-                           int eventType, String uuid, int numberOfAffectedEntries) {
+                                        int eventType, String uuid, int numberOfAffectedEntries) {
             Member member = getContext().getClusterService().getMember(uuid);
             final IMapEvent iMapEvent = createIMapEvent(key, value, oldValue,
                     mergingValue, eventType, numberOfAffectedEntries, member);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -37,6 +37,7 @@ import com.hazelcast.topic.impl.reliable.ReliableTopicMessage;
 import com.hazelcast.util.UuidUtil;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -88,8 +89,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     }
 
     @Override
-    public void publish(@Nonnull E payload) {
-        checkNotNull(payload, "Null message is not allowed!");
+    public void publish(@Nullable E payload) {
         try {
             Data data = serializationService.toData(payload);
             ReliableTopicMessage message = new ReliableTopicMessage(data, null);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -36,6 +36,7 @@ import com.hazelcast.topic.impl.reliable.ReliableMessageListenerAdapter;
 import com.hazelcast.topic.impl.reliable.ReliableTopicMessage;
 import com.hazelcast.util.UuidUtil;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -87,7 +88,8 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     }
 
     @Override
-    public void publish(E payload) {
+    public void publish(@Nonnull E payload) {
+        checkNotNull(payload, "Null message is not allowed!");
         try {
             Data data = serializationService.toData(payload);
             ReliableTopicMessage message = new ReliableTopicMessage(data, null);
@@ -140,8 +142,9 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
         }
     }
 
+    @Nonnull
     @Override
-    public String addMessageListener(MessageListener<E> listener) {
+    public String addMessageListener(@Nonnull MessageListener<E> listener) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
 
         String id = UuidUtil.newUnsecureUuidString();
@@ -175,7 +178,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     }
 
     @Override
-    public boolean removeMessageListener(String registrationId) {
+    public boolean removeMessageListener(@Nonnull String registrationId) {
         checkNotNull(registrationId, "registrationId can't be null");
 
         MessageRunner runner = runnersMap.get(registrationId);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
@@ -34,15 +34,14 @@ import com.hazelcast.client.impl.protocol.codec.SetSizeCodec;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
-import com.hazelcast.collection.impl.common.DataAwareItemEvent;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.collection.ItemEvent;
-import com.hazelcast.core.ItemEventType;
 import com.hazelcast.collection.ItemListener;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.collection.impl.common.DataAwareItemEvent;
+import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
-import com.hazelcast.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
@@ -50,7 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
-import static com.hazelcast.util.Preconditions.isNotNull;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Proxy implementation of {@link ISet}.
@@ -80,8 +79,8 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean contains(Object o) {
-        Preconditions.checkNotNull(o);
+    public boolean contains(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
         Data value = toData(o);
         ClientMessage request = SetContainsCodec.encodeRequest(name, value);
         ClientMessage response = invokeOnPartition(request);
@@ -100,13 +99,14 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public <T> T[] toArray(T[] a) {
+    public <T> T[] toArray(@Nonnull T[] a) {
+        checkNotNull(a, "Null array parameter is not allowed!");
         return getAll().toArray(a);
     }
 
     @Override
-    public boolean add(E e) {
-        Preconditions.checkNotNull(e);
+    public boolean add(@Nonnull E e) {
+        checkNotNull(e, "Null item is not allowed");
         Data element = toData(e);
         ClientMessage request = SetAddCodec.encodeRequest(name, element);
         ClientMessage response = invokeOnPartition(request);
@@ -115,8 +115,8 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean remove(Object o) {
-        Preconditions.checkNotNull(o);
+    public boolean remove(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
         Data value = toData(o);
         ClientMessage request = SetRemoveCodec.encodeRequest(name, value);
         ClientMessage response = invokeOnPartition(request);
@@ -125,8 +125,8 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean containsAll(Collection<?> c) {
-        Preconditions.checkNotNull(c);
+    public boolean containsAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = SetContainsAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -135,8 +135,8 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean addAll(Collection<? extends E> c) {
-        Preconditions.checkNotNull(c);
+    public boolean addAll(@Nonnull Collection<? extends E> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = SetAddAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -145,8 +145,8 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
-        Preconditions.checkNotNull(c);
+    public boolean removeAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = SetCompareAndRemoveAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -155,8 +155,8 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
-        Preconditions.checkNotNull(c);
+    public boolean retainAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = SetCompareAndRetainAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -173,7 +173,7 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     @Nonnull
     @Override
     public String addItemListener(@Nonnull final ItemListener<E> listener, final boolean includeValue) {
-        isNotNull(listener, "listener");
+        checkNotNull(listener, "Null listener is not allowed!");
         EventHandler<ClientMessage> eventHandler = new ItemEventHandler(listener);
         return registerListener(createItemListenerCodec(includeValue), eventHandler);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
@@ -32,6 +32,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.topic.impl.DataAwareMessage;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.hazelcast.client.proxy.ClientMapProxy.NULL_LISTENER_IS_NOT_ALLOWED;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -48,8 +49,7 @@ public class ClientTopicProxy<E> extends PartitionSpecificClientProxy implements
     }
 
     @Override
-    public void publish(@Nonnull E message) {
-        checkNotNull(message, "Null message is not allowed!");
+    public void publish(@Nullable E message) {
         Data data = toData(message);
         ClientMessage request = TopicPublishCodec.encodeRequest(name, data);
         invokeOnPartition(request);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
@@ -31,6 +31,8 @@ import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.topic.impl.DataAwareMessage;
 
+import javax.annotation.Nonnull;
+
 import static com.hazelcast.client.proxy.ClientMapProxy.NULL_LISTENER_IS_NOT_ALLOWED;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -46,21 +48,23 @@ public class ClientTopicProxy<E> extends PartitionSpecificClientProxy implements
     }
 
     @Override
-    public void publish(E message) {
+    public void publish(@Nonnull E message) {
+        checkNotNull(message, "Null message is not allowed!");
         Data data = toData(message);
         ClientMessage request = TopicPublishCodec.encodeRequest(name, data);
         invokeOnPartition(request);
     }
 
+    @Nonnull
     @Override
-    public String addMessageListener(final MessageListener<E> listener) {
+    public String addMessageListener(@Nonnull final MessageListener<E> listener) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         EventHandler<ClientMessage> handler = new TopicItemHandler(listener);
         return registerListener(new Codec(), handler);
     }
 
     @Override
-    public boolean removeMessageListener(String registrationId) {
+    public boolean removeMessageListener(@Nonnull String registrationId) {
         return deregisterListener(registrationId);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientListNullTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientListNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.collections;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.impl.list.AbstractListNullTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic queue methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientListNullTest extends AbstractListNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientSetNullTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientSetNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.collections;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.impl.set.AbstractSetNullTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic queue methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientSetNullTest extends AbstractSetNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
@@ -76,7 +76,7 @@ public class ClientMultiMapListenersTest {
         mm.addLocalEntryListener(myEntryListener);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testAddListener_whenListenerNull() throws InterruptedException {
         final MultiMap mm = client.getMultiMap(randomString());
         mm.addEntryListener(null, true);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapNullTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapNullTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.multimap;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.impl.queue.AbstractQueueNullTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.multimap.AbstractMultiMapNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic queue methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientMultiMapNullTest extends AbstractMultiMapNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected boolean isNotClient() {
+        return false;
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapNullTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapNullTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.multimap;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.collection.impl.queue.AbstractQueueNullTest;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.multimap.AbstractMultiMapNullTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientTopicNullTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientTopicNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.topic;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.AbstractTopicNullTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic queue methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientTopicNullTest extends AbstractTopicNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/IList.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/IList.java
@@ -21,10 +21,12 @@ import java.util.List;
 /**
  * Concurrent, distributed implementation of {@link List}.
  *
- * <p>The Hazelcast IList is not a partitioned data-structure. Entire contents of an IList is stored on a single machine (and
- * in the backup). The IList will not scale by adding more members to the cluster.
+ * <p>The Hazelcast IList is not a partitioned data-structure. Entire contents
+ * of an IList is stored on a single machine (and in the backup). The IList
+ * will not scale by adding more members to the cluster.
  *
- * <p>Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
+ * <p>Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10
+ * in cluster versions 3.10 and higher.
  *
  * @param <E>
  * @see List

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.collection;
 
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.collection.impl.collection.operations.CollectionAddAllOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionAddOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionClearOperation;
@@ -29,7 +30,6 @@ import com.hazelcast.collection.impl.collection.operations.CollectionSizeOperati
 import com.hazelcast.config.CollectionConfig;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.collection.ItemListener;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.AbstractDistributedObject;
@@ -106,16 +106,16 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return partitionId;
     }
 
-    public boolean add(E e) {
-        checkObjectNotNull(e);
+    public boolean add(@Nonnull E e) {
+        checkNotNull(e, "Null item is not allowed");
         final Data value = getNodeEngine().toData(e);
         final CollectionAddOperation operation = new CollectionAddOperation(name, value);
         final Boolean result = invoke(operation);
         return result;
     }
 
-    public boolean remove(Object o) {
-        checkObjectNotNull(o);
+    public boolean remove(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
 
         final Data value = getNodeEngine().toData(o);
         final CollectionRemoveOperation operation = new CollectionRemoveOperation(name, value);
@@ -135,8 +135,8 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return result;
     }
 
-    public boolean contains(Object o) {
-        checkObjectNotNull(o);
+    public boolean contains(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
 
         final CollectionContainsOperation operation = new CollectionContainsOperation(name,
                 singleton(getNodeEngine().toData(o)));
@@ -144,13 +144,13 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return result;
     }
 
-    public boolean containsAll(Collection<?> c) {
-        checkObjectNotNull(c);
+    public boolean containsAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
 
         Set<Data> valueSet = createHashSet(c.size());
         final NodeEngine nodeEngine = getNodeEngine();
         for (Object o : c) {
-            checkObjectNotNull(o);
+            checkNotNull(o, "Null collection element is not allowed");
             valueSet.add(nodeEngine.toData(o));
         }
         final CollectionContainsOperation operation = new CollectionContainsOperation(name, valueSet);
@@ -158,13 +158,13 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return result;
     }
 
-    public boolean addAll(Collection<? extends E> c) {
-        checkObjectNotNull(c);
+    public boolean addAll(@Nonnull Collection<? extends E> c) {
+        checkNotNull(c, "Null collection is not allowed");
 
         List<Data> valueList = new ArrayList<Data>(c.size());
         final NodeEngine nodeEngine = getNodeEngine();
         for (E e : c) {
-            checkObjectNotNull(e);
+            checkNotNull(e, "Null collection element is not allowed");
             valueList.add(nodeEngine.toData(e));
         }
         final CollectionAddAllOperation operation = new CollectionAddAllOperation(name, valueList);
@@ -172,21 +172,21 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return result;
     }
 
-    public boolean retainAll(Collection<?> c) {
+    public boolean retainAll(@Nonnull Collection<?> c) {
         return compareAndRemove(true, c);
     }
 
-    public boolean removeAll(Collection<?> c) {
+    public boolean removeAll(@Nonnull Collection<?> c) {
         return compareAndRemove(false, c);
     }
 
-    private boolean compareAndRemove(boolean retain, Collection<?> c) {
-        checkObjectNotNull(c);
+    private boolean compareAndRemove(boolean retain, @Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed");
 
         Set<Data> valueSet = createHashSet(c.size());
         final NodeEngine nodeEngine = getNodeEngine();
         for (Object o : c) {
-            checkObjectNotNull(o);
+            checkNotNull(o, "Null collection element is not allowed");
             valueSet.add(nodeEngine.toData(o));
         }
         final CollectionCompareAndRemoveOperation operation = new CollectionCompareAndRemoveOperation(name, retain, valueSet);
@@ -207,7 +207,8 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return getAll().toArray();
     }
 
-    public <T> T[] toArray(T[] a) {
+    public <T> T[] toArray(@Nonnull T[] a) {
+        checkNotNull(a, "Null array parameter is not allowed!");
         return getAll().toArray(a);
     }
 
@@ -219,7 +220,9 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return new UnmodifiableLazyList<E>(collection, serializationService);
     }
 
-    public @Nonnull String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue) {
+    public @Nonnull
+    String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue) {
+        checkNotNull(listener, "Null listener is not allowed!");
         final EventService eventService = getNodeEngine().getEventService();
         final CollectionEventFilter filter = new CollectionEventFilter(includeValue);
         final EventRegistration registration = eventService.registerListener(getServiceName(), name, filter, listener);
@@ -239,10 +242,6 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);
         }
-    }
-
-    protected void checkObjectNotNull(Object o) {
-        checkNotNull(o, "Object is null");
     }
 
     protected void checkIndexNotNegative(int index) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListProxyImpl.java
@@ -32,11 +32,14 @@ import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.spi.serialization.SerializationService;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E> implements IList<E> {
 
@@ -50,8 +53,8 @@ public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E
     }
 
     @Override
-    public void add(int index, E e) {
-        checkObjectNotNull(e);
+    public void add(int index, @Nonnull E e) {
+        checkNotNull(e, "Null item is not allowed");
         checkIndexNotNegative(index);
 
         final Data value = getNodeEngine().toData(e);
@@ -68,8 +71,8 @@ public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E
     }
 
     @Override
-    public E set(int index, E element) {
-        checkObjectNotNull(element);
+    public E set(int index, @Nonnull E element) {
+        checkNotNull(element, "Null item is not allowed");
         checkIndexNotNegative(index);
 
         final Data value = getNodeEngine().toData(element);
@@ -86,17 +89,17 @@ public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E
     }
 
     @Override
-    public int indexOf(Object o) {
+    public int indexOf(@Nonnull Object o) {
         return indexOfInternal(false, o);
     }
 
     @Override
-    public int lastIndexOf(Object o) {
+    public int lastIndexOf(@Nonnull Object o) {
         return indexOfInternal(true, o);
     }
 
-    private int indexOfInternal(boolean last, Object o) {
-        checkObjectNotNull(o);
+    private int indexOfInternal(boolean last, @Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed");
 
         final Data value = getNodeEngine().toData(o);
         final ListIndexOfOperation operation = new ListIndexOfOperation(name, last, value);
@@ -105,14 +108,14 @@ public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E
     }
 
     @Override
-    public boolean addAll(int index, Collection<? extends E> c) {
-        checkObjectNotNull(c);
+    public boolean addAll(int index, @Nonnull Collection<? extends E> c) {
+        checkNotNull(c, "Null collection is not allowed");
         checkIndexNotNegative(index);
 
         List<Data> valueList = new ArrayList<Data>(c.size());
         final NodeEngine nodeEngine = getNodeEngine();
         for (E e : c) {
-            checkObjectNotNull(e);
+            checkNotNull(e, "Null collection element is not allowed");
             valueList.add(nodeEngine.toData(e));
         }
         final ListAddAllOperation operation = new ListAddAllOperation(name, index, valueList);
@@ -151,8 +154,8 @@ public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E
     }
 
     @Override
-    public <T> T[] toArray(T[] a) {
-        checkObjectNotNull(a);
+    public <T> T[] toArray(@Nonnull T[] a) {
+        checkNotNull(a, "Null array parameter is not allowed!");
         return subList(-1, -1).toArray(a);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -20,6 +20,8 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.map.IMap;
 import com.hazelcast.monitor.LocalMultiMapStats;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -65,7 +67,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if size of the multimap is increased,
      * {@code false} if the multimap already contains the key-value pair
      */
-    boolean put(K key, V value);
+    boolean put(@Nonnull K key, @Nonnull V value);
 
     /**
      * Returns the collection of values associated with the key.
@@ -81,7 +83,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param key the key whose associated values are to be returned
      * @return the collection of the values associated with the key
      */
-    Collection<V> get(K key);
+    Collection<V> get(@Nonnull K key);
 
     /**
      * Removes the given key value pair from the multimap.
@@ -95,7 +97,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if the size of the multimap changed after the remove operation,
      * {@code false} otherwise
      */
-    boolean remove(Object key, Object value);
+    boolean remove(@Nonnull Object key, @Nonnull Object value);
 
     /**
      * Removes all the entries with the given key.
@@ -112,7 +114,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return the collection of removed values associated with the given key.
      * The returned collection might be modifiable but it has no effect on the multimap.
      */
-    Collection<V> remove(Object key);
+    Collection<V> remove(@Nonnull Object key);
 
     /**
      * Deletes all the entries with the given key.
@@ -123,8 +125,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      *
      * @param key the key of the entry to remove
      */
-
-    void delete(Object key);
+    void delete(@Nonnull Object key);
 
     /**
      * Returns the locally owned set of keys.
@@ -190,7 +191,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if the multimap contains an entry with the key,
      * {@code false} otherwise
      */
-    boolean containsKey(K key);
+    boolean containsKey(@Nonnull K key);
 
     /**
      * Returns whether the multimap contains an entry with the value.
@@ -199,7 +200,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if the multimap contains an entry with the value,
      * {@code false} otherwise.
      */
-    boolean containsValue(Object value);
+    boolean containsValue(@Nonnull Object value);
 
     /**
      * Returns whether the multimap contains the given key-value pair.
@@ -213,7 +214,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if the multimap contains the key-value pair,
      * {@code false} otherwise
      */
-    boolean containsEntry(K key, V value);
+    boolean containsEntry(@Nonnull K key, @Nonnull V value);
 
     /**
      * Returns the number of key-value pairs in the multimap.
@@ -237,7 +238,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param key the key whose values count is to be returned
      * @return the number of values that match the given key in the multimap
      */
-    int valueCount(K key);
+    int valueCount(@Nonnull K key);
 
     /**
      * Adds a local entry listener for this multimap.
@@ -260,7 +261,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return returns registration ID for the entry listener
      * @see #localKeySet()
      */
-    String addLocalEntryListener(EntryListener<K, V> listener);
+    String addLocalEntryListener(@Nonnull EntryListener<K, V> listener);
 
     /**
      * Adds an entry listener for this multimap.
@@ -273,7 +274,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      *                     {@code false} otherwise
      * @return returns registration ID for the entry listener
      */
-    String addEntryListener(EntryListener<K, V> listener, boolean includeValue);
+    String addEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue);
 
     /**
      * Removes the specified entry listener.
@@ -283,7 +284,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param registrationId registration ID of listener
      * @return true if registration is removed, false otherwise
      */
-    boolean removeEntryListener(String registrationId);
+    boolean removeEntryListener(@Nonnull String registrationId);
 
     /**
      * Adds the specified entry listener for the specified key.
@@ -301,7 +302,8 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      *                     {@code false} otherwise
      * @return returns registration ID
      */
-    String addEntryListener(EntryListener<K, V> listener, K key, boolean includeValue);
+    String addEntryListener(@Nonnull EntryListener<K, V> listener,
+                            @Nonnull K key, boolean includeValue);
 
     /**
      * Acquires a lock for the specified key.
@@ -322,7 +324,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      *
      * @param key the key to lock
      */
-    void lock(K key);
+    void lock(@Nonnull K key);
 
     /**
      * Acquires the lock for the specified key for the specified lease time.
@@ -347,7 +349,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param leaseTime time to wait before releasing the lock
      * @param timeUnit  unit of time for the lease time
      */
-    void lock(K key, long leaseTime, TimeUnit timeUnit);
+    void lock(@Nonnull K key, long leaseTime, @Nonnull TimeUnit timeUnit);
 
     /**
      * Checks the lock for the specified key.
@@ -362,7 +364,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param key key to lock to be checked.
      * @return {@code true} if the lock is acquired, {@code false} otherwise.
      */
-    boolean isLocked(K key);
+    boolean isLocked(@Nonnull K key);
 
     /**
      * Tries to acquire the lock for the specified key.
@@ -377,7 +379,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param key the key to lock.
      * @return {@code true} if lock is acquired, {@code false} otherwise
      */
-    boolean tryLock(K key);
+    boolean tryLock(@Nonnull K key);
 
     /**
      * Tries to acquire the lock for the specified key.
@@ -399,7 +401,8 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if the lock was acquired, {@code false} if the
      * waiting time elapsed before the lock was acquired
      */
-    boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException;
+    boolean tryLock(@Nonnull K key,
+                    long time, @Nullable TimeUnit timeunit) throws InterruptedException;
 
     /**
      * Tries to acquire the lock for the specified key for the specified
@@ -427,7 +430,9 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * waiting time elapsed before the lock was acquired
      * @throws NullPointerException if the specified key is {@code null}
      */
-    boolean tryLock(K key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseTimeunit) throws InterruptedException;
+    boolean tryLock(@Nonnull K key,
+                    long time, @Nullable TimeUnit timeunit,
+                    long leaseTime, @Nullable TimeUnit leaseTimeunit) throws InterruptedException;
 
     /**
      * Releases the lock for the specified key.
@@ -440,7 +445,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      *
      * @param key the key to lock
      */
-    void unlock(K key);
+    void unlock(@Nonnull K key);
 
     /**
      * Releases the lock for the specified key regardless of the lock owner.
@@ -453,7 +458,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      *
      * @param key key to lock
      */
-    void forceUnlock(K key);
+    void forceUnlock(@Nonnull K key);
 
     /**
      * Returns {@code LocalMultiMapStats} for this map.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -61,6 +61,7 @@ import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EventListener;
@@ -234,7 +235,11 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         publisher.publishEntryEvent(multiMapName, eventType, key, newValue, oldValue);
     }
 
-    public String addListener(String name, EventListener listener, Data key, boolean includeValue, boolean local) {
+    public String addListener(String name,
+                              @Nonnull EventListener listener,
+                              Data key,
+                              boolean includeValue,
+                              boolean local) {
         EventService eventService = nodeEngine.getEventService();
         EventRegistration registration;
         MultiMapEventFilter filter = new MultiMapEventFilter(includeValue, key);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
@@ -31,6 +31,8 @@ import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -50,6 +52,7 @@ public class ObjectMultiMapProxy<K, V>
 
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
+    protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
 
     public ObjectMultiMapProxy(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
         super(config, service, nodeEngine, name);
@@ -85,7 +88,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean put(K key, V value) {
+    public boolean put(@Nonnull K key, @Nonnull V value) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
@@ -96,7 +99,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public Collection<V> get(K key) {
+    public Collection<V> get(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -106,7 +109,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean remove(Object key, Object value) {
+    public boolean remove(@Nonnull Object key, @Nonnull Object value) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
@@ -117,7 +120,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public Collection<V> remove(Object key) {
+    public Collection<V> remove(@Nonnull Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -126,7 +129,7 @@ public class ObjectMultiMapProxy<K, V>
         return result.getObjectCollection(nodeEngine);
     }
 
-    public void delete(Object key) {
+    public void delete(@Nonnull Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         NodeEngine nodeEngine = getNodeEngine();
         Data dataKey = nodeEngine.toData(key);
@@ -178,7 +181,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean containsKey(K key) {
+    public boolean containsKey(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -187,7 +190,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean containsValue(Object value) {
+    public boolean containsValue(@Nonnull Object value) {
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -196,7 +199,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean containsEntry(K key, V value) {
+    public boolean containsEntry(@Nonnull K key, @Nonnull V value) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
@@ -207,7 +210,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public int valueCount(K key) {
+    public int valueCount(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -216,29 +219,34 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public String addLocalEntryListener(EntryListener<K, V> listener) {
+    public String addLocalEntryListener(@Nonnull EntryListener<K, V> listener) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         return getService().addListener(name, listener, null, false, true);
     }
 
     @Override
-    public String addEntryListener(EntryListener<K, V> listener, boolean includeValue) {
+    public String addEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         return getService().addListener(name, listener, null, includeValue, false);
     }
 
     @Override
-    public boolean removeEntryListener(String registrationId) {
+    public boolean removeEntryListener(@Nonnull String registrationId) {
+        checkNotNull(registrationId, "Registration ID should not be null!");
         return getService().removeListener(name, registrationId);
     }
 
     @Override
-    public String addEntryListener(EntryListener<K, V> listener, K key, boolean includeValue) {
+    public String addEntryListener(@Nonnull EntryListener<K, V> listener, @Nonnull K key, boolean includeValue) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         NodeEngine nodeEngine = getNodeEngine();
         Data dataKey = nodeEngine.toData(key);
         return getService().addListener(name, listener, dataKey, includeValue, false);
     }
 
     @Override
-    public void lock(K key) {
+    public void lock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -247,8 +255,9 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public void lock(K key, long leaseTime, TimeUnit timeUnit) {
+    public void lock(@Nonnull K key, long leaseTime, @Nonnull TimeUnit timeUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(timeUnit, "Null timeUnit is not allowed!");
         checkPositive(leaseTime, "leaseTime should be positive");
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -257,7 +266,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean isLocked(K key) {
+    public boolean isLocked(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -266,7 +275,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean tryLock(K key) {
+    public boolean tryLock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -275,7 +284,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean tryLock(K key, long time, TimeUnit timeunit)
+    public boolean tryLock(@Nonnull K key, long time, TimeUnit timeunit)
             throws InterruptedException {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
@@ -285,7 +294,9 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public boolean tryLock(K key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseUnit) throws InterruptedException {
+    public boolean tryLock(@Nonnull K key,
+                           long time, @Nullable TimeUnit timeunit,
+                           long leaseTime, @Nullable TimeUnit leaseUnit) throws InterruptedException {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -294,7 +305,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public void unlock(K key) {
+    public void unlock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -303,7 +314,7 @@ public class ObjectMultiMapProxy<K, V>
     }
 
     @Override
-    public void forceUnlock(K key) {
+    public void forceUnlock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         NodeEngine nodeEngine = getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
@@ -56,7 +56,8 @@ public interface EventService {
      * @return event registration
      * @throws IllegalArgumentException if the listener is {@code null}
      */
-    EventRegistration registerLocalListener(String serviceName, String topic,
+    EventRegistration registerLocalListener(String serviceName,
+                                            @Nonnull String topic,
                                             @Nonnull Object listener);
 
     /**
@@ -69,7 +70,8 @@ public interface EventService {
      * @return event registration
      * @throws IllegalArgumentException if the listener or filter is {@code null}
      */
-    EventRegistration registerLocalListener(String serviceName, String topic,
+    EventRegistration registerLocalListener(String serviceName,
+                                            @Nonnull String topic,
                                             @Nonnull EventFilter filter,
                                             @Nonnull Object listener);
 
@@ -82,7 +84,8 @@ public interface EventService {
      * @return event registration
      * @throws IllegalArgumentException if the listener is {@code null}
      */
-    EventRegistration registerListener(String serviceName, String topic,
+    EventRegistration registerListener(String serviceName,
+                                       @Nonnull String topic,
                                        @Nonnull Object listener);
 
     /**
@@ -129,7 +132,7 @@ public interface EventService {
      * @param topic       topic name
      * @return registrations
      */
-    Collection<EventRegistration> getRegistrations(String serviceName, String topic);
+    Collection<EventRegistration> getRegistrations(String serviceName, @Nonnull String topic);
 
     /**
      * Returns all registrations belonging to the given service and topic as an array.
@@ -138,7 +141,7 @@ public interface EventService {
      * @param topic       topic name
      * @return registrations array
      */
-    EventRegistration[] getRegistrationsAsArray(String serviceName, String topic);
+    EventRegistration[] getRegistrationsAsArray(String serviceName, @Nonnull String topic);
 
     /**
      * Returns true if a listener is registered with the specified service name and topic.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -242,25 +242,30 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
     }
 
     @Override
-    public EventRegistration registerLocalListener(String serviceName, String topic,
+    public EventRegistration registerLocalListener(String serviceName,
+                                                   @Nonnull String topic,
                                                    @Nonnull Object listener) {
         return registerListenerInternal(serviceName, topic, TrueEventFilter.INSTANCE, listener, true);
     }
 
     @Override
-    public EventRegistration registerLocalListener(String serviceName, String topic,
+    public EventRegistration registerLocalListener(String serviceName,
+                                                   @Nonnull String topic,
                                                    @Nonnull EventFilter filter,
                                                    @Nonnull Object listener) {
         return registerListenerInternal(serviceName, topic, filter, listener, true);
     }
 
     @Override
-    public EventRegistration registerListener(String serviceName, String topic, @Nonnull Object listener) {
+    public EventRegistration registerListener(String serviceName,
+                                              @Nonnull String topic,
+                                              @Nonnull Object listener) {
         return registerListenerInternal(serviceName, topic, TrueEventFilter.INSTANCE, listener, false);
     }
 
     @Override
-    public EventRegistration registerListener(String serviceName, String topic,
+    public EventRegistration registerListener(String serviceName,
+                                              @Nonnull String topic,
                                               @Nonnull EventFilter filter,
                                               @Nonnull Object listener) {
         return registerListenerInternal(serviceName, topic, filter, listener, false);
@@ -281,7 +286,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
      * @throws IllegalArgumentException if the listener or filter is null
      */
     private EventRegistration registerListenerInternal(String serviceName,
-                                                       String topic,
+                                                       @Nonnull String topic,
                                                        @Nonnull EventFilter filter,
                                                        @Nonnull Object listener,
                                                        boolean localOnly) {
@@ -358,7 +363,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
     }
 
     @Override
-    public EventRegistration[] getRegistrationsAsArray(String serviceName, String topic) {
+    public EventRegistration[] getRegistrationsAsArray(String serviceName, @Nonnull String topic) {
         EventServiceSegment segment = getSegment(serviceName, false);
         if (segment == null) {
             return EMPTY_REGISTRATIONS;
@@ -380,7 +385,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
      * @return a non-null immutable collection of listener registrations
      */
     @Override
-    public Collection<EventRegistration> getRegistrations(String serviceName, String topic) {
+    public Collection<EventRegistration> getRegistrations(String serviceName, @Nonnull String topic) {
         EventServiceSegment segment = getSegment(serviceName, false);
         if (segment == null) {
             return Collections.emptySet();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.NotifiableEventListener;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,7 +120,7 @@ public class EventServiceSegment<S> {
      * @param forceCreate whether to create the registration set if none exists or to return null
      * @return the collection of registrations for the topic or null if none exists and {@code forceCreate} is {@code false}
      */
-    public Collection<Registration> getRegistrations(String topic, boolean forceCreate) {
+    public Collection<Registration> getRegistrations(@Nonnull String topic, boolean forceCreate) {
         Collection<Registration> listenerList = registrations.get(topic);
         if (listenerList == null && forceCreate) {
             ConstructorFunction<String, Collection<Registration>> func
@@ -150,7 +151,7 @@ public class EventServiceSegment<S> {
      * @param registration the listener registration
      * @return if the registration is added
      */
-    public boolean addRegistration(String topic, Registration registration) {
+    public boolean addRegistration(@Nonnull String topic, Registration registration) {
         Collection<Registration> registrations = getRegistrations(topic, true);
         if (registrations.add(registration)) {
             registrationIdMap.put(registration.getId(), registration);

--- a/hazelcast/src/main/java/com/hazelcast/topic/ITopic.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/ITopic.java
@@ -19,6 +19,8 @@ package com.hazelcast.topic;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.monitor.LocalTopicStats;
 
+import javax.annotation.Nonnull;
+
 /**
  * Hazelcast provides distribution mechanism for publishing messages that are
  * delivered to multiple subscribers, which is also known as a publish/subscribe
@@ -59,7 +61,7 @@ public interface ITopic<E> extends DistributedObject {
      * @throws TopicOverloadException if the consumer is too slow
      *                                (only works in combination with reliable topic)
      */
-    void publish(E message);
+    void publish(@Nonnull E message);
 
     /**
      * Subscribes to this topic. When a message is published, the
@@ -71,7 +73,7 @@ public interface ITopic<E> extends DistributedObject {
      * @return returns the registration ID
      * @throws java.lang.NullPointerException if listener is {@code null}
      */
-    String addMessageListener(MessageListener<E> listener);
+    @Nonnull String addMessageListener(@Nonnull MessageListener<E> listener);
 
     /**
      * Stops receiving messages for the given message listener.
@@ -81,7 +83,7 @@ public interface ITopic<E> extends DistributedObject {
      * @param registrationId ID of listener registration
      * @return {@code true} if registration is removed, {@code false} otherwise
      */
-    boolean removeMessageListener(String registrationId);
+    boolean removeMessageListener(@Nonnull String registrationId);
 
     /**
      * Returns statistics about this topic, like total number of publishes/receives.

--- a/hazelcast/src/main/java/com/hazelcast/topic/ITopic.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/ITopic.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.monitor.LocalTopicStats;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Hazelcast provides distribution mechanism for publishing messages that are
@@ -61,7 +62,7 @@ public interface ITopic<E> extends DistributedObject {
      * @throws TopicOverloadException if the consumer is too slow
      *                                (only works in combination with reliable topic)
      */
-    void publish(@Nonnull E message);
+    void publish(@Nullable E message);
 
     /**
      * Subscribes to this topic. When a message is published, the

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.spi.NodeEngine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -40,7 +41,7 @@ public class TopicProxy<E> extends TopicProxySupport implements ITopic<E> {
     }
 
     @Override
-    public void publish(@Nonnull E message) {
+    public void publish(@Nullable E message) {
         publishInternal(message);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
@@ -21,6 +21,10 @@ import com.hazelcast.topic.MessageListener;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.spi.NodeEngine;
 
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Topic proxy used when global ordering is disabled (nodes get
  * the messages in the order that the messages are published).
@@ -29,26 +33,26 @@ import com.hazelcast.spi.NodeEngine;
  */
 public class TopicProxy<E> extends TopicProxySupport implements ITopic<E> {
 
+    private static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
+
     public TopicProxy(String name, NodeEngine nodeEngine, TopicService service) {
         super(name, nodeEngine, service);
     }
 
     @Override
-    public void publish(E message) {
+    public void publish(@Nonnull E message) {
         publishInternal(message);
     }
 
+    @Nonnull
     @Override
-    public String addMessageListener(MessageListener<E> listener) {
-        if (listener == null) {
-            throw new NullPointerException("listener can't be null");
-        }
-
+    public String addMessageListener(@Nonnull MessageListener<E> listener) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         return addMessageListenerInternal(listener);
     }
 
     @Override
-    public boolean removeMessageListener(String registrationId) {
+    public boolean removeMessageListener(@Nonnull String registrationId) {
         return removeMessageListenerInternal(registrationId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -97,7 +97,6 @@ public abstract class TopicProxySupport extends AbstractDistributedObject<TopicS
      * @param message the message to be published
      */
     public void publishInternal(Object message) {
-        checkNotNull(message, "Null message is not allowed!");
         topicStats.incrementPublishes();
         topicService.publishMessage(name, message, multithreaded);
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -30,8 +30,6 @@ import com.hazelcast.util.ExceptionUtil;
 
 import javax.annotation.Nonnull;
 
-import static com.hazelcast.util.Preconditions.checkNotNull;
-
 public abstract class TopicProxySupport extends AbstractDistributedObject<TopicService> implements InitializingObject {
 
     private final String name;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -19,14 +19,18 @@ package com.hazelcast.topic.impl;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.topic.MessageListener;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.monitor.impl.LocalTopicStatsImpl;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.topic.MessageListener;
 import com.hazelcast.util.ExceptionUtil;
+
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public abstract class TopicProxySupport extends AbstractDistributedObject<TopicService> implements InitializingObject {
 
@@ -93,15 +97,17 @@ public abstract class TopicProxySupport extends AbstractDistributedObject<TopicS
      * @param message the message to be published
      */
     public void publishInternal(Object message) {
+        checkNotNull(message, "Null message is not allowed!");
         topicStats.incrementPublishes();
         topicService.publishMessage(name, message, multithreaded);
     }
 
-    public String addMessageListenerInternal(MessageListener listener) {
+    public @Nonnull
+    String addMessageListenerInternal(@Nonnull MessageListener listener) {
         return topicService.addMessageListener(name, listener, false);
     }
 
-    public boolean removeMessageListenerInternal(final String registrationId) {
+    public boolean removeMessageListenerInternal(@Nonnull String registrationId) {
         return topicService.removeMessageListener(name, registrationId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -174,7 +174,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     }
 
     public @Nonnull
-    String addMessageListener(String name,
+    String addMessageListener(@Nonnull String name,
                               @Nonnull MessageListener listener,
                               boolean localOnly) {
         EventRegistration eventRegistration;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -16,11 +16,8 @@
 
 package com.hazelcast.topic.impl;
 
-import com.hazelcast.config.TopicConfig;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.topic.Message;
-import com.hazelcast.topic.MessageListener;
 import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.config.TopicConfig;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.monitor.impl.LocalTopicStatsImpl;
@@ -33,10 +30,14 @@ import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.HashUtil;
 import com.hazelcast.util.MapUtil;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
@@ -172,7 +173,10 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
         }
     }
 
-    public String addMessageListener(String name, MessageListener listener, boolean localOnly) {
+    public @Nonnull
+    String addMessageListener(String name,
+                              @Nonnull MessageListener listener,
+                              boolean localOnly) {
         EventRegistration eventRegistration;
         if (localOnly) {
             eventRegistration = eventService.registerLocalListener(TopicService.SERVICE_NAME, name, listener);
@@ -183,7 +187,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
         return eventRegistration.getId();
     }
 
-    public boolean removeMessageListener(String name, String registrationId) {
+    public boolean removeMessageListener(@Nonnull String name, @Nonnull String registrationId) {
         return eventService.deregisterListener(TopicService.SERVICE_NAME, name, registrationId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -20,6 +20,10 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Topic proxy used when global ordering is enabled (all nodes listening to
  * the same topic get their messages in the same order).
@@ -36,7 +40,8 @@ public class TotalOrderedTopicProxy<E> extends TopicProxy<E> {
     }
 
     @Override
-    public void publish(E message) {
+    public void publish(@Nonnull E message) {
+        checkNotNull(message, "Null message is not allowed!");
         Operation operation = new PublishOperation(getName(), toData(message))
                 .setPartitionId(partitionId);
         InternalCompletableFuture f = invokeOnPartition(operation);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -20,9 +20,7 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import javax.annotation.Nonnull;
-
-import static com.hazelcast.util.Preconditions.checkNotNull;
+import javax.annotation.Nullable;
 
 /**
  * Topic proxy used when global ordering is enabled (all nodes listening to
@@ -40,8 +38,7 @@ public class TotalOrderedTopicProxy<E> extends TopicProxy<E> {
     }
 
     @Override
-    public void publish(@Nonnull E message) {
-        checkNotNull(message, "Null message is not allowed!");
+    public void publish(@Nullable E message) {
         Operation operation = new PublishOperation(getName(), toData(message))
                 .setPartitionId(partitionId);
         InternalCompletableFuture f = invokeOnPartition(operation);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -37,6 +37,7 @@ import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.UuidUtil;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -57,6 +58,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
 
     public static final int MAX_BACKOFF = 2000;
     public static final int INITIAL_BACKOFF_MS = 100;
+    private static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
 
     final Ringbuffer<ReliableTopicMessage> ringbuffer;
     final Executor executor;
@@ -151,7 +153,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     }
 
     @Override
-    public void publish(E payload) {
+    public void publish(@Nonnull E payload) {
+        checkNotNull(payload, "Null message is not allowed!");
         try {
             Data data = nodeEngine.toData(payload);
             ReliableTopicMessage message = new ReliableTopicMessage(data, thisAddress);
@@ -206,9 +209,10 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         }
     }
 
+    @Nonnull
     @Override
-    public String addMessageListener(MessageListener<E> listener) {
-        checkNotNull(listener, "listener can't be null");
+    public String addMessageListener(@Nonnull MessageListener<E> listener) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
 
         String id = UuidUtil.newUnsecureUuidString();
         ReliableMessageListener<E> reliableMessageListener;
@@ -227,7 +231,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     }
 
     @Override
-    public boolean removeMessageListener(String registrationId) {
+    public boolean removeMessageListener(@Nonnull String registrationId) {
         checkNotNull(registrationId, "registrationId can't be null");
 
         MessageRunner runner = runnersMap.get(registrationId);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -38,6 +38,7 @@ import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.UuidUtil;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -153,8 +154,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     }
 
     @Override
-    public void publish(@Nonnull E payload) {
-        checkNotNull(payload, "Null message is not allowed!");
+    public void publish(@Nullable E payload) {
         try {
             Data data = nodeEngine.toData(payload);
             ReliableTopicMessage message = new ReliableTopicMessage(data, thisAddress);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/AbstractListNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/AbstractListNullTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.list;
+
+import com.hazelcast.collection.IList;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractListNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(l -> l.contains(null));
+        assertThrowsNPE(l -> l.toArray(null));
+        assertThrowsNPE(l -> l.add(null));
+        assertThrowsNPE(l -> l.remove(null));
+        assertThrowsNPE(l -> l.containsAll(null));
+        assertThrowsNPE(l -> l.addAll(null));
+        assertThrowsNPE(l -> l.removeAll(null));
+        assertThrowsNPE(l -> l.retainAll(null));
+        assertThrowsNPE(l -> l.addItemListener(null, true));
+        assertThrowsNPE(l -> l.removeItemListener(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<IList<Object>> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<IList<Object>> method) {
+        try {
+            method.accept(getDriver().getList(randomName()));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/MemberListNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/MemberListNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.list;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberListNullTest extends AbstractListNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/AbstractSetNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/AbstractSetNullTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.set;
+
+import com.hazelcast.collection.ISet;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractSetNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(s -> s.contains(null));
+        assertThrowsNPE(s -> s.toArray(null));
+        assertThrowsNPE(s -> s.add(null));
+        assertThrowsNPE(s -> s.remove(null));
+        assertThrowsNPE(s -> s.containsAll(null));
+        assertThrowsNPE(s -> s.addAll(null));
+        assertThrowsNPE(s -> s.removeAll(null));
+        assertThrowsNPE(s -> s.retainAll(null));
+        assertThrowsNPE(s -> s.addItemListener(null, true));
+        assertThrowsNPE(s -> s.removeItemListener(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<ISet<Object>> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<ISet<Object>> method) {
+        try {
+            method.accept(getDriver().getSet(randomName()));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/MemberSetNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/MemberSetNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.set;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberSetNullTest extends AbstractSetNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/listeners/AddListenerWithNullParameterTests.java
+++ b/hazelcast/src/test/java/com/hazelcast/listeners/AddListenerWithNullParameterTests.java
@@ -71,12 +71,12 @@ public class AddListenerWithNullParameterTests extends HazelcastTestSupport {
         instance.getMap("test").addEntryListener(mock(EntryListener.class), null, "key", true);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testMultiMapAddEntryListener() {
         instance.getMultiMap("test").addEntryListener(null, true);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testMultiMapAddEntryListenerKey() {
         instance.getMultiMap("test").addEntryListener(null, "key", true);
     }
@@ -111,12 +111,12 @@ public class AddListenerWithNullParameterTests extends HazelcastTestSupport {
         instance.getReplicatedMap("test").addEntryListener(mock(EntryListener.class), null, "key");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testListAddItemListener() {
         instance.getList("test").addItemListener(null, true);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testSetAddItemListener() {
         instance.getSet("test").addItemListener(null, true);
     }

--- a/hazelcast/src/test/java/com/hazelcast/multimap/AbstractMultiMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/AbstractMultiMapNullTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap;
+
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractMultiMapNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        EntryAdapter sampleEntryListener = new EntryAdapter();
+        Predicate<Object, Object> samplePredicate = Predicates.alwaysTrue();
+        TimeUnit sampleTimeUnit = TimeUnit.SECONDS;
+
+        assertThrowsNPE(m -> m.put(null, ""));
+        assertThrowsNPE(m -> m.put("", null));
+        assertThrowsNPE(m -> m.get(null));
+        assertThrowsNPE(m -> m.remove(null));
+        assertThrowsNPE(m -> m.remove(null, ""));
+        assertThrowsNPE(m -> m.remove("", null));
+        assertThrowsNPE(m -> m.delete(null));
+        assertThrowsNPE(m -> m.containsKey(null));
+        assertThrowsNPE(m -> m.containsValue(null));
+        assertThrowsNPE(m -> m.containsEntry(null, ""));
+        assertThrowsNPE(m -> m.containsEntry("", null));
+        assertThrowsNPE(m -> m.valueCount(null));
+
+        if (isNotClient()) {
+            assertThrowsNPE(m -> m.addLocalEntryListener(null));
+        }
+        assertThrowsNPE(m -> m.addEntryListener(null, "", true));
+
+        assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, null, true));
+        assertThrowsNPE(m -> m.addEntryListener(null, samplePredicate, true));
+        assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, null, true));
+
+        assertThrowsNPE(m -> m.removeEntryListener(null));
+
+        assertThrowsNPE(m -> m.lock(null));
+        assertThrowsNPE(m -> m.lock(null, -1, sampleTimeUnit));
+        assertThrowsNPE(m -> m.lock("", -1, null));
+        assertThrowsNPE(m -> m.isLocked(null));
+
+
+        assertThrowsNPE(m -> m.tryLock(null));
+        assertThrowsNPE(m -> m.tryLock(null, -1, sampleTimeUnit));
+        assertThrowsNPE(m -> m.tryLock(null, -1, sampleTimeUnit, -1, sampleTimeUnit));
+
+        assertThrowsNPE(m -> m.unlock(null));
+        assertThrowsNPE(m -> m.forceUnlock(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<MultiMap<Object, Object>> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<MultiMap<Object, Object>> method) {
+        try {
+            method.accept(getDriver().getMultiMap(randomName()));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract boolean isNotClient();
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MemberMultiMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MemberMultiMapNullTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberMultiMapNullTest extends AbstractMultiMapNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected boolean isNotClient() {
+        return true;
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapListenerTest.java
@@ -50,13 +50,13 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MultiMapListenerTest extends HazelcastTestSupport {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testAddLocalEntryListener_whenNull() {
         MultiMap<String, String> multiMap = createHazelcastInstance().getMultiMap(randomString());
         multiMap.addLocalEntryListener(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testAddListener_whenListenerNull() {
         MultiMap<String, String> multiMap = createHazelcastInstance().getMultiMap(randomString());
         multiMap.addEntryListener(null, true);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -238,17 +238,17 @@ public class MockIOService implements IOService {
             }
 
             @Override
-            public EventRegistration registerLocalListener(String serviceName, String topic, @Nonnull Object listener) {
+            public EventRegistration registerLocalListener(String serviceName, @Nonnull String topic, @Nonnull Object listener) {
                 return null;
             }
 
             @Override
-            public EventRegistration registerLocalListener(String serviceName, String topic, @Nonnull EventFilter filter, @Nonnull Object listener) {
+            public EventRegistration registerLocalListener(String serviceName, @Nonnull String topic, @Nonnull EventFilter filter, @Nonnull Object listener) {
                 return null;
             }
 
             @Override
-            public EventRegistration registerListener(String serviceName, String topic, @Nonnull Object listener) {
+            public EventRegistration registerListener(String serviceName, @Nonnull String topic, @Nonnull Object listener) {
                 return null;
             }
 
@@ -267,12 +267,12 @@ public class MockIOService implements IOService {
             }
 
             @Override
-            public Collection<EventRegistration> getRegistrations(String serviceName, String topic) {
+            public Collection<EventRegistration> getRegistrations(String serviceName, @Nonnull String topic) {
                 return null;
             }
 
             @Override
-            public EventRegistration[] getRegistrationsAsArray(String serviceName, String topic) {
+            public EventRegistration[] getRegistrationsAsArray(String serviceName, @Nonnull String topic) {
                 return new EventRegistration[0];
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/topic/AbstractTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/AbstractTopicNullTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.topic;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractTopicNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(t -> t.publish(null));
+        assertThrowsNPE(t -> t.addMessageListener(null));
+        assertThrowsNPE(t -> t.removeMessageListener(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<ITopic<Object>> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<ITopic<Object>> method) {
+        try {
+            method.accept(getDriver().getTopic(randomName()));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/topic/AbstractTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/AbstractTopicNullTest.java
@@ -30,7 +30,6 @@ public abstract class AbstractTopicNullTest extends HazelcastTestSupport {
 
     @Test
     public void testNullability() {
-        assertThrowsNPE(t -> t.publish(null));
         assertThrowsNPE(t -> t.addMessageListener(null));
         assertThrowsNPE(t -> t.removeMessageListener(null));
     }

--- a/hazelcast/src/test/java/com/hazelcast/topic/MemberTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/MemberTopicNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.topic;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberTopicNullTest extends AbstractTopicNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}


### PR DESCRIPTION
Added Nonnull and Nullable annotations and null checks with more
informative messages to IList, ISet, ITopic and MultiMap.

Depends on: https://github.com/hazelcast/hazelcast/pull/15156