### PR TITLE
Handle UNKNOWN current runtime version in JavaVersion.isAtLeast

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -38,8 +38,9 @@ public enum JavaVersion {
      * Check if the current runtime version is at least the given version.
      *
      * @param version version to be compared against the current runtime version
-     * @return Return true if current runtime version of Java is the same or greater than given version.
-     *         When the passed version is {@link #UNKNOWN} then it always returns true.
+     * @return {@code true} if current runtime version of Java is the same or greater than given version.
+     *         When the passed version is {@link #UNKNOWN} or the current runtime version cannot be detected
+     *         then it always returns true.
      */
     public static boolean isAtLeast(JavaVersion version) {
         return isAtLeast(CURRENT_VERSION, version);
@@ -93,7 +94,7 @@ public enum JavaVersion {
     }
 
     static boolean isAtLeast(JavaVersion currentVersion, JavaVersion minVersion) {
-        return currentVersion.ordinal() >= minVersion.ordinal();
+        return currentVersion.ordinal() >= minVersion.ordinal() || currentVersion == UNKNOWN;
     }
 
     static boolean isAtMost(JavaVersion currentVersion, JavaVersion maxVersion) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
@@ -64,15 +64,15 @@ public class JavaVersionTest extends HazelcastTestSupport {
     @Test
     public void testIsAtLeast_unknown() {
         assertTrue(JavaVersion.isAtLeast(UNKNOWN, UNKNOWN));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_7));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_8));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_9));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_10));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_11));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_12));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_13));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_14));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_7));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_8));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_9));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_10));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_11));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_12));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_13));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_14));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtLeast(JAVA_13, JAVA_12));
         assertTrue(JavaVersion.isAtLeast(JAVA_14, JAVA_13));
 
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_7));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_8));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_9));


### PR DESCRIPTION
Changes behavior of `JavaVersion.isAtLeast` to return `true` when the
detected current runtime version is `UNKNOWN`.
Reasoning: failure to detect runtime version should not occur with older
java versions (since the java.version property format is documented)
but will certainly occur with newer Java versions (eg when JDK 1x is
released). To avoid having runtime functionality that relies on
`JavaVersion.isAtLeast` broken with each new major Java release, `UNKNOWN`
as a detected current runtime version is considered to be at least any
other version.

This change existed in #15357 and was discussed for inclusion in #15354 