### PR TITLE
 LockedEntryCount to include locks on non-existing keys

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapStatsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.multimap;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.monitor.LocalMultiMapStats;
+import com.hazelcast.multimap.LocalMultiMapStatsTest;
+import com.hazelcast.multimap.MultiMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientMultiMapStatsTest extends LocalMultiMapStatsTest {
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private String mapName = "mapName";
+    private HazelcastInstance client;
+    private HazelcastInstance member;
+
+    @Before
+    public void setUp() {
+        member = factory.newHazelcastInstance();
+        client = factory.newHazelcastClient();
+    }
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected LocalMultiMapStats getMultiMapStats() {
+        return member.getMultiMap(mapName).getLocalMultiMapStats();
+    }
+
+    @Override
+    public void testOtherOperationCount_localKeySet() {
+        // localKeySet is not supported on client
+    }
+
+    @Override
+    protected <K, V> MultiMap<K, V> getMultiMap() {
+        return client.getMultiMap(mapName);
+    }
+
+    @Override
+    @Test
+    @Ignore("GH issue 15307")
+    public void testDelete() {
+    }
+
+    @Override
+    @Test
+    @Ignore("GH issue 15307")
+    public void testGetAndHitsGenerated() {
+    }
+
+    @Override
+    @Test
+    @Ignore("GH issue 15307")
+    public void testPutAndHitsGenerated() {
+    }
+
+    @Override
+    @Test
+    @Ignore("GH issue 15307")
+    public void testRemove() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -199,13 +199,18 @@ public class LocalMapStatsProvider {
     }
 
     private static void addPrimaryStatsOf(RecordStore recordStore, LocalMapOnDemandCalculatedStats onDemandStats) {
+        if (recordStore != null) {
+            // we need to update the locked entry count here whether or not the map is empty
+            // keys that are not contained by a map can be locked
+            onDemandStats.incrementLockedEntryCount(recordStore.getLockedEntryCount());
+        }
+
         if (!hasRecords(recordStore)) {
             return;
         }
 
         LocalRecordStoreStats stats = recordStore.getLocalRecordStoreStats();
 
-        onDemandStats.incrementLockedEntryCount(recordStore.getLockedEntryCount());
         onDemandStats.incrementHits(stats.getHits());
         onDemandStats.incrementDirtyEntryCount(recordStore.getMapDataStore().notFinishedOperationsCount());
         onDemandStats.incrementOwnedEntryMemoryCost(recordStore.getOwnedEntryCost());

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -102,7 +102,9 @@ public interface LocalMapStats extends LocalInstanceStats {
     long getHits();
 
     /**
-     * Returns the number of currently locked locally owned keys.
+     * Returns the number of currently locked keys. The returned count
+     * includes locks on keys whether or not they are present in the map,
+     * since it is allowed to lock on keys that are not present.
      *
      * @return number of locked entries.
      */

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -202,7 +202,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
     }
 
     public Set<Data> localKeySet(String name) {
-        Set<Data> keySet = new HashSet<Data>();
+        Set<Data> keySet = new HashSet<>();
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
             IPartition partition = nodeEngine.getPartitionService().getPartition(i);
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
@@ -447,7 +447,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
     @Override
     public Map<String, LocalMultiMapStats> getStats() {
-        Map<String, LocalMultiMapStats> multiMapStats = new HashMap<String, LocalMultiMapStats>();
+        Map<String, LocalMultiMapStats> multiMapStats = new HashMap<>();
         for (MultiMapPartitionContainer partitionContainer : partitionContainers) {
             for (String name : partitionContainer.containerMap.keySet()) {
                 if (!multiMapStats.containsKey(name)) {
@@ -524,7 +524,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
                     int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
 
-                    List<MultiMapMergeContainer> mergeContainers = new ArrayList<MultiMapMergeContainer>(batchSize);
+                    List<MultiMapMergeContainer> mergeContainers = new ArrayList<>(batchSize);
                     for (Map.Entry<Data, MultiMapValue> multiMapValueEntry : container.getMultiMapValues().entrySet()) {
                         Data key = multiMapValueEntry.getKey();
                         MultiMapValue multiMapValue = multiMapValueEntry.getValue();
@@ -537,7 +537,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
                         if (mergeContainers.size() == batchSize) {
                             sendBatch(partitionId, name, mergePolicy, mergeContainers);
-                            mergeContainers = new ArrayList<MultiMapMergeContainer>(batchSize);
+                            mergeContainers = new ArrayList<>(batchSize);
                         }
                     }
                     if (mergeContainers.size() > 0) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.multimap.impl;
 
-import com.hazelcast.cp.internal.datastructures.unsafe.lock.LockService;
-import com.hazelcast.cp.internal.datastructures.unsafe.lock.LockStoreInfo;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
+import com.hazelcast.cp.internal.datastructures.unsafe.lock.LockService;
+import com.hazelcast.cp.internal.datastructures.unsafe.lock.LockStoreInfo;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.monitor.LocalMultiMapStats;
@@ -36,13 +36,10 @@ import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
-import com.hazelcast.spi.partition.FragmentedMigrationAwareService;
+import com.hazelcast.spi.LockInterceptorService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.partition.PartitionMigrationEvent;
-import com.hazelcast.spi.partition.PartitionReplicationEvent;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ServiceNamespace;
@@ -50,10 +47,14 @@ import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
+import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MultiMapMergeTypes;
+import com.hazelcast.spi.partition.FragmentedMigrationAwareService;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.MigrationEndpoint;
+import com.hazelcast.spi.partition.PartitionMigrationEvent;
+import com.hazelcast.spi.partition.PartitionReplicationEvent;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
@@ -85,8 +86,9 @@ import static java.lang.Thread.currentThread;
 
 @SuppressWarnings({"checkstyle:classfanoutcomplexity", "checkstyle:methodcount"})
 public class MultiMapService implements ManagedService, RemoteService, FragmentedMigrationAwareService,
-        EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsAwareService<LocalMultiMapStats>,
-        QuorumAwareService, SplitBrainHandlerService {
+                                        EventPublishingService<EventData, EntryListener>, TransactionalService,
+                                        StatisticsAwareService<LocalMultiMapStats>,
+                                        QuorumAwareService, SplitBrainHandlerService, LockInterceptorService<Data> {
 
     public static final String SERVICE_NAME = "hz:impl:multiMapService";
 
@@ -382,9 +384,9 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         int backupCount = config.getTotalBackupCount();
 
         Address thisAddress = clusterService.getThisAddress();
-        for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
-            IPartition partition = nodeEngine.getPartitionService().getPartition(i, false);
-            MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
+        for (int partitionId = 0; partitionId < nodeEngine.getPartitionService().getPartitionCount(); partitionId++) {
+            IPartition partition = nodeEngine.getPartitionService().getPartition(partitionId, false);
+            MultiMapPartitionContainer partitionContainer = getPartitionContainer(partitionId);
             MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name);
             if (multiMapContainer == null) {
                 continue;
@@ -489,6 +491,14 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         MultiMapContainerCollector collector = new MultiMapContainerCollector(nodeEngine, partitionContainers);
         collector.run();
         return new Merger(collector);
+    }
+
+    @Override
+    public void onBeforeLock(String distributedObjectName, Data key) {
+        int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
+        MultiMapPartitionContainer partitionContainer = getPartitionContainer(partitionId);
+        // we have no use for the return value, invoked just for the side-effects
+        partitionContainer.getOrCreateMultiMapContainer(distributedObjectName);
     }
 
     private class Merger extends AbstractContainerMerger<MultiMapContainer, Collection<Object>, MultiMapMergeTypes> {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -63,7 +63,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testHitsGenerated() throws Exception {
+    public void testHitsGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
@@ -74,7 +74,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutAndHitsGenerated() throws Exception {
+    public void testPutAndHitsGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
@@ -86,7 +86,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutIfAbsentAndHitsGenerated() throws Exception {
+    public void testPutIfAbsentAndHitsGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.putIfAbsent(i, i);
@@ -98,7 +98,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutAsync() throws Exception {
+    public void testPutAsync() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.putAsync(i, i);
@@ -114,7 +114,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testGetAndHitsGenerated() throws Exception {
+    public void testGetAndHitsGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
@@ -126,7 +126,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutAllGenerated() throws Exception {
+    public void testPutAllGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             Map<Integer, Integer> putMap = new HashMap<Integer, Integer>(2);
@@ -139,7 +139,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testGetAllGenerated() throws Exception {
+    public void testGetAllGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 200; i++) {
             map.put(i, i);
@@ -174,7 +174,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    public void testDelete() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
@@ -307,7 +307,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testRemove() throws Exception {
+    public void testRemove() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
@@ -318,7 +318,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testRemoveAsync() throws Exception {
+    public void testRemoveAsync() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
@@ -335,7 +335,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testHitsGenerated_updatedConcurrently() throws Exception {
+    public void testHitsGenerated_updatedConcurrently() {
         final IMap<Integer, Integer> map = getMap();
         final int actionCount = 100;
         for (int i = 0; i < actionCount; i++) {
@@ -385,7 +385,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testLastAccessTime_updatedConcurrently() throws InterruptedException {
+    public void testLastAccessTime_updatedConcurrently() {
         final long startTime = Clock.currentTimeMillis();
         final IMap<String, String> map = getMap();
 
@@ -416,7 +416,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testEvictAll() throws Exception {
+    public void testEvictAll() {
         IMap<String, String> map = getMap();
         map.put("key", "value");
         map.evictAll();
@@ -547,5 +547,27 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
 
         LocalMapStats stats = getMapStats();
         assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testLockedEntryCount_emptyMap() {
+        IMap<String, String> map = getMap();
+
+        map.lock("non-existent-key");
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(1, stats.getLockedEntryCount());
+    }
+
+    @Test
+    public void testLockedEntryCount_mapWithOneEntry() {
+        IMap<String, String> map = getMap();
+
+        map.put("key", "value");
+        map.lock("key");
+        map.lock("non-existent-key");
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(2, stats.getLockedEntryCount());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -104,13 +103,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.putAsync(i, i);
         }
         final LocalMapStats localMapStats = getMapStats();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(100, localMapStats.getPutOperationCount());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(100, localMapStats.getPutOperationCount()));
     }
 
     @Test
@@ -129,7 +122,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     public void testPutAllGenerated() {
         IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
-            Map<Integer, Integer> putMap = new HashMap<Integer, Integer>(2);
+            Map<Integer, Integer> putMap = new HashMap<>(2);
             putMap.put(i, i);
             putMap.put(100 + i, 100 + i);
             map.putAll(putMap);
@@ -145,7 +138,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
         }
         for (int i = 0; i < 100; i++) {
-            Set<Integer> keys = new HashSet<Integer>();
+            Set<Integer> keys = new HashSet<>();
             keys.add(i);
             keys.add(100 + i);
             map.getAll(keys);
@@ -162,14 +155,10 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.getAsync(i).get();
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                final LocalMapStats localMapStats = getMapStats();
-                assertEquals(100, localMapStats.getGetOperationCount());
-                assertEquals(100, localMapStats.getHits());
-            }
+        assertTrueEventually(() -> {
+            final LocalMapStats localMapStats = getMapStats();
+            assertEquals(100, localMapStats.getGetOperationCount());
+            assertEquals(100, localMapStats.getHits());
         });
     }
 
@@ -251,16 +240,13 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.setAsync(i, i);
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                LocalMapStats localMapStats = getMapStats();
-                assertEquals(0, localMapStats.getPutOperationCount());
-                assertEquals(260, localMapStats.getSetOperationCount());
-                assertEquals(130, localMapStats.getHits());
-                assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
-                assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
-            }
+        assertTrueEventually(() -> {
+            LocalMapStats localMapStats = getMapStats();
+            assertEquals(0, localMapStats.getPutOperationCount());
+            assertEquals(260, localMapStats.getSetOperationCount());
+            assertEquals(130, localMapStats.getHits());
+            assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+            assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
         });
     }
 
@@ -272,16 +258,13 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.setAsync(i, i, 1, TimeUnit.MINUTES);
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                LocalMapStats localMapStats = getMapStats();
-                assertEquals(0, localMapStats.getPutOperationCount());
-                assertEquals(114, localMapStats.getSetOperationCount());
-                assertEquals(57, localMapStats.getHits());
-                assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
-                assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
-            }
+        assertTrueEventually(() -> {
+            LocalMapStats localMapStats = getMapStats();
+            assertEquals(0, localMapStats.getPutOperationCount());
+            assertEquals(114, localMapStats.getSetOperationCount());
+            assertEquals(57, localMapStats.getHits());
+            assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+            assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
         });
     }
 
@@ -293,16 +276,13 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.setAsync(i, i, 1, TimeUnit.MINUTES, 1, TimeUnit.MINUTES);
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                LocalMapStats localMapStats = getMapStats();
-                assertEquals(0, localMapStats.getPutOperationCount());
-                assertEquals(200, localMapStats.getSetOperationCount());
-                assertEquals(100, localMapStats.getHits());
-                assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
-                assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
-            }
+        assertTrueEventually(() -> {
+            LocalMapStats localMapStats = getMapStats();
+            assertEquals(0, localMapStats.getPutOperationCount());
+            assertEquals(200, localMapStats.getSetOperationCount());
+            assertEquals(100, localMapStats.getHits());
+            assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+            assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
         });
     }
 
@@ -325,13 +305,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.removeAsync(i);
         }
         final LocalMapStats localMapStats = getMapStats();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(100, localMapStats.getRemoveOperationCount());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(100, localMapStats.getRemoveOperationCount()));
     }
 
     @Test
@@ -345,24 +319,15 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         final LocalMapStats localMapStats = getMapStats();
         final long initialHits = localMapStats.getHits();
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                for (int i = 0; i < actionCount; i++) {
-                    map.get(i);
-                }
-                getMapStats(); // causes the local stats object to update
+        new Thread(() -> {
+            for (int i = 0; i < actionCount; i++) {
+                map.get(i);
             }
+            getMapStats(); // causes the local stats object to update
         }).start();
 
         assertEquals(actionCount, initialHits);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(actionCount * 2, localMapStats.getHits());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(actionCount * 2, localMapStats.getHits()));
     }
 
     @Test
@@ -396,23 +361,14 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         final LocalMapStats localMapStats = getMapStats();
         final long lastUpdateTime = localMapStats.getLastUpdateTime();
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                sleepAtLeastMillis(1);
-                map.put(key, "value2");
-                getMapStats(); // causes the local stats object to update
-            }
+        new Thread(() -> {
+            sleepAtLeastMillis(1);
+            map.put(key, "value2");
+            getMapStats(); // causes the local stats object to update
         }).start();
 
         assertTrue(lastUpdateTime >= startTime);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertTrue(localMapStats.getLastUpdateTime() > lastUpdateTime);
-            }
-        });
+        assertTrueEventually(() -> assertTrue(localMapStats.getLastUpdateTime() > lastUpdateTime));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/multimap/LocalMultiMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/LocalMultiMapStatsTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.LocalMultiMapStats;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class LocalMultiMapStatsTest extends HazelcastTestSupport {
+
+    private static final int OPERATION_COUNT = 10;
+
+    private HazelcastInstance instance;
+    private String mapName = "mapName";
+
+    @Before
+    public void setUp() {
+        instance = createHazelcastInstance(getConfig());
+    }
+
+    protected LocalMultiMapStats getMultiMapStats() {
+        return instance.getMultiMap(mapName).getLocalMultiMapStats();
+    }
+
+    protected <K, V> MultiMap<K, V> getMultiMap() {
+        warmUpPartitions(instance);
+        return instance.getMultiMap(mapName);
+    }
+
+    @Test
+    public void testHitsGenerated() {
+        MultiMap<Integer, Integer> map = getMultiMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.get(i);
+        }
+        LocalMapStats localMapStats = getMultiMapStats();
+        assertEquals(100, localMapStats.getHits());
+    }
+
+    @Test
+    public void testPutAndHitsGenerated() {
+        MultiMap<Integer, Integer> map = getMultiMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.get(i);
+        }
+        LocalMapStats localMapStats = getMultiMapStats();
+        assertEquals(100, localMapStats.getPutOperationCount());
+        assertEquals(100, localMapStats.getHits());
+    }
+
+    @Test
+    public void testGetAndHitsGenerated() {
+        MultiMap<Integer, Integer> map = getMultiMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.get(i);
+        }
+        LocalMapStats localMapStats = getMultiMapStats();
+        assertEquals(100, localMapStats.getGetOperationCount());
+        assertEquals(100, localMapStats.getHits());
+    }
+
+    @Test
+    public void testDelete() {
+        MultiMap<Integer, Integer> map = getMultiMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.delete(i);
+        }
+        LocalMapStats localMapStats = getMultiMapStats();
+        assertEquals(100, localMapStats.getRemoveOperationCount());
+    }
+
+    @Test
+    public void testRemove() {
+        MultiMap<Integer, Integer> map = getMultiMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.remove(i);
+        }
+        LocalMapStats localMapStats = getMultiMapStats();
+        assertEquals(100, localMapStats.getRemoveOperationCount());
+    }
+
+    @Test
+    public void testHitsGenerated_updatedConcurrently() {
+        final MultiMap<Integer, Integer> map = getMultiMap();
+        final int actionCount = 100;
+        for (int i = 0; i < actionCount; i++) {
+            map.put(i, i);
+            map.get(i);
+        }
+        final LocalMapStats localMapStats = getMultiMapStats();
+        final long initialHits = localMapStats.getHits();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < actionCount; i++) {
+                    map.get(i);
+                }
+                getMultiMapStats(); // causes the local stats object to update
+            }
+        }).start();
+
+        assertEquals(actionCount, initialHits);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(actionCount * 2, localMapStats.getHits());
+            }
+        });
+    }
+
+    @Test
+    public void testLastAccessTime() throws InterruptedException {
+        final long startTime = Clock.currentTimeMillis();
+
+        MultiMap<String, String> map = getMultiMap();
+
+        String key = "key";
+        map.put(key, "value");
+        map.get(key);
+
+        long lastAccessTime = getMultiMapStats().getLastAccessTime();
+        assertTrue(lastAccessTime >= startTime);
+
+        Thread.sleep(5);
+        map.put(key, "value2");
+        long lastAccessTime2 = getMultiMapStats().getLastAccessTime();
+        assertTrue(lastAccessTime2 > lastAccessTime);
+    }
+
+    @Test
+    public void testLastAccessTime_updatedConcurrently() {
+        final long startTime = Clock.currentTimeMillis();
+        final MultiMap<String, String> map = getMultiMap();
+
+        final String key = "key";
+        map.put(key, "value");
+        map.put(key, "value");
+
+        final LocalMapStats localMapStats = getMultiMapStats();
+        final long lastUpdateTime = localMapStats.getLastUpdateTime();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                sleepAtLeastMillis(1);
+                map.put(key, "value2");
+                getMultiMapStats(); // causes the local stats object to update
+            }
+        }).start();
+
+        assertTrue(lastUpdateTime >= startTime);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(localMapStats.getLastUpdateTime() > lastUpdateTime);
+            }
+        });
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_containsKey() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsKey(i);
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_entrySet() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.entrySet();
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_keySet() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.keySet();
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_localKeySet() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.localKeySet();
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_values() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.values();
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_clear() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.clear();
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_containsValue() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsValue(1);
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    @Ignore("GH issue 15307")
+    public void testOtherOperationCount_size() {
+        MultiMap map = getMultiMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.size();
+        }
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testLockedEntryCount_emptyMultiMap() {
+        MultiMap<String, String> map = getMultiMap();
+
+        map.lock("non-existent-key");
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(1, stats.getLockedEntryCount());
+    }
+
+    @Test
+    public void testLockedEntryCount_multiMapWithOneEntry() {
+        MultiMap<String, String> map = getMultiMap();
+
+        map.put("key", "value");
+        map.lock("key");
+        map.lock("non-existent-key");
+
+        LocalMapStats stats = getMultiMapStats();
+        assertEquals(2, stats.getLockedEntryCount());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/multimap/LocalMultiMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/LocalMultiMapStatsTest.java
@@ -124,24 +124,15 @@ public class LocalMultiMapStatsTest extends HazelcastTestSupport {
         final LocalMapStats localMapStats = getMultiMapStats();
         final long initialHits = localMapStats.getHits();
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                for (int i = 0; i < actionCount; i++) {
-                    map.get(i);
-                }
-                getMultiMapStats(); // causes the local stats object to update
+        new Thread(() -> {
+            for (int i = 0; i < actionCount; i++) {
+                map.get(i);
             }
+            getMultiMapStats(); // causes the local stats object to update
         }).start();
 
         assertEquals(actionCount, initialHits);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(actionCount * 2, localMapStats.getHits());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(actionCount * 2, localMapStats.getHits()));
     }
 
     @Test
@@ -175,23 +166,14 @@ public class LocalMultiMapStatsTest extends HazelcastTestSupport {
         final LocalMapStats localMapStats = getMultiMapStats();
         final long lastUpdateTime = localMapStats.getLastUpdateTime();
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                sleepAtLeastMillis(1);
-                map.put(key, "value2");
-                getMultiMapStats(); // causes the local stats object to update
-            }
+        new Thread(() -> {
+            sleepAtLeastMillis(1);
+            map.put(key, "value2");
+            getMultiMapStats(); // causes the local stats object to update
         }).start();
 
         assertTrue(lastUpdateTime >= startTime);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertTrue(localMapStats.getLastUpdateTime() > lastUpdateTime);
-            }
-        });
+        assertTrueEventually(() -> assertTrue(localMapStats.getLastUpdateTime() > lastUpdateTime));
     }
 
     @Test


### PR DESCRIPTION
The fix includes changes in `IMap` and `MultiMap`:
- Count locked keys in `IMap` stats regardless of `RecordStore`'s emptiness
- Make `MultiMapService` to implement `LockInterceptorService` SPI to create
`MultiMapContainer` before locking
- Add `LocalMultiMapStatsTest` and client counterpart

Fixes #15218
Raised https://github.com/hazelcast/hazelcast/issues/15307
Backport: #15311 