### PR TITLE
Fixed EntryLoaderInitializationTest (#15376)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -34,6 +34,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
         super(name, dataKey);
 
         this.dataKey = dataKey;
+        Thread.dumpStack();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -34,7 +34,6 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
         super(name, dataKey);
 
         this.dataKey = dataKey;
-        Thread.dumpStack();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderInitializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderInitializationTest.java
@@ -72,7 +72,9 @@ public class EntryLoaderInitializationTest extends HazelcastTestSupport {
             assertNull(map.get("key" + i));
         }
 
-        assertEquals(entryCount, entryLoader.getLoadCallCount());
+        // entryLoader.loadCallCount() may be greater than entryCount because of retries
+        assertGreaterOrEquals("entryLoader.loadCallCount()", entryLoader.getLoadCallCount(), entryCount);
+        assertEquals(entryCount, entryLoader.getLoadUniqueKeysCount());
     }
 
     @Test
@@ -103,12 +105,15 @@ public class EntryLoaderInitializationTest extends HazelcastTestSupport {
         for (int i = 0; i < entryCount; i++) {
             assertEquals("val" + i, map.get("key" + i));
         }
+        assertEquals(0, entryLoader.getLoadCallCount());
         sleepAtLeastSeconds(6);
-
         for (int i = 0; i < entryCount; i++) {
             assertNull(map.get("key" + i));
         }
-        assertEquals(entryCount, entryLoader.getLoadCallCount());
+
+        // entryLoader.loadCallCount() may be greater than entryCount because of retries
+        assertGreaterOrEquals("entryLoader.loadCallCount()", entryLoader.getLoadCallCount(), entryCount);
+        assertEquals(entryCount, entryLoader.getLoadUniqueKeysCount());
     }
 
     private Config createConfig(MapStoreConfig.InitialLoadMode loadMode, EntryLoader entryLoader) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/TestEntryLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/TestEntryLoader.java
@@ -21,6 +21,8 @@ import com.hazelcast.map.EntryLoader;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,11 +34,13 @@ public class TestEntryLoader implements EntryLoader<String, String> {
     private AtomicInteger loadedEntryCount = new AtomicInteger();
     private AtomicInteger loadAllCallCount = new AtomicInteger();
     private AtomicInteger loadCallCount = new AtomicInteger();
+    private Set<String> loadUniqueKeys = ConcurrentHashMap.newKeySet();
     private AtomicInteger loadKeysCallCount = new AtomicInteger();
 
     @Override
     public MetadataAwareValue<String> load(String key) {
         loadCallCount.incrementAndGet();
+        loadUniqueKeys.add(key);
         if (NULL_RETURNING_KEY.equals(key)) {
             return null;
         }
@@ -84,6 +88,10 @@ public class TestEntryLoader implements EntryLoader<String, String> {
 
     public int getLoadCallCount() {
         return loadCallCount.get();
+    }
+
+    public int getLoadUniqueKeysCount() {
+        return loadUniqueKeys.size();
     }
 
     public int getLoadAllCallCount() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/TestEntryLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/TestEntryLoader.java
@@ -30,7 +30,7 @@ public class TestEntryLoader implements EntryLoader<String, String> {
 
     static final String NULL_RETURNING_KEY = "nullReturningKey";
 
-    private Map<String, Record> records = new HashMap<>();
+    private Map<String, Record> records = new ConcurrentHashMap<>();
     private AtomicInteger loadedEntryCount = new AtomicInteger();
     private AtomicInteger loadAllCallCount = new AtomicInteger();
     private AtomicInteger loadCallCount = new AtomicInteger();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/TestEntryLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/TestEntryLoader.java
@@ -30,12 +30,12 @@ public class TestEntryLoader implements EntryLoader<String, String> {
 
     static final String NULL_RETURNING_KEY = "nullReturningKey";
 
-    private Map<String, Record> records = new ConcurrentHashMap<>();
-    private AtomicInteger loadedEntryCount = new AtomicInteger();
-    private AtomicInteger loadAllCallCount = new AtomicInteger();
-    private AtomicInteger loadCallCount = new AtomicInteger();
-    private Set<String> loadUniqueKeys = ConcurrentHashMap.newKeySet();
-    private AtomicInteger loadKeysCallCount = new AtomicInteger();
+    private final Map<String, Record> records = new ConcurrentHashMap<>();
+    private final AtomicInteger loadedEntryCount = new AtomicInteger();
+    private final AtomicInteger loadAllCallCount = new AtomicInteger();
+    private final AtomicInteger loadCallCount = new AtomicInteger();
+    private final Set<String> loadUniqueKeys = ConcurrentHashMap.newKeySet();
+    private final AtomicInteger loadKeysCallCount = new AtomicInteger();
 
     @Override
     public MetadataAwareValue<String> load(String key) {


### PR DESCRIPTION
Made `test[Eager|Lazy]EntryLoaderInitializesValues_withExpirationTime`
not sensitive to `GetOperation` retries.

Fixes https://github.com/hazelcast/hazelcast/issues/15376