### PR TITLE
Fixes SerializationService String serialization to obey the UTF-8 standard (RFC 3629) including the 4-byte characters

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -556,7 +556,6 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
             return null;
         }
 
-        checkAvailable(pos, numberOfBytes);
         String result = new String(data, pos, numberOfBytes, UTF_8);
         pos += numberOfBytes;
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -31,6 +31,7 @@ import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.UTF_8;
 import static com.hazelcast.version.Version.UNKNOWN;
 
 class ByteArrayObjectDataInput extends VersionedObjectDataInput implements BufferObjectDataInput {
@@ -550,23 +551,15 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
      */
     @Override
     public final String readUTF() throws IOException {
-        int charCount = readInt();
-        if (charCount == NULL_ARRAY_LENGTH) {
+        int numberOfBytes = readInt();
+        if (numberOfBytes == NULL_ARRAY_LENGTH) {
             return null;
         }
-        if (charBuffer == null || charCount > charBuffer.length) {
-            charBuffer = new char[charCount];
-        }
-        byte b;
-        for (int i = 0; i < charCount; i++) {
-            b = readByte();
-            if (b < 0) {
-                charBuffer[i] = Bits.readUtf8Char(this, b);
-            } else {
-                charBuffer[i] = (char) b;
-            }
-        }
-        return new String(charBuffer, 0, charCount);
+
+        checkAvailable(pos, numberOfBytes);
+        String result = new String(data, pos, numberOfBytes, UTF_8);
+        pos += numberOfBytes;
+        return result;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -31,6 +31,7 @@ import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.UTF_8;
 import static com.hazelcast.version.Version.UNKNOWN;
 
 class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements BufferObjectDataOutput {
@@ -251,14 +252,15 @@ class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements Buf
 
     @Override
     public void writeUTF(final String str) throws IOException {
-        int len = (str != null) ? str.length() : NULL_ARRAY_LENGTH;
-        writeInt(len);
-        if (len > 0) {
-            ensureAvailable(len * 3);
-            for (int i = 0; i < len; i++) {
-                pos += Bits.writeUtf8Char(buffer, pos, str.charAt(i));
-            }
+        if (str == null) {
+            writeInt(NULL_ARRAY_LENGTH);
+            return;
         }
+
+        byte[] utf8Bytes = str.getBytes(UTF_8);
+        writeInt(utf8Bytes.length);
+        ensureAvailable(utf8Bytes.length);
+        write(utf8Bytes);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.Closeable;
@@ -27,6 +26,7 @@ import java.io.InputStream;
 import java.nio.ByteOrder;
 
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
+import static com.hazelcast.nio.Bits.UTF_8;
 
 public class ObjectDataInputStream extends VersionedObjectDataInput implements Closeable {
 
@@ -293,21 +293,14 @@ public class ObjectDataInputStream extends VersionedObjectDataInput implements C
 
     @Override
     public String readUTF() throws IOException {
-        int charCount = readInt();
-        if (charCount == NULL_ARRAY_LENGTH) {
+        int numberOfBytes = readInt();
+        if (numberOfBytes == NULL_ARRAY_LENGTH) {
             return null;
         }
-        char[] charBuffer = new char[charCount];
-        byte b;
-        for (int i = 0; i < charCount; i++) {
-            b = dataInput.readByte();
-            if (b < 0) {
-                charBuffer[i] = Bits.readUtf8Char(dataInput, b);
-            } else {
-                charBuffer[i] = (char) b;
-            }
-        }
-        return new String(charBuffer, 0, charCount);
+
+        byte[] utf8Bytes = new byte[numberOfBytes];
+        dataInput.readFully(utf8Bytes);
+        return new String(utf8Bytes, UTF_8);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -29,6 +28,7 @@ import java.io.OutputStream;
 import java.nio.ByteOrder;
 
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
+import static com.hazelcast.nio.Bits.UTF_8;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class ObjectDataOutputStream extends VersionedObjectDataOutput implements ObjectDataOutput, Closeable {
@@ -231,15 +231,14 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput implements
 
     @Override
     public void writeUTF(String str) throws IOException {
-        int len = str != null ? str.length() : NULL_ARRAY_LENGTH;
-        writeInt(len);
-        if (len > 0) {
-            final byte[] buffer = new byte[3];
-            for (int i = 0; i < len; i++) {
-                int count = Bits.writeUtf8Char(buffer, 0, str.charAt(i));
-                dataOut.write(buffer, 0, count);
-            }
+        if (str == null) {
+            writeInt(NULL_ARRAY_LENGTH);
+            return;
         }
+
+        byte[] utf8Bytes = str.getBytes(UTF_8);
+        writeInt(utf8Bytes.length);
+        write(utf8Bytes);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -295,6 +295,22 @@ public class SerializationTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testUTF8() {
+        SerializationService ss = new DefaultSerializationServiceBuilder().build();
+        String name = "Orhan";
+        Data data = ss.toData(name);
+        assertEquals(name, ss.toObject(data));
+    }
+
+    @Test
+    public void testDataSerializableObjectSerialization() {
+        SerializationService ss = new DefaultSerializationServiceBuilder().build();
+        Person person = new Person(35, 180, 100, "Orhan", null);
+        Data data = ss.toData(person);
+        assertEquals(person, ss.toObject(data));
+    }
+
+    @Test
     public void testArrayListSerialization() {
         SerializationService ss = new DefaultSerializationServiceBuilder().build();
         ArrayList<Person> arrayList = new ArrayList<Person>();

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
@@ -49,7 +49,9 @@ public class StringSerializationTest {
     private static final String TEST_DATA_TURKISH = "Pijamalı hasta, yağız şoföre çabucak güvendi.";
     private static final String TEST_DATA_JAPANESE = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム";
     private static final String TEST_DATA_ASCII = "The quick brown fox jumps over the lazy dog";
-    private static final String TEST_DATA_ALL = TEST_DATA_TURKISH + TEST_DATA_JAPANESE + TEST_DATA_ASCII;
+    private static final String TEST_DATA_UTF_4_BYTE_EMOJIS = "loudly crying face:\uD83D\uDE2D nerd face: \uD83E\uDD13";
+    private static final String TEST_DATA_ALL =
+            TEST_DATA_TURKISH + TEST_DATA_JAPANESE + TEST_DATA_ASCII + TEST_DATA_UTF_4_BYTE_EMOJIS;
     private static final int TEST_STR_SIZE = 1 << 20;
 
     private static final byte[] TEST_DATA_BYTES_ALL = TEST_DATA_ALL.getBytes(Charset.forName("utf8"));
@@ -80,14 +82,14 @@ public class StringSerializationTest {
 
     @Test
     public void testStringEncode() {
-        byte[] expected = toDataByte(TEST_DATA_BYTES_ALL, TEST_DATA_ALL.length());
+        byte[] expected = toDataByte(TEST_DATA_BYTES_ALL);
         byte[] actual = serializationService.toBytes(TEST_DATA_ALL);
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void testStringDecode() {
-        Data data = new HeapData(toDataByte(TEST_DATA_BYTES_ALL, TEST_DATA_ALL.length()));
+        Data data = new HeapData(toDataByte(TEST_DATA_BYTES_ALL));
         String actualStr = serializationService.toObject(data);
         assertEquals(TEST_DATA_ALL, actualStr);
     }
@@ -116,7 +118,7 @@ public class StringSerializationTest {
         String actualStr = sb.toString();
         byte[] strBytes = actualStr.getBytes(Charset.forName("utf8"));
         byte[] actualDataBytes = serializationService.toBytes(actualStr);
-        byte[] expectedDataByte = toDataByte(strBytes, actualStr.length());
+        byte[] expectedDataByte = toDataByte(strBytes);
         String decodedStr = serializationService.toObject(new HeapData(expectedDataByte));
         assertArrayEquals("Deserialized byte array do not match utf-8 encoding", expectedDataByte, actualDataBytes);
         assertEquals(decodedStr, actualStr);
@@ -148,7 +150,7 @@ public class StringSerializationTest {
     public void testStringAllCharLetterDecode() {
         String allStr = new String(allChars);
         byte[] expected = allStr.getBytes(Charset.forName("utf8"));
-        Data data = new HeapData(toDataByte(expected, allStr.length()));
+        Data data = new HeapData(toDataByte(expected));
         String actualStr = serializationService.toObject(data);
         assertEquals(allStr, actualStr);
     }
@@ -166,25 +168,25 @@ public class StringSerializationTest {
         assertArrayEquals(stringArray, actualStr);
     }
 
-    private byte[] toDataByte(byte[] input, int length) {
+    private byte[] toDataByte(byte[] input) {
         // the first 4 byte of type id, 4 byte string length and last 4 byte of partition hashCode
         if (serializationService.getByteOrder() == BIG_ENDIAN) {
-            return toDataByteBigEndian(input, length);
+            return toDataByteBigEndian(input);
         } else {
-            return toDataByteLittleEndian(input, length);
+            return toDataByteLittleEndian(input);
         }
     }
 
-    private byte[] toDataByteBigEndian(byte[] input, int length) {
+    private byte[] toDataByteBigEndian(byte[] input) {
         ByteBuffer bf = ByteBuffer.allocate(input.length + 12);
         bf.putInt(0);
         bf.putInt(SerializationConstants.CONSTANT_TYPE_STRING);
-        bf.putInt(length);
+        bf.putInt(input.length);
         bf.put(input);
         return bf.array();
     }
 
-    private byte[] toDataByteLittleEndian(byte[] input, int length) {
+    private byte[] toDataByteLittleEndian(byte[] input) {
         ByteBuffer bf = ByteBuffer.allocate(input.length + 12);
         bf.order(LITTLE_ENDIAN);
         bf.putInt(0);
@@ -194,7 +196,7 @@ public class StringSerializationTest {
         bf.put((byte) 0xFF);
         bf.put((byte) 0xFF);
         bf.put((byte) 0xF5);
-        bf.putInt(length);
+        bf.putInt(input.length);
         bf.put(input);
         return bf.array();
     }


### PR DESCRIPTION
Fixes SerializationService 4-byte utf-8 support when serializing and de-serializing strings. The new format uses number of bytes for the length field instead of number of Java characters in the string. The fix enables string data type serialization to follow UTF-8 standard (RFC 3629).

The fix is for `Hazelcast Serialization Improvements` PRD.