### PR TITLE
Add txn specific backup operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -137,12 +137,14 @@ import com.hazelcast.map.impl.querycache.subscriber.operation.SetReadCursorOpera
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.map.impl.record.RecordReplicationInfo;
 import com.hazelcast.map.impl.tx.MapTransactionLogRecord;
+import com.hazelcast.map.impl.tx.TxnDeleteBackupOperation;
 import com.hazelcast.map.impl.tx.TxnDeleteOperation;
 import com.hazelcast.map.impl.tx.TxnLockAndGetOperation;
 import com.hazelcast.map.impl.tx.TxnPrepareBackupOperation;
 import com.hazelcast.map.impl.tx.TxnPrepareOperation;
 import com.hazelcast.map.impl.tx.TxnRollbackBackupOperation;
 import com.hazelcast.map.impl.tx.TxnRollbackOperation;
+import com.hazelcast.map.impl.tx.TxnSetBackupOperation;
 import com.hazelcast.map.impl.tx.TxnSetOperation;
 import com.hazelcast.map.impl.tx.TxnUnlockBackupOperation;
 import com.hazelcast.map.impl.tx.TxnUnlockOperation;
@@ -315,8 +317,10 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int SET_TTL_BACKUP = 149;
     public static final int MERKLE_TREE_NODE_ENTRIES = 150;
     public static final int ADD_INDEX_BACKUP = 151;
+    public static final int TXN_SET_BACKUP = 152;
+    public static final int TXN_DELETE_BACKUP = 153;
 
-    private static final int LEN = ADD_INDEX_BACKUP + 1;
+    private static final int LEN = TXN_DELETE_BACKUP + 1;
 
     @Override
     public int getFactoryId() {
@@ -474,6 +478,8 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[SET_TTL_BACKUP] = arg -> new SetTtlBackupOperation();
         constructors[MERKLE_TREE_NODE_ENTRIES] = arg -> new MerkleTreeNodeEntries();
         constructors[ADD_INDEX_BACKUP] = arg -> new AddIndexBackupOperation();
+        constructors[TXN_SET_BACKUP] = arg -> new TxnSetBackupOperation();
+        constructors[TXN_DELETE_BACKUP] = arg -> new TxnDeleteBackupOperation();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -76,12 +76,8 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         if (isPostProcessing(recordStore)) {
             dataValue = mapServiceContext.toData(record.getValue());
         }
-        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, shouldUnlockKeyOnBackup(),
-                putTransient, !canThisOpGenerateWANEvent());
-    }
-
-    protected boolean shouldUnlockKeyOnBackup() {
-        return false;
+        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo,
+                putTransient, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -19,8 +19,8 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 public abstract class BaseRemoveOperation extends LockAwareOperation
         implements BackupAwareOperation, MutatingOperation {
@@ -56,8 +56,7 @@ public abstract class BaseRemoveOperation extends LockAwareOperation
 
     @Override
     public Operation getBackupOperation() {
-        return new RemoveBackupOperation(name, dataKey,
-                false, disableWanReplicationEvent);
+        return new RemoveBackupOperation(name, dataKey, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LegacyMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LegacyMergeOperation.java
@@ -86,7 +86,7 @@ public class LegacyMergeOperation extends BasePutOperation {
     @Override
     public Operation getBackupOperation() {
         if (dataValue == null) {
-            return new RemoveBackupOperation(name, dataKey, false, disableWanReplicationEvent);
+            return new RemoveBackupOperation(name, dataKey, disableWanReplicationEvent);
         } else {
             return super.getBackupOperation();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -204,7 +204,7 @@ public abstract class MapOperation extends AbstractNamedOperation
 
     private boolean canPublishWanEvent(MapContainer mapContainer) {
         boolean canPublishWanEvent = mapContainer.isWanReplicationEnabled()
-                && canThisOpGenerateWANEvent();
+                && !disableWanReplicationEvent;
 
         if (canPublishWanEvent) {
             mapContainer.getWanReplicationPublisher().checkWanReplicationQueues();
@@ -304,14 +304,6 @@ public abstract class MapOperation extends AbstractNamedOperation
     // for testing only
     public void setMapContainer(MapContainer mapContainer) {
         this.mapContainer = mapContainer;
-    }
-
-    /**
-     * @return {@code true} if this operation can generate WAN event, otherwise return {@code false}
-     * to indicate WAN event generation is not allowed for this operation
-     */
-    protected final boolean canThisOpGenerateWANEvent() {
-        return !disableWanReplicationEvent;
     }
 
     protected final void publishWanUpdate(Data dataKey, Object value) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -26,32 +26,18 @@ import java.io.IOException;
 
 public class RemoveBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
-    protected boolean unlockKey;
-
     public RemoveBackupOperation() {
     }
 
-    public RemoveBackupOperation(String name, Data dataKey) {
+    public RemoveBackupOperation(String name, Data dataKey,
+                                 boolean disableWanReplicationEvent) {
         super(name, dataKey);
-    }
-
-    public RemoveBackupOperation(String name, Data dataKey, boolean unlockKey) {
-        super(name, dataKey);
-        this.unlockKey = unlockKey;
-    }
-
-    public RemoveBackupOperation(String name, Data dataKey, boolean unlockKey, boolean disableWanReplicationEvent) {
-        super(name, dataKey);
-        this.unlockKey = unlockKey;
         this.disableWanReplicationEvent = disableWanReplicationEvent;
     }
 
     @Override
     protected void runInternal() {
         recordStore.removeBackup(dataKey, getCallerProvenance());
-        if (unlockKey) {
-            recordStore.forceUnlock(dataKey);
-        }
     }
 
     @Override
@@ -75,14 +61,12 @@ public class RemoveBackupOperation extends KeyBasedMapOperation implements Backu
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeBoolean(unlockKey);
         out.writeBoolean(disableWanReplicationEvent);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        unlockKey = in.readBoolean();
         disableWanReplicationEvent = in.readBoolean();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteBackupOperation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.tx;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.operation.RemoveBackupOperation;
+import com.hazelcast.nio.serialization.Data;
+
+public class TxnDeleteBackupOperation extends RemoveBackupOperation {
+
+    public TxnDeleteBackupOperation() {
+    }
+
+    public TxnDeleteBackupOperation(String name, Data dataKey, boolean disableWanReplicationEvent) {
+        super(name, dataKey, disableWanReplicationEvent);
+    }
+
+    @Override
+    protected void runInternal() {
+        super.runInternal();
+
+        recordStore.forceUnlock(dataKey);
+    }
+
+    @Override
+    public int getClassId() {
+        return MapDataSerializerHook.TXN_DELETE_BACKUP;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.BaseRemoveOperation;
-import com.hazelcast.map.impl.operation.RemoveBackupOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -32,7 +31,8 @@ import java.io.IOException;
 /**
  * Transactional delete operation
  */
-public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOperation {
+public class TxnDeleteOperation
+        extends BaseRemoveOperation implements MapTxnOperation {
 
     private long version;
     private boolean successful;
@@ -82,10 +82,12 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
         sendResponse(false);
     }
 
+    @Override
     public long getVersion() {
         return version;
     }
 
+    @Override
     public void setVersion(long version) {
         this.version = version;
     }
@@ -95,12 +97,14 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
         return Boolean.TRUE;
     }
 
+    @Override
     public boolean shouldNotify() {
         return true;
     }
 
+    @Override
     public Operation getBackupOperation() {
-        return new RemoveBackupOperation(name, dataKey, true);
+        return new TxnDeleteBackupOperation(name, dataKey, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetBackupOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.tx;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.operation.PutBackupOperation;
+import com.hazelcast.map.impl.record.RecordInfo;
+import com.hazelcast.nio.serialization.Data;
+
+public class TxnSetBackupOperation extends PutBackupOperation {
+
+    public TxnSetBackupOperation() {
+    }
+
+    public TxnSetBackupOperation(String name, Data dataKey, Data dataValue,
+                                 RecordInfo recordInfo, boolean putTransient,
+                                 boolean disableWanReplicationEvent) {
+        super(name, dataKey, dataValue, recordInfo, putTransient, disableWanReplicationEvent);
+    }
+
+    @Override
+    protected void runInternal() {
+        super.runInternal();
+
+        recordStore.forceUnlock(dataKey);
+    }
+
+    @Override
+    public int getClassId() {
+        return MapDataSerializerHook.TXN_SET_BACKUP;
+    }
+}


### PR DESCRIPTION
New backup operations: `TxnSetBackupOperation` & `TxnDeleteBackupOperation `

Reasonings:

- addressed this [todo](https://github.com/hazelcast/hazelcast/compare/hazelcast:aa76885...ahmetmircik:a942c3f#diff-bbb39670d55902607979b63be1c4b8fdL32).
- and also needed for https://github.com/hazelcast/hazelcast/pull/15186