### PR TITLE
Makes EntryStore & Loader tests less timing sensitive

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -90,7 +90,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
 
     @Override
     protected Config getConfig() {
-        Config config = super.getConfig();
+        Config config = smallInstanceConfig();
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true).setImplementation(testEntryLoader);
         config.getMapConfig("default")
@@ -101,9 +101,9 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
 
     @Test
     public void testEntryWithExpirationTime_expires() {
-        testEntryLoader.putExternally("key", "val", System.currentTimeMillis() + 2500);
+        testEntryLoader.putExternally("key", "val", System.currentTimeMillis() + 10000);
         assertEquals("val", map.get("key"));
-        sleepAtLeastMillis(2500);
+        sleepAtLeastMillis(10000);
         assertNull(map.get("key"));
     }
 
@@ -123,7 +123,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     public void testLoadAllWithExpirationTimes() {
         final int entryCount = 100;
         for (int i = 0; i < entryCount; i++) {
-            testEntryLoader.putExternally("key" + i, "val" + i, System.currentTimeMillis() + 5000);
+            testEntryLoader.putExternally("key" + i, "val" + i, System.currentTimeMillis() + 10000);
         }
         map.loadAll(false);
 
@@ -164,7 +164,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testGetAllLoadsEntriesWithExpiration() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 5000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
         Set<String> requestedKeys = new HashSet<>();
         for (int i = 0; i < 50; i++) {
             requestedKeys.add("key" + i);
@@ -173,7 +173,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             assertEquals("val" + i, entries.get("key" + i));
         }
-        sleepAtLeastSeconds(6);
+        sleepAtLeastSeconds(10);
         for (int i = 0; i < 50; i++) {
             assertInMemory(instances, map.getName(), "key" + i, null);
         }
@@ -279,7 +279,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testValues() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 5000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
         Collection<String> entries = map.values();
         for (int i = 0; i < entryCount; i++) {
             assertContains(entries, "val" + i);
@@ -290,7 +290,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testValues_withPredicate() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 5000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
         Collection<String> entries = map.values(Predicates.greaterEqual("this", "val90"));
         for (int i = 90; i < entryCount; i++) {
             assertContains(entries, "val" + i);
@@ -301,7 +301,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testEntrySet() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 5000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
         Set<Map.Entry<String, String>> entries = map.entrySet();
         for (int i = 0; i < entryCount; i++) {
             assertContains(entries, new AbstractMap.SimpleEntry<>("key" + i, "val" + i));
@@ -312,7 +312,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testEntrySet_withPredicate() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 5000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
         Set<Map.Entry<String, String>> entries = map.entrySet(Predicates.greaterEqual("__key", "key90"));
         for (int i = 90; i < entryCount; i++) {
             assertContains(entries, new AbstractMap.SimpleEntry<>("key" + i, "val" + i));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
@@ -77,7 +77,7 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
 
     @Override
     protected Config getConfig() {
-        Config config = super.getConfig();
+        Config config = smallInstanceConfig();
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true).setImplementation(testEntryStore);
         config.getMapConfig("default")
@@ -95,27 +95,27 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     @Test
     public void testPut_withTtl() {
         map.put("key", "value", 10, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testPut_withMaxIdle() {
         map.put("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testOverrideValueWithTtl() {
         map.put("key", "value", 10, TimeUnit.DAYS);
         map.put("key", "value2", 5, TimeUnit.DAYS);
-        assertEntryStore("key", "value2", 5, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value2", 5, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testOverrideValueWithMaxIdle() {
         map.put("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS);
         map.put("key", "value2", 10, TimeUnit.DAYS, 1, TimeUnit.DAYS);
-        assertEntryStore("key", "value2", 1, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value2", 1, TimeUnit.DAYS, 10000);
     }
 
     @Test
@@ -139,13 +139,13 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     @Test
     public void testPutAsync_withTtl() throws ExecutionException, InterruptedException {
         map.putAsync("key", "value", 10, TimeUnit.DAYS).get();
-        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testPutAsync_withMaxIdle() throws ExecutionException, InterruptedException {
         map.putAsync("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS).get();
-        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
     }
 
     @Test
@@ -157,13 +157,13 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     @Test
     public void testPutIfAbsent_withTtl() {
         map.putIfAbsent("key", "value", 10, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testPutIfAbsent_withMaxIdle() {
         map.putIfAbsent("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     public void testReplace_withTtl() {
         map.put("key", "value", 10, TimeUnit.DAYS);
         map.replace("key", "replaced");
-        assertEntryStore("key", "replaced", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "replaced", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
@@ -224,7 +224,7 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     public void testReplaceIfSame_withTtl() {
         map.put("key", "value", 10, TimeUnit.DAYS);
         map.replace("key", "value", "replaced");
-        assertEntryStore("key", "replaced", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "replaced", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
@@ -236,13 +236,13 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     @Test
     public void testSet_withTtl() {
         map.set("key", "value", 10, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testSet_withMaxIdle() {
         map.set("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
     }
 
     @Test
@@ -254,20 +254,20 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     @Test
     public void testSetAsync_withTtl() throws ExecutionException, InterruptedException {
         map.setAsync("key", "value", 10, TimeUnit.DAYS).get();
-        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testSetAsync_withMaxIdle() throws ExecutionException, InterruptedException {
         map.setAsync("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS).get();
-        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
     }
 
     @Test
     public void testSetTtl() {
         map.set("key", "value");
         map.setTtl("key", 1, TimeUnit.DAYS);
-        assertEntryStore("key", "value", 1, TimeUnit.DAYS, 5000);
+        assertEntryStore("key", "value", 1, TimeUnit.DAYS, 10000);
     }
 
     @Test


### PR DESCRIPTION
Tests use small instances. Also milliseconds validations are less sensitive.
Fixes https://github.com/hazelcast/hazelcast/issues/15297