### PR TITLE
Adds invalidation events log to client cache near cache test

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheInvalidationTest.java
@@ -467,8 +467,9 @@ public class ClientCacheNearCacheInvalidationTest extends HazelcastTestSupport {
     private void assertNoFurtherInvalidationThan(final int expectedInvalidationCount) {
         AssertTask assertTask = () -> {
             long invalidationCount = invalidationListener.getInvalidationCount();
-            assertTrue(format("Expected no further Near Cache invalidation events than %d, but received %d (%s)",
-                    expectedInvalidationCount, invalidationCount, testContext.stats),
+            assertTrue(format("Expected no further Near Cache invalidation events than %d, but received %d (%s)\n"
+                            + "(%s)", expectedInvalidationCount, invalidationCount, testContext.stats,
+                    String.join("\n", invalidationListener.getSingleInvalidationEventsLog())),
                     invalidationCount <= expectedInvalidationCount);
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationMetaDataFetcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationMetaDataFetcher.java
@@ -115,8 +115,8 @@ public abstract class InvalidationMetaDataFetcher {
             return;
         }
 
-        repairUuids(resultHolder.partitionUuidList, handlers);
-        repairSequences(resultHolder.namePartitionSequenceList, handlers);
+        repairUuids(resultHolder.getPartitionUuidList(), handlers);
+        repairSequences(resultHolder.getNamePartitionSequenceList(), handlers);
     }
 
     protected void handleExceptionWhileProcessingMetadata(Member member, Exception e) {


### PR DESCRIPTION
This just adds a log of observed invalidation events in ClientCacheNearCacheInvalidationTest to find out where extra invalidation comes from during a failure.

https://github.com/hazelcast/hazelcast-enterprise/issues/2562