### PR TITLE
BindHandlerTest rewritten with real network

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpEndpointManager.java
@@ -71,14 +71,13 @@ public class TcpIpEndpointManager
     private static final long DELAY_FACTOR = 100L;
 
     @Probe(name = "inProgressCount")
-    final Set<Address> connectionsInProgress = newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
+    final Set<Address> connectionsInProgress = newSetFromMap(new ConcurrentHashMap<>());
 
     @Probe(name = "count", level = MANDATORY)
-    final ConcurrentHashMap<Address, TcpIpConnection> connectionsMap =
-            new ConcurrentHashMap<Address, TcpIpConnection>(100);
+    final ConcurrentHashMap<Address, TcpIpConnection> connectionsMap = new ConcurrentHashMap<>(100);
 
     @Probe(name = "activeCount", level = MANDATORY)
-    final Set<TcpIpConnection> activeConnections = newSetFromMap(new ConcurrentHashMap<TcpIpConnection, Boolean>());
+    final Set<TcpIpConnection> activeConnections = newSetFromMap(new ConcurrentHashMap<>());
 
     private final ILogger logger;
     private final IOService ioService;
@@ -90,19 +89,13 @@ public class TcpIpEndpointManager
     private final BindHandler bindHandler;
 
     @Probe(name = "connectionListenerCount")
-    private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
+    private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<>();
 
     private final ConstructorFunction<Address, TcpIpConnectionErrorHandler> monitorConstructor =
-            new ConstructorFunction<Address, TcpIpConnectionErrorHandler>() {
-                public TcpIpConnectionErrorHandler createNew(Address endpoint) {
-                    return new TcpIpConnectionErrorHandler(TcpIpEndpointManager.this, endpoint);
-                }
-            };
+            endpoint -> new TcpIpConnectionErrorHandler(TcpIpEndpointManager.this, endpoint);
 
     @Probe(name = "monitorCount")
-    private final ConcurrentHashMap<Address, TcpIpConnectionErrorHandler> monitors =
-            new ConcurrentHashMap<Address, TcpIpConnectionErrorHandler>(100);
-
+    private final ConcurrentHashMap<Address, TcpIpConnectionErrorHandler> monitors = new ConcurrentHashMap<>(100);
 
     private final AtomicInteger connectionIdGen = new AtomicInteger();
 
@@ -152,7 +145,7 @@ public class TcpIpEndpointManager
     }
 
     public Collection<TcpIpConnection> getConnections() {
-        return unmodifiableCollection(new HashSet<TcpIpConnection>(connectionsMap.values()));
+        return unmodifiableCollection(new HashSet<>(connectionsMap.values()));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerInterfacesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerInterfacesTest.java
@@ -43,11 +43,10 @@ import java.util.List;
 
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV4_STACK;
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
-import static com.hazelcast.instance.impl.DefaultAddressPickerInterfacesTest.NetworkInterfaceOptions.builder;
+import static com.hazelcast.instance.impl.NetworkInterfaceMockingOptions.builder;
 import static com.hazelcast.instance.impl.TestUtil.setSystemProperty;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.OverridePropertyRule.set;
-import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.Collections.enumeration;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -339,8 +338,8 @@ public class DefaultAddressPickerInterfacesTest {
     /**
      * Creates a mocked NetworkInterface instance with given configuration.
      */
-    private NetworkInterface createNetworkConfig(NetworkInterfaceOptions.Builder builder) throws IOException {
-        NetworkInterfaceOptions networkConfigOptions = builder.build();
+    private NetworkInterface createNetworkConfig(NetworkInterfaceMockingOptions.Builder builder) throws IOException {
+        NetworkInterfaceMockingOptions networkConfigOptions = builder.build();
         NetworkInterface networkInterface = mock(NetworkInterface.class);
         when(networkInterface.getName()).thenReturn(networkConfigOptions.name);
         when(networkInterface.isUp()).thenReturn(networkConfigOptions.up);
@@ -361,77 +360,4 @@ public class DefaultAddressPickerInterfacesTest {
         return enumeration(inetAddresses);
     }
 
-    /**
-     * Configuration object for {@link NetworkInterface} mocking.
-     */
-    public static class NetworkInterfaceOptions {
-
-        private final String name;
-        private final boolean up;
-        private final boolean loopback;
-        private final boolean virtual;
-        private final String[] addresses;
-
-        private NetworkInterfaceOptions(Builder builder) {
-            this.name = checkNotNull(builder.name);
-            this.up = builder.up;
-            this.loopback = builder.loopback;
-            this.virtual = builder.virtual;
-            this.addresses = checkNotNull(builder.addresses);
-        }
-
-        /**
-         * Creates builder to build {@link NetworkInterfaceOptions}.
-         *
-         * @return created builder
-         */
-        public static Builder builder() {
-            return new Builder();
-        }
-
-        /**
-         * Builder to build {@link NetworkInterfaceOptions}.
-         */
-        @SuppressWarnings("SameParameterValue")
-        public static final class Builder {
-
-            private String name;
-            private boolean up = true;
-            private boolean loopback = false;
-            private boolean virtual = false;
-            private String[] addresses = {};
-
-            private Builder() {
-            }
-
-            Builder withName(String name) {
-                this.name = name;
-                return this;
-            }
-
-            Builder withUp(boolean up) {
-                this.up = up;
-                return this;
-            }
-
-            Builder withLoopback(boolean loopback) {
-                this.loopback = loopback;
-                return this;
-            }
-
-            Builder withVirtual(boolean virtual) {
-                this.virtual = virtual;
-                return this;
-            }
-
-            Builder withAddresses(String... addresses) {
-                this.addresses = addresses;
-                return this;
-            }
-
-            NetworkInterfaceOptions build() {
-                return new NetworkInterfaceOptions(this);
-            }
-        }
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NetworkInterfaceMockingOptions.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NetworkInterfaceMockingOptions.java
@@ -1,0 +1,79 @@
+package com.hazelcast.instance.impl;
+
+import java.net.NetworkInterface;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Configuration object for {@link NetworkInterface} mocking.
+ */
+public class NetworkInterfaceMockingOptions {
+
+    final String name;
+    final boolean up;
+    final boolean loopback;
+    final boolean virtual;
+    final String[] addresses;
+
+    private NetworkInterfaceMockingOptions(Builder builder) {
+        this.name = checkNotNull(builder.name);
+        this.up = builder.up;
+        this.loopback = builder.loopback;
+        this.virtual = builder.virtual;
+        this.addresses = checkNotNull(builder.addresses);
+    }
+
+    /**
+     * Creates builder to build {@link NetworkInterfaceMockingOptions}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link NetworkInterfaceMockingOptions}.
+     */
+    @SuppressWarnings("SameParameterValue")
+    public static final class Builder {
+
+        private String name;
+        private boolean up = true;
+        private boolean loopback = false;
+        private boolean virtual = false;
+        private String[] addresses = {};
+
+        private Builder() {
+        }
+
+        Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        Builder withUp(boolean up) {
+            this.up = up;
+            return this;
+        }
+
+        Builder withLoopback(boolean loopback) {
+            this.loopback = loopback;
+            return this;
+        }
+
+        Builder withVirtual(boolean virtual) {
+            this.virtual = virtual;
+            return this;
+        }
+
+        Builder withAddresses(String... addresses) {
+            this.addresses = addresses;
+            return this;
+        }
+
+        NetworkInterfaceMockingOptions build() {
+            return new NetworkInterfaceMockingOptions(this);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NetworkInterfaceMockingOptions.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NetworkInterfaceMockingOptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.instance.impl;
 
 import java.net.NetworkInterface;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/BindHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/BindHandlerTest.java
@@ -16,23 +16,22 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServerSocketEndpointConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ExtendedBindMessage;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionType;
-import com.hazelcast.nio.IOService;
-import com.hazelcast.nio.NetworkingService;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,8 +40,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -50,26 +47,26 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.instance.ProtocolType.WAN;
-import static com.hazelcast.test.HazelcastTestSupport.randomName;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.getSerializationService;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.reflect.Whitebox.setInternalState;
 
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class})
 public class BindHandlerTest {
 
     // client side socket address of the new connection
@@ -120,10 +117,7 @@ public class BindHandlerTest {
     @Parameter(4)
     public List<Address> expectedAddresses;
 
-    // connection registrations will be asserted against contents of this map
-    private final ConcurrentHashMap<Address, TcpIpConnection> connectionsMap = new ConcurrentHashMap<Address, TcpIpConnection>();
-
-    private InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+    private InternalSerializationService serializationService;
     private BindHandler bindHandler;
 
     // mocks
@@ -157,17 +151,41 @@ public class BindHandlerTest {
     }
 
     @Before
-    public void setup() {
-        setup(connectionsMap, protocolType);
+    public void setup() throws IllegalAccessException {
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfig());
+        serializationService = getSerializationService(hz);
+        Node node = getNode(hz);
+        endpointManager = TcpIpEndpointManager.class.cast(
+                node.getEndpointManager(EndpointQualifier.resolve(protocolType, "wan")));
+        bindHandler = (BindHandler) getFieldValueReflectively(endpointManager, "bindHandler");
+
+        // setup mock channel & socket
+        Socket socket = mock(Socket.class);
+        when(socket.getRemoteSocketAddress()).thenReturn(CLIENT_SOCKET_ADDRESS);
+
+        channel = mock(Channel.class);
+        ConcurrentMap channelAttributeMap = new ConcurrentHashMap();
+        when(channel.attributeMap()).thenReturn(channelAttributeMap);
+        when(channel.socket()).thenReturn(socket);
+        when(channel.remoteSocketAddress()).thenReturn(CLIENT_SOCKET_ADDRESS);
+    }
+
+    @After
+    public void tearDown() {
+        Hazelcast.shutdownAll();
     }
 
     @Test
-    public void process() {
+    public void process() throws IllegalAccessException {
         bindHandler.process(extendedBind());
         assertExpectedAddressesRegistered();
     }
 
-    private void assertExpectedAddressesRegistered() {
+    private void assertExpectedAddressesRegistered()
+            throws IllegalAccessException {
+        // inspect connections in TcpIpEndpointManager
+        ConcurrentHashMap<Address, TcpIpConnection> connectionsMap =
+                (ConcurrentHashMap<Address, TcpIpConnection>) getFieldValueReflectively(endpointManager, "connectionsMap");
         try {
             for (Address address : expectedAddresses) {
                 assertTrue(connectionsMap.containsKey(address));
@@ -198,7 +216,7 @@ public class BindHandlerTest {
     }
 
     private static Map<ProtocolType, Collection<Address>> localAddresses_memberWan() {
-        Map<ProtocolType, Collection<Address>> addresses = new HashMap<ProtocolType, Collection<Address>>();
+        Map<ProtocolType, Collection<Address>> addresses = new HashMap<>();
 
         Collection<Address> memberAddresses = singletonList(new Address(INITIATOR_MEMBER_ADDRESS));
         Collection<Address> wanAddresses = singletonList(new Address(INITIATOR_WAN_ADDRESS));
@@ -208,57 +226,25 @@ public class BindHandlerTest {
         return addresses;
     }
 
-    private static Map<EndpointQualifier, Address> serverAddresses() {
-        Map<EndpointQualifier, Address> addressMap = new HashMap<EndpointQualifier, Address>();
-        addressMap.put(EndpointQualifier.MEMBER, SERVER_MEMBER_ADDRESS);
-        addressMap.put(EndpointQualifier.CLIENT, SERVER_CLIENT_ADDRESS);
-        addressMap.put(EndpointQualifier.resolve(WAN, "wan"), SERVER_WAN_ADDRESS);
-        return addressMap;
-    }
+    private Config createConfig() {
+        ServerSocketEndpointConfig memberServerSocketConfig = new ServerSocketEndpointConfig()
+                .setPort(SERVER_MEMBER_ADDRESS.getPort());
+        memberServerSocketConfig.getInterfaces().addInterface(SERVER_MEMBER_ADDRESS.getHost());
+        ServerSocketEndpointConfig clientServerSocketConfig = new ServerSocketEndpointConfig()
+                .setPort(SERVER_CLIENT_ADDRESS.getPort());
+        clientServerSocketConfig.getInterfaces().addInterface(SERVER_CLIENT_ADDRESS.getHost());
+        ServerSocketEndpointConfig wanServerSocketConfig = new ServerSocketEndpointConfig()
+                .setName("wan")
+                .setPort(SERVER_WAN_ADDRESS.getPort());
+        wanServerSocketConfig.getInterfaces().addInterface(SERVER_WAN_ADDRESS.getHost());
 
-    private void setup(final ConcurrentHashMap<Address, TcpIpConnection> connectionsMap,
-                       ProtocolType protocolType) {
-        ILogger logger = Logger.getLogger(BindHandlerTest.class);
-
-        LoggingService loggingService = mock(LoggingService.class);
-        when(loggingService.getLogger(any(Class.class))).thenReturn(logger);
-
-        IOService ioService = mock(IOService.class);
-        when(ioService.getSerializationService()).thenReturn(serializationService);
-        when(ioService.getLoggingService()).thenReturn(loggingService);
-        when(ioService.getThisAddress()).thenReturn(SERVER_MEMBER_ADDRESS);
-        when(ioService.getThisAddresses()).thenReturn(serverAddresses());
-
-        NetworkingService networkingService = mock(NetworkingService.class);
-        when(networkingService.getIoService()).thenReturn(ioService);
-
-        endpointManager = mock(TcpIpEndpointManager.class);
-        when(endpointManager.getNetworkingService()).thenReturn(networkingService);
-        when(endpointManager.registerConnection(any(Address.class), any(TcpIpConnection.class)))
-                .then(new Answer<Boolean>() {
-                    @Override
-                    public Boolean answer(InvocationOnMock invocation)
-                            throws Throwable {
-                        connectionsMap.put(
-                                (Address) invocation.getArgument(0),
-                                (TcpIpConnection) invocation.getArgument(1)
-                        );
-                        return true;
-                    }
-                });
-        when(endpointManager.getEndpointQualifier()).thenReturn(EndpointQualifier.resolve(protocolType, randomName()));
-        setInternalState(endpointManager, "connectionsInProgress", new HashSet<Address>());
-        setInternalState(endpointManager, "connectionsMap", connectionsMap);
-
-        Socket socket = mock(Socket.class);
-        when(socket.getRemoteSocketAddress()).thenReturn(CLIENT_SOCKET_ADDRESS);
-
-        channel = mock(Channel.class);
-        ConcurrentMap channelAttributeMap = new ConcurrentHashMap();
-        when(channel.attributeMap()).thenReturn(channelAttributeMap);
-        when(channel.socket()).thenReturn(socket);
-        when(channel.remoteSocketAddress()).thenReturn(CLIENT_SOCKET_ADDRESS);
-
-        bindHandler = new BindHandler(endpointManager, ioService, logger, true, Collections.singleton(protocolType));
+        memberServerSocketConfig.getInterfaces().addInterface("127.0.0.1");
+        Config config = smallInstanceConfig();
+        config.getAdvancedNetworkConfig()
+              .setEnabled(true)
+              .setMemberEndpointConfig(memberServerSocketConfig)
+              .setClientEndpointConfig(clientServerSocketConfig)
+              .addWanEndpointConfig(wanServerSocketConfig);
+        return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -23,8 +23,8 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.impl.DefaultNodeContext;
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.impl.DefaultNodeContext;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.instance.impl.NodeContext;
 import com.hazelcast.internal.jmx.ManagementService;
@@ -46,14 +46,13 @@ import static com.hazelcast.test.HazelcastTestSupport.getAddress;
  * {@link org.junit.After} methods (see {@link #terminateAll()}). The factory methods also sets custom group name which prevents
  * accidental joins (e.g. dangling members).
  * <p>
- * <b>Tests using this factory should not be annotated with {@code ParallelJVMTest} category to avoid runs in multiple JVMs.</b>
+ * <b>Tests using this factory should not be annotated with {@link ParallelJVMTest} category to avoid runs in multiple JVMs.</b>
  * <p>
- * Usage of {@link ParallelJVMTest} is allowed with this instance factory.<br>
  * Example:
  *
  * <pre>
  * &#64;RunWith(HazelcastParallelClassRunner.class)
- * &#64;Category({QuickTest.class, ParallelJVMTest.class})
+ * &#64;Category(QuickTest.class)
  * public class Test {
  *
  *     private final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
@@ -85,7 +84,7 @@ public class TestAwareInstanceFactory {
 
     private static final AtomicInteger PORT = new AtomicInteger(5000);
 
-    protected final Map<String, List<HazelcastInstance>> perMethodMembers = new ConcurrentHashMap<String, List<HazelcastInstance>>();
+    protected final Map<String, List<HazelcastInstance>> perMethodMembers = new ConcurrentHashMap<>();
 
     /**
      * Calls {@link #newHazelcastInstance(Config, NodeContext)} using the
@@ -158,11 +157,7 @@ public class TestAwareInstanceFactory {
 
     protected List<HazelcastInstance> getOrInitInstances(Map<String, List<HazelcastInstance>> map) {
         String methodName = getTestMethodName();
-        List<HazelcastInstance> list = map.get(methodName);
-        if (list == null) {
-            list = new ArrayList<HazelcastInstance>();
-            map.put(methodName, list);
-        }
+        List<HazelcastInstance> list = map.computeIfAbsent(methodName, k -> new ArrayList<>());
         return list;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
@@ -129,7 +129,7 @@ public final class ReflectionUtils {
         return clazz.getName().equals(arg.getClass().getName());
     }
 
-    public static Object getFieldValueReflectively(Object arg, String fieldName) throws IllegalAccessException {
+    public static <T> T getFieldValueReflectively(Object arg, String fieldName) throws IllegalAccessException {
         checkNotNull(arg, "Argument cannot be null");
         checkHasText(fieldName, "Field name cannot be null");
 
@@ -141,7 +141,7 @@ public final class ReflectionUtils {
         }
 
         field.setAccessible(true);
-        return field.get(arg);
+        return (T) field.get(arg);
     }
 
     public static void setFieldValueReflectively(Object arg, String fieldName, Object newValue) throws IllegalAccessException {

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>
-        <powermock.version>2.0.0-beta.5</powermock.version>
+        <powermock.version>2.0.2</powermock.version>
         <bytebuddy.version>1.8.17</bytebuddy.version>
         <reflections.version>0.9.10</reflections.version>
         <jmh.version>1.16</jmh.version>


### PR DESCRIPTION
Due to [changes in JDK12+](https://bugs.openjdk.java.net/browse/JDK-8210522) not allowing access to `Field.modifiers field`,
final fields can no longer be manipulated at runtime (unless an agent
removes the final modifier at class loading time). Instead of using
Powermock to set final fields in mock `TcpIpEndpointManager`, the test
now uses a real network `HazelcastInstance` configured with advanced
network.

Also upgrades to latest stable Powermock version.

Fixes #15422 