### PR TITLE
Change the `MemberAttributeEvent` to include the list of existing members

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -113,12 +113,16 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
     public void handleMemberAttributeChangeEventV10(Member member, Collection<Member> members, String key, int opType,
                                                     String value) {
         Collection<Member> currentMembersList = clusterService.getMemberList();
-        if (currentMembersList.contains(member)) {
-            final MemberAttributeOperationType operationType = MemberAttributeOperationType.getValue(opType);
-            ((AbstractMember) member).updateAttribute(operationType, key, value);
-            MemberAttributeEvent memberAttributeEvent =
-                    new MemberAttributeEvent(client.getCluster(), member, new HashSet<>(members), operationType, key, value);
-            clusterService.fireMemberAttributeEvent(memberAttributeEvent);
+        String uuid = member.getUuid();
+        for (Member target : currentMembersList) {
+            if (target.getUuid().equals(uuid)) {
+                final MemberAttributeOperationType operationType = MemberAttributeOperationType.getValue(opType);
+                ((AbstractMember) member).updateAttribute(operationType, key, value);
+                MemberAttributeEvent memberAttributeEvent =
+                        new MemberAttributeEvent(client.getCluster(), member, new HashSet<>(members), operationType, key, value);
+                clusterService.fireMemberAttributeEvent(memberAttributeEvent);
+                break;
+            }
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -35,6 +35,7 @@ import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -109,17 +110,15 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
     }
 
     @Override
-    public void handleMemberAttributeChangeEventV10(String uuid, String key, int opType, String value) {
-        Collection<Member> members = clusterService.getMemberList();
-        for (Member target : members) {
-            if (target.getUuid().equals(uuid)) {
-                final MemberAttributeOperationType operationType = MemberAttributeOperationType.getValue(opType);
-                ((AbstractMember) target).updateAttribute(operationType, key, value);
-                MemberAttributeEvent memberAttributeEvent =
-                        new MemberAttributeEvent(client.getCluster(), target, operationType, key, value);
-                clusterService.fireMemberAttributeEvent(memberAttributeEvent);
-                break;
-            }
+    public void handleMemberAttributeChangeEventV10(Member member, Collection<Member> members, String key, int opType,
+                                                    String value) {
+        Collection<Member> currentMembersList = clusterService.getMemberList();
+        if (currentMembersList.contains(member)) {
+            final MemberAttributeOperationType operationType = MemberAttributeOperationType.getValue(opType);
+            ((AbstractMember) member).updateAttribute(operationType, key, value);
+            MemberAttributeEvent memberAttributeEvent =
+                    new MemberAttributeEvent(client.getCluster(), member, new HashSet<>(members), operationType, key, value);
+            clusterService.fireMemberAttributeEvent(memberAttributeEvent);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -117,9 +117,9 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
         for (Member target : currentMembersList) {
             if (target.getUuid().equals(uuid)) {
                 final MemberAttributeOperationType operationType = MemberAttributeOperationType.getValue(opType);
-                ((AbstractMember) member).updateAttribute(operationType, key, value);
+                ((AbstractMember) target).updateAttribute(operationType, key, value);
                 MemberAttributeEvent memberAttributeEvent =
-                        new MemberAttributeEvent(client.getCluster(), member, new HashSet<>(members), operationType, key, value);
+                        new MemberAttributeEvent(client.getCluster(), target, new HashSet<>(members), operationType, key, value);
                 clusterService.fireMemberAttributeEvent(memberAttributeEvent);
                 break;
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
@@ -143,13 +143,12 @@ public class AddMembershipListenerMessageTask
                 return;
             }
 
-            MemberImpl member = (MemberImpl) memberAttributeEvent.getMember();
-            String uuid = member.getUuid();
             MemberAttributeOperationType op = memberAttributeEvent.getOperationType();
             String key = memberAttributeEvent.getKey();
             String value = memberAttributeEvent.getValue() == null ? null : memberAttributeEvent.getValue().toString();
-            ClientMessage eventMessage =
-                    ClientAddMembershipListenerCodec.encodeMemberAttributeChangeEvent(uuid, key, op.getId(), value);
+            ClientMessage eventMessage = ClientAddMembershipListenerCodec
+                    .encodeMemberAttributeChangeEvent(memberAttributeEvent.getMember(), memberAttributeEvent.getMembers(), key,
+                            op.getId(), value);
             sendClientMessage(endpoint.getUuid(), eventMessage);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/MembershipEvent.java
@@ -51,14 +51,13 @@ public class MembershipEvent extends EventObject {
      */
     public static final int MEMBER_ATTRIBUTE_CHANGED = 5;
 
-
     private static final long serialVersionUID = -2010865371829087371L;
 
-    private final Member member;
+    protected Member member;
+
+    protected Set<Member> members;
 
     private final int eventType;
-
-    private final Set<Member> members;
 
     public MembershipEvent(Cluster cluster, Member member, int eventType, Set<Member> members) {
         super(cluster);

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.MemberAttributeEvent;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.nio.serialization.SerializableByConvention;
+
+import java.util.Set;
 
 import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
@@ -33,9 +36,9 @@ public class MemberAttributeServiceEvent extends MemberAttributeEvent {
     public MemberAttributeServiceEvent() {
     }
 
-    public MemberAttributeServiceEvent(Cluster cluster, MemberImpl member, MemberAttributeOperationType operationType,
-                                       String key, Object value) {
-        super(cluster, member, operationType, key, value);
+    public MemberAttributeServiceEvent(Cluster cluster, MemberImpl member, Set<Member> members,
+                                       MemberAttributeOperationType operationType, String key, Object value) {
+        super(cluster, member, members, operationType, key, value);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>2.0.0-2</client.protocol.version>
+        <client.protocol.version>2.0.0-3</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>8</jdk.version>


### PR DESCRIPTION
Fixed MemberAttributeEvent getMembers method to return a correct members list for client.

related to https://github.com/hazelcast/hazelcast/pull/8241
related to https://github.com/hazelcast/hazelcast-client-protocol/pull/191