### PR TITLE
Optimize shutdown for on-heap indexes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -58,7 +58,7 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
     protected void onStoreCollection(RecordStore recordStore) {
         assertRunningOnPartitionThread();
 
-        ((DefaultRecordStore) recordStore).clearOtherDataThanStorage(true);
+        ((DefaultRecordStore) recordStore).clearOtherDataThanStorage(false, true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1215,7 +1215,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public void clearPartition(boolean onShutdown, boolean onStorageDestroy) {
         clearLockStore();
-        clearOtherDataThanStorage(onStorageDestroy);
+        clearOtherDataThanStorage(onShutdown, onStorageDestroy);
 
         if (onShutdown) {
             if (hasPooledMemoryAllocator()) {
@@ -1242,9 +1242,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
      * Only cleans the data other than storage-data that is held on this record
      * store. Other services data like lock-service-data is not cleared here.
      */
-    public void clearOtherDataThanStorage(boolean onStorageDestroy) {
+    public void clearOtherDataThanStorage(boolean onShutdown, boolean onStorageDestroy) {
         clearMapStore();
-        clearIndexedData(onStorageDestroy);
+        clearIndexedData(onShutdown, onStorageDestroy);
     }
 
     private void destroyStorageImmediate(boolean isDuringShutdown, boolean internal) {
@@ -1286,18 +1286,22 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     /**
      * Only indexed data will be removed, index info will stay.
      */
-    private void clearIndexedData(boolean onStorageDestroy) {
-        clearGlobalIndexes();
+    private void clearIndexedData(boolean onShutdown, boolean onStorageDestroy) {
+        clearGlobalIndexes(onShutdown);
         clearPartitionedIndexes(onStorageDestroy);
     }
 
-    private void clearGlobalIndexes() {
+    private void clearGlobalIndexes(boolean onShutdown) {
         Indexes indexes = mapContainer.getIndexes(partitionId);
         if (indexes.isGlobal()) {
-            if (indexes.haveAtLeastOneIndex()) {
-                // clears indexed data of this partition
-                // from shared global index.
-                fullScanLocalDataToClear(indexes);
+            if (onShutdown) {
+                indexes.destroyIndexes();
+            } else {
+                if (indexes.haveAtLeastOneIndex()) {
+                    // clears indexed data of this partition
+                    // from shared global index.
+                    fullScanLocalDataToClear(indexes);
+                }
             }
         }
     }


### PR DESCRIPTION
There is no point in cleaning on-heap global indexes on a per partition
basis on shutdown, so we are just destroying global indexes as a whole
on instance shutdown.

Fixes: https://github.com/hazelcast/hazelcast/issues/15340