### PR TITLE
Use config from parent for LockBasicTest subclasses

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/unsafe/lock/LockBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/unsafe/lock/LockBasicDistributedTest.java
@@ -28,6 +28,6 @@ import org.junit.runner.RunWith;
 public class LockBasicDistributedTest extends LockBasicTest {
     @Override
     protected HazelcastInstance[] newInstances() {
-        return createHazelcastInstanceFactory(2).newInstances();
+        return createHazelcastInstanceFactory(2).newInstances(getConfig());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/unsafe/lock/LockBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/unsafe/lock/LockBasicLocalTest.java
@@ -28,6 +28,6 @@ import org.junit.runner.RunWith;
 public class LockBasicLocalTest extends LockBasicTest {
     @Override
     protected HazelcastInstance[] newInstances() {
-        return createHazelcastInstanceFactory(1).newInstances();
+        return createHazelcastInstanceFactory(1).newInstances(getConfig());
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/hazelcast/hazelcast/pull/15167. LockBasicLocalTest and LockBasicDistributedTest will use config from LockBasicTest to use small instance config.