### PR TITLE
Change the XACollectTransactionsMessageTask to return Xid list instead if List of Data.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -204,13 +204,8 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     public Xid[] recover(int flag) throws XAException {
         ClientMessage request = XATransactionCollectTransactionsCodec.encodeRequest();
         ClientMessage response = invoke(request);
-        Collection<Data> list = XATransactionCollectTransactionsCodec.decodeResponse(response).response;
-        SerializableXID[] xidArray = new SerializableXID[list.size()];
-        int index = 0;
-        for (Data xidData : list) {
-            xidArray[index++] = toObject(xidData);
-        }
-        return xidArray;
+        Collection<Xid> list = XATransactionCollectTransactionsCodec.decodeResponse(response).response;
+        return list.toArray(new Xid[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.transaction.impl.xa.XAService;
 
+import javax.transaction.xa.Xid;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,7 +52,7 @@ public class XACollectTransactionsMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return XATransactionCollectTransactionsCodec.encodeResponse((List<Data>) response);
+        return XATransactionCollectTransactionsCodec.encodeResponse((List<Xid>) response);
     }
 
     @Override
@@ -61,7 +62,7 @@ public class XACollectTransactionsMessageTask
 
     @Override
     protected Object reduce(Map<Member, Object> map) throws Throwable {
-        List<Data> list = new ArrayList<Data>();
+        List<Data> list = new ArrayList<>();
         for (Object o : map.values()) {
             if (o instanceof Throwable) {
                 if (o instanceof MemberLeftException) {
@@ -72,7 +73,10 @@ public class XACollectTransactionsMessageTask
             SerializableList xidSet = (SerializableList) o;
             list.addAll(xidSet.getCollection());
         }
-        return list;
+
+        List<Xid> xidList = new ArrayList<>(list.size());
+        list.forEach(xidData -> xidList.add(serializationService.toObject(xidData)));
+        return xidList;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>2.0.0-1</client.protocol.version>
+        <client.protocol.version>2.0.0-2</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>8</jdk.version>


### PR DESCRIPTION
Changed the XACollectTransactionsMessageTask (and XATransactionCollectTransactionsCodec.encodeResponse in the protocol) to return the Xid list instead of List of Data when returning response.