### PR TITLE
MapEventJournalExpiringTest: fixed map config (#15295)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalExpiringTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalExpiringTest.java
@@ -44,8 +44,8 @@ public abstract class AbstractEventJournalExpiringTest<EJ_TYPE> extends Hazelcas
     protected HazelcastInstance[] instances;
 
     private int partitionId;
-    private TruePredicate<EJ_TYPE> TRUE_PREDICATE = new TruePredicate<EJ_TYPE>();
-    private Function<EJ_TYPE, EJ_TYPE> IDENTITY_FUNCTION = new IdentityFunction<EJ_TYPE>();
+    private TruePredicate<EJ_TYPE> TRUE_PREDICATE = new TruePredicate<>();
+    private Function<EJ_TYPE, EJ_TYPE> IDENTITY_FUNCTION = new IdentityFunction<>();
 
     private void init() {
         instances = createInstances();
@@ -74,7 +74,7 @@ public abstract class AbstractEventJournalExpiringTest<EJ_TYPE> extends Hazelcas
         final EventJournalTestContext<String, Integer, EJ_TYPE> context = createContext();
 
         String key = randomPartitionKey();
-        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
 
         readFromJournal(context, exception, 0);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/MapEventJournalExpiringTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/MapEventJournalExpiringTest.java
@@ -36,11 +36,10 @@ public class MapEventJournalExpiringTest<K, V> extends AbstractEventJournalExpir
 
     @Override
     protected Config getConfig() {
-        final MapConfig nonExpiringMapConfig = new MapConfig(MAP_NAME)
-                .setInMemoryFormat(getInMemoryFormat());
-
-        return super.getConfig()
-                    .addMapConfig(nonExpiringMapConfig);
+        Config defConfig = super.getConfig();
+        defConfig.getMapConfig(MAP_NAME)
+                 .setInMemoryFormat(getInMemoryFormat());
+        return defConfig;
     }
 
     protected InMemoryFormat getInMemoryFormat() {
@@ -49,10 +48,10 @@ public class MapEventJournalExpiringTest<K, V> extends AbstractEventJournalExpir
 
     @Override
     protected EventJournalTestContext<K, V, EventJournalMapEvent<K, V>> createContext() {
-        return new EventJournalTestContext<K, V, EventJournalMapEvent<K, V>>(
-                new EventJournalMapDataStructureAdapter<K, V>(getRandomInstance().<K, V>getMap(MAP_NAME)),
+        return new EventJournalTestContext<>(
+                new EventJournalMapDataStructureAdapter<>(getRandomInstance().getMap(MAP_NAME)),
                 null,
-                new EventJournalMapEventAdapter<K, V>()
+                new EventJournalMapEventAdapter<>()
         );
     }
 }


### PR DESCRIPTION
Made sure that the map config created in `MapEventJournalExpiringTest`
inherits from the default map config created in the super class.

Relates to PR https://github.com/hazelcast/hazelcast/pull/15185
Fixes https://github.com/hazelcast/hazelcast/issues/15295