### PR TITLE
Send IP address & canonical host name of client to MC

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
@@ -39,7 +39,7 @@ public class ClientEndPointDTO implements JsonSerializable {
     public String uuid;
 
     /**
-     * Client's socket address as "hostname : port"
+     * Client's socket address as "hostname:port"
      */
     public String address;
     public String clientType;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
@@ -23,6 +23,8 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.management.JsonSerializable;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -35,20 +37,40 @@ import static com.hazelcast.util.JsonUtil.getString;
 public class ClientEndPointDTO implements JsonSerializable {
 
     public String uuid;
+
+    /**
+     * Client's socket address as "hostname : port"
+     */
     public String address;
     public String clientType;
     public String name;
     public Set<String> labels;
+
+    /**
+     * Client's IP address (without port) or {@code null} if client's address is unresolved
+     */
+    public String ipAddress;
+
+    /**
+     * Client's FQDN if we're able to resolve it, host name if not. {@code null} if client's address is unresolved
+     */
+    public String canonicalHostName;
 
     public ClientEndPointDTO() {
     }
 
     public ClientEndPointDTO(Client client) {
         this.uuid = client.getUuid();
-        this.address = client.getSocketAddress().getHostName() + ":" + client.getSocketAddress().getPort();
         this.clientType = client.getClientType().toString();
         this.name = client.getName();
         this.labels = client.getLabels();
+
+        InetSocketAddress socketAddress = client.getSocketAddress();
+        this.address = socketAddress.getHostName() + ":" + socketAddress.getPort();
+
+        InetAddress address = socketAddress.getAddress();
+        this.ipAddress = address != null ? address.getHostAddress() : null;
+        this.canonicalHostName = address != null ? address.getCanonicalHostName() : null;
     }
 
     @Override
@@ -63,6 +85,8 @@ public class ClientEndPointDTO implements JsonSerializable {
             labelsObject.add(label);
         }
         root.add("labels", labelsObject);
+        root.add("ipAddress", ipAddress);
+        root.add("canonicalHostName", canonicalHostName);
         return root;
     }
 
@@ -77,5 +101,7 @@ public class ClientEndPointDTO implements JsonSerializable {
         for (JsonValue labelValue : labelsArray) {
             labels.add(labelValue.asString());
         }
+        ipAddress = getString(json, "ipAddress", null);
+        canonicalHostName = getString(json, "canonicalHostName", null);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -85,6 +85,8 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         client.clientType = "undefined";
         client.name = "aClient";
         client.labels = new HashSet<String>(Collections.singletonList("label"));
+        client.ipAddress = "10.176.167.34";
+        client.canonicalHostName = "ip-10-176-167-34.ec2.internal";
         clients.add(client);
 
         Map<String, Long> runtimeProps = new HashMap<String, Long>();
@@ -167,6 +169,8 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         assertEquals("undefined", client.clientType);
         assertEquals("aClient", client.name);
         assertContains(client.labels, "label");
+        assertEquals("10.176.167.34", client.ipAddress);
+        assertEquals("ip-10-176-167-34.ec2.internal", client.canonicalHostName);
 
         NodeState deserializedState = deserialized.getNodeState();
         assertEquals(clusterState, deserializedState.getClusterState());


### PR DESCRIPTION
Corresponding MC PR: https://github.com/hazelcast/management-center/pull/2021

Currently, we show the hostname of the client on MC UI. In order to let the user show the client's IP address or its canonical hostname instead, we're sending both to MC with this PR.