### PR TITLE
Make comparators able to act on keys and values

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1271,11 +1271,18 @@ public class ClientMapProxy<K, V> extends ClientProxy
         return setBuilder.build();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public Set<K> keySet(Predicate predicate) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         if (containsPagingPredicate(predicate)) {
-            return keySetWithPagingPredicate(predicate);
+            PagingPredicate pagingPredicate = unwrapPagingPredicate(predicate);
+            if (pagingPredicate.getComparator() == null) {
+                return keySetWithPagingPredicate(predicate);
+            } else {
+                // custom comparator may act on keys and values at the same time
+                return entrySetWithPagingPredicate(predicate, IterationType.KEY);
+            }
         }
 
         ClientMessage request = MapKeySetWithPredicateCodec.encodeRequest(name, toData(predicate));
@@ -1309,10 +1316,11 @@ public class ClientMapProxy<K, V> extends ClientProxy
         return (Set<K>) getSortedQueryResultSet(resultList, pagingPredicate, IterationType.KEY);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public Set<Entry<K, V>> entrySet(Predicate predicate) {
         if (containsPagingPredicate(predicate)) {
-            return entrySetWithPagingPredicate(predicate);
+            return entrySetWithPagingPredicate(predicate, IterationType.ENTRY);
         }
         ClientMessage request = MapEntriesWithPredicateCodec.encodeRequest(name, toData(predicate));
 
@@ -1328,8 +1336,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         return setBuilder.build();
     }
 
-    @SuppressWarnings("unchecked")
-    private Set<Entry<K, V>> entrySetWithPagingPredicate(Predicate predicate) {
+    private Set entrySetWithPagingPredicate(Predicate predicate, IterationType iterationType) {
         PagingPredicate pagingPredicate = unwrapPagingPredicate(predicate);
 
         pagingPredicate.setIterationType(IterationType.ENTRY);
@@ -1346,8 +1353,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
             V value = toObject(entry.getValue());
             resultList.add(new AbstractMap.SimpleEntry<K, V>(key, value));
         }
-        Set result = getSortedQueryResultSet(resultList, pagingPredicate, IterationType.ENTRY);
-        return (Set<Entry<K, V>>) result;
+        return getSortedQueryResultSet(resultList, pagingPredicate, iterationType);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
@@ -50,6 +50,7 @@ import java.util.Random;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -444,6 +445,33 @@ public class ClientPagingPredicateTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void testCustomComparatorAbleToActOnKeysAndValues() {
+        Set<Integer> keys = map.keySet(new PagingPredicate<Integer, Integer>(new CustomComparator(), pageSize));
+        assertEquals(pageSize, keys.size());
+        int counter = 0;
+        for (Integer key : keys) {
+            assertEquals(counter++, (int) key);
+        }
+
+        Collection<Integer> values = map.values(new PagingPredicate<Integer, Integer>(new CustomComparator(), pageSize));
+        assertEquals(pageSize, values.size());
+        counter = 0;
+        for (Integer value : values) {
+            assertEquals(counter++, (int) value);
+        }
+
+        Set<Map.Entry<Integer, Integer>> entries =
+                map.entrySet(new PagingPredicate<Integer, Integer>(new CustomComparator(), pageSize));
+        assertEquals(pageSize, entries.size());
+        counter = 0;
+        for (Map.Entry<Integer, Integer> entry : entries) {
+            assertEquals(counter, (int) entry.getKey());
+            assertEquals(counter, (int) entry.getValue());
+            ++counter;
+        }
+    }
+
     private static class TestComparator implements Comparator<Map.Entry<Integer, Integer>>, Serializable {
 
         int ascending = 1;
@@ -573,5 +601,19 @@ public class ClientPagingPredicateTest extends HazelcastTestSupport {
         }
 
     }
+
+    static class CustomComparator implements Comparator<Map.Entry<Integer, Integer>>, Serializable {
+
+        @Override
+        public int compare(Map.Entry<Integer, Integer> a, Map.Entry<Integer, Integer> b) {
+            assertNotNull(a.getKey());
+            assertNotNull(a.getValue());
+            assertNotNull(b.getKey());
+            assertNotNull(b.getValue());
+            return a.getKey() - b.getValue();
+        }
+
+    }
+
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
@@ -231,8 +231,14 @@ public class QueryEngineImpl implements QueryEngine {
     private IterationType getRetrievalIterationType(Predicate predicate, IterationType iterationType) {
         IterationType retrievalIterationType = iterationType;
         if (predicate instanceof PagingPredicate) {
-            // in case of value, we also need to get the keys for sorting.
-            retrievalIterationType = (iterationType == IterationType.VALUE) ? IterationType.ENTRY : iterationType;
+            PagingPredicate pagingPredicate = (PagingPredicate) predicate;
+            if (pagingPredicate.getComparator() != null) {
+                // custom comparators may act on keys and values at the same time
+                retrievalIterationType = IterationType.ENTRY;
+            } else {
+                // in case of value, we also need to get the keys for sorting
+                retrievalIterationType = iterationType == IterationType.VALUE ? IterationType.ENTRY : iterationType;
+            }
         }
         return retrievalIterationType;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -311,6 +312,33 @@ public class PagingPredicateTest extends HazelcastTestSupport {
         assertEquals(0, resultSize);
     }
 
+    @Test
+    public void testCustomComparatorAbleToActOnKeysAndValues() {
+        Set<Integer> keys = map.keySet(new PagingPredicate<Integer, Integer>(new CustomComparator(), pageSize));
+        assertEquals(pageSize, keys.size());
+        int counter = 0;
+        for (Integer key : keys) {
+            assertEquals(counter++, (int) key);
+        }
+
+        Collection<Integer> values = map.values(new PagingPredicate<Integer, Integer>(new CustomComparator(), pageSize));
+        assertEquals(pageSize, values.size());
+        counter = 0;
+        for (Integer value : values) {
+            assertEquals(counter++, (int) value);
+        }
+
+        Set<Map.Entry<Integer, Integer>> entries =
+                map.entrySet(new PagingPredicate<Integer, Integer>(new CustomComparator(), pageSize));
+        assertEquals(pageSize, entries.size());
+        counter = 0;
+        for (Map.Entry<Integer, Integer> entry : entries) {
+            assertEquals(counter, (int) entry.getKey());
+            assertEquals(counter, (int) entry.getValue());
+            ++counter;
+        }
+    }
+
     static class TestComparator implements Comparator<Map.Entry<Integer, Integer>>, Serializable {
 
         int ascending = 1;
@@ -341,4 +369,18 @@ public class PagingPredicateTest extends HazelcastTestSupport {
             }
         }
     }
+
+    static class CustomComparator implements Comparator<Map.Entry<Integer, Integer>>, Serializable {
+
+        @Override
+        public int compare(Map.Entry<Integer, Integer> a, Map.Entry<Integer, Integer> b) {
+            assertNotNull(a.getKey());
+            assertNotNull(a.getValue());
+            assertNotNull(b.getKey());
+            assertNotNull(b.getValue());
+            return a.getKey() - b.getValue();
+        }
+
+    }
+
 }


### PR DESCRIPTION
A custom paging predicate comparator may act on keys and values at the
same time even if only the keys were requested, e.g. using `IMap.keySet`
call. Before this fix only keys were fetched for `IMap.keySet`, making
comparators unable to act on values.