### PR TITLE
Do not store map store instance in MapStoreConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.mapstore;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -125,8 +124,6 @@ final class BasicMapStoreContext implements MapStoreContext {
         final MapStoreWrapper storeWrapper = new MapStoreWrapper(mapName, store);
         storeWrapper.instrument(nodeEngine);
 
-        setStoreImplToWritableMapStoreConfig(nodeEngine, mapName, store);
-
         context.setMapName(mapName);
         context.setMapStoreConfig(mapStoreConfig);
         context.setPartitioningStrategy(partitioningStrategy);
@@ -140,14 +137,6 @@ final class BasicMapStoreContext implements MapStoreContext {
         callLifecycleSupportInit(context);
 
         return context;
-    }
-
-    private static void setStoreImplToWritableMapStoreConfig(NodeEngine nodeEngine, String mapName, Object store) {
-        final Config config = nodeEngine.getConfig();
-        // get writable config (not read-only one) from node engine.
-        final MapConfig mapConfig = config.getMapConfig(mapName);
-        final MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
-        mapStoreConfig.setImplementation(store);
     }
 
     private static MapStoreManager createMapStoreManager(MapStoreContext mapStoreContext) {

--- a/hazelcast/src/test/java/classloading/domain/IntMapLoader.java
+++ b/hazelcast/src/test/java/classloading/domain/IntMapLoader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading.domain;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class IntMapLoader implements com.hazelcast.core.MapLoader<Integer, Integer>, Serializable {
+    @Override
+    public Integer load(Integer integer) {
+        return integer;
+    }
+
+    @Override
+    public Map<Integer, Integer> loadAll(Collection<Integer> collection) {
+        Map<Integer, Integer> map = new HashMap<>();
+        collection.forEach(value -> map.put(value, value));
+        return map;
+    }
+
+    @Override
+    public Iterable<Integer> loadAllKeys() {
+        Collection<Integer> keys = IntStream.range(0, 10_000).boxed().collect(Collectors.toList());
+        return keys;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -256,9 +256,6 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testParseExceptionIsNotSwallowed();
 
     @Test
-    public abstract void setMapStoreConfigImplementationTest();
-
-    @Test
     public abstract void testMapPartitionLostListenerConfig();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -23,9 +23,6 @@ import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
-import com.hazelcast.config.helpers.DummyMapStore;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.quorum.QuorumType;
@@ -1629,33 +1626,6 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String invalidXml = HAZELCAST_START_TAG + "</hazelcast";
         expected.expect(InvalidConfigurationException.class);
         buildConfig(invalidXml);
-    }
-
-    @Override
-    @Test
-    public void setMapStoreConfigImplementationTest() {
-        String mapName = "mapStoreImpObjTest";
-        String xml = HAZELCAST_START_TAG
-                + "<map name=\"" + mapName + "\">\n"
-                + "    <map-store enabled=\"true\">\n"
-                + "        <class-name>com.hazelcast.config.helpers.DummyMapStore</class-name>\n"
-                + "        <write-delay-seconds>5</write-delay-seconds>\n"
-                + "    </map-store>\n"
-                + "</map>\n"
-                + HAZELCAST_END_TAG;
-
-        Config config = buildConfig(xml);
-        HazelcastInstance hz = createHazelcastInstance(config);
-        IMap<String, String> map = hz.getMap(mapName);
-        // MapStore is not instantiated until the MapContainer is created lazily
-        map.put("sample", "data");
-
-        MapConfig mapConfig = hz.getConfig().getMapConfig(mapName);
-        MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
-        Object o = mapStoreConfig.getImplementation();
-
-        assertNotNull(o);
-        assertTrue(o instanceof DummyMapStore);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -21,9 +21,6 @@ import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
-import com.hazelcast.config.helpers.DummyMapStore;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.quorum.QuorumType;
@@ -1679,33 +1676,6 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
         // if we (for any reason) get through the parsing, then fail
         fail();
-    }
-
-    @Override
-    @Test
-    public void setMapStoreConfigImplementationTest() {
-        String mapName = "mapStoreImpObjTest";
-        String yaml = ""
-                + "hazelcast:\n"
-                + "  map:\n"
-                + "    " + mapName + ":\n"
-                + "      map-store:\n"
-                + "        enabled: true\n"
-                + "        class-name: com.hazelcast.config.helpers.DummyMapStore\n"
-                + "        write-delay-seconds: 5";
-
-        Config config = buildConfig(yaml);
-        HazelcastInstance hz = createHazelcastInstance(config);
-        IMap<String, String> map = hz.getMap(mapName);
-        // MapStore is not instantiated until the MapContainer is created lazily
-        map.put("sample", "data");
-
-        MapConfig mapConfig = hz.getConfig().getMapConfig(mapName);
-        MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
-        Object o = mapStoreConfig.getImplementation();
-
-        assertNotNull(o);
-        assertTrue(o instanceof DummyMapStore);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigAdvancedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.dynamicconfig;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.FilteringClassLoader;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.UserCodeDeploymentConfig.ClassCacheMode.ETERNAL;
+import static com.hazelcast.config.UserCodeDeploymentConfig.ProviderMode.LOCAL_AND_CACHED_CLASSES;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+// Test resolution of user customization class names in dynamic data structure config via user code deployment
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DynamicConfigAdvancedTest {
+
+    private static final int CLUSTER_SIZE = 3;
+    private static final String MAP_NAME = "map-with-maploader";
+
+    private TestHazelcastInstanceFactory factory;
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void test_userCustomizations_withUserCodeDeployment() {
+        factory = new TestHazelcastInstanceFactory();
+        // first member is aware of MapLoader class
+        HazelcastInstance member1 = factory.newHazelcastInstance(newConfigWithUserCodeDeployment());
+        member1.getConfig().addMapConfig(mapConfigWithMapLoader());
+
+        IMap<Integer, Integer> intMap = member1.getMap(MAP_NAME);
+        assertEquals(1, (long) intMap.get(1));
+
+        // start another member which is not aware of map loader
+        Config config = newConfigWithUserCodeDeployment();
+        FilteringClassLoader cl = new FilteringClassLoader(singletonList("classloading"), null);
+        config.setClassLoader(cl);
+        factory.newHazelcastInstance(config);
+
+        for (int i = 0; i < 1000; i++) {
+            assertEquals(i, (long) intMap.get(i));
+        }
+    }
+
+    private MapConfig mapConfigWithMapLoader() {
+        MapConfig mapConfig = new MapConfig(MAP_NAME);
+        mapConfig.getMapStoreConfig()
+                 .setEnabled(true)
+                 .setClassName("classloading.domain.IntMapLoader");
+        return mapConfig;
+    }
+
+    private Config newConfigWithUserCodeDeployment() {
+        Config config = new Config();
+        config.getUserCodeDeploymentConfig()
+              .setEnabled(true)
+              .setClassCacheMode(ETERNAL)
+              .setProviderMode(LOCAL_AND_CACHED_CLASSES)
+              .setWhitelistedPrefixes("classloading");
+        return config;
+    }
+
+}


### PR DESCRIPTION
Reasoning: the `MapStoreConfig` may have been added dynamically, so
storing the actual map store instance in `MapStoreConfig#implementation`
may result in failures as members join the cluster such as:
 - failure to serialize the `MapStoreConfig`, in case the map store class
 is not serializable
 - failure to deserialize the `MapStoreConfig` on the joining member side
 if the class is only resolvable over user code deployment, as the
 deserialization occurs within `DynamicConfigPreJoinOperation`
 deserialization, before members list is updated

Additionally, the behaviour of storing the actual instance
back in the implementation field is specific to `MapStoreConfig` and
differs from any other similar config's behaviour
(eg `RingbufferStoreConfig`).