### PR TITLE
com.hz.spi classes/interface privateapi

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.version.Version;
@@ -30,6 +31,7 @@ import com.hazelcast.version.Version;
  *
  * @param <S>
  */
+@PrivateApi
 public abstract class AbstractDistributedObject<S extends RemoteService> implements DistributedObject {
 
     protected static final PartitioningStrategy PARTITIONING_STRATEGY = StringPartitioningStrategy.INSTANCE;

--- a/hazelcast/src/main/java/com/hazelcast/spi/CanCancelOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CanCancelOperations.java
@@ -17,10 +17,12 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * Implemented by a service that can cancel its operations.
  */
+@PrivateApi
 public interface CanCancelOperations {
     /**
      * Notifies this service that an operation was requested to be cancelled. The caller is not aware which

--- a/hazelcast/src/main/java/com/hazelcast/spi/ClientAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ClientAwareService.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * A interface that can be implemented by a SPI Service so that it can be notified about client disconnects.
  * <p>
  * This is useful if a service needs to cleanup resources when a client leaves, e.g. release locks.
  */
+@PrivateApi
 public interface ClientAwareService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ConfigurableService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ConfigurableService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * A capability for SPI services. So if your SPI service needs to be configured, implement this method. It will get the
  * configured properties injected.
  *
  * @param <T>
  */
+@PrivateApi
 public interface ConfigurableService<T> {
 
     void configure(T configObject);

--- a/hazelcast/src/main/java/com/hazelcast/spi/DistributedObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DistributedObjectNamespace.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.io.IOException;
  *
  * @since 3.9
  */
+@PrivateApi
 public final class DistributedObjectNamespace implements ObjectNamespace, IdentifiedDataSerializable {
 
     private String service;

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventFilter.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * A predicate that can filter out events.
  */
+@PrivateApi
 public interface EventFilter {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventPublishingService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * A service for publishing events. For example a Topic that receives an message (the event)
  * and dispatches it to a listener.
@@ -23,6 +25,7 @@ package com.hazelcast.spi;
  * @param <E> the event type
  * @param <T> the event listener type
  */
+@PrivateApi
 public interface EventPublishingService<E, T> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventRegistration.java
@@ -18,10 +18,12 @@ package com.hazelcast.spi;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * The result of a Event Registration.
  */
+@PrivateApi
 public interface EventRegistration extends IdentifiedDataSerializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
  * Component responsible for handling events like topic events or map.listener events. The events are divided into topics.
  */
+@PrivateApi
 public interface EventService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi;
 
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.map.MapLoader;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
  *
  * It also has functionality for scheduling tasks.
  */
+@PrivateApi
 public interface ExecutionService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/GracefulShutdownAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/GracefulShutdownAwareService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * An interface that can be implemented by SPI services to participate in graceful shutdown process, such as moving
  * their internal data to another node or releasing their allocated resources gracefully.
  */
+@PrivateApi
 public interface GracefulShutdownAwareService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/InitializingObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InitializingObject.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Can be implemented by DistributedObject (proxies) to indicate that they want to be initialized.
  */
+@PrivateApi
 public interface InitializingObject {
 
     void initialize();

--- a/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * A {@link com.hazelcast.core.ICompletableFuture} with more functionality like getting
@@ -24,6 +25,7 @@ import com.hazelcast.core.ICompletableFuture;
  *
  * @param <E>
  */
+@PrivateApi
 public interface InternalCompletableFuture<E> extends ICompletableFuture<E> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Contract point for {@link com.hazelcast.spi.EventFilter} instances these wrap listeners.
  */
+@PrivateApi
 public interface ListenerWrapperEventFilter extends EventFilter {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/LockInterceptorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/LockInterceptorService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Interface to be implemented by services that need to intercept lock operation
  * for distributed objects it manages.
  *
  * @param <T> type of key
  */
+@PrivateApi
 public interface LockInterceptorService<T> {
 
     void onBeforeLock(String distributedObjectName, T key);

--- a/hazelcast/src/main/java/com/hazelcast/spi/ManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ManagedService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import java.util.Properties;
 
 /**
@@ -26,6 +28,7 @@ import java.util.Properties;
  * <li>reset</li>
  * </ol>
  */
+@PrivateApi
 public interface ManagedService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.cluster.Member;
-import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberAttributeEvent;
+import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.nio.serialization.SerializableByConvention;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.Set;
 
@@ -30,6 +31,7 @@ import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PU
 /**
  * This service event is fired to inform services about a change in a member's attributes collection
  */
+@PrivateApi
 @SerializableByConvention(PUBLIC_API)
 public class MemberAttributeServiceEvent extends MemberAttributeEvent {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipAwareService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * An interface that can be implemented by a SPI service that needs to be notified members joining and leaving
  * the cluster.
  *
  * @author mdogan 9/5/12
  */
+@PrivateApi
 public interface MembershipAwareService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi;
 
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * Membership event fired when a new member is added
@@ -25,6 +26,7 @@ import com.hazelcast.cluster.impl.MemberImpl;
  *
  * @see com.hazelcast.spi.MembershipAwareService
  */
+@PrivateApi
 public class MembershipServiceEvent extends MembershipEvent {
 
     public MembershipServiceEvent(MembershipEvent e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeAware.java
@@ -17,10 +17,12 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * A 'capability' that can be implemented by object to get the Node injected.
  */
+@PrivateApi
 public interface NodeAware {
 
     void setNode(Node node);

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -16,15 +16,16 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cluster.Cluster;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.quorum.QuorumService;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -42,6 +43,7 @@ import java.util.Collection;
  * So if you are writing a custom SPI service, such as a stack-service, this service should probably implement
  * the {@link ManagedService} so you can get access to the services within the system.
  */
+@PrivateApi
 public interface NodeEngine {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Contract point for event listeners to be notified by {@link com.hazelcast.spi.EventService}.
  *
  * @param <S> the type of the {@link com.hazelcast.spi.ManagedService}
  */
+@PrivateApi
 public interface NotifiableEventListener<S> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ObjectNamespace.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * An ObjectNamespace that makes identification of object within a service possible.
  */
+@PrivateApi
 public interface ObjectNamespace extends ServiceNamespace {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
@@ -23,6 +24,7 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
  * Marker interface for services that want to return operations to be executed on the cluster
  * members after a join has been finalized.
  */
+@PrivateApi
 public interface PostJoinAwareService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/PreJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PreJoinAwareService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
@@ -28,6 +29,7 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
  *
  * @since 3.9
  */
+@PrivateApi
 public interface PreJoinAwareService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ProxyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ProxyService.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi;
 
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.Collection;
 
@@ -26,6 +27,7 @@ import java.util.Collection;
  *
  * @author mdogan 1/14/13
  */
+@PrivateApi
 public interface ProxyService extends CoreService {
 
     int getProxyCount();

--- a/hazelcast/src/main/java/com/hazelcast/spi/QuorumAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/QuorumAwareService.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Quorum service can ask for quorum information to the {@link QuorumAwareService}
  * to decide whether operation participates into a quorum or not.
  */
+@PrivateApi
 public interface QuorumAwareService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/RemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/RemoteService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * An interface that can be implemented by SPI-Services to give them the ability to create proxies to
@@ -24,6 +25,7 @@ import com.hazelcast.core.DistributedObject;
  *
  * @author mdogan 10/31/12
  */
+@PrivateApi
 public interface RemoteService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ReplicationSupportingService.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.wan.WanReplicationEvent;
 
 /**
  * An interface that can be implemented by SPI services to give them the
  * ability to listen to WAN replication events.
  */
+@PrivateApi
 public interface ReplicationSupportingService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/ServiceConfigurationParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ServiceConfigurationParser.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * A hook into the parsing system. So if your SPI service needs to parse XML in the hazelcast-xml configuration, then use
  * this interface to hook into the XML parser.
  *
  * @param <T>
  */
+@PrivateApi
 public interface ServiceConfigurationParser<T> {
 
     T parse(org.w3c.dom.Element element);

--- a/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespace.java
@@ -17,12 +17,14 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * {@code ServiceNamespace} is a namespace to group objects, structures, fragments within a service.
  *
  * @since 3.9
  */
+@PrivateApi
 public interface ServiceNamespace extends DataSerializable {
     /**
      * Name of the service

--- a/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespaceAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespaceAware.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.spi.partition.FragmentedMigrationAwareService;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.BackupOperation;
+import com.hazelcast.spi.partition.FragmentedMigrationAwareService;
 
 /**
  * An object which is aware of {@link ServiceNamespace} which object itself belongs to.
@@ -30,6 +31,7 @@ import com.hazelcast.spi.impl.operationservice.BackupOperation;
  * @see FragmentedMigrationAwareService
  * @since 3.9
  */
+@PrivateApi
 public interface ServiceNamespaceAware {
     /**
      * Returns the {@link ServiceNamespace} which this object belongs to.

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainHandlerService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * An interface that can be implemented by SPI services that want to be able to resolve a split-brain.
  * <p>
  * When the two separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
  * a {@link Runnable}, that will merge the clusters.
  */
+@PrivateApi
 public interface SplitBrainHandlerService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.monitor.LocalInstanceStats;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import java.util.Map;
  *
  * @param <T> type of returned
  */
+@PrivateApi
 public interface StatisticsAwareService<T extends LocalInstanceStats> {
     /**
      * Return the service statistics for the local instance.

--- a/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +41,7 @@ import java.util.concurrent.TimeUnit;
  * {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
  *
  */
+@PrivateApi
 public interface TaskScheduler extends Executor {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.transaction.impl.Transaction;
 
 /**
@@ -23,6 +24,7 @@ import com.hazelcast.transaction.impl.Transaction;
  *
  * @param <S> type of the {@link RemoteService}
  */
+@PrivateApi
 public abstract class TransactionalDistributedObject<S extends RemoteService> extends AbstractDistributedObject<S> {
 
     protected final Transaction tx;

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalService.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 
 /**
  * An interface that can be implemented by SPI services that want to deal with transactions.
  */
+@PrivateApi
 public interface TransactionalService {
 
     <T extends TransactionalObject> T createTransactionalObject(String name, Transaction transaction);


### PR DESCRIPTION
All the classes from the com.hz.spi package are made privateapi.

So if we are not ready in time cleaning up the com.hz.spi, these
classes are not for external consumption and therefor we can safely
move them in a later release.

We do not expect end users to write custom services. This was a goal
in 3.0, but not any longer.