### PR TITLE
Trim unneeded fields from binary form of operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutMessageTask.java
@@ -17,11 +17,12 @@
 package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.instance.impl.Node;
 import com.hazelcast.client.impl.protocol.codec.MapPutCodec;
+import com.hazelcast.instance.impl.Node;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.concurrent.TimeUnit;
@@ -36,11 +37,15 @@ public class MapPutMessageTask extends AbstractMapPutMessageTask<MapPutCodec.Req
 
     @Override
     protected Operation prepareOperation() {
-        MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
-        MapOperation op = operationProvider.createPutOperation(parameters.name, parameters.key,
-                parameters.value, parameters.ttl, DEFAULT_MAX_IDLE);
+        MapOperation op = newPutOperation(parameters.name, parameters.key,
+                parameters.value, parameters.ttl);
         op.setThreadId(parameters.threadId);
         return op;
+    }
+
+    private MapOperation newPutOperation(String name, Data keyData, Data valueData, long ttl) {
+        MapOperationProvider operationProvider = getMapOperationProvider(name);
+        return operationProvider.createPutOperation(name, keyData, valueData, ttl, DEFAULT_MAX_IDLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutTransientMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutTransientMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.concurrent.TimeUnit;
@@ -37,11 +38,15 @@ public class MapPutTransientMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
-        MapOperation op = operationProvider.createPutTransientOperation(parameters.name, parameters.key,
-                parameters.value, parameters.ttl, DEFAULT_MAX_IDLE);
+        MapOperation op = newOperation(parameters.name, parameters.key,
+                parameters.value, parameters.ttl);
         op.setThreadId(parameters.threadId);
         return op;
+    }
+
+    private MapOperation newOperation(String name, Data keyData, Data valueData, long ttl) {
+        MapOperationProvider operationProvider = getMapOperationProvider(name);
+        return operationProvider.createPutTransientOperation(name, keyData, valueData, ttl, DEFAULT_MAX_IDLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
@@ -58,7 +58,7 @@ public class MapRemoveMessageTask
     @Override
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
-        MapOperation op = operationProvider.createRemoveOperation(parameters.name, parameters.key, false);
+        MapOperation op = operationProvider.createRemoveOperation(parameters.name, parameters.key);
         op.setThreadId(parameters.threadId);
         return op;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -415,7 +415,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
 
     @Override
     public ICompletableFuture<Void> setAsync(@Nonnull K key, @Nonnull V value) {
-        return setAsync(key, value, -1, MILLISECONDS);
+        return setAsync(key, value, DEFAULT_TTL, MILLISECONDS);
     }
 
     @Override
@@ -695,7 +695,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
     @Override
     public void lock(@Nonnull K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
-        lockInternal(key, timeInMsOrTimeIfNullUnit(-1, MILLISECONDS));
+        lockInternal(key, timeInMsOrTimeIfNullUnit(DEFAULT_TTL, MILLISECONDS));
     }
 
     @Override
@@ -1686,7 +1686,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
 
     @Override
     public void set(@Nonnull K key, @Nonnull V value) {
-        set(key, value, -1, MILLISECONDS);
+        set(key, value, DEFAULT_TTL, MILLISECONDS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -99,8 +99,12 @@ import com.hazelcast.map.impl.operation.PutBackupOperation;
 import com.hazelcast.map.impl.operation.PutFromLoadAllBackupOperation;
 import com.hazelcast.map.impl.operation.PutFromLoadAllOperation;
 import com.hazelcast.map.impl.operation.PutIfAbsentOperation;
+import com.hazelcast.map.impl.operation.PutIfAbsentWithExpiryOperation;
 import com.hazelcast.map.impl.operation.PutOperation;
+import com.hazelcast.map.impl.operation.PutTransientBackupOperation;
 import com.hazelcast.map.impl.operation.PutTransientOperation;
+import com.hazelcast.map.impl.operation.PutTransientWithExpiryOperation;
+import com.hazelcast.map.impl.operation.PutWithExpiryOperation;
 import com.hazelcast.map.impl.operation.RemoveBackupOperation;
 import com.hazelcast.map.impl.operation.RemoveFromLoadAllOperation;
 import com.hazelcast.map.impl.operation.RemoveIfSameOperation;
@@ -111,6 +115,7 @@ import com.hazelcast.map.impl.operation.ReplaceOperation;
 import com.hazelcast.map.impl.operation.SetOperation;
 import com.hazelcast.map.impl.operation.SetTtlBackupOperation;
 import com.hazelcast.map.impl.operation.SetTtlOperation;
+import com.hazelcast.map.impl.operation.SetWithExpiryOperation;
 import com.hazelcast.map.impl.operation.SizeOperationFactory;
 import com.hazelcast.map.impl.operation.TriggerLoadIfNeededOperation;
 import com.hazelcast.map.impl.operation.TryPutOperation;
@@ -303,8 +308,13 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int ADD_INDEX_BACKUP = 140;
     public static final int TXN_SET_BACKUP = 141;
     public static final int TXN_DELETE_BACKUP = 142;
+    public static final int SET_WITH_EXPIRY = 143;
+    public static final int PUT_WITH_EXPIRY = 144;
+    public static final int PUT_TRANSIENT_WITH_EXPIRY = 145;
+    public static final int PUT_IF_ABSENT_WITH_EXPIRY = 146;
+    public static final int PUT_TRANSIENT_BACKUP = 147;
 
-    private static final int LEN = TXN_DELETE_BACKUP + 1;
+    private static final int LEN = PUT_TRANSIENT_BACKUP + 1;
 
     @Override
     public int getFactoryId() {
@@ -458,6 +468,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[ADD_INDEX_BACKUP] = arg -> new AddIndexBackupOperation();
         constructors[TXN_SET_BACKUP] = arg -> new TxnSetBackupOperation();
         constructors[TXN_DELETE_BACKUP] = arg -> new TxnDeleteBackupOperation();
+        constructors[SET_WITH_EXPIRY] = arg -> new SetWithExpiryOperation();
+        constructors[PUT_WITH_EXPIRY] = arg -> new PutWithExpiryOperation();
+        constructors[PUT_TRANSIENT_WITH_EXPIRY] = arg -> new PutTransientWithExpiryOperation();
+        constructors[PUT_IF_ABSENT_WITH_EXPIRY] = arg -> new PutIfAbsentWithExpiryOperation();
+        constructors[PUT_TRANSIENT_BACKUP] = arg -> new PutTransientBackupOperation();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -60,7 +60,7 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
     private void handleRemove(MapReplicationRemove replicationRemove) {
         String mapName = replicationRemove.getMapName();
         MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(mapName);
-        MapOperation operation = operationProvider.createRemoveOperation(replicationRemove.getMapName(),
+        MapOperation operation = operationProvider.createDeleteOperation(replicationRemove.getMapName(),
                 replicationRemove.getKey(), true);
 
         try {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -24,21 +24,15 @@ import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
-import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
-import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
-public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation {
+public abstract class BasePutOperation
+        extends LockAwareOperation implements BackupAwareOperation {
 
     protected transient Object oldValue;
     protected transient EntryEventType eventType;
-    protected transient boolean putTransient;
 
     public BasePutOperation(String name, Data dataKey, Data value) {
-        super(name, dataKey, value, DEFAULT_TTL, DEFAULT_MAX_IDLE);
-    }
-
-    public BasePutOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
-        super(name, dataKey, value, ttl, maxIdle);
+        super(name, dataKey, value);
     }
 
     public BasePutOperation() {
@@ -76,8 +70,11 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         if (isPostProcessing(recordStore)) {
             dataValue = mapServiceContext.toData(record.getValue());
         }
-        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo,
-                putTransient, disableWanReplicationEvent);
+        return newBackupOperation(replicationInfo);
+    }
+
+    protected PutBackupOperation newBackupOperation(RecordInfo replicationInfo) {
+        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -27,16 +27,11 @@ public abstract class BaseRemoveOperation extends LockAwareOperation
 
     protected transient Data dataOldValue;
 
-    public BaseRemoveOperation(String name, Data dataKey, boolean disableWanReplicationEvent) {
-        super(name, dataKey);
-        this.disableWanReplicationEvent = disableWanReplicationEvent;
+    public BaseRemoveOperation() {
     }
 
     public BaseRemoveOperation(String name, Data dataKey) {
-        this(name, dataKey, false);
-    }
-
-    public BaseRemoveOperation() {
+        super(name, dataKey);
     }
 
     @Override
@@ -56,7 +51,7 @@ public abstract class BaseRemoveOperation extends LockAwareOperation
 
     @Override
     public Operation getBackupOperation() {
-        return new RemoveBackupOperation(name, dataKey, disableWanReplicationEvent);
+        return new RemoveBackupOperation(name, dataKey, disableWanReplicationEvent());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -34,6 +34,8 @@ import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 import static java.util.Collections.singletonList;
 
 /**
@@ -50,33 +52,53 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutOperation(String name, Data key, Data value, long ttl, long maxIdle) {
-        return new PutOperation(name, key, value, ttl, maxIdle);
-    }
-
-    @Override
     public MapOperation createTryPutOperation(String name, Data dataKey, Data value, long timeout) {
         return new TryPutOperation(name, dataKey, value, timeout);
     }
 
     @Override
+    public MapOperation createPutOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        if (hasNoExpiry(ttl, maxIdle)) {
+            return new PutOperation(name, key, value);
+        } else {
+            return new PutWithExpiryOperation(name, key, value, ttl, maxIdle);
+        }
+    }
+
+    private static boolean hasNoExpiry(long ttl, long maxIdle) {
+        return ttl == DEFAULT_TTL && maxIdle == DEFAULT_MAX_IDLE;
+    }
+
+    @Override
     public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
-        return new SetOperation(name, dataKey, value, ttl, maxIdle);
+        if (hasNoExpiry(ttl, maxIdle)) {
+            return new SetOperation(name, dataKey, value);
+        } else {
+            return new SetWithExpiryOperation(name, dataKey, value, ttl, maxIdle);
+        }
     }
 
     @Override
     public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle) {
-        return new PutIfAbsentOperation(name, key, value, ttl, maxIdle);
+        if (hasNoExpiry(ttl, maxIdle)) {
+            return new PutIfAbsentOperation(name, key, value);
+        } else {
+            return new PutIfAbsentWithExpiryOperation(name, key, value, ttl, maxIdle);
+        }
     }
 
     @Override
-    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl, long maxIdle) {
-        return new PutTransientOperation(name, key, value, ttl, maxIdle);
+    public MapOperation createPutTransientOperation(String name, Data keyData, Data valueData, long ttl, long maxIdle) {
+        if (hasNoExpiry(ttl, maxIdle)) {
+            return new PutTransientOperation(name, keyData, valueData);
+        } else {
+            return new PutTransientWithExpiryOperation(name, keyData, valueData, ttl, maxIdle);
+        }
     }
 
     @Override
-    public MapOperation createRemoveOperation(String name, Data key, boolean disableWanReplicationEvent) {
-        return new RemoveOperation(name, key, disableWanReplicationEvent);
+    public MapOperation createRemoveOperation(String name, Data key) {
+        return new RemoveOperation(name, key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.cp.internal.datastructures.unsafe.lock.LockWaitNotifyKey;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.HazelcastException;
@@ -29,17 +28,16 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.BlockingOperation;
 import com.hazelcast.spi.impl.operationservice.CallStatus;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Offload;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
-import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
-import com.hazelcast.spi.exception.WrongTargetException;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.util.Clock;
@@ -51,9 +49,9 @@ import java.io.IOException;
 import static com.hazelcast.core.Offloadable.NO_OFFLOADING;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
+import static com.hazelcast.spi.impl.executionservice.ExecutionService.OFFLOADABLE_EXECUTOR;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.WAIT;
-import static com.hazelcast.spi.impl.executionservice.ExecutionService.OFFLOADABLE_EXECUTOR;
 import static com.hazelcast.spi.impl.operationservice.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 import static java.lang.String.format;
@@ -136,7 +134,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * GOTCHA: This operation LOADS missing keys from map-store, in contrast with PartitionWideEntryOperation.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class EntryOperation extends KeyBasedMapOperation
+public class EntryOperation extends LockAwareOperation
         implements BackupAwareOperation, BlockingOperation, MutatingOperation {
 
     private static final int SET_UNLOCK_FAST_RETRY_LIMIT = 10;
@@ -199,11 +197,6 @@ public class EntryOperation extends KeyBasedMapOperation
     }
 
     @Override
-    public WaitNotifyKey getWaitKey() {
-        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
-    }
-
-    @Override
     public boolean shouldWait() {
         // optimisation for ReadOnly processors -> they will not wait for the lock
         if (entryProcessor instanceof ReadOnly) {
@@ -218,7 +211,7 @@ public class EntryOperation extends KeyBasedMapOperation
         //at this point we cannot offload. the entry is locked or the EP does not support offload
         //if the entry is locked by us then we can still run the EP on the partition thread
         offload = false;
-        return !recordStore.canAcquireLock(dataKey, getCallerUuid(), getThreadId());
+        return super.shouldWait();
     }
 
     private boolean isOffloadingRequested(EntryProcessor entryProcessor) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
@@ -62,14 +62,12 @@ public class EvictBackupOperation extends KeyBasedMapOperation implements Backup
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeBoolean(unlockKey);
-        out.writeBoolean(disableWanReplicationEvent);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         unlockKey = in.readBoolean();
-        disableWanReplicationEvent = in.readBoolean();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -23,17 +23,12 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
 import java.io.IOException;
 
-import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
-import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
-
 public abstract class KeyBasedMapOperation extends MapOperation
         implements PartitionAwareOperation {
 
-    protected Data dataKey;
     protected long threadId;
+    protected Data dataKey;
     protected Data dataValue;
-    protected long ttl = DEFAULT_TTL;
-    protected long maxIdle = DEFAULT_MAX_IDLE;
 
     public KeyBasedMapOperation() {
     }
@@ -47,21 +42,6 @@ public abstract class KeyBasedMapOperation extends MapOperation
         super(name);
         this.dataKey = dataKey;
         this.dataValue = dataValue;
-    }
-
-    protected KeyBasedMapOperation(String name, Data dataKey, long ttl, long maxIdle) {
-        super(name);
-        this.dataKey = dataKey;
-        this.ttl = ttl;
-        this.maxIdle = maxIdle;
-    }
-
-    protected KeyBasedMapOperation(String name, Data dataKey, Data dataValue, long ttl, long maxIdle) {
-        super(name);
-        this.dataKey = dataKey;
-        this.dataValue = dataValue;
-        this.ttl = ttl;
-        this.maxIdle = maxIdle;
     }
 
     public final Data getKey() {
@@ -82,27 +62,19 @@ public abstract class KeyBasedMapOperation extends MapOperation
         return dataValue;
     }
 
-    public final long getTtl() {
-        return ttl;
-    }
-
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeData(dataKey);
-        out.writeLong(threadId);
         out.writeData(dataValue);
-        out.writeLong(ttl);
-        out.writeLong(maxIdle);
+        out.writeLong(threadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         dataKey = in.readData();
-        threadId = in.readLong();
         dataValue = in.readData();
-        ttl = in.readLong();
-        maxIdle = in.readLong();
+        threadId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -30,12 +30,8 @@ public abstract class LockAwareOperation extends KeyBasedMapOperation implements
         super(name, dataKey);
     }
 
-    protected LockAwareOperation(String name, Data dataKey, long ttl, long maxIdle) {
-        super(name, dataKey, ttl, maxIdle);
-    }
-
-    protected LockAwareOperation(String name, Data dataKey, Data dataValue, long ttl, long maxIdle) {
-        super(name, dataKey, dataValue, ttl, maxIdle);
+    public LockAwareOperation(String name, Data dataKey, Data dataValue) {
+        super(name, dataKey, dataValue);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -18,6 +18,8 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryView;
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidator;
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.internal.services.ServiceNamespaceAware;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
@@ -32,10 +34,8 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.memory.NativeOutOfMemoryError;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.operationservice.BackupOperation;
-import com.hazelcast.internal.services.ObjectNamespace;
-import com.hazelcast.internal.services.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
+import com.hazelcast.spi.impl.operationservice.BackupOperation;
 import com.hazelcast.wan.impl.CallerProvenance;
 
 import java.util.List;
@@ -62,11 +62,6 @@ public abstract class MapOperation extends AbstractNamedOperation
     protected transient boolean createRecordStoreOnDemand = true;
     protected transient boolean disposeDeferredBlocks = true;
 
-    /**
-     * Used by wan-replication-service to disable wan-replication event publishing
-     * otherwise in active-active scenarios infinite loop of event forwarding can be seen.
-     */
-    protected boolean disableWanReplicationEvent;
     private transient boolean canPublishWanEvent;
 
     public MapOperation() {
@@ -149,7 +144,7 @@ public abstract class MapOperation extends AbstractNamedOperation
     }
 
     protected final CallerProvenance getCallerProvenance() {
-        return disableWanReplicationEvent ? CallerProvenance.WAN : CallerProvenance.NOT_WAN;
+        return disableWanReplicationEvent() ? CallerProvenance.WAN : CallerProvenance.NOT_WAN;
     }
 
     private RecordStore getRecordStoreOrNull() {
@@ -204,7 +199,7 @@ public abstract class MapOperation extends AbstractNamedOperation
 
     private boolean canPublishWanEvent(MapContainer mapContainer) {
         boolean canPublishWanEvent = mapContainer.isWanReplicationEnabled()
-                && !disableWanReplicationEvent;
+                && !disableWanReplicationEvent();
 
         if (canPublishWanEvent) {
             mapContainer.getWanReplicationPublisher().checkWanReplicationQueues();
@@ -336,5 +331,9 @@ public abstract class MapOperation extends AbstractNamedOperation
         }
 
         mapEventPublisher.publishWanRemove(name, toHeapData(dataKey));
+    }
+
+    protected boolean disableWanReplicationEvent() {
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -56,7 +56,7 @@ public interface MapOperationProvider {
 
     MapOperation createReplaceIfSameOperation(String name, Data dataKey, Data expect, Data update);
 
-    MapOperation createRemoveOperation(String name, Data key, boolean disableWanReplicationEvent);
+    MapOperation createRemoveOperation(String name, Data key);
 
     /**
      * Creates a delete operation for an entry with key equal to {@code key} from the map named {@code name}.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -37,12 +37,15 @@ import static com.hazelcast.core.EntryEventType.MERGED;
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 
 /**
- * Contains multiple merge entries for split-brain healing with a {@link SplitBrainMergePolicy}.
+ * Contains multiple merge entries for split-brain
+ * healing with a {@link SplitBrainMergePolicy}.
  *
  * @since 3.10
  */
-public class MergeOperation extends MapOperation implements PartitionAwareOperation, BackupAwareOperation {
+public class MergeOperation extends MapOperation
+        implements PartitionAwareOperation, BackupAwareOperation {
 
+    private boolean disableWanReplicationEvent;
     private List<MapMergeTypes> mergingEntries;
     private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
 
@@ -66,6 +69,11 @@ public class MergeOperation extends MapOperation implements PartitionAwareOperat
         this.mergingEntries = mergingEntries;
         this.mergePolicy = mergePolicy;
         this.disableWanReplicationEvent = disableWanReplicationEvent;
+    }
+
+    @Override
+    protected boolean disableWanReplicationEvent() {
+        return disableWanReplicationEvent;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -35,6 +35,7 @@ import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
 public class PutAllBackupOperation extends MapOperation
         implements PartitionAwareOperation, BackupOperation {
 
+    private boolean disableWanReplicationEvent;
     private MapEntries entries;
     private List<RecordInfo> recordInfos;
 
@@ -60,6 +61,11 @@ public class PutAllBackupOperation extends MapOperation
             publishWanUpdate(dataKey, dataValue);
             evict(dataKey);
         }
+    }
+
+    @Override
+    protected boolean disableWanReplicationEvent() {
+        return disableWanReplicationEvent;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -26,9 +26,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -23,9 +23,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,8 +39,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 /**
  * Puts records to map which are loaded from map store by {@link IMap#loadAll}
  */
-public class PutFromLoadAllOperation extends MapOperation implements PartitionAwareOperation, MutatingOperation,
-        BackupAwareOperation {
+public class PutFromLoadAllOperation extends MapOperation
+        implements PartitionAwareOperation, MutatingOperation, BackupAwareOperation {
 
     private List<Data> loadingSequence;
     private List<Data> invalidationKeys;
@@ -63,7 +63,7 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
         boolean hasInterceptor = mapServiceContext.hasInterceptor(name);
 
         List<Data> loadingSequence = this.loadingSequence;
-        for (int i = 0; i < loadingSequence.size();) {
+        for (int i = 0; i < loadingSequence.size(); ) {
             Data key = loadingSequence.get(i++);
             Data dataValue = loadingSequence.get(i++);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -20,12 +20,15 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
+
 public class PutIfAbsentOperation extends BasePutOperation implements MutatingOperation {
 
-    private boolean successful;
+    protected transient boolean successful;
 
-    public PutIfAbsentOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
-        super(name, dataKey, value, ttl, maxIdle);
+    public PutIfAbsentOperation(String name, Data dataKey, Data value) {
+        super(name, dataKey, value);
     }
 
     public PutIfAbsentOperation() {
@@ -33,9 +36,18 @@ public class PutIfAbsentOperation extends BasePutOperation implements MutatingOp
 
     @Override
     protected void runInternal() {
-        final Object oldValue = recordStore.putIfAbsent(dataKey, dataValue, ttl, maxIdle, getCallerAddress());
+        Object oldValue = recordStore.putIfAbsent(dataKey, dataValue,
+                getTtl(), getMaxIdle(), getCallerAddress());
         this.oldValue = mapServiceContext.toData(oldValue);
         successful = this.oldValue == null;
+    }
+
+    protected long getTtl() {
+        return DEFAULT_TTL;
+    }
+
+    protected long getMaxIdle() {
+        return DEFAULT_MAX_IDLE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentWithExpiryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentWithExpiryOperation.java
@@ -23,66 +23,46 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
-public class DeleteOperation extends BaseRemoveOperation {
+public class PutIfAbsentWithExpiryOperation extends PutIfAbsentOperation {
 
-    // package private for testing purposes
-    boolean disableWanReplicationEvent;
-    private boolean success;
+    private long ttl;
+    private long maxIdle;
 
-    public DeleteOperation(String name, Data dataKey, boolean disableWanReplicationEvent) {
-        super(name, dataKey);
-        this.disableWanReplicationEvent = disableWanReplicationEvent;
+    public PutIfAbsentWithExpiryOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value);
+        this.ttl = ttl;
+        this.maxIdle = maxIdle;
     }
 
-    public DeleteOperation() {
-    }
-
-    @Override
-    protected void runInternal() {
-        success = recordStore.delete(dataKey, getCallerProvenance());
+    public PutIfAbsentWithExpiryOperation() {
     }
 
     @Override
-    protected boolean disableWanReplicationEvent() {
-        return disableWanReplicationEvent;
+    protected long getTtl() {
+        return ttl;
     }
 
     @Override
-    public Object getResponse() {
-        return success;
-    }
-
-    @Override
-    protected void afterRunInternal() {
-        if (success) {
-            super.afterRunInternal();
-        }
-    }
-
-    @Override
-    public boolean shouldBackup() {
-        return success;
-    }
-
-    @Override
-    public void onWaitExpire() {
-        sendResponse(false);
+    protected long getMaxIdle() {
+        return maxIdle;
     }
 
     @Override
     public int getClassId() {
-        return MapDataSerializerHook.DELETE;
+        return MapDataSerializerHook.PUT_IF_ABSENT_WITH_EXPIRY;
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeBoolean(disableWanReplicationEvent);
+        out.writeLong(ttl);
+        out.writeLong(maxIdle);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        disableWanReplicationEvent = in.readBoolean();
+        ttl = in.readLong();
+        maxIdle = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
@@ -20,18 +20,29 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
+
 public class PutOperation extends BasePutOperation implements MutatingOperation {
 
     public PutOperation() {
     }
 
-    public PutOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
-        super(name, dataKey, value, ttl, maxIdle);
+    public PutOperation(String name, Data dataKey, Data value) {
+        super(name, dataKey, value);
     }
 
     @Override
     protected void runInternal() {
-        oldValue = mapServiceContext.toData(recordStore.put(dataKey, dataValue, ttl, maxIdle));
+        oldValue = mapServiceContext.toData(recordStore.put(dataKey, dataValue, getTtl(), getMaxIdle()));
+    }
+
+    protected long getTtl() {
+        return DEFAULT_TTL;
+    }
+
+    protected long getMaxIdle() {
+        return DEFAULT_MAX_IDLE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientBackupOperation.java
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl.tx;
+package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.operation.RemoveBackupOperation;
+import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.serialization.Data;
 
-public class TxnDeleteBackupOperation extends RemoveBackupOperation {
+public class PutTransientBackupOperation extends PutBackupOperation {
 
-    public TxnDeleteBackupOperation() {
+    public PutTransientBackupOperation() {
     }
 
-    public TxnDeleteBackupOperation(String name, Data dataKey) {
-        super(name, dataKey, false);
+    public PutTransientBackupOperation(String name, Data dataKey, Data dataValue,
+                                       RecordInfo recordInfo) {
+        super(name, dataKey, dataValue, recordInfo);
     }
 
     @Override
-    protected void runInternal() {
-        super.runInternal();
-
-        recordStore.forceUnlock(dataKey);
+    protected boolean isPutTransient() {
+        return true;
     }
 
     @Override
     public int getClassId() {
-        return MapDataSerializerHook.TXN_DELETE_BACKUP;
+        return MapDataSerializerHook.PUT_TRANSIENT_BACKUP;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -17,22 +17,39 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
+
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
 public class PutTransientOperation extends BasePutOperation implements MutatingOperation {
 
     public PutTransientOperation() {
     }
 
-    public PutTransientOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
-        super(name, dataKey, value, ttl, maxIdle);
+    public PutTransientOperation(String name, Data dataKey, Data value) {
+        super(name, dataKey, value);
     }
 
     @Override
     protected void runInternal() {
-        oldValue = mapServiceContext.toData(recordStore.putTransient(dataKey, dataValue, ttl, maxIdle));
-        putTransient = true;
+        oldValue = mapServiceContext.toData(recordStore.putTransient(dataKey,
+                dataValue, getTtl(), getMaxIdle()));
+    }
+
+    @Override
+    protected PutBackupOperation newBackupOperation(RecordInfo replicationInfo) {
+        return new PutTransientBackupOperation(name, dataKey, dataValue, replicationInfo);
+    }
+
+    protected long getTtl() {
+        return DEFAULT_TTL;
+    }
+
+    protected long getMaxIdle() {
+        return DEFAULT_MAX_IDLE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReadonlyKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReadonlyKeyBasedMapOperation.java
@@ -27,7 +27,8 @@ import java.io.IOException;
 /**
  * Abstract {@link MapOperation} that serves as based for readonly operations.
  */
-public abstract class ReadonlyKeyBasedMapOperation extends MapOperation implements ReadonlyOperation, PartitionAwareOperation {
+public abstract class ReadonlyKeyBasedMapOperation extends MapOperation
+        implements ReadonlyOperation, PartitionAwareOperation {
 
     protected Data dataKey;
     protected long threadId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 
 public class RemoveBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
+    private boolean disableWanReplicationEvent;
+
     public RemoveBackupOperation() {
     }
 
@@ -38,6 +40,11 @@ public class RemoveBackupOperation extends KeyBasedMapOperation implements Backu
     @Override
     protected void runInternal() {
         recordStore.removeBackup(dataKey, getCallerProvenance());
+    }
+
+    @Override
+    protected boolean disableWanReplicationEvent() {
+        return disableWanReplicationEvent;
     }
 
     @Override
@@ -69,5 +76,4 @@ public class RemoveBackupOperation extends KeyBasedMapOperation implements Backu
         super.readInternal(in);
         disableWanReplicationEvent = in.readBoolean();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
@@ -17,11 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-
-import java.io.IOException;
 
 public class RemoveOperation extends BaseRemoveOperation {
 
@@ -30,8 +26,8 @@ public class RemoveOperation extends BaseRemoveOperation {
     public RemoveOperation() {
     }
 
-    public RemoveOperation(String name, Data dataKey, boolean disableWanReplicationEvent) {
-        super(name, dataKey, disableWanReplicationEvent);
+    public RemoveOperation(String name, Data dataKey) {
+        super(name, dataKey);
     }
 
     @Override
@@ -55,17 +51,5 @@ public class RemoveOperation extends BaseRemoveOperation {
     @Override
     public int getClassId() {
         return MapDataSerializerHook.REMOVE;
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        super.writeInternal(out);
-        out.writeBoolean(disableWanReplicationEvent);
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        super.readInternal(in);
-        disableWanReplicationEvent = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlBackupOperation.java
@@ -18,19 +18,23 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupOperation;
 
-import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import java.io.IOException;
 
 public class SetTtlBackupOperation extends KeyBasedMapOperation implements BackupOperation {
+    private long ttl;
 
     public SetTtlBackupOperation() {
 
     }
 
     public SetTtlBackupOperation(String name, Data dataKey, long ttl) {
-        super(name, dataKey, ttl, DEFAULT_MAX_IDLE);
+        super(name, dataKey);
+        this.ttl = ttl;
     }
 
     @Override
@@ -50,5 +54,17 @@ public class SetTtlBackupOperation extends KeyBasedMapOperation implements Backu
             publishWanUpdate(dataKey, record.getValue());
         }
         super.afterRunInternal();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeLong(ttl);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        ttl = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlOperation.java
@@ -18,23 +18,28 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
-import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import java.io.IOException;
 
-public class SetTtlOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
+public class SetTtlOperation extends LockAwareOperation
+        implements BackupAwareOperation, MutatingOperation {
 
     private transient boolean response;
 
-    public SetTtlOperation() {
+    private long ttl;
 
+    public SetTtlOperation() {
     }
 
     public SetTtlOperation(String name, Data dataKey, long ttl) {
-        super(name, dataKey, ttl, DEFAULT_MAX_IDLE);
+        super(name, dataKey);
+        this.ttl = ttl;
     }
 
     @Override
@@ -85,5 +90,17 @@ public class SetTtlOperation extends LockAwareOperation implements BackupAwareOp
     @Override
     public Operation getBackupOperation() {
         return new SetTtlBackupOperation(name, dataKey, ttl);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeLong(ttl);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        ttl = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetWithExpiryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetWithExpiryOperation.java
@@ -23,66 +23,48 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
-public class DeleteOperation extends BaseRemoveOperation {
+public class SetWithExpiryOperation extends SetOperation {
 
-    // package private for testing purposes
-    boolean disableWanReplicationEvent;
-    private boolean success;
+    private long ttl;
+    private long maxIdle;
 
-    public DeleteOperation(String name, Data dataKey, boolean disableWanReplicationEvent) {
-        super(name, dataKey);
-        this.disableWanReplicationEvent = disableWanReplicationEvent;
+    public SetWithExpiryOperation() {
     }
 
-    public DeleteOperation() {
-    }
-
-    @Override
-    protected void runInternal() {
-        success = recordStore.delete(dataKey, getCallerProvenance());
+    public SetWithExpiryOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value);
+        this.ttl = ttl;
+        this.maxIdle = maxIdle;
     }
 
     @Override
-    protected boolean disableWanReplicationEvent() {
-        return disableWanReplicationEvent;
+    protected long getTtl() {
+        return ttl;
     }
 
     @Override
-    public Object getResponse() {
-        return success;
-    }
-
-    @Override
-    protected void afterRunInternal() {
-        if (success) {
-            super.afterRunInternal();
-        }
-    }
-
-    @Override
-    public boolean shouldBackup() {
-        return success;
-    }
-
-    @Override
-    public void onWaitExpire() {
-        sendResponse(false);
+    protected long getMaxIdle() {
+        return maxIdle;
     }
 
     @Override
     public int getClassId() {
-        return MapDataSerializerHook.DELETE;
+        return MapDataSerializerHook.SET_WITH_EXPIRY;
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeBoolean(disableWanReplicationEvent);
+
+        out.writeLong(ttl);
+        out.writeLong(maxIdle);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        disableWanReplicationEvent = in.readBoolean();
+
+        ttl = in.readLong();
+        maxIdle = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -20,6 +20,9 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
+
 public class TryPutOperation extends BasePutOperation implements MutatingOperation {
 
     public TryPutOperation() {
@@ -32,7 +35,7 @@ public class TryPutOperation extends BasePutOperation implements MutatingOperati
 
     @Override
     protected void runInternal() {
-        recordStore.put(dataKey, dataValue, ttl, maxIdle);
+        recordStore.put(dataKey, dataValue, DEFAULT_TTL, DEFAULT_MAX_IDLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -22,13 +22,13 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.internal.util.SimpleCompletableFuture;
-import com.hazelcast.map.IMap;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.internal.journal.EventJournalReader;
+import com.hazelcast.internal.util.SimpleCompletableFuture;
 import com.hazelcast.internal.util.SimpleCompletedFuture;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.QueryCache;
 import com.hazelcast.map.impl.MapService;
@@ -77,6 +77,7 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.query.QueryResultUtils.transformToSet;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest.newQueryCacheRequest;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNoNullInside;
@@ -110,7 +111,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public V put(@Nonnull K key, @Nonnull V value) {
-        return put(key, value, -1, TimeUnit.MILLISECONDS);
+        return put(key, value, DEFAULT_TTL, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -150,7 +151,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public V putIfAbsent(@Nonnull K key, @Nonnull V value) {
-        return putIfAbsent(key, value, -1, TimeUnit.MILLISECONDS);
+        return putIfAbsent(key, value, DEFAULT_TTL, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -224,7 +225,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public void set(@Nonnull K key, @Nonnull V value) {
-        set(key, value, -1, TimeUnit.MILLISECONDS);
+        set(key, value, DEFAULT_TTL, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -347,7 +348,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public ICompletableFuture<V> putAsync(@Nonnull K key, @Nonnull V value) {
-        return putAsync(key, value, -1, TimeUnit.MILLISECONDS);
+        return putAsync(key, value, DEFAULT_TTL, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -370,7 +371,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
         checkNotNull(ttlUnit, NULL_TTL_UNIT_IS_NOT_ALLOWED);
-        checkNotNull(ttlUnit, NULL_MAX_IDLE_UNIT_IS_NOT_ALLOWED);
+        checkNotNull(maxIdleUnit, NULL_MAX_IDLE_UNIT_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
         return new DelegatingFuture<>(
@@ -380,7 +381,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public ICompletableFuture<Void> setAsync(@Nonnull K key, @Nonnull V value) {
-        return setAsync(key, value, -1, TimeUnit.MILLISECONDS);
+        return setAsync(key, value, DEFAULT_TTL, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -403,7 +404,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
         checkNotNull(ttlUnit, NULL_TTL_UNIT_IS_NOT_ALLOWED);
-        checkNotNull(ttlUnit, NULL_MAX_IDLE_UNIT_IS_NOT_ALLOWED);
+        checkNotNull(maxIdleUnit, NULL_MAX_IDLE_UNIT_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
         return new DelegatingFuture<>(

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -160,10 +160,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected Data putInternal(Object key, Data valueData, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
+            return super.putInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
@@ -210,22 +210,22 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit ttlUnit,
+    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data valueData, long ttl, TimeUnit ttlUnit,
                                                                long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putAsyncInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
+            return super.putAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit ttlUnit,
+    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data valueData, long ttl, TimeUnit ttlUnit,
                                                                long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.setAsyncInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
+            return super.setAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
@@ -252,10 +252,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void setInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected void setInternal(Object key, Data valueData, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            super.setInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
+            super.setInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -104,7 +104,7 @@ public class TxnDeleteOperation
 
     @Override
     public Operation getBackupOperation() {
-        return new TxnDeleteBackupOperation(name, dataKey, disableWanReplicationEvent);
+        return new TxnDeleteBackupOperation(name, dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -32,20 +32,22 @@ import java.io.IOException;
  */
 public class TxnLockAndGetOperation extends LockAwareOperation implements MutatingOperation {
 
-    private VersionedValue response;
-    private String ownerUuid;
+    private long ttl;
     private boolean shouldLoad;
     private boolean blockReads;
+    private String ownerUuid;
+    private VersionedValue response;
 
     public TxnLockAndGetOperation() {
     }
 
     public TxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String ownerUuid,
                                   boolean shouldLoad, boolean blockReads) {
-        super(name, dataKey, ttl, -1);
+        super(name, dataKey);
         this.ownerUuid = ownerUuid;
         this.shouldLoad = shouldLoad;
         this.blockReads = blockReads;
+        this.ttl = ttl;
         setWaitTimeout(timeout);
     }
 
@@ -82,6 +84,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
         out.writeUTF(ownerUuid);
         out.writeBoolean(shouldLoad);
         out.writeBoolean(blockReads);
+        out.writeLong(ttl);
     }
 
     @Override
@@ -90,6 +93,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
         ownerUuid = in.readUTF();
         shouldLoad = in.readBoolean();
         blockReads = in.readBoolean();
+        ttl = in.readLong();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -33,12 +33,11 @@ public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements B
 
     private static final long LOCK_TTL_MILLIS = 10000L;
     private String lockOwner;
-    private long lockThreadId;
 
     protected TxnPrepareBackupOperation(String name, Data dataKey, String lockOwner, long lockThreadId) {
         super(name, dataKey);
         this.lockOwner = lockOwner;
-        this.lockThreadId = lockThreadId;
+        this.threadId = lockThreadId;
     }
 
     public TxnPrepareBackupOperation() {
@@ -46,7 +45,7 @@ public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements B
 
     @Override
     protected void runInternal() {
-        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, getCallId(), LOCK_TTL_MILLIS, true)) {
+        if (!recordStore.txnLock(getKey(), lockOwner, threadId, getCallId(), LOCK_TTL_MILLIS, true)) {
             throw new TransactionException("Lock is not owned by the transaction! Caller: " + lockOwner
                     + ", Owner: " + recordStore.getLockOwnerInfo(getKey()));
         }
@@ -61,14 +60,12 @@ public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements B
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(lockOwner);
-        out.writeLong(lockThreadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         lockOwner = in.readUTF();
-        lockThreadId = in.readLong();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -32,12 +32,11 @@ import java.io.IOException;
 public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     private String lockOwner;
-    private long lockThreadId;
 
     protected TxnRollbackBackupOperation(String name, Data dataKey, String lockOwner, long lockThreadId) {
         super(name, dataKey);
         this.lockOwner = lockOwner;
-        this.lockThreadId = lockThreadId;
+        this.threadId = lockThreadId;
     }
 
     public TxnRollbackBackupOperation() {
@@ -45,7 +44,7 @@ public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements 
 
     @Override
     protected void runInternal() {
-        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), lockOwner, lockThreadId, getCallId())) {
+        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), lockOwner, threadId, getCallId())) {
             throw new TransactionException("Lock is not owned by the transaction! Owner: "
                     + recordStore.getLockOwnerInfo(getKey()));
         }
@@ -60,14 +59,12 @@ public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements 
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(lockOwner);
-        out.writeLong(lockThreadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         lockOwner = in.readUTF();
-        lockThreadId = in.readLong();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetBackupOperation.java
@@ -26,10 +26,8 @@ public class TxnSetBackupOperation extends PutBackupOperation {
     public TxnSetBackupOperation() {
     }
 
-    public TxnSetBackupOperation(String name, Data dataKey, Data dataValue,
-                                 RecordInfo recordInfo, boolean putTransient,
-                                 boolean disableWanReplicationEvent) {
-        super(name, dataKey, dataValue, recordInfo, putTransient, disableWanReplicationEvent);
+    public TxnSetBackupOperation(String name, Data dataKey, Data dataValue, RecordInfo recordInfo) {
+        super(name, dataKey, dataValue, recordInfo);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.BasePutOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
+import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -41,6 +42,7 @@ import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 public class TxnSetOperation extends BasePutOperation
         implements MapTxnOperation, MutatingOperation {
 
+    private long ttl;
     private long version;
     private String ownerUuid;
 
@@ -80,7 +82,7 @@ public class TxnSetOperation extends BasePutOperation
                 oldValue = record == null ? null : mapServiceContext.toData(record.getValue());
             }
             eventType = record == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
-            recordStore.set(dataKey, dataValue, ttl, maxIdle);
+            recordStore.set(dataKey, dataValue, ttl, RecordStore.DEFAULT_MAX_IDLE);
             shouldBackup = true;
         }
     }
@@ -127,8 +129,7 @@ public class TxnSetOperation extends BasePutOperation
         if (isPostProcessing(recordStore)) {
             dataValue = mapServiceContext.toData(record.getValue());
         }
-        return new TxnSetBackupOperation(name, dataKey, dataValue, replicationInfo,
-                putTransient, disableWanReplicationEvent);
+        return new TxnSetBackupOperation(name, dataKey, dataValue, replicationInfo);
     }
 
     @Override
@@ -141,6 +142,7 @@ public class TxnSetOperation extends BasePutOperation
         super.writeInternal(out);
         out.writeLong(version);
         out.writeUTF(ownerUuid);
+        out.writeLong(ttl);
     }
 
     @Override
@@ -148,6 +150,7 @@ public class TxnSetOperation extends BasePutOperation
         super.readInternal(in);
         version = in.readLong();
         ownerUuid = in.readUTF();
+        ttl = in.readLong();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -35,14 +35,15 @@ public class TxnUnlockBackupOperation extends KeyBasedMapOperation implements Ba
     public TxnUnlockBackupOperation() {
     }
 
-    public TxnUnlockBackupOperation(String name, Data dataKey, String ownerUuid) {
-        super(name, dataKey, -1, -1);
+    public TxnUnlockBackupOperation(String name, Data dataKey, String ownerUuid, long lockThreadId) {
+        super(name, dataKey);
         this.ownerUuid = ownerUuid;
+        this.threadId = lockThreadId;
     }
 
     @Override
     protected void runInternal() {
-        recordStore.unlock(dataKey, ownerUuid, getThreadId(), getCallId());
+        recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -22,9 +22,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
@@ -32,7 +32,8 @@ import java.io.IOException;
 /**
  * An operation to unlock key on the partition owner.
  */
-public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOperation, BackupAwareOperation, MutatingOperation {
+public class TxnUnlockOperation extends LockAwareOperation
+        implements MapTxnOperation, BackupAwareOperation, MutatingOperation {
 
     private long version;
     private String ownerUuid;
@@ -41,7 +42,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
     }
 
     public TxnUnlockOperation(String name, Data dataKey, long version) {
-        super(name, dataKey, -1, -1);
+        super(name, dataKey);
         this.version = version;
     }
 
@@ -86,9 +87,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
 
     @Override
     public Operation getBackupOperation() {
-        TxnUnlockBackupOperation txnUnlockOperation = new TxnUnlockBackupOperation(name, dataKey, ownerUuid);
-        txnUnlockOperation.setThreadId(getThreadId());
-        return txnUnlockOperation;
+        return new TxnUnlockBackupOperation(name, dataKey, ownerUuid, getThreadId());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/DeleteOperationWanFlagSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/DeleteOperationWanFlagSerializationTest.java
@@ -50,7 +50,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class RemoveBaseOperationWanFlagSerializationTest {
+public class DeleteOperationWanFlagSerializationTest {
 
     static final String MAP_NAME = "map";
 
@@ -91,22 +91,14 @@ public class RemoveBaseOperationWanFlagSerializationTest {
     }
 
     @Test
-    public void testRemoveOperation() throws IOException {
-        BaseRemoveOperation original = new RemoveOperation(MAP_NAME, keyMock, disableWanReplication);
-        BaseRemoveOperation deserialized = new RemoveOperation();
-
-        testSerialization(original, deserialized);
-    }
-
-    @Test
     public void testDeleteOperation() throws IOException {
-        BaseRemoveOperation original = new DeleteOperation(MAP_NAME, keyMock, disableWanReplication);
-        BaseRemoveOperation deserialized = new DeleteOperation();
+        DeleteOperation original = new DeleteOperation(MAP_NAME, keyMock, disableWanReplication);
+        DeleteOperation deserialized = new DeleteOperation();
 
         testSerialization(original, deserialized);
     }
 
-    private void testSerialization(BaseRemoveOperation originalOp, BaseRemoveOperation deserializedOp) throws IOException {
+    private void testSerialization(DeleteOperation originalOp, DeleteOperation deserializedOp) throws IOException {
         serializeAndDeserialize(originalOp, deserializedOp);
 
         assertEquals(originalOp.disableWanReplicationEvent, deserializedOp.disableWanReplicationEvent);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
@@ -67,7 +67,7 @@ public class OperationServiceImpl_asyncInvokeOnPartitionTest extends HazelcastTe
             Data sourceKey = nodeEngine.toData(entry.getKey());
             Data key = generateKey_FallsToSamePartitionThread_ButDifferentPartition(nodeEngine, sourceKey);
             Data val = nodeEngine.toData(randomString());
-            PutOperation op = new PutOperation((String) entry.getValue(), key, val, -1, -1);
+            PutOperation op = new PutOperation((String) entry.getValue(), key, val);
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             operationService.asyncInvokeOnPartition(MapService.SERVICE_NAME, op, partitionId,
                     new ExecutionCallback<Object>() {


### PR DESCRIPTION
- Move ttl and maxIdle fields to operations they are needed.
- Move disableWanReplicationEvent to related operations.
- Move putTransient and threadId fields to related operations.

As an example, to explain with numbers, after merge of improvement PRs(this and https://github.com/hazelcast/hazelcast/pull/15410), put-back-up operation will have 54 bytes smaller binary form with default config.

closes https://github.com/hazelcast/hazelcast/issues/14883

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3113