### PR TITLE
Report WAN sync progress based on acknowledgement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -39,11 +39,11 @@ import com.hazelcast.version.Version;
 import com.hazelcast.wan.impl.AddWanConfigResult;
 import com.hazelcast.wan.impl.WanReplicationService;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.UUID;
 
 import static com.hazelcast.cp.CPGroup.METADATA_CP_GROUP_NAME;
 import static com.hazelcast.util.ExceptionUtil.peel;
@@ -413,8 +413,9 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         final String publisherId = params[1];
         final String mapName = params[2];
         try {
-            textCommandService.getNode().getNodeEngine().getWanReplicationService().syncMap(wanRepName, publisherId, mapName);
-            res = response(ResponseType.SUCCESS, "message", "Sync initiated");
+            UUID uuid = textCommandService.getNode().getNodeEngine().getWanReplicationService()
+                                          .syncMap(wanRepName, publisherId, mapName);
+            res = response(ResponseType.SUCCESS, "message", "Sync initiated", "uuid", uuid.toString());
         } catch (Exception ex) {
             logger.warning("Error occurred while syncing map", ex);
             res = exceptionResponse(ex);
@@ -437,8 +438,9 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         final String wanRepName = params[0];
         final String publisherId = params[1];
         try {
-            textCommandService.getNode().getNodeEngine().getWanReplicationService().syncAllMaps(wanRepName, publisherId);
-            res = response(ResponseType.SUCCESS, "message", "Sync initiated");
+            UUID uuid = textCommandService.getNode().getNodeEngine().getWanReplicationService()
+                                          .syncAllMaps(wanRepName, publisherId);
+            res = response(ResponseType.SUCCESS, "message", "Sync initiated", "uuid", uuid.toString());
         } catch (Exception ex) {
             logger.warning("Error occurred while syncing maps", ex);
             res = exceptionResponse(ex);
@@ -463,8 +465,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         WanReplicationService service = textCommandService.getNode().getNodeEngine().getWanReplicationService();
 
         try {
-            service.consistencyCheck(wanReplicationName, publisherId, mapName);
-            res = response(ResponseType.SUCCESS, "message", "Consistency check initiated");
+            UUID uuid = service.consistencyCheck(wanReplicationName, publisherId, mapName);
+            res = response(ResponseType.SUCCESS, "message", "Consistency check initiated", "uuid", uuid.toString());
         } catch (Exception ex) {
             logger.warning("Error occurred while initiating consistency check", ex);
             res = exceptionResponse(ex);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterEventListener.java
@@ -14,21 +14,25 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.management.events;
+package com.hazelcast.internal.management;
 
-import com.hazelcast.internal.management.events.EventMetadata.EventType;
+import com.hazelcast.internal.management.events.Event;
 
-import java.util.UUID;
+/**
+ * Callback interface that captures {@link Event}s logged to Management
+ * Center. It captures only events that are about to be sent to Management
+ * Center. If the {@link ManagementCenterService} is not running or not
+ * enabled, this event listener is not called.
+ *
+ * @see ManagementCenterService#log(Event)
+ */
+@FunctionalInterface
+public interface ManagementCenterEventListener {
 
-import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_STARTED;
-
-public class WanSyncStartedEvent extends AbstractWanAntiEntropyEventBase {
-    public WanSyncStartedEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName) {
-        super(uuid, wanReplicationName, targetGroupName, mapName);
-    }
-
-    @Override
-    public EventType getType() {
-        return WAN_SYNC_STARTED;
-    }
+    /**
+     * Callback for logging MC events.
+     *
+     * @param event The event logged
+     */
+    void onEventLogged(Event event);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanAntiEntropyEventBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanAntiEntropyEventBase.java
@@ -20,25 +20,22 @@ import com.hazelcast.internal.json.JsonObject;
 
 import java.util.UUID;
 
-abstract class AbstractWanSyncFinishedEvent extends AbstractWanAntiEntropyEventBase {
-    private final int partitionsSynced;
-    private final long recordsSynced;
-    private final long durationSecs;
+public abstract class AbstractWanAntiEntropyEventBase extends AbstractWanEventBase {
+    private final UUID uuid;
 
-    AbstractWanSyncFinishedEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName, long durationSecs,
-                                 long recordsSynced, int partitionsSynced) {
-        super(uuid, wanReplicationName, targetGroupName, mapName);
-        this.durationSecs = durationSecs;
-        this.recordsSynced = recordsSynced;
-        this.partitionsSynced = partitionsSynced;
+    protected AbstractWanAntiEntropyEventBase(UUID uuid, String wanReplicationName, String targetGroupName, String mapName) {
+        super(wanReplicationName, targetGroupName, mapName);
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
     }
 
     @Override
     public JsonObject toJson() {
         JsonObject json = super.toJson();
-        json.add("durationSecs", durationSecs);
-        json.add("partitionsSynced", partitionsSynced);
-        json.add("recordsSynced", recordsSynced);
+        json.add("uuid", uuid.toString());
         return json;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEventBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEventBase.java
@@ -23,10 +23,22 @@ abstract class AbstractWanEventBase extends AbstractEventBase {
     protected final String targetGroupName;
     protected final String mapName;
 
-    protected AbstractWanEventBase(String wanReplicationName, String targetGroupName, String mapName) {
+    AbstractWanEventBase(String wanReplicationName, String targetGroupName, String mapName) {
         this.wanReplicationName = wanReplicationName;
         this.targetGroupName = targetGroupName;
         this.mapName = mapName;
+    }
+
+    public String getWanReplicationName() {
+        return wanReplicationName;
+    }
+
+    public String getTargetGroupName() {
+        return targetGroupName;
+    }
+
+    public String getMapName() {
+        return mapName;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckFinishedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckFinishedEvent.java
@@ -18,16 +18,18 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONSISTENCY_CHECK_FINISHED;
 
-public class WanConsistencyCheckFinishedEvent extends AbstractWanEventBase {
+public class WanConsistencyCheckFinishedEvent extends AbstractWanAntiEntropyEventBase {
     private final int diffCount;
     private final int checkedCount;
     private final int entriesToSync;
 
-    public WanConsistencyCheckFinishedEvent(String wanReplicationName, String targetGroupName, String mapName,
+    public WanConsistencyCheckFinishedEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName,
                                             int diffCount, int checkedCount, int entriesToSync) {
-        super(wanReplicationName, targetGroupName, mapName);
+        super(uuid, wanReplicationName, targetGroupName, mapName);
 
         this.diffCount = diffCount;
         this.checkedCount = checkedCount;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckIgnoredEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckIgnoredEvent.java
@@ -20,12 +20,12 @@ import com.hazelcast.internal.json.JsonObject;
 
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONSISTENCY_CHECK_IGNORED;
 
-public class WanConsistencyCheckIgnoredEvent extends AbstractWanEventBase {
+public class WanConsistencyCheckIgnoredEvent extends AbstractWanAntiEntropyEventBase {
     private final String reason;
 
     public WanConsistencyCheckIgnoredEvent(String wanReplicationName, String targetGroupName, String mapName,
                                            String reason) {
-        super(wanReplicationName, targetGroupName, mapName);
+        super(null, wanReplicationName, targetGroupName, mapName);
 
         this.reason = reason;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckStartedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckStartedEvent.java
@@ -18,11 +18,13 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONSISTENCY_CHECK_STARTED;
 
-public class WanConsistencyCheckStartedEvent extends AbstractWanEventBase {
-    public WanConsistencyCheckStartedEvent(String wanReplicationName, String targetGroupName, String mapName) {
-        super(wanReplicationName, targetGroupName, mapName);
+public class WanConsistencyCheckStartedEvent extends AbstractWanAntiEntropyEventBase {
+    public WanConsistencyCheckStartedEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName) {
+        super(uuid, wanReplicationName, targetGroupName, mapName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanFullSyncFinishedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanFullSyncFinishedEvent.java
@@ -18,12 +18,14 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_FINISHED_FULL;
 
 public class WanFullSyncFinishedEvent extends AbstractWanSyncFinishedEvent {
-    public WanFullSyncFinishedEvent(String wanReplicationName, String targetGroupName, String mapName, long durationSecs,
-                                    long recordsSynced, int partitionsSynced) {
-        super(wanReplicationName, targetGroupName, mapName, durationSecs, recordsSynced, partitionsSynced);
+    public WanFullSyncFinishedEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName,
+                                    long durationSecs, long recordsSynced, int partitionsSynced) {
+        super(uuid, wanReplicationName, targetGroupName, mapName, durationSecs, recordsSynced, partitionsSynced);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanMerkleSyncFinishedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanMerkleSyncFinishedEvent.java
@@ -18,6 +18,8 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_FINISHED_MERKLE;
 
 public class WanMerkleSyncFinishedEvent extends AbstractWanSyncFinishedEvent {
@@ -28,10 +30,11 @@ public class WanMerkleSyncFinishedEvent extends AbstractWanSyncFinishedEvent {
     private final double stdDevEntriesPerLeaf;
 
     @SuppressWarnings("checkstyle:parameternumber")
-    public WanMerkleSyncFinishedEvent(String wanReplicationName, String targetGroupName, String mapName, long durationSecs,
+    public WanMerkleSyncFinishedEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName,
+                                      long durationSecs,
                                       int partitionsSynced, int nodesSynced, long recordsSynced, int minLeafEntryCount,
                                       int maxLeafEntryCount, double avgEntriesPerLeaf, double stdDevEntriesPerLeaf) {
-        super(wanReplicationName, targetGroupName, mapName, durationSecs, recordsSynced, partitionsSynced);
+        super(uuid, wanReplicationName, targetGroupName, mapName, durationSecs, recordsSynced, partitionsSynced);
         this.nodesSynced = nodesSynced;
         this.minLeafEntryCount = minLeafEntryCount;
         this.maxLeafEntryCount = maxLeafEntryCount;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanSyncIgnoredEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanSyncIgnoredEvent.java
@@ -19,19 +19,21 @@ package com.hazelcast.internal.management.events;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_IGNORED;
 
-public final class WanSyncIgnoredEvent extends AbstractWanEventBase {
+public final class WanSyncIgnoredEvent extends AbstractWanAntiEntropyEventBase {
     private final String reason;
 
-    private WanSyncIgnoredEvent(String wanReplicationName, String targetGroupName, String mapName, String reason) {
-        super(wanReplicationName, targetGroupName, mapName);
+    private WanSyncIgnoredEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName, String reason) {
+        super(uuid, wanReplicationName, targetGroupName, mapName);
 
         this.reason = reason;
     }
 
     public static WanSyncIgnoredEvent enterpriseOnly(String wanReplicationName, String targetGroupName, String mapName) {
-        return new WanSyncIgnoredEvent(wanReplicationName, targetGroupName, mapName,
+        return new WanSyncIgnoredEvent(null, wanReplicationName, targetGroupName, mapName,
                 "WAN sync is supported for enterprise clusters only.");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanSyncProgressUpdateEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanSyncProgressUpdateEvent.java
@@ -18,17 +18,33 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_PROGRESS_UPDATE;
 
-public class WanSyncProgressUpdateEvent extends AbstractWanEventBase {
+public class WanSyncProgressUpdateEvent extends AbstractWanAntiEntropyEventBase {
     private final int partitionsToSync;
     private final int partitionsSynced;
+    private final int recordsSynced;
 
-    public WanSyncProgressUpdateEvent(String wanReplicationName, String targetGroupName, String mapName, int partitionsToSync,
-                                      int partitionsSynced) {
-        super(wanReplicationName, targetGroupName, mapName);
+    public WanSyncProgressUpdateEvent(UUID uuid, String wanReplicationName, String targetGroupName, String mapName,
+                                      int partitionsToSync, int partitionsSynced, int recordsSynced) {
+        super(uuid, wanReplicationName, targetGroupName, mapName);
         this.partitionsToSync = partitionsToSync;
         this.partitionsSynced = partitionsSynced;
+        this.recordsSynced = recordsSynced;
+    }
+
+    public int getPartitionsToSync() {
+        return partitionsToSync;
+    }
+
+    public int getPartitionsSynced() {
+        return partitionsSynced;
+    }
+
+    public int getRecordsSynced() {
+        return recordsSynced;
     }
 
     @Override
@@ -41,6 +57,7 @@ public class WanSyncProgressUpdateEvent extends AbstractWanEventBase {
         JsonObject json = super.toJson();
         json.add("partitionsToSync", partitionsToSync);
         json.add("partitionsSynced", partitionsSynced);
+        json.add("recordsSynced", recordsSynced);
         return json;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/ConsistencyCheckResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/ConsistencyCheckResult.java
@@ -16,32 +16,39 @@
 
 package com.hazelcast.wan;
 
+import java.util.UUID;
+
 /**
- * Result of the last WAN consistency check result
+ * Result of the last WAN consistency check result.
  */
 public class ConsistencyCheckResult {
     /**
-     * Number of checked partitions
+     * The UUID of the consistency check request.
+     */
+    private final UUID uuid;
+    /**
+     * Number of checked partitions.
      */
     private final int lastCheckedPartitionCount;
     /**
-     * Number of partitions found to be inconsistent
+     * Number of partitions found to be inconsistent.
      */
     private final int lastDiffPartitionCount;
     /**
-     * Number of checked Merkle tree leaves
+     * Number of checked Merkle tree leaves.
      */
     private final int lastCheckedLeafCount;
     /**
-     * Number of different Merkle tree leaves
+     * Number of different Merkle tree leaves.
      */
     private final int lastDiffLeafCount;
     /**
-     * Number of entries to synchronize to get the clusters into sync
+     * Number of entries to synchronize to get the clusters into sync.
      */
     private final int lastEntriesToSync;
 
-    public ConsistencyCheckResult() {
+    public ConsistencyCheckResult(UUID uuid) {
+        this.uuid = uuid;
         lastCheckedPartitionCount = 0;
         lastDiffPartitionCount = 0;
         lastCheckedLeafCount = 0;
@@ -51,6 +58,8 @@ public class ConsistencyCheckResult {
 
     /**
      * Constructs the result of the WAN consistency check comparison
+     * @param uuid                      the UUID of the consistency check
+     *                                  request
      * @param lastCheckedPartitionCount the number of last checked
      *                                  partitions
      * @param lastDiffPartitionCount    the number of different partitions
@@ -60,13 +69,18 @@ public class ConsistencyCheckResult {
      *                                  found different
      * @param lastEntriesToSync         the number of the entries need to
      */
-    public ConsistencyCheckResult(int lastCheckedPartitionCount, int lastDiffPartitionCount, int lastCheckedLeafCount,
+    public ConsistencyCheckResult(UUID uuid, int lastCheckedPartitionCount, int lastDiffPartitionCount, int lastCheckedLeafCount,
                                   int lastDiffLeafCount, int lastEntriesToSync) {
+        this.uuid = uuid;
         this.lastCheckedPartitionCount = lastCheckedPartitionCount;
         this.lastDiffPartitionCount = lastDiffPartitionCount;
         this.lastCheckedLeafCount = lastCheckedLeafCount;
         this.lastDiffLeafCount = lastDiffLeafCount;
         this.lastEntriesToSync = lastEntriesToSync;
+    }
+
+    public UUID getUuid() {
+        return uuid;
     }
 
     public int getLastCheckedPartitionCount() {

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanSyncStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanSyncStats.java
@@ -16,22 +16,45 @@
 
 package com.hazelcast.wan;
 
+import java.util.UUID;
+
 /**
- * WAN Synchronization statistics
+ * Base interface of WAN Synchronization statistics.
  */
 public interface WanSyncStats {
+
     /**
-     * Returns the duration of the synchronization in seconds
+     * Returns the UUID of the synchronization.
+     *
+     * @return the UUID of the synchronization
+     */
+    UUID getUuid();
+
+    /**
+     * Returns the duration of the synchronization in seconds.
+     *
+     * @return the duration of the synchronization in seconds
      */
     long getDurationSecs();
 
     /**
-     * Returns the number of the partitions synchronized
+     * Returns the number of the partitions to synchronize.
+     *
+     * @return the number of partitions to synchronize
+     */
+    int getPartitionsToSync();
+
+    /**
+     * Returns the number of the partitions synchronized.
+     *
+     * @return the number of the partitions synchronized
      */
     int getPartitionsSynced();
 
     /**
-     * Returns the number of the records synchronized
+     * Returns the number of the records synchronized.
+     *
+     * @return the number of records synchronized
      */
     int getRecordsSynced();
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationService.java
@@ -25,6 +25,8 @@ import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.wan.WanReplicationPublisher;
 import com.hazelcast.wan.DistributedServiceWanEventCounters;
 
+import java.util.UUID;
+
 /**
  * This is the WAN replications service API core interface. The
  * WanReplicationService needs to be capable of creating the actual
@@ -92,13 +94,14 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the group name on the target cluster
      * @param mapName            the map name
+     * @return the UUID of the synchronization
      * @throws UnsupportedOperationException if the operation is not supported (not EE)
      * @throws InvalidConfigurationException if there is no WAN replication
      *                                       config for {@code wanReplicationName}
      * @throws SyncFailedException           if there is a anti-entropy request in
      *                                       progress
      */
-    void syncMap(String wanReplicationName, String targetGroupName, String mapName);
+    UUID syncMap(String wanReplicationName, String targetGroupName, String mapName);
 
     /**
      * Initiate wan sync for all maps.
@@ -106,12 +109,13 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      *
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the group name on the target cluster
+     * @return the UUID of the synchronization
      * @throws UnsupportedOperationException if the operation is not supported (not EE)
      * @throws InvalidConfigurationException if there is no WAN replication config for
      *                                       {@code wanReplicationName}
      * @throws SyncFailedException           if there is a anti-entropy request in progress
      */
-    void syncAllMaps(String wanReplicationName, String targetGroupName);
+    UUID syncAllMaps(String wanReplicationName, String targetGroupName);
 
 
     /**
@@ -121,11 +125,13 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the group name on the target cluster
      * @param mapName            the map name
+     * @return the UUID of the consistency check request or {@code null}
+     * if consistency check is ignored because of the configuration
      * @throws UnsupportedOperationException if the operation is not supported (not EE)
      * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
      * @throws SyncFailedException           if there is a anti-entropy request in progress
      */
-    void consistencyCheck(String wanReplicationName, String targetGroupName, String mapName);
+    UUID consistencyCheck(String wanReplicationName, String targetGroupName, String mapName);
 
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -32,6 +32,7 @@ import com.hazelcast.wan.WanReplicationPublisher;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.nio.ClassLoaderUtil.getOrCreate;
@@ -130,7 +131,7 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void syncMap(String wanReplicationName, String targetGroupName, String mapName) {
+    public UUID syncMap(String wanReplicationName, String targetGroupName, String mapName) {
         node.getManagementCenterService().log(
                 WanSyncIgnoredEvent.enterpriseOnly(wanReplicationName, targetGroupName, mapName));
 
@@ -138,7 +139,7 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void syncAllMaps(String wanReplicationName, String targetGroupName) {
+    public UUID syncAllMaps(String wanReplicationName, String targetGroupName) {
         node.getManagementCenterService().log(
                 WanSyncIgnoredEvent.enterpriseOnly(wanReplicationName, targetGroupName, null));
 
@@ -146,7 +147,7 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void consistencyCheck(String wanReplicationName, String targetGroupName, String mapName) {
+    public UUID consistencyCheck(String wanReplicationName, String targetGroupName, String mapName) {
         node.getManagementCenterService().log(
                 new WanConsistencyCheckIgnoredEvent(wanReplicationName, targetGroupName, mapName,
                         "Consistency check is supported for enterprise clusters only."));

--- a/hazelcast/src/test/java/com/hazelcast/test/ProgressCheckerTask.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ProgressCheckerTask.java
@@ -24,6 +24,7 @@ package com.hazelcast.test;
  * @see HazelcastTestSupport#assertCompletesEventually(ProgressCheckerTask, long)
  * @see TaskProgress
  */
+@FunctionalInterface
 public interface ProgressCheckerTask {
     /**
      * Collects and returns progress information


### PR DESCRIPTION
The change makes WAN synchronization to report progress based on target acknowledgments instead of reporting based on enqueueing WAN synchronization events in the local cluster. This way the user sees progress only when the events reached the target cluster. Synchronization events are getting acknowledged when the WAN operation carrying the event gets enqueued in the target cluster. This still leaves it possible that in the target cluster the synchronization event won't get processed. WAN operations trigger merge operations in the target cluster that possibly ends in remote invocations. Since WAN operations are throttled by acknowledgments, acknowledging when the merging is done would make synchronization more time consuming hence the acknowledgment is not changed.

As part of this change, a synchronization UUID has been introduced that uniquely identifies a WAN synchronization (or consistency check) request. This UUID is visible in the logs, diagnostics and is sent to MC as well. The UUID is useful for matching related events when troubleshooting and also helps to distinguish between consecutive or overlapping synchronization processes. As a downside, UUIDs make synchronization events heavier by adding two longs to all of them.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3058