### PR TITLE
Fix compilation on JDK11

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/AbstractQueueNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/AbstractQueueNullTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractQueueNullTest extends HazelcastTestSupport {
         assertThrowsNPE(q -> q.contains(null));
         assertThrowsNPE(q -> q.drainTo(null));
         assertThrowsNPE(q -> q.drainTo(null, 1));
-        assertThrowsNPE(q -> q.toArray(null));
+        assertThrowsNPE(q -> q.toArray((Object[]) null));
         assertThrowsNPE(q -> q.containsAll(null));
         assertThrowsNPE(q -> q.addAll(null));
         assertThrowsNPE(q -> q.removeAll(null));


### PR DESCRIPTION
JDK11 added
```
    default <T> T[] toArray(IntFunction<T[]> generator) {
        return toArray(generator.apply(0));
    }
```
hence `q.toArray(null)` was ambigious.