### PR TITLE
[BACKPORT] Fixes transfer of MapConfig fields when dynamically added from client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -70,6 +70,8 @@ public class AddMapConfigMessageTask
         config.setHotRestartConfig(parameters.hotRestartConfig);
         config.setInMemoryFormat(InMemoryFormat.valueOf(parameters.inMemoryFormat));
         config.setMapAttributeConfigs(parameters.mapAttributeConfigs);
+        config.setReadBackupData(parameters.readBackupData);
+        config.setStatisticsEnabled(parameters.statisticsEnabled);
         if (parameters.mapEvictionPolicy != null) {
             MapEvictionPolicy evictionPolicy = serializationService.toObject(parameters.mapEvictionPolicy);
             config.setMapEvictionPolicy(evictionPolicy);

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -903,7 +903,9 @@ public class DynamicConfigTest extends HazelcastTestSupport {
                 .setQuorumName(randomString())
                 .addMapAttributeConfig(new MapAttributeConfig("attributeName", "com.attribute.extractor"))
                 .addMapIndexConfig(new MapIndexConfig("attr", true))
-                .setMetadataPolicy(MetadataPolicy.OFF);
+                .setMetadataPolicy(MetadataPolicy.OFF)
+                .setReadBackupData(true)
+                .setStatisticsEnabled(false);
     }
 
     private MapConfig getMapConfig_withEntryListenerImplementation() {


### PR DESCRIPTION
`readBackupData` and `statisticsEnabled` were not taken into account when
a new `MapConfig` was added dynamically from a client

Fixes #15382 on `maintenance-3.x`