### PR TITLE
Protocol Cleanup - Remove unneeded partitionIds and use List<Xid> in XACollectTransactionsMessageTask

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -73,8 +73,7 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
         HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
         String name = cacheProxy.getPrefixedName();
         if (prefetchValues) {
-            ClientMessage request = CacheIterateEntriesCodec.encodeRequest(name, partitionIndex,
-                    lastTableIndex, fetchSize);
+            ClientMessage request = CacheIterateEntriesCodec.encodeRequest(name, lastTableIndex, fetchSize);
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, name, partitionIndex);
                 ClientInvocationFuture future = clientInvocation.invoke();
@@ -86,8 +85,7 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
                 throw rethrow(e);
             }
         } else {
-            ClientMessage request = CacheIterateCodec.encodeRequest(name, partitionIndex, lastTableIndex,
-                    fetchSize);
+            ClientMessage request = CacheIterateCodec.encodeRequest(name, lastTableIndex, fetchSize);
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, name, partitionIndex);
                 ClientInvocationFuture future = clientInvocation.invoke();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -61,8 +61,7 @@ public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterat
     }
 
     private List fetchWithoutPrefetchValues(HazelcastClientInstanceImpl client) {
-        ClientMessage request = MapFetchKeysCodec.encodeRequest(mapProxy.getName(), partitionId,
-                lastTableIndex, fetchSize);
+        ClientMessage request = MapFetchKeysCodec.encodeRequest(mapProxy.getName(), lastTableIndex, fetchSize);
         ClientInvocation clientInvocation = new ClientInvocation(client, request, mapProxy.getName(), partitionId);
         try {
             ClientInvocationFuture f = clientInvocation.invoke();
@@ -75,8 +74,7 @@ public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterat
     }
 
     private List fetchWithPrefetchValues(HazelcastClientInstanceImpl client) {
-        ClientMessage request = MapFetchEntriesCodec.encodeRequest(mapProxy.getName(), partitionId, lastTableIndex,
-                fetchSize);
+        ClientMessage request = MapFetchEntriesCodec.encodeRequest(mapProxy.getName(), lastTableIndex, fetchSize);
         ClientInvocation clientInvocation = new ClientInvocation(client, request, mapProxy.getName(), partitionId);
         try {
             ClientInvocationFuture f = clientInvocation.invoke();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
@@ -96,7 +96,7 @@ public final class IExecutorDelegatingFuture<V> extends ClientDelegatingFuture<V
         HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
         if (partitionId > -1) {
             ClientMessage request =
-                    ExecutorServiceCancelOnPartitionCodec.encodeRequest(uuid, partitionId, mayInterruptIfRunning);
+                    ExecutorServiceCancelOnPartitionCodec.encodeRequest(uuid, mayInterruptIfRunning);
             ClientInvocation clientInvocation = new ClientInvocation(client, request, objectName, partitionId);
             ClientInvocationFuture f = clientInvocation.invoke();
             return ExecutorServiceCancelOnPartitionCodec.decodeResponse(f.get()).response;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -204,13 +204,8 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     public Xid[] recover(int flag) throws XAException {
         ClientMessage request = XATransactionCollectTransactionsCodec.encodeRequest();
         ClientMessage response = invoke(request);
-        Collection<Data> list = XATransactionCollectTransactionsCodec.decodeResponse(response).response;
-        SerializableXID[] xidArray = new SerializableXID[list.size()];
-        int index = 0;
-        for (Data xidData : list) {
-            xidArray[index++] = toObject(xidData);
-        }
-        return xidArray;
+        Collection<Xid> list = XATransactionCollectTransactionsCodec.decodeResponse(response).response;
+        return list.toArray(new Xid[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnPartitionMessageTask.java
@@ -39,7 +39,7 @@ public class ExecutorServiceCancelOnPartitionMessageTask
         final OperationServiceImpl operationService = nodeEngine.getOperationService();
         final String serviceName = DistributedExecutorService.SERVICE_NAME;
         CancellationOperation op = new CancellationOperation(parameters.uuid, parameters.interrupt);
-        return operationService.createInvocationBuilder(serviceName, op, parameters.partitionId);
+        return operationService.createInvocationBuilder(serviceName, op, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.transaction.impl.xa.XAService;
 
+import javax.transaction.xa.Xid;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,7 +52,7 @@ public class XACollectTransactionsMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return XATransactionCollectTransactionsCodec.encodeResponse((List<Data>) response);
+        return XATransactionCollectTransactionsCodec.encodeResponse((List<Xid>) response);
     }
 
     @Override
@@ -61,7 +62,7 @@ public class XACollectTransactionsMessageTask
 
     @Override
     protected Object reduce(Map<Member, Object> map) throws Throwable {
-        List<Data> list = new ArrayList<Data>();
+        List<Data> list = new ArrayList<>();
         for (Object o : map.values()) {
             if (o instanceof Throwable) {
                 if (o instanceof MemberLeftException) {
@@ -72,7 +73,10 @@ public class XACollectTransactionsMessageTask
             SerializableList xidSet = (SerializableList) o;
             list.addAll(xidSet.getCollection());
         }
-        return list;
+
+        List<Xid> xidList = new ArrayList<>(list.size());
+        list.forEach(xidData -> xidList.add(serializationService.toObject(xidData)));
+        return xidList;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>2.0.0-1</client.protocol.version>
+        <client.protocol.version>2.0.0-2</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>8</jdk.version>


### PR DESCRIPTION
Removed partition id usage in codec parameter where it was not needed since the same information already exists on the ClientMessage and available to the message tasks.

Changed the XACollectTransactionsMessageTask (and XATransactionCollectTransactionsCodec.encodeResponse in the protocol) to return the Xid list instead of List of Data when returning response.