### PR TITLE
Add efficient UuidSerializer to the list of ConstantSerializers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.ByteArraySerializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_BOOLEAN;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_BOOLEAN_ARRAY;
@@ -42,7 +43,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.C
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SHORT_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_STRING;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_STRING_ARRAY;
-
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_UUID;
 
 public final class ConstantSerializers {
 
@@ -388,6 +389,25 @@ public final class ConstantSerializers {
         @Override
         public void write(final ObjectDataOutput out, final String[] obj) throws IOException {
             out.writeUTFArray(obj);
+        }
+    }
+
+    public static final class UuidSerializer extends SingletonSerializer<UUID> {
+
+        @Override
+        public int getTypeId() {
+            return CONSTANT_TYPE_UUID;
+        }
+
+        @Override
+        public UUID read(final ObjectDataInput in) throws IOException {
+            return new UUID(in.readLong(), in.readLong());
+        }
+
+        @Override
+        public void write(final ObjectDataOutput out, final UUID uuid) throws IOException {
+            out.writeLong(uuid.getMostSignificantBits());
+            out.writeLong(uuid.getLeastSignificantBits());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -63,6 +63,8 @@ public final class SerializationConstants {
 
     public static final int CONSTANT_TYPE_STRING_ARRAY = -20;
 
+    public static final int CONSTANT_TYPE_UUID = -28;
+
     // ------------------------------------------------------------
     // DEFAULT SERIALIZERS
 
@@ -81,7 +83,7 @@ public final class SerializationConstants {
     public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -27;
 
     // NUMBER OF CONSTANT SERIALIZERS...
-    public static final int CONSTANT_SERIALIZERS_LENGTH = 28;
+    public static final int CONSTANT_SERIALIZERS_LENGTH = 29;
 
     // ------------------------------------------------------------
     // JAVA SERIALIZATION

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -49,6 +49,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.BooleanArraySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.CharArraySerializer;
@@ -64,6 +65,7 @@ import static com.hazelcast.internal.serialization.impl.ConstantSerializers.Long
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.ShortArraySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.ShortSerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.StringSerializer;
+import static com.hazelcast.internal.serialization.impl.ConstantSerializers.UuidSerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.TheByteArraySerializer;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.EE_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.IDS_FLAG;
@@ -157,6 +159,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         registerConstant(Float.class, new FloatSerializer());
         registerConstant(Double.class, new DoubleSerializer());
         registerConstant(String.class, new StringSerializer());
+        registerConstant(UUID.class, new UuidSerializer());
         //Arrays of primitives and String
         registerConstant(byte[].class, new TheByteArraySerializer());
         registerConstant(boolean[].class, new BooleanArraySerializer());

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -65,6 +65,7 @@ import java.util.LinkedList;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
@@ -596,6 +597,14 @@ public class SerializationTest extends HazelcastTestSupport {
         VersionedDataSerializable otherObject = ss.toObject(ss.toData(object));
         assertEquals("ObjectDataInput.getVersion should be equal to member version",
                 Version.of(BuildInfoProvider.getBuildInfo().getVersion()), otherObject.getVersion());
+    }
+
+    @Test
+    public void testUuidSerializer() {
+        SerializationService ss = new DefaultSerializationServiceBuilder().build();
+        Random random = new Random();
+        UUID uuid = new UUID(random.nextLong(), random.nextLong());
+        assertEquals(uuid, ss.toObject(ss.toData(uuid)));
     }
 
     private static final class DynamicProxyTestClassLoader extends ClassLoader {


### PR DESCRIPTION
Added an efficient UuidSerializer to the list of ConstantSerializers. A UUID can be serialized to 16 bytes instead of string of 40 chars.