### PR TITLE
Remove partitionId from client executor submit

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
@@ -32,8 +32,7 @@ public final class ExecutorServiceSubmitToPartitionCodec {
     public static final int REQUEST_MESSAGE_TYPE = 591104;
     //hex: 0x090501
     public static final int RESPONSE_MESSAGE_TYPE = 591105;
-    private static final int REQUEST_PARTITION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
+    private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = CORRELATION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
 
     private ExecutorServiceSubmitToPartitionCodec() {
@@ -56,21 +55,15 @@ public final class ExecutorServiceSubmitToPartitionCodec {
          * The callable object to be executed.
          */
         public com.hazelcast.nio.serialization.Data callable;
-
-        /**
-         * The id of the partition which the callable shall be executed on.
-         */
-        public int partitionId;
     }
 
-    public static ClientMessage encodeRequest(java.lang.String name, java.lang.String uuid, com.hazelcast.nio.serialization.Data callable, int partitionId) {
+    public static ClientMessage encodeRequest(java.lang.String name, java.lang.String uuid, com.hazelcast.nio.serialization.Data callable) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
         clientMessage.setAcquiresResource(false);
         clientMessage.setOperationName("ExecutorService.SubmitToPartition");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
-        encodeInt(initialFrame.content, REQUEST_PARTITION_ID_FIELD_OFFSET, partitionId);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
         StringCodec.encode(clientMessage, uuid);
@@ -81,8 +74,8 @@ public final class ExecutorServiceSubmitToPartitionCodec {
     public static ExecutorServiceSubmitToPartitionCodec.RequestParameters decodeRequest(ClientMessage clientMessage) {
         ListIterator<ClientMessage.Frame> iterator = clientMessage.listIterator();
         RequestParameters request = new RequestParameters();
-        ClientMessage.Frame initialFrame = iterator.next();
-        request.partitionId = decodeInt(initialFrame.content, REQUEST_PARTITION_ID_FIELD_OFFSET);
+        //empty initial frame
+        iterator.next();
         request.name = StringCodec.decode(iterator);
         request.uuid = StringCodec.decode(iterator);
         request.callable = DataCodec.decode(iterator);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.executorservice;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceSubmitToPartitionCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.executor.impl.operations.CallableTaskOperation;
@@ -26,30 +26,18 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.SecurityContext;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import javax.security.auth.Subject;
 import java.security.Permission;
 import java.util.concurrent.Callable;
 
 public class ExecutorServiceSubmitToPartitionMessageTask
-        extends AbstractInvocationMessageTask<ExecutorServiceSubmitToPartitionCodec.RequestParameters>
+        extends AbstractPartitionMessageTask<ExecutorServiceSubmitToPartitionCodec.RequestParameters>
         implements ExecutionCallback {
 
     public ExecutorServiceSubmitToPartitionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
-    }
-
-    @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        if (parameters.partitionId == -1) {
-            throw new IllegalArgumentException("Partition ID is -1");
-        }
-
-        final OperationServiceImpl operationService = nodeEngine.getOperationService();
-        return operationService.createInvocationBuilder(getServiceName(), op, parameters.partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.proxy;
 
+import com.hazelcast.client.impl.ClientDelegatingFuture;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceIsShutdownCodec;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceShutdownCodec;
@@ -26,18 +27,17 @@ import com.hazelcast.client.impl.spi.ClientPartitionService;
 import com.hazelcast.client.impl.spi.ClientProxy;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
-import com.hazelcast.client.impl.ClientDelegatingFuture;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MemberSelector;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.IExecutorService;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.cluster.MemberSelector;
 import com.hazelcast.core.MultiExecutionCallback;
-import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.executor.CompletedFuture;
@@ -396,8 +396,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
         String uuid = getUUID();
         int partitionId = getPartitionId(key);
-        ClientMessage request =
-                ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task, partitionId);
+        ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
         return checkSync(f, uuid, partitionId, false, defaultValue);
     }
@@ -406,7 +405,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         checkNotNull(task, "task should not be null");
         String uuid = getUUID();
         int partitionId = getPartitionId(key);
-        ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task, partitionId);
+        ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
 
         ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
@@ -420,8 +419,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
         String uuid = getUUID();
         int partitionId = randomPartitionId();
-        ClientMessage request =
-                ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task, partitionId);
+        ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
         return checkSync(f, uuid, partitionId, preventSync, defaultValue);
     }
@@ -431,8 +429,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
         String uuid = getUUID();
         int partitionId = randomPartitionId();
-        ClientMessage request =
-                ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task, partitionId);
+        ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
         ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
                 message -> ExecutorServiceSubmitToPartitionCodec.decodeResponse(message).response);


### PR DESCRIPTION
Partition id is already available on  the client messages.
As a general rule, requests should not carry a partition id
as a second parameter.