### PR TITLE
Adds Java 13 to JavaVersion

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -28,7 +28,8 @@ public enum JavaVersion {
     JAVA_9,
     JAVA_10,
     JAVA_11,
-    JAVA_12;
+    JAVA_12,
+    JAVA_13;
 
     private static final JavaVersion CURRENT_VERSION = detectCurrentVersion();
 
@@ -36,8 +37,9 @@ public enum JavaVersion {
      * Check if the current runtime version is at least the given version.
      *
      * @param version version to be compared against the current runtime version
-     * @return Return true if current runtime version of Java is the same or greater than given version.
-     *         When the passed version is {@link #UNKNOWN} then it always returns true.
+     * @return {@code true} if current runtime version of Java is the same or greater than given version.
+     *         When the passed version is {@link #UNKNOWN} or the current runtime version cannot be detected
+     *         then it always returns true.
      */
     public static boolean isAtLeast(JavaVersion version) {
         return isAtLeast(CURRENT_VERSION, version);
@@ -82,12 +84,14 @@ public enum JavaVersion {
             result = JAVA_11;
         } else if (version.startsWith("12")) {
             result = JAVA_12;
+        } else if (version.startsWith("13")) {
+            result = JAVA_13;
         }
         return result;
     }
 
     static boolean isAtLeast(JavaVersion currentVersion, JavaVersion minVersion) {
-        return currentVersion.ordinal() >= minVersion.ordinal();
+        return currentVersion.ordinal() >= minVersion.ordinal() || currentVersion == UNKNOWN;
     }
 
     static boolean isAtMost(JavaVersion currentVersion, JavaVersion minVersion) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_10;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_12;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_13;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_1_6;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_1_7;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_1_8;
@@ -53,18 +54,21 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertEquals(JAVA_11, JavaVersion.parseVersion("11"));
         assertEquals(JAVA_12, JavaVersion.parseVersion("12-ea"));
         assertEquals(JAVA_12, JavaVersion.parseVersion("12"));
+        assertEquals(JAVA_13, JavaVersion.parseVersion("13-ea"));
+        assertEquals(JAVA_13, JavaVersion.parseVersion("13"));
     }
 
     @Test
     public void testIsAtLeast_unknown() {
         assertTrue(JavaVersion.isAtLeast(UNKNOWN, UNKNOWN));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_7));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_8));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_9));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_10));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_11));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_12));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_7));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_8));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_9));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_10));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_11));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_12));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_13));
     }
 
     @Test
@@ -77,6 +81,7 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_10));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_11));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_12));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_13));
     }
 
     @Test
@@ -88,6 +93,8 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_9));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_10));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_11));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_12));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_13));
     }
 
     @Test
@@ -99,6 +106,8 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_9));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_10));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_11));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_12));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_13));
     }
 
     @Test
@@ -110,6 +119,8 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtLeast(JAVA_9, JAVA_9));
         assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_10));
         assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_11));
+        assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_12));
+        assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_13));
     }
 
     @Test
@@ -121,14 +132,16 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtLeast(JAVA_10, JAVA_9));
         assertTrue(JavaVersion.isAtLeast(JAVA_11, JAVA_10));
         assertTrue(JavaVersion.isAtLeast(JAVA_12, JAVA_11));
+        assertTrue(JavaVersion.isAtLeast(JAVA_13, JAVA_12));
 
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_7));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_8));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_9));
         assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_10));
         assertFalse(JavaVersion.isAtLeast(JAVA_10, JAVA_11));
         assertFalse(JavaVersion.isAtLeast(JAVA_11, JAVA_12));
+        assertFalse(JavaVersion.isAtLeast(JAVA_12, JAVA_13));
     }
 
     @Test
@@ -139,6 +152,8 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtMost(JAVA_9, JAVA_10));
         assertTrue(JavaVersion.isAtMost(JAVA_11, JAVA_12));
         assertTrue(JavaVersion.isAtMost(JAVA_12, JAVA_12));
+        assertTrue(JavaVersion.isAtMost(JAVA_12, JAVA_13));
+        assertTrue(JavaVersion.isAtMost(JAVA_13, JAVA_13));
 
         assertFalse(JavaVersion.isAtMost(JAVA_1_7, JAVA_1_6));
         assertFalse(JavaVersion.isAtMost(JAVA_1_8, JAVA_1_7));
@@ -146,5 +161,6 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertFalse(JavaVersion.isAtMost(JAVA_10, JAVA_9));
         assertFalse(JavaVersion.isAtMost(JAVA_11, JAVA_10));
         assertFalse(JavaVersion.isAtMost(JAVA_12, JAVA_11));
+        assertFalse(JavaVersion.isAtMost(JAVA_13, JAVA_12));
     }
 }


### PR DESCRIPTION
Also changes behavior of `JavaVersion.isAtLeast` to return `true` when the
detected current runtime version is `UNKNOWN`.
Reasoning: failure to detect runtime version should not occur with older
java versions (since the `java.version` property format is documented)
but will certainly occur with newer Java versions (eg when JDK 14 is
released). To avoid having runtime functionality that relies on
`JavaVersion.isAtLeast` broken with each new major Java release, `UNKNOWN`
as a detected current runtime version is considered to be at least any
other version.

Fixes #15348 on `maintenance-3.x` branch