### PR TITLE
Add HTTPs support to cluster.sh, healthcheck.sh and cp-subsystem.sh

### DIFF
--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -9,10 +9,10 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "  -g, --groupname  : Defines groupname of the cluster. Default value is 'dev'."
     echo "  -P, --password   : Defines password of the cluster. Default value is 'dev-pass'."
     echo "  -v, --version    : Defines the cluster version to change to. To be used in conjunction with '-o change-cluster-version'."
-    echo "  -d, --debug      : Prints curl error output."
+    echo "  -d, --debug      : Prints error output."
     echo
     echo "HTTPs related (when TLS is enabled):"
-    echo "      --https      : Uses HTTPs protocol for REST calls.(no parameter value expected)"
+    echo "      --https      : Uses HTTPs protocol for REST calls. (no parameter value expected)"
     echo "      --cacert     : Defines trusted PEM-encoded certificate file path. It's used to verify member certificates."
     echo "      --cert       : Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used."
     echo "      --key        : Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used."
@@ -79,8 +79,8 @@ shift # past argument or value
 done
 
 if [ -z "$OPERATION" ]; then
-  echo "No operation is defined, running script with default operation: 'get-state'."
-  OPERATION="get-state"
+    echo "No operation is defined, running script with default operation: 'get-state'."
+    OPERATION="get-state"
 fi
 
 if [ -z "$PORT" ]; then
@@ -110,12 +110,12 @@ fi
 
 if [ "$OPERATION" = "get-state" ]; then
     echo "Getting cluster state on address ${ADDRESS}:${PORT}"
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/state");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/state")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "success" ];then
-        CURRSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+        CURRSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//')
         echo "Cluster is in ${CURRSTATE} state."
         exit 0
     fi
@@ -133,12 +133,12 @@ elif [ "$OPERATION" = "change-state" ]; then
     fi
 
     echo "Changing cluster state to ${STATE} on address ${ADDRESS}:${PORT}"
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}&${STATE}" "${URL_BASE}/changeState");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}&${STATE}" "${URL_BASE}/changeState")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "fail" ];then
-       NEWSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+       NEWSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//')
        if [ "$NEWSTATE" != "null" ]; then
            echo "Cluster is already in ${STATE} state}"
        else
@@ -148,7 +148,7 @@ elif [ "$OPERATION" = "change-state" ]; then
     fi
 
     if [ "$STATUS" = "success" ];then
-        NEWSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+        NEWSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//')
         echo "State of the cluster changed to ${NEWSTATE} state"
         exit 0
     fi
@@ -158,9 +158,9 @@ elif [ "$OPERATION" = "force-start" ]; then
     echo "Force-start makes cluster operational if cluster start is blocked by problematic members."
     echo "Starting cluster from member on address ${ADDRESS}:${PORT}"
 
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/forceStart");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/forceStart")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "success" ];then
         echo "Cluster force-start completed!"
@@ -172,9 +172,9 @@ elif [ "$OPERATION" = "partial-start" ]; then
     echo "Partial-start makes cluster operational by starting only a portion of available members if cluster start is blocked by problematic members."
     echo "Starting cluster from member on address ${ADDRESS}:${PORT}"
 
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/partialStart");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/partialStart")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "success" ];then
         echo "Cluster partial-start completed!"
@@ -186,9 +186,9 @@ elif [ "$OPERATION" = "shutdown" ]; then
     echo "You are shutting down the cluster."
     echo "Shutting down from member on address ${ADDRESS}:${PORT}"
 
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/clusterShutdown");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/clusterShutdown")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "success" ];then
         echo "Cluster shutdown completed!"
@@ -198,12 +198,12 @@ elif [ "$OPERATION" = "shutdown" ]; then
 elif [ "$OPERATION" = "get-cluster-version" ]; then
 
     echo "Getting cluster version on address ${ADDRESS}:${PORT}"
-    response=$(${CURL_CMD} "${URL_BASE}/version");
+    response=$(${CURL_CMD} "${URL_BASE}/version")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "success" ];then
-        CURRVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//');
+        CURRVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//')
         echo "Cluster operates in version ${CURRVERSION}."
         exit 0
     fi
@@ -216,12 +216,12 @@ elif [ "$OPERATION" = "change-cluster-version" ]; then
     fi
 
     echo "Changing cluster version to ${CLUSTER_VERSION} on address ${ADDRESS}:${PORT}"
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}&${CLUSTER_VERSION}" "${URL_BASE}/version");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}&${CLUSTER_VERSION}" "${URL_BASE}/version")
     CURL_EXIT_CODE=$?
-    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
+    STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//')
 
     if [ "$STATUS" = "fail" ]; then
-       MESSAGE=$(echo "${response}" | sed -e 's/^.*"message"[ ]*:[ ]*"//' -e 's/".*//');
+       MESSAGE=$(echo "${response}" | sed -e 's/^.*"message"[ ]*:[ ]*"//' -e 's/".*//')
        # when there is no "message" element in response, above sed process returns "{"
        if [ "$MESSAGE" != "{" ]; then
            echo "Cluster version change failed: ${MESSAGE}"
@@ -232,7 +232,7 @@ elif [ "$OPERATION" = "change-cluster-version" ]; then
     fi
 
     if [ "$STATUS" = "success" ]; then
-        NEWVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//');
+        NEWVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//')
         echo "Cluster version changed to ${NEWVERSION}."
         exit 0
     fi

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -1,22 +1,33 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
-   	echo "parameters: "
-   	echo "	-o, --operation	    : Executes cluster-wide operation. Operation can be 'get-state','change-state','shutdown','force-start','partial-start','get-cluster-version','change-cluster-version'."
-    echo "	-s, --state 	    : Updates state of the cluster to new state. New state can be 'active', 'frozen', 'passive', 'no_migration'."
-    echo "	-a, --address  	    : Defines which ip address hazelcast is running. Default value is '127.0.0.1'."
-   	echo "	-p, --port  	    : Defines which port hazelcast is running. Default value is '5701'."
-   	echo "	-g, --groupname     : Defines groupname of the cluster. Default value is 'dev'."
-   	echo "	-P, --password      : Defines password of the cluster. Default value is 'dev-pass'."
-   	echo "	-v, --version       : Defines the cluster version to change to. To be used in conjunction with '-o change-cluster-version'."
-   	exit 0
+    echo "parameters: "
+    echo "  -o, --operation  : Executes cluster-wide operation. Operation can be 'get-state','change-state','shutdown','force-start','partial-start','get-cluster-version','change-cluster-version'."
+    echo "  -s, --state      : Updates state of the cluster to new state. New state can be 'active', 'frozen', 'passive', 'no_migration'."
+    echo "  -a, --address    : Defines which ip address hazelcast is running. Default value is '127.0.0.1'."
+    echo "  -p, --port       : Defines which port hazelcast is running. Default value is '5701'."
+    echo "  -g, --groupname  : Defines groupname of the cluster. Default value is 'dev'."
+    echo "  -P, --password   : Defines password of the cluster. Default value is 'dev-pass'."
+    echo "  -v, --version    : Defines the cluster version to change to. To be used in conjunction with '-o change-cluster-version'."
+    echo "  -d, --debug      : Prints curl error output."
+    echo
+    echo "HTTPs related (when TLS is enabled):"
+    echo "      --https      : Uses HTTPs protocol for REST calls.(no parameter value expected)"
+    echo "      --cacert     : Defines trusted PEM-encoded certificate file path. It's used to verify member certificates."
+    echo "      --cert       : Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used."
+    echo "      --key        : Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used."
+    echo "      --insecure   : Disables member certificate verification. (no parameter value expected)"
+    exit 0
 fi
 
-while [ $# -gt 1 ]
+URL_SCHEME="http"
+CURL_ARGS="--silent"
+
+while [ $# -ge 1 ]
 do
 key="$1"
 case "$key" in
-  	-o|--operation)
+    -o|--operation)
     OPERATION="$2"
     shift # past argument
     ;;
@@ -44,14 +55,32 @@ case "$key" in
     CLUSTER_VERSION="$2"
     shift # past argument
     ;;
+    -d|--debug)
+    CURL_ARGS="$CURL_ARGS --show-error"
+    ;;
+    --https)
+    URL_SCHEME="https"
+    ;;
+    --cert|--key)
+    CURL_ARGS="$CURL_ARGS $1 $2"
+    shift # past argument
+    ;;
+    --cacert)
+    CURL_ARGS="$CURL_ARGS --capath /dev/null $1 $2"
+    shift # past argument
+    ;;
+    --insecure)
+    echo "WARNING: You're using the insecure switch. Hazelcast member TLS certificates will not be verified!" >&2
+    CURL_ARGS="$CURL_ARGS $1"
+    ;;
     *)
 esac
 shift # past argument or value
 done
 
 if [ -z "$OPERATION" ]; then
- 	echo "No operation is defined, running script with default operation: 'get-state'."
- 	OPERATION="get-state"
+  echo "No operation is defined, running script with default operation: 'get-state'."
+  OPERATION="get-state"
 fi
 
 if [ -z "$PORT" ]; then
@@ -71,50 +100,41 @@ fi
 
 command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit -1; }
 
+URL_BASE="${URL_SCHEME}://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster"
+CURL_CMD="curl $CURL_ARGS"
+
 if [ "$OPERATION" != "get-state" ] && [ "$OPERATION" != "change-state" ] && [ "$OPERATION" != "shutdown" ] &&  [ "$OPERATION" != "force-start" ] && [ "$OPERATION" != "partial-start" ] && [ "$OPERATION" != "get-cluster-version" ] && [ "$OPERATION" != "change-cluster-version" ]; then
     echo "Not a valid cluster operation, valid operations  are 'get-state' || 'change-state' || 'shutdown' || 'force-start' || 'partial-start' || 'get-cluster-version' || 'change-cluster-version'"
-    exit 0
+    exit 2
 fi
-
-MSG_FORBIDDEN="Please make sure you provide valid group name (or valid username/password combination when the Hazelcast security is enabled)."
 
 if [ "$OPERATION" = "get-state" ]; then
-    echo "Getting cluster state on ip ${ADDRESS} on port ${PORT}"
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/state"
- 	response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    echo "Getting cluster state on address ${ADDRESS}:${PORT}"
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/state");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
- 	if [ "$STATUS" = "fail" ];then
-        echo "An error occurred while listing!";
-    	exit 0
-    fi
-	if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
+
+    if [ "$STATUS" = "success" ];then
+        CURRSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+        echo "Cluster is in ${CURRSTATE} state."
         exit 0
     fi
-	if [ "$STATUS" = "success" ];then
-	    CURRSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
-	    echo "Cluster is in ${CURRSTATE} state."
-    	exit 0
-    fi
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
-fi
 
-if [ "$OPERATION" = "change-state" ]; then
+elif [ "$OPERATION" = "change-state" ]; then
 
     if [ -z "$STATE" ]; then
         echo "No new state is defined. Please define new state with --state 'active', 'no_migration, 'frozen', 'passive'"
-        exit 0
+        exit 2
     fi
 
     if [ "$STATE" != "frozen" ] && [ "$STATE" != "active" ] && [ "$STATE" != "no_migration" ] && [ "$STATE" != "passive" ]; then
         echo "Not a valid cluster state, valid states  are 'active' || 'frozen' || 'passive' || 'no_migration'"
-        exit 0
+        exit 2
     fi
 
-    echo "Changing cluster state to ${STATE} on ip ${ADDRESS} on port ${PORT}"
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/changeState"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}&${STATE}" --silent "${request}");
+    echo "Changing cluster state to ${STATE} on address ${ADDRESS}:${PORT}"
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}&${STATE}" "${URL_BASE}/changeState");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
     if [ "$STATUS" = "fail" ];then
@@ -124,12 +144,7 @@ if [ "$OPERATION" = "change-state" ]; then
        else
             echo "An error occured while changing cluster state!";
        fi
-       exit 0
-    fi
-
-    if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
-        exit 0
+       exit 3
     fi
 
     if [ "$STATUS" = "success" ];then
@@ -138,127 +153,74 @@ if [ "$OPERATION" = "change-state" ]; then
         exit 0
     fi
 
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
-fi
+elif [ "$OPERATION" = "force-start" ]; then
 
-if [ "$OPERATION" = "force-start" ]; then
     echo "Force-start makes cluster operational if cluster start is blocked by problematic members."
-    echo "Starting cluster from member on ip ${ADDRESS} on port ${PORT}"
+    echo "Starting cluster from member on address ${ADDRESS}:${PORT}"
 
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/forceStart"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/forceStart");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
-
-    if [ "$STATUS" = "fail" ];then
-       echo "An error occurred while force starting the cluster!";
-       exit 0
-    fi
-
-    if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
-        exit 0
-    fi
 
     if [ "$STATUS" = "success" ];then
         echo "Cluster force-start completed!"
         exit 0
     fi
 
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
-fi
+elif [ "$OPERATION" = "partial-start" ]; then
 
-if [ "$OPERATION" = "partial-start" ]; then
     echo "Partial-start makes cluster operational by starting only a portion of available members if cluster start is blocked by problematic members."
-    echo "Starting cluster from member on ip ${ADDRESS} on port ${PORT}"
+    echo "Starting cluster from member on address ${ADDRESS}:${PORT}"
 
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/partialStart"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/partialStart");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
-
-    if [ "$STATUS" = "fail" ];then
-       echo "An error occurred while partially starting the cluster!";
-       exit 0
-    fi
-
-    if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
-        exit 0
-    fi
 
     if [ "$STATUS" = "success" ];then
         echo "Cluster partial-start completed!"
         exit 0
     fi
 
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
-fi
-
-if [ "$OPERATION" = "shutdown" ]; then
+elif [ "$OPERATION" = "shutdown" ]; then
 
     echo "You are shutting down the cluster."
-    echo "Shutting down from member on ip ${ADDRESS} on port ${PORT}"
+    echo "Shutting down from member on address ${ADDRESS}:${PORT}"
 
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/clusterShutdown"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/clusterShutdown");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
-
-    if [ "$STATUS" = "fail" ];then
-        echo "An error occured while shutting down cluster!";
-        exit 0
-    fi
-
-    if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
-        exit 0
-    fi
 
     if [ "$STATUS" = "success" ];then
         echo "Cluster shutdown completed!"
         exit 0
     fi
 
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
-fi
+elif [ "$OPERATION" = "get-cluster-version" ]; then
 
-if [ "$OPERATION" = "get-cluster-version" ]; then
-    echo "Getting cluster version on ip ${ADDRESS} on port ${PORT}"
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/version"
- 	response=$(curl --silent "${request}");
+    echo "Getting cluster version on address ${ADDRESS}:${PORT}"
+    response=$(${CURL_CMD} "${URL_BASE}/version");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
- 	if [ "$STATUS" = "fail" ];then
-        echo "An error occured while listing!";
-    	exit 0
-    fi
-	if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
+
+    if [ "$STATUS" = "success" ];then
+        CURRVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//');
+        echo "Cluster operates in version ${CURRVERSION}."
         exit 0
     fi
-	if [ "$STATUS" = "success" ];then
-	    CURRVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//');
-	    echo "Cluster operates in version ${CURRVERSION}."
-    	exit 0
-    fi
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
-fi
 
-if [ "$OPERATION" = "change-cluster-version" ]; then
+elif [ "$OPERATION" = "change-cluster-version" ]; then
 
     if [ -z "$CLUSTER_VERSION" ]; then
         echo "No new cluster version is defined. Please define new cluster version with --version MAJOR.MINOR (for example --version 3.8)"
-        exit 0
+        exit 2
     fi
 
-    echo "Changing cluster version to ${CLUSTER_VERSION} on ip ${ADDRESS} on port ${PORT}"
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/version"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}&${CLUSTER_VERSION}" --silent "${request}");
+    echo "Changing cluster version to ${CLUSTER_VERSION} on address ${ADDRESS}:${PORT}"
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}&${CLUSTER_VERSION}" "${URL_BASE}/version");
+    CURL_EXIT_CODE=$?
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
-    if [ "$STATUS" = "fail" ];then
+    if [ "$STATUS" = "fail" ]; then
        MESSAGE=$(echo "${response}" | sed -e 's/^.*"message"[ ]*:[ ]*"//' -e 's/".*//');
        # when there is no "message" element in response, above sed process returns "{"
        if [ "$MESSAGE" != "{" ]; then
@@ -266,20 +228,28 @@ if [ "$OPERATION" = "change-cluster-version" ]; then
        else
             echo "An error occured while changing cluster version!";
        fi
-       exit 0
+       exit 3
     fi
 
-    if [ "$STATUS" = "forbidden" ];then
-        echo "$MSG_FORBIDDEN";
-        exit 0
-    fi
-
-    if [ "$STATUS" = "success" ];then
+    if [ "$STATUS" = "success" ]; then
         NEWVERSION=$(echo "${response}" | sed -e 's/^.*"version"[ ]*:[ ]*"//' -e 's/".*//');
         echo "Cluster version changed to ${NEWVERSION}."
         exit 0
     fi
 
-    echo "No hazelcast cluster is running on ip ${ADDRESS} on port ${PORT}."
-    exit 0
+fi
+
+if [ "$STATUS" = "fail" ];then
+   echo "An error occurred while performing HTTP REST operation on the Hazelcast cluster!";
+   exit 3
+fi
+
+if [ "$STATUS" = "forbidden" ];then
+    echo "Please make sure you provide valid group name (or valid username/password combination when the Hazelcast security is enabled).";
+    exit 4
+fi
+
+if [ $CURL_EXIT_CODE -ne 0 ]; then
+    echo "HTTP REST call on address ${ADDRESS}:${PORT} failed. "
+    exit $CURL_EXIT_CODE
 fi

--- a/hazelcast/src/main/resources/cp-subsystem.sh
+++ b/hazelcast/src/main/resources/cp-subsystem.sh
@@ -13,7 +13,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "  -P, --password    : Defines password of the cluster. Default value is 'dev-pass'."
     echo "  -d, --debug       : Prints curl error output."
     echo "HTTPs related (TLS enabled):"
-    echo "      --https       : Uses HTTPs protocol for REST calls.(no parameter value expected)"
+    echo "      --https       : Uses HTTPs protocol for REST calls. (no parameter value expected)"
     echo "      --cacert      : Defines trusted PEM-encoded certificate file path. It's used to verify member certificates."
     echo "      --cert        : Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used."
     echo "      --key         : Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used."
@@ -149,7 +149,7 @@ CURL_CMD="curl $CURL_ARGS"
 
 if [[ "$OPERATION" = "get-local-member" ]]; then
     echo "Getting local CP member information on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} "${URL_BASE}/members/local");
+    response=$(${CURL_CMD} "${URL_BASE}/members/local")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -168,7 +168,7 @@ fi
 
 if [[ "$OPERATION" = "get-groups" ]]; then
     echo "Getting CP group IDs on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} "${URL_BASE}/groups");
+    response=$(${CURL_CMD} "${URL_BASE}/groups")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -188,7 +188,7 @@ if [[ "$OPERATION" = "get-group" ]]; then
     fi
 
     echo "Getting CP group: ${CP_GROUP_NAME} on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} "${URL_BASE}/groups/${CP_GROUP_NAME}");
+    response=$(${CURL_CMD} "${URL_BASE}/groups/${CP_GROUP_NAME}")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -207,7 +207,7 @@ fi
 
 if [[ "$OPERATION" = "get-members" ]]; then
     echo "Getting CP members on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} "${URL_BASE}/members");
+    response=$(${CURL_CMD} "${URL_BASE}/members")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -227,7 +227,7 @@ if [[ "$OPERATION" = "get-sessions" ]]; then
     fi
 
     echo "Getting CP sessions in CP group: ${CP_GROUP_NAME} on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} "${URL_BASE}/groups/${CP_GROUP_NAME}/sessions");
+    response=$(${CURL_CMD} "${URL_BASE}/groups/${CP_GROUP_NAME}/sessions")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -251,7 +251,7 @@ if [[ "$OPERATION" = "force-destroy-group" ]]; then
     fi
 
     echo "Force-destroying CP group: ${CP_GROUP_NAME} on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/groups/${CP_GROUP_NAME}/remove");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/groups/${CP_GROUP_NAME}/remove")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -274,7 +274,7 @@ fi
 
 if [[ "$OPERATION" = "promote-member" ]]; then
     echo "Promoting to CP member on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/members");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/members")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -298,7 +298,7 @@ if [[ "$OPERATION" = "remove-member" ]]; then
     fi
 
     echo "Removing CP member: ${CP_MEMBER_UID} on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/members/${CP_MEMBER_UID}/remove");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/members/${CP_MEMBER_UID}/remove")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -331,7 +331,7 @@ if [[ "$OPERATION" = "force-close-session" ]]; then
     fi
 
     echo "Closing CP session: ${CP_SESSION_ID} in CP group: ${CP_GROUP_NAME} ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/groups/${CP_GROUP_NAME}/sessions/${CP_SESSION_ID}/remove");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/groups/${CP_GROUP_NAME}/sessions/${CP_SESSION_ID}/remove")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -354,7 +354,7 @@ fi
 
 if [[ "$OPERATION" = "restart" ]]; then
     echo "Restarting the CP subsystem on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/restart");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/restart")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 

--- a/hazelcast/src/main/resources/cp-subsystem.sh
+++ b/hazelcast/src/main/resources/cp-subsystem.sh
@@ -1,42 +1,49 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
-   	echo "Sends CP subsystem management operations to a Hazelcast instance."
-   	echo "Parameters: "
-   	echo "	-o, --operation	            : Operation to be called."
-    echo "	-c, --group       	        : Name of the CP group. Must be provided for 'get-group', 'force-destroy-group', 'get-sessions', 'force-close-session'."
-    echo "	-m, --member      	        : UUID of the CP member. Must be provided for 'remove-member'."
-    echo "	-s, --session-id 	        : CP Session ID. Must be provided for 'force-close-session'."
-    echo "	-a, --address  	            : Defines which ip address hazelcast is running. Default value is '127.0.0.1'."
-   	echo "	-p, --port  	            : Defines which port hazelcast is running. Default value is '5701'."
-   	echo "	-g, --groupname             : Defines groupname of the cluster. Default value is 'dev'."
-   	echo "	-P, --password              : Defines password of the cluster. Default value is 'dev-pass'."
-   	echo "Operations: "
-   	echo "	- 'get-local-member' returns the local CP member information from the accessed Hazelcast member."
-   	echo "	- 'get-groups' returns the list of active CP groups."
-   	echo "	- 'get-group' expects a CP group name (-c or --group) and returns a its details."
-   	echo "	- 'force-destroy-group' destroys a CP group (-c or --group) non-gracefully."
-   	echo "	   It must be called only when a CP group loses its majority."
-   	echo "	   All CP data structure proxies created before the force-destroy step will fail."
-   	echo "	   If you create a new proxy for a CP data structure that is mapped to the destroyed CP group, the CP group will be initialized from scratch."
-   	echo "     Please note that you cannot force-destroy the METADATA CP group. If you lose majority of the METADATA CP group, you have to restart the CP subsystem."
-   	echo "	- 'get-members' returns the list of active CP members in the cluster."
-   	echo "	   Please note that even if a CP member has left the cluster, it is not automatically removed from the active CP member list immediately."
-   	echo "	- 'remove-member' removes the given CP member (-m) from the active CP member list."
-   	echo "	   The removed member will be removed from the CP groups as well."
-   	echo "	   Before removing a CP member, please make sure that the missing member is actually crashed, not partitioned away."
-   	echo "	- 'promote-member' promotes the contacted Hazelcast member to the CP member role."
-   	echo "	- 'get-sessions' returns the list of CP sessions created in the requested CP group (-c)."
-   	echo "	- 'force-close-session' closes the given CP session (-s) on the given CP group (-c)."
-   	echo "	   Once the CP session is closed, all CP resources (locks, semaphore permits, etc.) will be released."
-   	echo "	   Before force-closing a CP session, please make sure that owner endpoint of the CP session is crashed and will not show up."
-   	echo "	- 'restart' wipes out all CP subsystem state and restarts it from scratch."
-   	echo "	   Please call this API only on the Hazelcast master member (i.e., the first member in the Hazelcast cluster member list)."
-   	echo "	   Please make sure that you call this API only once. Once you make the call, please observe the cluster to see if the CP subsystem initialization is successful."
+    echo "Sends CP subsystem management operations to a Hazelcast instance."
+    echo "Parameters:"
+    echo "  -o, --operation   : Operation to be called."
+    echo "  -c, --group       : Name of the CP group. Must be provided for 'get-group', 'force-destroy-group', 'get-sessions', 'force-close-session'."
+    echo "  -m, --member      : UUID of the CP member. Must be provided for 'remove-member'."
+    echo "  -s, --session-id  : CP Session ID. Must be provided for 'force-close-session'."
+    echo "  -a, --address     : Defines which ip address hazelcast is running. Default value is '127.0.0.1'."
+    echo "  -p, --port        : Defines which port hazelcast is running. Default value is '5701'."
+    echo "  -g, --groupname   : Defines groupname of the cluster. Default value is 'dev'."
+    echo "  -P, --password    : Defines password of the cluster. Default value is 'dev-pass'."
+    echo "  -d, --debug       : Prints curl error output."
+    echo "HTTPs related (TLS enabled):"
+    echo "      --https       : Uses HTTPs protocol for REST calls.(no parameter value expected)"
+    echo "      --cacert      : Defines trusted PEM-encoded certificate file path. It's used to verify member certificates."
+    echo "      --cert        : Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used."
+    echo "      --key         : Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used."
+    echo "      --insecure    : Disables member certificate verification. (no parameter value expected)"
+    echo "Operations:"
+    echo "  - 'get-local-member' returns the local CP member information from the accessed Hazelcast member."
+    echo "  - 'get-groups' returns the list of active CP groups."
+    echo "  - 'get-group' expects a CP group name (-c or --group) and returns a its details."
+    echo "  - 'force-destroy-group' destroys a CP group (-c or --group) non-gracefully."
+    echo "     It must be called only when a CP group loses its majority."
+    echo "     All CP data structure proxies created before the force-destroy step will fail."
+    echo "     If you create a new proxy for a CP data structure that is mapped to the destroyed CP group, the CP group will be initialized from scratch."
+    echo "     Please note that you cannot force-destroy the METADATA CP group. If you lose majority of the METADATA CP group, you have to restart the CP subsystem."
+    echo "  - 'get-members' returns the list of active CP members in the cluster."
+    echo "     Please note that even if a CP member has left the cluster, it is not automatically removed from the active CP member list immediately."
+    echo "  - 'remove-member' removes the given CP member (-m) from the active CP member list."
+    echo "     The removed member will be removed from the CP groups as well."
+    echo "     Before removing a CP member, please make sure that the missing member is actually crashed, not partitioned away."
+    echo "  - 'promote-member' promotes the contacted Hazelcast member to the CP member role."
+    echo "  - 'get-sessions' returns the list of CP sessions created in the requested CP group (-c)."
+    echo "  - 'force-close-session' closes the given CP session (-s) on the given CP group (-c)."
+    echo "     Once the CP session is closed, all CP resources (locks, semaphore permits, etc.) will be released."
+    echo "     Before force-closing a CP session, please make sure that owner endpoint of the CP session is crashed and will not show up."
+    echo "  - 'restart' wipes out all CP subsystem state and restarts it from scratch."
+    echo "     Please call this API only on the Hazelcast master member (i.e., the first member in the Hazelcast cluster member list)."
+    echo "     Please make sure that you call this API only once. Once you make the call, please observe the cluster to see if the CP subsystem initialization is successful."
     echo "If you query a non-existing CP group or a CP session, the call fails with 'Not found'."
     echo "If you trigger an operation with invalid credentials, the call fails with 'Invalid credentials'."
     echo "If you trigger an operation with invalid parameters, for instance destroying a non-existing CP group or removing a non-existing CP member, the call fails with 'Bad request'."
-   	exit 0
+    exit 0
 fi
 
 INVALID_ARGUMENT_RETURN_VALUE=1
@@ -46,11 +53,14 @@ NOT_FOUND_RETURN_VALUE=4
 BAD_REQUEST_RETURN_VALUE=5
 INTERNAL_ERROR_RETURN_VALUE=6
 
-while [[ $# -gt 1 ]]
+URL_SCHEME="http"
+CURL_ARGS="--silent -w \n%{http_code}"
+
+while [[ $# -ge 1 ]]
 do
 key="$1"
 case "$key" in
-  	-o|--operation)
+    -o|--operation)
     OPERATION="$2"
     shift # past argument
     ;;
@@ -82,6 +92,24 @@ case "$key" in
     ADDRESS="$2"
     shift # past argument
     ;;
+    -d|--debug)
+    CURL_ARGS="$CURL_ARGS --show-error"
+    ;;
+    --https)
+    URL_SCHEME="https"
+    ;;
+    --cert|--key)
+    CURL_ARGS="$CURL_ARGS $1 $2"
+    shift # past argument
+    ;;
+    --cacert)
+    CURL_ARGS="$CURL_ARGS --capath /dev/null $1 $2"
+    shift # past argument
+    ;;
+    --insecure)
+    echo "WARNING: You're using the insecure switch. Hazelcast member TLS certificates will not be verified!" >&2
+    CURL_ARGS="$CURL_ARGS $1"
+    ;;
     *)
 esac
 shift # past argument or value
@@ -89,8 +117,8 @@ done
 
 
 if [[ -z "$OPERATION" ]]; then
- 	echo "No operation is defined, running script with default operation: 'get-local-member'."
- 	OPERATION="get-local-member"
+    echo "No operation is defined, running script with default operation: 'get-local-member'."
+    OPERATION="get-local-member"
 fi
 
 
@@ -116,18 +144,20 @@ fi
 
 command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit -1; }
 
+URL_BASE="${URL_SCHEME}://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem"
+CURL_CMD="curl $CURL_ARGS"
+
 if [[ "$OPERATION" = "get-local-member" ]]; then
     echo "Getting local CP member information on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/members/local"
- 	response=$(curl -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} "${URL_BASE}/members/local");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "${json}\nOK"
-    	exit 0
+        exit 0
     fi
-	if [[ "$status_code" = "404" ]];then
+    if [[ "$status_code" = "404" ]];then
         echo "Not found";
         exit ${NOT_FOUND_RETURN_VALUE}
     fi
@@ -138,14 +168,13 @@ fi
 
 if [[ "$OPERATION" = "get-groups" ]]; then
     echo "Getting CP group IDs on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/groups"
- 	response=$(curl -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} "${URL_BASE}/groups");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "${json}\nOK"
-    	exit 0
+        exit 0
     fi
 
     echo "Status Code: ${status_code}\nResponse: ${json}\nInternal error!"
@@ -159,14 +188,13 @@ if [[ "$OPERATION" = "get-group" ]]; then
     fi
 
     echo "Getting CP group: ${CP_GROUP_NAME} on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/groups/${CP_GROUP_NAME}"
- 	response=$(curl -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} "${URL_BASE}/groups/${CP_GROUP_NAME}");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "${json}\nOK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "404" ]];then
         echo "Not found"
@@ -179,14 +207,13 @@ fi
 
 if [[ "$OPERATION" = "get-members" ]]; then
     echo "Getting CP members on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/members"
- 	response=$(curl -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} "${URL_BASE}/members");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "${json}\nOK"
-    	exit 0
+        exit 0
     fi
 
     echo "Internal error!\nStatus Code: ${status_code}\nResponse: ${json}"
@@ -200,14 +227,13 @@ if [[ "$OPERATION" = "get-sessions" ]]; then
     fi
 
     echo "Getting CP sessions in CP group: ${CP_GROUP_NAME} on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/groups/${CP_GROUP_NAME}/sessions"
- 	response=$(curl -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} "${URL_BASE}/groups/${CP_GROUP_NAME}/sessions");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "${json}\nOK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "404" ]];then
         echo "Not found"
@@ -225,14 +251,13 @@ if [[ "$OPERATION" = "force-destroy-group" ]]; then
     fi
 
     echo "Force-destroying CP group: ${CP_GROUP_NAME} on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/groups/${CP_GROUP_NAME}/remove"
- 	response=$(curl -X POST --data "${GROUPNAME}&${PASSWORD}" -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/groups/${CP_GROUP_NAME}/remove");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "OK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "400" ]];then
         echo "Bad request"
@@ -240,7 +265,7 @@ if [[ "$OPERATION" = "force-destroy-group" ]]; then
     fi
     if [[ "$status_code" = "403" ]];then
         echo "Invalid credentials"
-    	exit 3
+        exit 3
     fi
 
     echo "Status Code: ${status_code}\nResponse: ${json}\nInternal error!"
@@ -249,18 +274,17 @@ fi
 
 if [[ "$OPERATION" = "promote-member" ]]; then
     echo "Promoting to CP member on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/members"
- 	response=$(curl -X POST --data "${GROUPNAME}&${PASSWORD}" -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/members");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "OK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "403" ]];then
         echo "Invalid credentials"
-    	exit ${INVALID_CREDENTIALS_RETURN_VALUE}
+        exit ${INVALID_CREDENTIALS_RETURN_VALUE}
     fi
 
     echo "Status Code: ${status_code}\nResponse: ${json}\nInternal error!"
@@ -274,14 +298,13 @@ if [[ "$OPERATION" = "remove-member" ]]; then
     fi
 
     echo "Removing CP member: ${CP_MEMBER_UID} on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/members/${CP_MEMBER_UID}/remove"
- 	response=$(curl -X POST --data "${GROUPNAME}&${PASSWORD}" -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/members/${CP_MEMBER_UID}/remove");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "OK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "400" ]];then
         echo "Bad request"
@@ -289,7 +312,7 @@ if [[ "$OPERATION" = "remove-member" ]]; then
     fi
     if [[ "$status_code" = "403" ]];then
         echo "Invalid credentials"
-    	exit ${INVALID_CREDENTIALS_RETURN_VALUE}
+        exit ${INVALID_CREDENTIALS_RETURN_VALUE}
     fi
 
     echo "Status Code: ${status_code}\nResponse: ${json}\nInternal error!"
@@ -308,14 +331,13 @@ if [[ "$OPERATION" = "force-close-session" ]]; then
     fi
 
     echo "Closing CP session: ${CP_SESSION_ID} in CP group: ${CP_GROUP_NAME} ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/groups/${CP_GROUP_NAME}/sessions/${CP_SESSION_ID}/remove"
- 	response=$(curl -X POST --data "${GROUPNAME}&${PASSWORD}" -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/groups/${CP_GROUP_NAME}/sessions/${CP_SESSION_ID}/remove");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "OK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "400" ]];then
         echo "Bad request"
@@ -323,7 +345,7 @@ if [[ "$OPERATION" = "force-close-session" ]]; then
     fi
     if [[ "$status_code" = "403" ]];then
         echo "Invalid credentials"
-    	exit ${INVALID_CREDENTIALS_RETURN_VALUE}
+        exit ${INVALID_CREDENTIALS_RETURN_VALUE}
     fi
 
     echo "Status Code: ${status_code}\nResponse: ${json}\nInternal error!"
@@ -332,18 +354,17 @@ fi
 
 if [[ "$OPERATION" = "restart" ]]; then
     echo "Restarting the CP subsystem on ${ADDRESS}:${PORT}."
-	request="http://${ADDRESS}:${PORT}/hazelcast/rest/cp-subsystem/restart"
- 	response=$(curl -X POST --data "${GROUPNAME}&${PASSWORD}" -w "\n%{http_code}" --silent "${request}");
+    response=$(${CURL_CMD} --data "${GROUPNAME}&${PASSWORD}" "${URL_BASE}/restart");
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
- 	if [[ "$status_code" = "200" ]];then
+    if [[ "$status_code" = "200" ]];then
         echo "OK"
-    	exit 0
+        exit 0
     fi
     if [[ "$status_code" = "403" ]];then
         echo "Invalid credentials"
-    	exit ${INVALID_CREDENTIALS_RETURN_VALUE}
+        exit ${INVALID_CREDENTIALS_RETURN_VALUE}
     fi
 
     echo "Status Code: ${status_code}\nResponse: ${json}\nInternal error!"

--- a/hazelcast/src/main/resources/healthcheck.sh
+++ b/hazelcast/src/main/resources/healthcheck.sh
@@ -7,7 +7,7 @@ print_help() {
     echo "  -p, --port        : Defines which port hazelcast node is running on. Default value is '5701'."
     echo "  -d, --debug       : Prints curl error output."
     echo "HTTPs related (TLS enabled):"
-    echo "      --https       : Uses HTTPs protocol for REST calls.(no parameter value expected)"
+    echo "      --https       : Uses HTTPs protocol for REST calls. (no parameter value expected)"
     echo "      --cacert      : Defines trusted PEM-encoded certificate file path. It's used to verify member certificates."
     echo "      --cert        : Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used."
     echo "      --key         : Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used."

--- a/hazelcast/src/main/resources/healthcheck.sh
+++ b/hazelcast/src/main/resources/healthcheck.sh
@@ -1,10 +1,18 @@
-#!/bin/sh
+#!/bin/bash
 
 print_help() {
     echo "Parameters: "
-    echo "	-o, --operation	    : Health check operation. Operation can be 'all', 'node-state','cluster-state','cluster-safe','migration-queue-size','cluster-size'."
-    echo "	-a, --address  	    : Defines which ip address hazelcast node is running on. Default value is '127.0.0.1'."
-    echo "	-p, --port  	    : Defines which port hazelcast node is running on. Default value is '5701'."
+    echo "  -o, --operation   : Health check operation. Operation can be 'all', 'node-state','cluster-state','cluster-safe','migration-queue-size','cluster-size'."
+    echo "  -a, --address     : Defines which ip address hazelcast node is running on. Default value is '127.0.0.1'."
+    echo "  -p, --port        : Defines which port hazelcast node is running on. Default value is '5701'."
+    echo "  -d, --debug       : Prints curl error output."
+    echo "HTTPs related (TLS enabled):"
+    echo "      --https       : Uses HTTPs protocol for REST calls.(no parameter value expected)"
+    echo "      --cacert      : Defines trusted PEM-encoded certificate file path. It's used to verify member certificates."
+    echo "      --cert        : Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used."
+    echo "      --key         : Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used."
+    echo "      --insecure    : Disables member certificate verification. (no parameter value expected)"
+
 }
 
 command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires 'curl' but it's not installed. Aborting."; exit 1; }
@@ -15,6 +23,9 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     print_help
     exit 0
 fi
+
+URL_SCHEME="http"
+CURL_ARGS="--silent"
 
 while [ $# -gt 0 ]; do
     key="$1"
@@ -30,6 +41,24 @@ while [ $# -gt 0 ]; do
         -a|--address)
             ADDRESS="$2"
             shift
+            ;;
+        -d|--debug)
+            CURL_ARGS="$CURL_ARGS --show-error"
+            ;;
+        --https)
+            URL_SCHEME="https"
+            ;;
+        --cert|--key)
+            CURL_ARGS="$CURL_ARGS $1 $2"
+            shift
+            ;;
+        --cacert)
+            CURL_ARGS="$CURL_ARGS --capath /dev/null $1 $2"
+            shift
+            ;;
+        --insecure)
+            echo "WARNING: You're using the insecure switch. Hazelcast member TLS certificates will not be verified!" >&2
+            CURL_ARGS="$CURL_ARGS $1"
             ;;
         *)
             echo "Unsupported parameter: '${1}'"
@@ -68,8 +97,8 @@ case "$OPERATION" in
         exit 1
 esac
 
-URL="http://${ADDRESS}:${PORT}/hazelcast/health"
-HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" $URL)
+URL="${URL_SCHEME}://${ADDRESS}:${PORT}/hazelcast/health"
+HTTP_RESPONSE=$(curl ${CURL_ARGS} --write-out "HTTPSTATUS:%{http_code}" $URL)
 HTTP_BODY=$(echo "${HTTP_RESPONSE}" | sed -e 's/HTTPSTATUS\:.*//g')
 HTTP_STATUS=$(echo "${HTTP_RESPONSE}" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 


### PR DESCRIPTION
This PR adds HTTPs support to `cluster.sh`, `healthcheck.sh` and `cp-subsystem.sh` management scripts.

Several new arguments are introduced. Their naming mostly copies names in `curl`.

New arguments:

| Argument | Default value | Description |
| ------------- | ------------- | -----------------|
| `--https` | *no argument expected* | Uses HTTPs protocol for REST calls.
| `--cacert` | *set of well-known CA certificates* | Defines trusted PEM-encoded certificate file path. It’s used to verify member certificates.
| `--cert` | None | Defines PEM-encoded client certificate file path. Only needed when client certificate authentication is used.
| `--key` | None | Defines PEM-encoded client private key file path. Only needed when client certificate authentication is used.
| `--insecure` | *no argument expected* | Disables member certificate verification.
| `-d`, `--debug` | *no argument expected* | Prints `curl` error output.
