### PR TITLE
Fix NPE in WanConsistencyCheckIgnoredEvent

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanAntiEntropyEventBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanAntiEntropyEventBase.java
@@ -35,7 +35,7 @@ public abstract class AbstractWanAntiEntropyEventBase extends AbstractWanEventBa
     @Override
     public JsonObject toJson() {
         JsonObject json = super.toJson();
-        json.add("uuid", uuid.toString());
+        json.add("uuid", uuid != null ? uuid.toString() : "null");
         return json;
     }
 }


### PR DESCRIPTION
`WanConsistencyCheckIgnoredEvent` is sent to MC if
- OS WAN is used,
- EE is used, but merkle trees are not enabled.

In these cases, we fail fast, without assigning a `UUID` to the consistency check request. `AbstractWanAntiEntropyEventBase.toJson` however expects a non-null UUID and throws NPE. It is
fixed now by sending `null` as `UUID`.

These MC events don't have tests and the NPE was caught on the
MC side. MC replaces the JSON-based communication in 4.0, hence
currently no point in adding new tests to these JSON-based classes.