### PR TITLE
Improve performance of TransactionLog.add() in 3.x

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
@@ -50,7 +50,7 @@ public class AllowedDuringPassiveStateTransactionImpl
 
     protected ReplicateTxBackupLogOperation createReplicateTxBackupLogOperation() {
         return new ReplicateAllowedDuringPassiveStateTxBackupLogOperation(
-                getTransactionLog().getRecordList(), getOwnerUuid(), getTxnId(), getTimeoutMillis(), getStartTime());
+                getTransactionLog().getRecords(), getOwnerUuid(), getTxnId(), getTimeoutMillis(), getStartTime());
     }
 
     protected RollbackTxBackupLogOperation createRollbackTxBackupLogOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -437,7 +437,7 @@ public class TransactionImpl implements Transaction {
 
     protected ReplicateTxBackupLogOperation createReplicateTxBackupLogOperation() {
         return new ReplicateTxBackupLogOperation(
-                transactionLog.getRecordList(), txOwnerUuid, txnId, timeoutMillis, startTime);
+                transactionLog.getRecords(), txOwnerUuid, txnId, timeoutMillis, startTime);
     }
 
     protected RollbackTxBackupLogOperation createRollbackTxBackupLogOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -25,9 +25,8 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -38,12 +37,12 @@ import java.util.concurrent.Future;
  * the TransactionLog will contains 4 {@link TransactionLogRecord} instances.
  *
  * planned optimization:
- * Most transaction will be small, but an linkedhashmap is created. Instead use an array and do a
+ * Most transaction will be small, but an hashmap is created. Instead use an array and do a
  * linear search in that array. When there are too many items added, then enable the hashmap.
  */
 public class TransactionLog {
 
-    private final Map<Object, TransactionLogRecord> recordMap = new LinkedHashMap<>();
+    private final Map<Object, TransactionLogRecord> recordMap = new HashMap<>();
 
     public TransactionLog() {
     }
@@ -103,10 +102,7 @@ public class TransactionLog {
 
     public List<Future> rollback(NodeEngine nodeEngine) {
         List<Future> futures = new ArrayList<Future>(size());
-        List<TransactionLogRecord> records = new ArrayList<>(recordMap.values());
-        ListIterator<TransactionLogRecord> iterator = records.listIterator(size());
-        while (iterator.hasPrevious()) {
-            TransactionLogRecord record = iterator.previous();
+        for (TransactionLogRecord record : recordMap.values()) {
             Future future = invoke(nodeEngine, record, record.newRollbackOperation());
             futures.add(future);
         }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -24,8 +24,7 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -38,38 +37,28 @@ import java.util.concurrent.Future;
  * the TransactionLog will contains 4 {@link TransactionLogRecord} instances.
  *
  * planned optimization:
- * Most transaction will be small, but an linkedlist + hashmap is created. Instead use an array and do a
+ * Most transaction will be small, but an linkedhashmap is created. Instead use an array and do a
  * linear search in that array. When there are too many items added, then enable the hashmap.
  */
 public class TransactionLog {
 
-    private final List<TransactionLogRecord> recordList = new LinkedList<TransactionLogRecord>();
-    private final Map<Object, TransactionLogRecord> recordMap = new HashMap<Object, TransactionLogRecord>();
+    private final Map<Object, TransactionLogRecord> recordMap = new LinkedHashMap<>();
 
     public TransactionLog() {
     }
 
     public TransactionLog(List<TransactionLogRecord> transactionLog) {
-        //
-        recordList.addAll(transactionLog);
+        for (TransactionLogRecord record : transactionLog) {
+            add(record);
+        }
     }
 
     public void add(TransactionLogRecord record) {
         Object key = record.getKey();
-
-        // there should be just one tx log for the same key. so if there is older we are removing it
-        if (key != null) {
-            TransactionLogRecord removed = recordMap.remove(key);
-            if (removed != null) {
-                recordList.remove(removed);
-            }
+        if (key == null) {
+            key = new Object();
         }
-
-        recordList.add(record);
-
-        if (key != null) {
-            recordMap.put(key, record);
-        }
+        recordMap.put(key, record);
     }
 
     public TransactionLogRecord get(Object key) {
@@ -77,14 +66,11 @@ public class TransactionLog {
     }
 
     public List<TransactionLogRecord> getRecordList() {
-        return recordList;
+        return new ArrayList<>(recordMap.values());
     }
 
     public void remove(Object key) {
-        TransactionLogRecord removed = recordMap.remove(key);
-        if (removed != null) {
-            recordList.remove(removed);
-        }
+        recordMap.remove(key);
     }
 
     /**
@@ -93,12 +79,12 @@ public class TransactionLog {
      * @return the number of TransactionRecords.
      */
     public int size() {
-        return recordList.size();
+        return recordMap.size();
     }
 
     public List<Future> commit(NodeEngine nodeEngine) {
         List<Future> futures = new ArrayList<Future>(size());
-        for (TransactionLogRecord record : recordList) {
+        for (TransactionLogRecord record : recordMap.values()) {
             Future future = invoke(nodeEngine, record, record.newCommitOperation());
             futures.add(future);
         }
@@ -107,7 +93,7 @@ public class TransactionLog {
 
     public List<Future> prepare(NodeEngine nodeEngine) {
         List<Future> futures = new ArrayList<Future>(size());
-        for (TransactionLogRecord record : recordList) {
+        for (TransactionLogRecord record : recordMap.values()) {
             Future future = invoke(nodeEngine, record, record.newPrepareOperation());
             futures.add(future);
         }
@@ -116,7 +102,7 @@ public class TransactionLog {
 
     public List<Future> rollback(NodeEngine nodeEngine) {
         List<Future> futures = new ArrayList<Future>(size());
-        ListIterator<TransactionLogRecord> iterator = recordList.listIterator(size());
+        ListIterator<TransactionLogRecord> iterator = getRecordList().listIterator(size());
         while (iterator.hasPrevious()) {
             TransactionLogRecord record = iterator.previous();
             Future future = invoke(nodeEngine, record, record.newRollbackOperation());
@@ -135,13 +121,13 @@ public class TransactionLog {
     }
 
     public void commitAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        for (TransactionLogRecord record : recordList) {
+        for (TransactionLogRecord record : recordMap.values()) {
             invokeAsync(nodeEngine, callback, record, record.newCommitOperation());
         }
     }
 
     public void rollbackAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        for (TransactionLogRecord record : recordList) {
+        for (TransactionLogRecord record : recordMap.values()) {
             invokeAsync(nodeEngine, callback, record, record.newRollbackOperation());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -47,7 +48,7 @@ public class TransactionLog {
     public TransactionLog() {
     }
 
-    public TransactionLog(List<TransactionLogRecord> transactionLog) {
+    public TransactionLog(Collection<TransactionLogRecord> transactionLog) {
         for (TransactionLogRecord record : transactionLog) {
             add(record);
         }
@@ -65,8 +66,8 @@ public class TransactionLog {
         return recordMap.get(key);
     }
 
-    public List<TransactionLogRecord> getRecordList() {
-        return new ArrayList<>(recordMap.values());
+    public Collection<TransactionLogRecord> getRecords() {
+        return recordMap.values();
     }
 
     public void remove(Object key) {
@@ -102,7 +103,8 @@ public class TransactionLog {
 
     public List<Future> rollback(NodeEngine nodeEngine) {
         List<Future> futures = new ArrayList<Future>(size());
-        ListIterator<TransactionLogRecord> iterator = getRecordList().listIterator(size());
+        List<TransactionLogRecord> records = new ArrayList<>(recordMap.values());
+        ListIterator<TransactionLogRecord> iterator = records.listIterator(size());
         while (iterator.hasPrevious()) {
             TransactionLogRecord record = iterator.previous();
             Future future = invoke(nodeEngine, record, record.newRollbackOperation());

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.transaction.impl.operations;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
 
-import java.util.List;
+import java.util.Collection;
 
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.REPLICATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
 
@@ -30,7 +30,7 @@ public final class ReplicateAllowedDuringPassiveStateTxBackupLogOperation
     public ReplicateAllowedDuringPassiveStateTxBackupLogOperation() {
     }
 
-    public ReplicateAllowedDuringPassiveStateTxBackupLogOperation(List<TransactionLogRecord> logs, String callerUuid,
+    public ReplicateAllowedDuringPassiveStateTxBackupLogOperation(Collection<TransactionLogRecord> logs, String callerUuid,
                                                                   String txnId, long timeoutMillis, long startTime) {
         super(logs, callerUuid, txnId, timeoutMillis, startTime);
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.transaction.impl.TransactionLogRecord;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -48,7 +49,7 @@ public class ReplicateTxBackupLogOperation extends AbstractTxOperation {
     public ReplicateTxBackupLogOperation() {
     }
 
-    public ReplicateTxBackupLogOperation(List<TransactionLogRecord> logs, String callerUuid, String txnId,
+    public ReplicateTxBackupLogOperation(Collection<TransactionLogRecord> logs, String callerUuid, String txnId,
                                          long timeoutMillis, long startTime) {
         records.addAll(logs);
         this.callerUuid = callerUuid;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -36,6 +36,7 @@ import com.hazelcast.util.UuidUtil;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -99,7 +100,7 @@ public final class XATransaction implements Transaction {
         this.originatedFromClient = originatedFromClient;
     }
 
-    public XATransaction(NodeEngine nodeEngine, List<TransactionLogRecord> logs,
+    public XATransaction(NodeEngine nodeEngine, Collection<TransactionLogRecord> logs,
                          String txnId, SerializableXID xid, String txOwnerUuid, long timeoutMillis, long startTime) {
         this.nodeEngine = nodeEngine;
         this.transactionLog = new TransactionLog(logs);
@@ -145,7 +146,7 @@ public final class XATransaction implements Transaction {
 
     private void putTransactionInfoRemote() throws ExecutionException, InterruptedException {
         PutRemoteTransactionOperation operation = new PutRemoteTransactionOperation(
-                transactionLog.getRecordList(), txnId, xid, txOwnerUuid, timeoutMillis, startTime);
+                transactionLog.getRecords(), txnId, xid, txOwnerUuid, timeoutMillis, startTime);
         OperationService operationService = nodeEngine.getOperationService();
         IPartitionService partitionService = nodeEngine.getPartitionService();
         int partitionId = partitionService.getPartitionId(xid);
@@ -221,8 +222,8 @@ public final class XATransaction implements Transaction {
         return startTime;
     }
 
-    public List<TransactionLogRecord> getTransactionRecords() {
-        return transactionLog.getRecordList();
+    public Collection<TransactionLogRecord> getTransactionRecords() {
+        return transactionLog.getRecords();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
@@ -24,6 +24,7 @@ import com.hazelcast.transaction.impl.TransactionLogRecord;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class XATransactionDTO implements IdentifiedDataSerializable {
@@ -32,7 +33,7 @@ public class XATransactionDTO implements IdentifiedDataSerializable {
     private String ownerUuid;
     private long timeoutMilis;
     private long startTime;
-    private List<TransactionLogRecord> records;
+    private Collection<TransactionLogRecord> records;
 
     public XATransactionDTO() {
     }
@@ -76,7 +77,7 @@ public class XATransactionDTO implements IdentifiedDataSerializable {
         return startTime;
     }
 
-    public List<TransactionLogRecord> getRecords() {
+    public Collection<TransactionLogRecord> getRecords() {
         return records;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
@@ -28,6 +28,7 @@ import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.transaction.impl.xa.XATransaction;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class PutRemoteTransactionOperation extends AbstractXAOperation implement
     public PutRemoteTransactionOperation() {
     }
 
-    public PutRemoteTransactionOperation(List<TransactionLogRecord> logs, String txnId, SerializableXID xid,
+    public PutRemoteTransactionOperation(Collection<TransactionLogRecord> logs, String txnId, SerializableXID xid,
                                          String txOwnerUuid, long timeoutMillis, long startTime) {
         records.addAll(logs);
         this.txnId = txnId;

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
@@ -29,7 +29,8 @@ import org.junit.runner.RunWith;
 
 import java.net.InetAddress;
 
-import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -63,7 +64,7 @@ public class TransactionLogTest {
         log.add(record);
 
         assertEquals(1, log.size());
-        assertEquals(asList(record), log.getRecordList());
+        assertThat(log.getRecords(), contains(record));
     }
 
     @Test


### PR DESCRIPTION
Backport of #15111 into 3.x line, improves performance of `TransactionLog.add()` by avoiding `LinkedList.remove()` call, see the original PR for details.