### PR TITLE
Ignore HazelcastStarterTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MergePolicyProviderConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MergePolicyProviderConstructorTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.test.starter.HazelcastStarter;
 import com.hazelcast.test.starter.constructor.MergePolicyProviderConstructor;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,6 +41,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
+@Ignore("To be enabled in 4.1 with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15263")
 public class MergePolicyProviderConstructorTest extends HazelcastTestSupport {
 
     private HazelcastInstance hz;

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastStarterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastStarterTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
+@Ignore("To be enabled in 4.1 with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15263")
 public class HazelcastStarterTest {
 
     private HazelcastInstance hz;


### PR DESCRIPTION
Testing HazelcastStarter with 3.x instances in some tests is broken
due to incompatible changes in 4.0 as expected.

Fixes #15263 