### PR TITLE
Data has @PrivateAPI

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
@@ -17,12 +17,14 @@
 package com.hazelcast.nio.serialization;
 
 import com.hazelcast.partition.PartitioningStrategy;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**
  * Data is basic unit of serialization. It stores binary form of an object serialized
  * by {@link SerializationService#toData(Object)}.
  */
+@PrivateApi
 public interface Data {
 
     /**


### PR DESCRIPTION
class is not part of a public API; should not be used by end users.

Unfortunately moving this class to com.hz.internal.serialization is
problematic due to client code generation. But we should at least
mark this class as off limits.