### PR TITLE
Fixed ambiguous toArray call for JDK11

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/AbstractListNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/AbstractListNullTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractListNullTest extends HazelcastTestSupport {
     @Test
     public void testNullability() {
         assertThrowsNPE(l -> l.contains(null));
-        assertThrowsNPE(l -> l.toArray(null));
+        assertThrowsNPE(l -> l.toArray((Object[]) null));
         assertThrowsNPE(l -> l.add(null));
         assertThrowsNPE(l -> l.remove(null));
         assertThrowsNPE(l -> l.containsAll(null));

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/AbstractSetNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/AbstractSetNullTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractSetNullTest extends HazelcastTestSupport {
     @Test
     public void testNullability() {
         assertThrowsNPE(s -> s.contains(null));
-        assertThrowsNPE(s -> s.toArray(null));
+        assertThrowsNPE(s -> s.toArray((Object[]) null));
         assertThrowsNPE(s -> s.add(null));
         assertThrowsNPE(s -> s.remove(null));
         assertThrowsNPE(s -> s.containsAll(null));


### PR DESCRIPTION
Ambiguous call in JDK11, both toArray(Object[]) from List, toArray(IntFunction<T[]>) from Collection match.