### PR TITLE
Make remaining configs NamedConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.config;
 
 import com.hazelcast.client.impl.proxy.ClientReliableTopicProxy;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.config.NamedConfig;
 import com.hazelcast.topic.TopicOverloadPolicy;
 
 import java.util.concurrent.Executor;
@@ -31,7 +32,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  *
  * @see ClientReliableTopicProxy
  */
-public class ClientReliableTopicConfig {
+public class ClientReliableTopicConfig implements NamedConfig {
     /**
      * The default read batch size.
      */
@@ -84,8 +85,9 @@ public class ClientReliableTopicConfig {
      * Sets the name or name pattern for this config. Must not be modified after this
      * instance is added to {@link ClientConfig}.
      */
-    public void setName(String name) {
+    public ClientReliableTopicConfig setName(String name) {
         this.name = name;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -35,7 +35,7 @@ import static com.hazelcast.util.Preconditions.checkTrue;
  *
  * @since 3.10
  */
-public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
+public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable , NamedConfig {
 
     /**
      * Default value for {@link #getPrefetchCount()}.
@@ -110,8 +110,9 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
      * Sets the name or name pattern for this config. Must not be modified after this
      * instance is added to {@link Config}.
      */
-    public void setName(String name) {
+    public FlakeIdGeneratorConfig setName(String name) {
         this.name = name;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfigReadOnly.java
@@ -28,7 +28,7 @@ public class FlakeIdGeneratorConfigReadOnly extends FlakeIdGeneratorConfig {
     }
 
     @Override
-    public void setName(String name) {
+    public FlakeIdGeneratorConfig setName(String name) {
         throw throwReadOnly();
     }
 


### PR DESCRIPTION
Remaining two data structure configs are also made NamedConfig
FlakeIdGeneratorConfig and ClientReliableTopicConfig

fixes https://github.com/hazelcast/hazelcast/issues/14144