### PR TITLE
REST API: Support for updating the license (forward-port from 3.12)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -501,4 +501,8 @@ public class DefaultNodeExtension implements NodeExtension {
     protected void createAndSetPhoneHome() {
         this.phoneHome = new PhoneHome(node);
     }
+
+    public void setLicenseKey(String licenseKey) {
+        // NOP
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/HazelcastMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/HazelcastMBean.java
@@ -63,12 +63,23 @@ public abstract class HazelcastMBean<T> implements DynamicMBean, MBeanRegistrati
         this.updateIntervalSec = service.instance.node.getProperties().getLong(GroupProperty.JMX_UPDATE_INTERVAL_SECONDS);
     }
 
-    public void register(HazelcastMBean mbean) {
+    public static void register(HazelcastMBean mbean) {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         try {
             mbs.registerMBean(mbean, mbean.objectName);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static void unregister(HazelcastMBean mbean) {
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        if (mbs.isRegistered(mbean.objectName)) {
+            try {
+                mbs.unregisterMBean(mbean.objectName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.management;
 import com.hazelcast.internal.management.dto.MapConfigDTO;
 import com.hazelcast.internal.management.dto.PermissionConfigDTO;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
+import com.hazelcast.internal.management.operation.SetLicenseOperation;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
 import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
 import com.hazelcast.internal.management.operation.UpdatePermissionConfigOperation;
@@ -42,8 +43,9 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
     public static final int MAP_CONFIG_DTO = 3;
     public static final int UPDATE_PERMISSION_CONFIG_OPERATION = 4;
     public static final int PERMISSION_CONFIG_DTO = 5;
+    public static final int SET_LICENSE = 6;
 
-    private static final int LEN = PERMISSION_CONFIG_DTO + 1;
+    private static final int LEN = SET_LICENSE + 1;
 
     @Override
     public int getFactoryId() {
@@ -62,6 +64,7 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
         constructors[MAP_CONFIG_DTO] = arg -> new MapConfigDTO();
         constructors[UPDATE_PERMISSION_CONFIG_OPERATION] = arg -> new UpdatePermissionConfigOperation();
         constructors[PERMISSION_CONFIG_DTO] = arg -> new PermissionConfigDTO();
+        constructors[SET_LICENSE] = arg -> new SetLicenseOperation();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/SetLicenseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/SetLicenseOperation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.operation;
+
+import com.hazelcast.instance.impl.DefaultNodeExtension;
+import com.hazelcast.internal.management.ManagementDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.io.IOException;
+
+/**
+ * Operation to update license at runtime.
+ */
+public class SetLicenseOperation extends AbstractManagementOperation {
+
+    private String licenseKey;
+
+    public SetLicenseOperation() {
+    }
+
+    public SetLicenseOperation(String licenseKey) {
+        this.licenseKey = licenseKey;
+    }
+
+    @Override
+    public void run() throws Exception {
+        DefaultNodeExtension nodeExtension
+                = (DefaultNodeExtension) ((NodeEngineImpl) getNodeEngine()).getNode().getNodeExtension();
+        nodeExtension.setLicenseKey(licenseKey);
+    }
+
+    @Override
+    public int getClassId() {
+        return ManagementDataSerializerHook.SET_LICENSE;
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        licenseKey = in.readUTF();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(licenseKey);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JsonUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JsonUtil.java
@@ -332,6 +332,8 @@ public final class JsonUtil {
             return '"' + (String) value + '"';
         } else if (value instanceof Collection) {
             return "[" + toJsonCollection((Collection) value) + "]";
+        } else if (value instanceof JsonValue) {
+            return value.toString();
         } else {
             throw new IllegalArgumentException("Unable to convert " + value + " to JSON");
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiFilter.java
@@ -92,7 +92,7 @@ public class RestApiFilter implements TextProtocolFilter {
         if (requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER)
                 || requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER_STATE_URL)
                 || requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER_NODES_URL)
-                || requestUri.startsWith(HttpCommandProcessor.URI_LICENSE_INFO)
+                || ("GET".equals(operation) && requestUri.startsWith(HttpCommandProcessor.URI_LICENSE_INFO))
                 || ("GET".equals(operation) && requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER_VERSION_URL))
                 || requestUri.startsWith(HttpCommandProcessor.URI_INSTANCE)) {
             return RestEndpointGroup.CLUSTER_READ;

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -171,6 +171,11 @@ public class HTTPCommunicator {
         return doGet(url).response;
     }
 
+    public ConnectionResponse setLicense(String groupName, String groupPassword, String licenseKey) throws IOException {
+        String url = address + "license";
+        return doPost(url, groupName, groupPassword, licenseKey);
+    }
+
     public int getFailingClusterHealthWithTrailingGarbage() throws IOException {
         String url = "http:/" + baseRestAddress + HttpCommandProcessor.URI_HEALTH_URL + "garbage";
         return doGet(url).responseCode;

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -364,4 +364,15 @@ public class RestClusterTest {
         int healthReadyResponseCode = communicator.getHealthReadyResponseCode();
         assertEquals(HttpURLConnection.HTTP_OK, healthReadyResponseCode);
     }
+
+    @Test
+    public void testSetLicenseKey() throws Exception {
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        HTTPCommunicator.ConnectionResponse response =
+                communicator.setLicense(config.getGroupConfig().getName(), getPassword(), "whatever");
+        assertEquals(HttpURLConnection.HTTP_OK, response.responseCode);
+        assertEquals(response.response, "{\"status\":\"success\"}");
+    }
 }


### PR DESCRIPTION
Added REST API infrastructure for updating the license
of a running member.
(cherry picked from commit f3da482c9c81916cda352165c0b5f97b66333941)

Added SetLicenseOperation and implementated
setting of the license in HttpPostCommandProcessor.
Added unregister(HazelcastMBean) to HazelcastMBeans.
(cherry picked from commit a117453a0406725f5a57ed97da3e677dfa3177b6)

Renamed DefaultNodeExtension.setLicense() to setLicenseKey()
(cherry picked from commit 48c6ab14841786335ae55a9dcc7608828f28c32d)

Removed a lambda expression
(cherry picked from commit 52b0ec31be8d09c22ff8347995c9a2aa061fa2de)

Added Javadoc to SetLicenseOperation
(cherry picked from commit 8b18f342dee375444e0c25738651c64ed22e7330)