### PR TITLE
Dedicated IO threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.Config;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSet;
@@ -133,6 +134,10 @@ public class HazelcastProperties {
             }
         }
 
+        Function<HazelcastProperties, ?> function = property.getFunction();
+        if (function != null) {
+            return "" + function.apply(this);
+        }
         return property.getDefaultValue();
     }
 
@@ -254,7 +259,7 @@ public class HazelcastProperties {
      * Returns the configured value of a {@link HazelcastProperty} converted to milliseconds if
      * it is positive, otherwise returns the passed default value.
      *
-     * @param property the {@link HazelcastProperty} to get the value from
+     * @param property     the {@link HazelcastProperty} to get the value from
      * @param defaultValue the default value to return if property has non positive value.
      * @return the value in milliseconds if it is positive, otherwise the passed default value.
      * @throws IllegalArgumentException if the {@link HazelcastProperty} has no {@link TimeUnit}

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.properties;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static java.lang.String.format;
@@ -30,10 +31,21 @@ public final class HazelcastProperty {
     private final String defaultValue;
     private final TimeUnit timeUnit;
     private final HazelcastProperty parent;
+    private final Function<HazelcastProperties, ?> function;
     private volatile String deprecatedName;
 
     public HazelcastProperty(String name) {
         this(name, (String) null);
+    }
+
+    public HazelcastProperty(String name, Function<HazelcastProperties, ?> function) {
+        checkHasText(name, "The property name cannot be null or empty!");
+        this.name = name;
+        this.function = function;
+        this.defaultValue = null;
+        this.deprecatedName = null;
+        this.parent = null;
+        this.timeUnit = null;
     }
 
     public HazelcastProperty(String name, boolean defaultValue) {
@@ -72,6 +84,7 @@ public final class HazelcastProperty {
         checkHasText(name, "The property name cannot be null or empty!");
         this.name = name;
         this.defaultValue = defaultValue;
+        this.function = null;
         this.timeUnit = timeUnit;
         this.parent = parent;
     }
@@ -82,7 +95,7 @@ public final class HazelcastProperty {
      * This method is thread-safe, but is expected to be called immediately after the HazelcastProperty is constructed.
      *
      * <code>
-     *     HazelcastProperty property = new HazelcastProperty("newname").setDeprecatedName("oldname");
+     * HazelcastProperty property = new HazelcastProperty("newname").setDeprecatedName("oldname");
      * </code>
      *
      * @param deprecatedName the deprecated name of the property
@@ -92,6 +105,10 @@ public final class HazelcastProperty {
     public HazelcastProperty setDeprecatedName(String deprecatedName) {
         this.deprecatedName = checkHasText(deprecatedName, "a valid string should be provided");
         return this;
+    }
+
+    public Function<HazelcastProperties, ?> getFunction() {
+        return function;
     }
 
     public String getDeprecatedName() {


### PR DESCRIPTION
If default configuration and many core box is detected (20+), then
reduce the number of partition thread count by the number of
io threads so they won't interfere with each other.

This PRD also increases the number of IO threads by one if 20 or more cores are detected.

So in case of a 36 core system:
4+4=8 IO threads
36-8=28 partition threads.

This is a heuristic that prefers key/value based setups. In case of number crunching (e.g. aggregation), having less partition threads than cores could have a negative impact on performance because it isn't possible to fully utilize all cores.