### PR TITLE
[#15346] Fix deserialization filtering for Externalizables and Deadlock in Map index

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/serialization/ExternalizableDeserializationProtectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/serialization/ExternalizableDeserializationProtectionTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.serialization;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import example.serialization.TestExternalizableDeserialized;
+
+/**
+ * Tests untrusted deserialization protection for Externalizables.
+ *
+ * <pre>
+ * Given: Hazelcast member and clients are started.
+ * </pre>
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ExternalizableDeserializationProtectionTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    protected static TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @AfterClass
+    public static final void stopHazelcastInstances() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Before
+    public void killAllHazelcastInstances() throws IOException {
+        hazelcastFactory.terminateAll();
+        TestExternalizableDeserialized.isDeserialized = false;
+    }
+
+    @Test
+    public void testExternalizableProtectedOnMember() {
+        JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig()
+                .setDefaultsDisabled(true);
+        javaSerializationFilterConfig.getBlacklist().addClasses(TestExternalizableDeserialized.class.getName());
+
+        Config config = smallInstanceConfig();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(javaSerializationFilterConfig);
+        // the index will force deserialization
+        config.getMapConfig("test").addMapIndexConfig(new MapIndexConfig("name", false));
+        hazelcastFactory.newHazelcastInstance(config);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        expected.expect(HazelcastSerializationException.class);
+        client.getMap("test").put("key", new TestExternalizableDeserialized());
+    }
+
+    @Test
+    public void testExternalizableProtectedOnClient() {
+        JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig()
+                .setDefaultsDisabled(true);
+        javaSerializationFilterConfig.getBlacklist().addClasses(TestExternalizableDeserialized.class.getName());
+
+        Config config = smallInstanceConfig();
+        hazelcastFactory.newHazelcastInstance(config);
+
+        ClientConfig clientConfig1 = new ClientConfig();
+        HazelcastInstance client1 = hazelcastFactory.newHazelcastClient(clientConfig1);
+        client1.getMap("test").put("key", new TestExternalizableDeserialized());
+        // we don't have an index on map, so the value should not be deserialized
+        assertFalse(TestExternalizableDeserialized.isDeserialized);
+        // deserialized on client
+        client1.getMap("test").get("key");
+        assertTrue(TestExternalizableDeserialized.isDeserialized);
+        TestExternalizableDeserialized.isDeserialized = false;
+
+        ClientConfig clientConfig2 = new ClientConfig();
+        clientConfig2.getSerializationConfig().setJavaSerializationFilterConfig(javaSerializationFilterConfig);
+        HazelcastInstance client2 = hazelcastFactory.newHazelcastClient(clientConfig2);
+        expected.expect(HazelcastSerializationException.class);
+        client2.getMap("test").get("key");
+    }
+
+    @Test
+    public void testExternalizableUnprotected() {
+        Config config = smallInstanceConfig();
+        config.getMapConfig("test").addMapIndexConfig(new MapIndexConfig("name", false));
+        hazelcastFactory.newHazelcastInstance(config);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        client.getMap("test").put("key", new TestExternalizableDeserialized());
+        assertTrue(TestExternalizableDeserialized.isDeserialized);
+        TestExternalizableDeserialized.isDeserialized = false;
+        client.getMap("test").get("key");
+        assertTrue(TestExternalizableDeserialized.isDeserialized);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -173,6 +173,9 @@ public final class JavaDefaultSerializers {
         }
 
         private Externalizable read(InputStream in, String className, ClassLoader classLoader) throws Exception {
+            if (classFilter != null) {
+                classFilter.filter(className);
+            }
             Externalizable ds = ClassLoaderUtil.newInstance(classLoader, className);
             ObjectInputStream objectInputStream = newObjectInputStream(classLoader, classFilter, in);
             ds.readExternal(objectInputStream);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
@@ -148,7 +148,13 @@ public final class Records {
 
         //we managed to lock the record for ourselves
         Object valueAfterCas = record.getValue();
-        Object object = serializationService.toObject(valueBeforeCas);
+        Object object = null;
+        try {
+            object = serializationService.toObject(valueBeforeCas);
+        } catch (Exception e) {
+            record.casCachedValue(currentThread, null);
+            throw e;
+        }
         if (valueAfterCas == valueBeforeCas) {
             //this check is needed to make sure a partition thread had not changed the value
             //right before we won the CAS

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -16,22 +16,11 @@
 
 package com.hazelcast.cluster;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.config.JavaSerializationFilterConfig;
-import com.hazelcast.config.JoinConfig;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.instance.impl.HazelcastInstanceFactory;
-import com.hazelcast.internal.serialization.impl.SerializationConstants;
-import com.hazelcast.nio.Packet;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.OverridePropertyRule;
-import com.hazelcast.test.annotation.QuickTest;
-import example.serialization.TestDeserialized;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,9 +30,22 @@ import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.nio.IOUtil.closeResource;
-import static com.hazelcast.test.OverridePropertyRule.clear;
-import static org.junit.Assert.assertFalse;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.internal.serialization.impl.SerializationConstants;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import example.serialization.TestDeserialized;
 
 /**
  * Tests if deserialization blacklisting works for MulticastService.
@@ -51,9 +53,6 @@ import static org.junit.Assert.assertFalse;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class MulticastDeserializationTest {
-
-    @Rule
-    public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear("hazelcast.local.localAddress");
 
     private static final int MULTICAST_PORT = 53535;
     private static final String MULTICAST_GROUP = "224.0.0.219";
@@ -74,7 +73,7 @@ public class MulticastDeserializationTest {
      */
     @Test
     public void test() throws Exception {
-        Config config = getConfig();
+        Config config = createConfig(true);
         Hazelcast.newHazelcastInstance(config);
 
         sendJoinDatagram(new TestDeserialized());
@@ -82,15 +81,26 @@ public class MulticastDeserializationTest {
         assertFalse("Untrusted deserialization is possible", TestDeserialized.isDeserialized);
     }
 
-    private Config getConfig() {
-        JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig()
-                .setDefaultsDisabled(true);
-        javaSerializationFilterConfig.getBlacklist()
-                .addClasses(TestDeserialized.class.getName());
+    @Test
+    public void testWithoutFilter() throws Exception {
+        Config config = createConfig(false);
+        Hazelcast.newHazelcastInstance(config);
 
-        Config config = new Config();
-        config.getSerializationConfig()
-                .setJavaSerializationFilterConfig(javaSerializationFilterConfig);
+        sendJoinDatagram(new TestDeserialized());
+        Thread.sleep(500L);
+        assertTrueEventually(() -> assertTrue("Object was not deserializaed", TestDeserialized.isDeserialized));
+    }
+
+    private Config createConfig(boolean withFilter) {
+        Config config = smallInstanceConfig();
+        if (withFilter) {
+            JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig()
+                    .setDefaultsDisabled(true);
+            javaSerializationFilterConfig.getBlacklist()
+                    .addClasses(TestDeserialized.class.getName());
+            config.getSerializationConfig()
+                    .setJavaSerializationFilterConfig(javaSerializationFilterConfig);
+        }
         JoinConfig join = config.getNetworkConfig().getJoin();
         join.getTcpIpConfig()
                 .setEnabled(false);
@@ -114,7 +124,6 @@ public class MulticastDeserializationTest {
         MulticastSocket multicastSocket = null;
         try {
             multicastSocket = new MulticastSocket(MULTICAST_PORT);
-            multicastSocket.setInterface(InetAddress.getLocalHost());
             multicastSocket.setTimeToLive(MULTICAST_TTL);
             InetAddress group = InetAddress.getByName(MULTICAST_GROUP);
             multicastSocket.joinGroup(group);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -87,8 +87,7 @@ public class MulticastDeserializationTest {
         Hazelcast.newHazelcastInstance(config);
 
         sendJoinDatagram(new TestDeserialized());
-        Thread.sleep(500L);
-        assertTrueEventually(() -> assertTrue("Object was not deserializaed", TestDeserialized.isDeserialized));
+        assertTrueEventually(() -> assertTrue("Object was not deserialized", TestDeserialized.isDeserialized));
     }
 
     private Config createConfig(boolean withFilter) {

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/AbstractListNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/AbstractListNullTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractListNullTest extends HazelcastTestSupport {
     @Test
     public void testNullability() {
         assertThrowsNPE(l -> l.contains(null));
-        assertThrowsNPE(l -> l.toArray(null));
+        assertThrowsNPE(l -> l.toArray((Object[]) null));
         assertThrowsNPE(l -> l.add(null));
         assertThrowsNPE(l -> l.remove(null));
         assertThrowsNPE(l -> l.containsAll(null));

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/AbstractSetNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/AbstractSetNullTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractSetNullTest extends HazelcastTestSupport {
     @Test
     public void testNullability() {
         assertThrowsNPE(s -> s.contains(null));
-        assertThrowsNPE(s -> s.toArray(null));
+        assertThrowsNPE(s -> s.toArray((Object[]) null));
         assertThrowsNPE(s -> s.add(null));
         assertThrowsNPE(s -> s.remove(null));
         assertThrowsNPE(s -> s.containsAll(null));

--- a/hazelcast/src/test/java/example/serialization/TestExternalizableDeserialized.java
+++ b/hazelcast/src/test/java/example/serialization/TestExternalizableDeserialized.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class TestExternalizableDeserialized implements Externalizable {
+
+    public static volatile boolean isDeserialized = false;
+
+    // field used for indexing in IMap
+    private String name = "foo";
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        isDeserialized = true;
+    }
+}


### PR DESCRIPTION
Fixes #15346 and also leaking record lock in the `Records`  class.