### PR TITLE
Add Nonnull and Nullable annotations and minor behaviour fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
@@ -21,9 +21,12 @@ import com.hazelcast.core.DistributedObject;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.annotation.Nonnull;
+
 /**
- * CardinalityEstimator is a redundant and highly available distributed data-structure used
- * for probabilistic cardinality estimation purposes, on unique items, in significantly sized data cultures.
+ * CardinalityEstimator is a redundant and highly available distributed
+ * data-structure used for probabilistic cardinality estimation purposes,
+ * on unique items, in significantly sized data cultures.
  * <p>
  * CardinalityEstimator is internally based on a HyperLogLog++ data-structure,
  * and uses P^2 byte registers for storage and computation. (Default P = 14)
@@ -36,18 +39,20 @@ public interface CardinalityEstimator extends DistributedObject {
      * Add a new object in the estimation set. This is the method you want to
      * use to feed objects into the estimator.
      * <p>
-     * Objects are considered identical if they are serialized into the same binary blob.
+     * Objects are considered identical if they are serialized into the same
+     * binary blob.
      * In other words: It does <strong>not</strong> use Java equality.
      *
      * @param obj object to add in the estimation set.
      * @throws NullPointerException if obj is null
      * @since 3.8
      */
-    void add(Object obj);
+    void add(@Nonnull Object obj);
 
     /**
      * Estimates the cardinality of the aggregation so far.
-     * If it was previously estimated and never invalidated, then a cached version is used.
+     * If it was previously estimated and never invalidated, then a cached
+     * version is used.
      *
      * @return a cached estimation or a newly computed one.
      * @since 3.8
@@ -58,7 +63,8 @@ public interface CardinalityEstimator extends DistributedObject {
      * Add a new object in the estimation set. This is the method you want to
      * use to feed objects into the estimator.
      * <p>
-     * Objects are considered identical if they are serialized into the same binary blob.
+     * Objects are considered identical if they are serialized into the same
+     * binary blob.
      * In other words: It does <strong>not</strong> use Java equality.
      * <p>
      * This method will dispatch a request and return immediately a {@link CompletionStage}.
@@ -85,11 +91,12 @@ public interface CardinalityEstimator extends DistributedObject {
      * @throws NullPointerException if obj is null
      * @since 3.8
      */
-    CompletionStage<Void> addAsync(Object obj);
+    CompletionStage<Void> addAsync(@Nonnull Object obj);
 
     /**
      * Estimates the cardinality of the aggregation so far.
-     * If it was previously estimated and never invalidated, then a cached version is used.
+     * If it was previously estimated and never invalidated, then a cached version
+     * is used.
      * <p>
      * This method will dispatch a request and return immediately a {@link CompletionStage}.
      * The operations result can be obtained in a blocking way, or a

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorProxy.java
@@ -25,6 +25,8 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
 
+import javax.annotation.Nonnull;
+
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 public class CardinalityEstimatorProxy
@@ -55,7 +57,7 @@ public class CardinalityEstimatorProxy
     }
 
     @Override
-    public void add(Object obj) {
+    public void add(@Nonnull Object obj) {
         addAsync(obj).joinInternal();
     }
 
@@ -65,8 +67,8 @@ public class CardinalityEstimatorProxy
     }
 
     @Override
-    public InvocationFuture<Void> addAsync(Object obj) {
-        checkNotNull(obj, "Object is null.");
+    public InvocationFuture<Void> addAsync(@Nonnull Object obj) {
+        checkNotNull(obj, "Object must not be null");
         Data data = getNodeEngine().getSerializationService().toData(obj);
         Operation operation = new AggregateOperation(name, data.hash64())
                 .setPartitionId(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -585,6 +585,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     @Override
     public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
+        checkNotNull(options, "TransactionOptions must not be null!");
         return transactionManager.newTransactionContext(options);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -135,6 +135,7 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.impl.xa.XAService;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -450,11 +451,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return metricsRegistry;
     }
 
+    @Nonnull
     @Override
     public HazelcastXAResource getXAResource() {
         return getDistributedObject(XAService.SERVICE_NAME, XAService.SERVICE_NAME);
     }
 
+    @Nonnull
     @Override
     public Config getConfig() {
         return new ClientDynamicClusterConfig(this);
@@ -464,62 +467,71 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return properties;
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return instanceName;
     }
 
+    @Nonnull
     @Override
-    public <E> IQueue<E> getQueue(String name) {
+    public <E> IQueue<E> getQueue(@Nonnull String name) {
         checkNotNull(name, "Retrieving a queue instance with a null name is not allowed!");
         return getDistributedObject(QueueService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getTopic(String name) {
+    public <E> ITopic<E> getTopic(@Nonnull String name) {
         checkNotNull(name, "Retrieving a topic instance with a null name is not allowed!");
         return getDistributedObject(TopicService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> ISet<E> getSet(String name) {
+    public <E> ISet<E> getSet(@Nonnull String name) {
         checkNotNull(name, "Retrieving a set instance with a null name is not allowed!");
         return getDistributedObject(SetService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> IList<E> getList(String name) {
+    public <E> IList<E> getList(@Nonnull String name) {
         checkNotNull(name, "Retrieving a list instance with a null name is not allowed!");
         return getDistributedObject(ListService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> IMap<K, V> getMap(String name) {
+    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a map instance with a null name is not allowed!");
         return getDistributedObject(MapService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> MultiMap<K, V> getMultiMap(String name) {
+    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a multi-map instance with a null name is not allowed!");
         return getDistributedObject(MultiMapService.SERVICE_NAME, name);
 
     }
 
+    @Nonnull
     @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a replicated map instance with a null name is not allowed!");
         return getDistributedObject(ReplicatedMapService.SERVICE_NAME, name);
     }
 
     @Override
-    public <E> ITopic<E> getReliableTopic(String name) {
+    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
         checkNotNull(name, "Retrieving a topic instance with a null name is not allowed!");
         return getDistributedObject(ReliableTopicService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> Ringbuffer<E> getRingbuffer(String name) {
+    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
         checkNotNull(name, "Retrieving a ringbuffer instance with a null name is not allowed!");
         return getDistributedObject(RingbufferService.SERVICE_NAME, name);
     }
@@ -529,35 +541,40 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return hazelcastCacheManager;
     }
 
+    @Nonnull
     @Override
     public Cluster getCluster() {
         return new ClientClusterProxy(clusterService);
     }
 
+    @Nonnull
     @Override
     public Client getLocalEndpoint() {
         return clusterService.getLocalClient();
     }
 
+    @Nonnull
     @Override
-    public IExecutorService getExecutorService(String name) {
+    public IExecutorService getExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving an executor instance with a null name is not allowed!");
         return getDistributedObject(DistributedExecutorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public DurableExecutorService getDurableExecutorService(String name) {
+    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving a durable executor instance with a null name is not allowed!");
         return getDistributedObject(DistributedDurableExecutorService.SERVICE_NAME, name);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
         return transactionManager.executeTransaction(task);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
         return transactionManager.executeTransaction(options, task);
     }
 
@@ -567,7 +584,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         return transactionManager.newTransactionContext(options);
     }
 
@@ -576,25 +593,26 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a Flake ID-generator instance with a null name is not allowed!");
         return getDistributedObject(FlakeIdGeneratorService.SERVICE_NAME, name);
     }
 
     @Override
-    public CardinalityEstimator getCardinalityEstimator(String name) {
+    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a cardinality estimator instance with a null name is not allowed!");
         return getDistributedObject(CardinalityEstimatorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public PNCounter getPNCounter(String name) {
+    public PNCounter getPNCounter(@Nonnull String name) {
         checkNotNull(name, "Retrieving a PN counter instance with a null name is not allowed!");
         return getDistributedObject(PNCounterService.SERVICE_NAME, name);
     }
 
     @Override
-    public IScheduledExecutorService getScheduledExecutorService(String name) {
+    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving a scheduled executor instance with a null name is not allowed!");
         return getDistributedObject(DistributedScheduledExecutorService.SERVICE_NAME, name);
     }
@@ -630,50 +648,61 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
+        checkNotNull(distributedObjectListener, "DistributedObjectListener must not be null!");
         return proxyManager.addDistributedObjectListener(distributedObjectListener);
     }
 
     @Override
-    public boolean removeDistributedObjectListener(UUID registrationId) {
+    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
+        checkNotNull(registrationId, "Registration ID must not be null!");
         return proxyManager.removeDistributedObjectListener(registrationId);
     }
 
+    @Nonnull
     @Override
     public PartitionService getPartitionService() {
         return new PartitionServiceProxy(partitionService, listenerService);
     }
 
+    @Nonnull
     @Override
     public SplitBrainProtectionService getSplitBrainProtectionService() {
         throw new UnsupportedOperationException();
     }
 
+    @Nonnull
     @Override
     public ClientService getClientService() {
         throw new UnsupportedOperationException();
     }
 
+    @Nonnull
     @Override
     public LoggingService getLoggingService() {
         return loggingService;
     }
 
+    @Nonnull
     @Override
     public LifecycleService getLifecycleService() {
         return lifecycleService;
     }
 
+    @Nonnull
     @Override
-    public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
+                                                                @Nonnull String name) {
         return (T) proxyManager.getOrCreateProxy(serviceName, name);
     }
 
+    @Nonnull
     @Override
     public CPSubsystem getCPSubsystem() {
         return cpSubsystem;
     }
 
+    @Nonnull
     @Override
     public ConcurrentMap<String, Object> getUserContext() {
         return userContext;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -54,6 +54,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
@@ -70,58 +71,69 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
         this.client = client;
     }
 
+    @Nonnull
     @Override
     public Config getConfig() {
         return getClient().getConfig();
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return getClient().getName();
     }
 
+    @Nonnull
     @Override
-    public <E> Ringbuffer<E> getRingbuffer(String name) {
+    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
         return getClient().getRingbuffer(name);
     }
 
+    @Nonnull
     @Override
-    public <E> IQueue<E> getQueue(String name) {
+    public <E> IQueue<E> getQueue(@Nonnull String name) {
         return getClient().getQueue(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getTopic(String name) {
+    public <E> ITopic<E> getTopic(@Nonnull String name) {
         return getClient().getTopic(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getReliableTopic(String name) {
+    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
         return getClient().getReliableTopic(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ISet<E> getSet(String name) {
+    public <E> ISet<E> getSet(@Nonnull String name) {
         return getClient().getSet(name);
     }
 
+    @Nonnull
     @Override
-    public <E> IList<E> getList(String name) {
+    public <E> IList<E> getList(@Nonnull String name) {
         return getClient().getList(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> IMap<K, V> getMap(String name) {
+    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
         return getClient().getMap(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> MultiMap<K, V> getMultiMap(String name) {
+    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
         return getClient().getMultiMap(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         return getClient().getReplicatedMap(name);
     }
 
@@ -130,34 +142,38 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
         return getClient().getCacheManager();
     }
 
+    @Nonnull
     @Override
     public Cluster getCluster() {
         return getClient().getCluster();
     }
 
+    @Nonnull
     @Override
     public Client getLocalEndpoint() {
         return getClient().getLocalEndpoint();
     }
 
+    @Nonnull
     @Override
-    public IExecutorService getExecutorService(String name) {
+    public IExecutorService getExecutorService(@Nonnull String name) {
         return getClient().getExecutorService(name);
     }
 
+    @Nonnull
     @Override
-    public DurableExecutorService getDurableExecutorService(String name) {
+    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
         return getClient().getDurableExecutorService(name);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionalTask<T> task)
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task)
             throws TransactionException {
         return getClient().executeTransaction(task);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task)
+    public <T> T executeTransaction(@Nonnull TransactionOptions options, @Nonnull TransactionalTask<T> task)
             throws TransactionException {
         return getClient().executeTransaction(options, task);
     }
@@ -168,27 +184,29 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         return getClient().newTransactionContext(options);
     }
 
     @Override
-    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         return getClient().getFlakeIdGenerator(name);
     }
 
     @Override
-    public CardinalityEstimator getCardinalityEstimator(String name) {
+    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         return getClient().getCardinalityEstimator(name);
     }
 
+    @Nonnull
     @Override
-    public PNCounter getPNCounter(String name) {
+    public PNCounter getPNCounter(@Nonnull String name) {
         return getClient().getPNCounter(name);
     }
 
+    @Nonnull
     @Override
-    public IScheduledExecutorService getScheduledExecutorService(String name) {
+    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
         return getClient().getScheduledExecutorService(name);
     }
 
@@ -198,51 +216,59 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
         return getClient().addDistributedObjectListener(distributedObjectListener);
     }
 
     @Override
-    public boolean removeDistributedObjectListener(UUID registrationId) {
+    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
         return getClient().removeDistributedObjectListener(registrationId);
     }
 
+    @Nonnull
     @Override
     public PartitionService getPartitionService() {
         return getClient().getPartitionService();
     }
 
+    @Nonnull
     @Override
     public SplitBrainProtectionService getSplitBrainProtectionService() {
         throw new UnsupportedOperationException();
     }
 
+    @Nonnull
     @Override
     public ClientService getClientService() {
         return getClient().getClientService();
     }
 
+    @Nonnull
     @Override
     public LoggingService getLoggingService() {
         return getClient().getLoggingService();
     }
 
+    @Nonnull
     @Override
     public LifecycleService getLifecycleService() {
         final HazelcastClientInstanceImpl hz = client;
         return hz != null ? hz.getLifecycleService() : new TerminatedLifecycleService();
     }
 
+    @Nonnull
     @Override
-    public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
         return getClient().getDistributedObject(serviceName, name);
     }
 
+    @Nonnull
     @Override
     public CPSubsystem getCPSubsystem() {
         return getClient().getCPSubsystem();
     }
 
+    @Nonnull
     @Override
     public ConcurrentMap<String, Object> getUserContext() {
         return getClient().getUserContext();
@@ -252,6 +278,7 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
         return getClient().getClientConfig();
     }
 
+    @Nonnull
     @Override
     public HazelcastXAResource getXAResource() {
         return getClient().getXAResource();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientCardinalityEstimatorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientCardinalityEstimatorProxy.java
@@ -25,6 +25,8 @@ import com.hazelcast.client.impl.spi.ClientContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
+import javax.annotation.Nonnull;
+
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -57,7 +59,7 @@ public class ClientCardinalityEstimatorProxy
     }
 
     @Override
-    public void add(Object obj) {
+    public void add(@Nonnull Object obj) {
         addAsync(obj).joinInternal();
     }
 
@@ -67,8 +69,8 @@ public class ClientCardinalityEstimatorProxy
     }
 
     @Override
-    public InternalCompletableFuture<Void> addAsync(Object obj) {
-        checkNotNull(obj, "Object is null");
+    public InternalCompletableFuture<Void> addAsync(@Nonnull Object obj) {
+        checkNotNull(obj, "Object must not be null");
 
         Data data = toData(obj);
         ClientMessage request = CardinalityEstimatorAddCodec.encodeRequest(name, data.hash64());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
@@ -42,6 +42,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -51,12 +53,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
@@ -82,43 +82,50 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     // execute on members
 
     @Override
-    public void execute(Runnable command) {
+    public void execute(@Nonnull Runnable command) {
         submit(command);
     }
 
     @Override
-    public void executeOnKeyOwner(Runnable command, Object key) {
+    public void executeOnKeyOwner(@Nonnull Runnable command,
+                                  @Nonnull Object key) {
         submitToKeyOwnerInternal(toData(command), key, null);
     }
 
     @Override
-    public void executeOnMember(Runnable command, Member member) {
+    public void executeOnMember(@Nonnull Runnable command,
+                                @Nonnull Member member) {
+        checkNotNull(member, "member must not be null");
         final Address memberAddress = getMemberAddress(member);
         submitToTargetInternal(toData(command), memberAddress, null);
     }
 
     @Override
-    public void executeOnMembers(Runnable command, Collection<Member> members) {
+    public void executeOnMembers(@Nonnull Runnable command,
+                                 @Nonnull Collection<Member> members) {
+        checkNotNull(members, "members must not be null");
         for (Member member : members) {
             executeOnMember(command, member);
         }
     }
 
     @Override
-    public void execute(Runnable command, MemberSelector memberSelector) {
+    public void execute(@Nonnull Runnable command,
+                        @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         executeOnMember(command, members.get(selectedMember));
     }
 
     @Override
-    public void executeOnMembers(Runnable command, MemberSelector memberSelector) {
+    public void executeOnMembers(@Nonnull Runnable command,
+                                 @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         executeOnMembers(command, members);
     }
 
     @Override
-    public void executeOnAllMembers(Runnable command) {
+    public void executeOnAllMembers(@Nonnull Runnable command) {
         final Collection<Member> memberList = getContext().getClusterService().getMemberList();
         for (Member member : memberList) {
             executeOnMember(command, member);
@@ -129,13 +136,17 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     // submit to members
 
     @Override
-    public <T> Future<T> submitToMember(Callable<T> task, Member member) {
+    public <T> Future<T> submitToMember(@Nonnull Callable<T> task,
+                                        @Nonnull Member member) {
+        checkNotNull(member, "member must not be null");
         final Address memberAddress = getMemberAddress(member);
         return submitToTargetInternal(toData(task), memberAddress, null, false);
     }
 
     @Override
-    public <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, Collection<Member> members) {
+    public <T> Map<Member, Future<T>> submitToMembers(@Nonnull Callable<T> task,
+                                                      @Nonnull Collection<Member> members) {
+        checkNotNull(members, "members must not be null");
         Map<Member, Future<T>> futureMap = new HashMap<>(members.size());
         Data taskData = toData(task);
         for (Member member : members) {
@@ -147,20 +158,22 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     @Override
-    public <T> Future<T> submit(Callable<T> task, MemberSelector memberSelector) {
+    public <T> Future<T> submit(@Nonnull Callable<T> task,
+                                @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         return submitToMember(task, members.get(selectedMember));
     }
 
     @Override
-    public <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, MemberSelector memberSelector) {
+    public <T> Map<Member, Future<T>> submitToMembers(@Nonnull Callable<T> task,
+                                                      @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         return submitToMembers(task, members);
     }
 
     @Override
-    public <T> Map<Member, Future<T>> submitToAllMembers(Callable<T> task) {
+    public <T> Map<Member, Future<T>> submitToAllMembers(@Nonnull Callable<T> task) {
         final Collection<Member> memberList = getContext().getClusterService().getMemberList();
         Map<Member, Future<T>> futureMap = new HashMap<>(memberList.size());
         Data taskData = toData(task);
@@ -173,13 +186,19 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
     // submit to members callback
     @Override
-    public void submitToMember(Runnable command, Member member, ExecutionCallback callback) {
+    public void submitToMember(@Nonnull Runnable command,
+                               @Nonnull Member member,
+                               @Nullable ExecutionCallback callback) {
+        checkNotNull(member, "member must not be null");
         final Address memberAddress = getMemberAddress(member);
         submitToTargetInternal(toData(command), memberAddress, callback);
     }
 
     @Override
-    public void submitToMembers(Runnable command, Collection<Member> members, MultiExecutionCallback callback) {
+    public void submitToMembers(@Nonnull Runnable command,
+                                @Nonnull Collection<Member> members,
+                                @Nonnull MultiExecutionCallback callback) {
+        checkNotNull(members, "members must not be null");
         MultiExecutionCallbackWrapper multiExecutionCallbackWrapper =
                 new MultiExecutionCallbackWrapper(members.size(), callback);
         for (Member member : members) {
@@ -190,65 +209,82 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     @Override
-    public <T> void submitToMember(Callable<T> task, Member member, ExecutionCallback<T> callback) {
+    public <T> void submitToMember(@Nonnull Callable<T> task,
+                                   @Nonnull Member member,
+                                   @Nullable ExecutionCallback<T> callback) {
+        checkNotNull(member, "member must not be null");
         final Address memberAddress = getMemberAddress(member);
         submitToTargetInternal(toData(task), memberAddress, callback);
     }
 
     @Override
-    public <T> void submitToMembers(Callable<T> task, Collection<Member> members, MultiExecutionCallback callback) {
+    public <T> void submitToMembers(@Nonnull Callable<T> task,
+                                    @Nonnull Collection<Member> members,
+                                    @Nonnull MultiExecutionCallback callback) {
+        checkNotNull(members, "members must not be null");
         MultiExecutionCallbackWrapper multiExecutionCallbackWrapper =
                 new MultiExecutionCallbackWrapper(members.size(), callback);
         Data taskData = toData(task);
-        for (Member member : members) {
+        members.forEach(member -> {
             final ExecutionCallbackWrapper<T> executionCallback =
-                    new ExecutionCallbackWrapper<T>(multiExecutionCallbackWrapper, member);
+                    new ExecutionCallbackWrapper<>(multiExecutionCallbackWrapper, member);
             submitToTargetInternal(taskData, getMemberAddress(member), executionCallback);
-        }
+        });
     }
 
     @Override
-    public void submit(Runnable task, MemberSelector memberSelector, ExecutionCallback callback) {
+    public void submit(@Nonnull Runnable task,
+                       @Nonnull MemberSelector memberSelector,
+                       @Nullable ExecutionCallback callback) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         submitToMember(task, members.get(selectedMember), callback);
     }
 
     @Override
-    public void submitToMembers(Runnable task, MemberSelector memberSelector, MultiExecutionCallback callback) {
+    public void submitToMembers(@Nonnull Runnable task,
+                                @Nonnull MemberSelector memberSelector,
+                                @Nonnull MultiExecutionCallback callback) {
         List<Member> members = selectMembers(memberSelector);
         submitToMembers(task, members, callback);
     }
 
     @Override
-    public <T> void submit(Callable<T> task, MemberSelector memberSelector, ExecutionCallback<T> callback) {
+    public <T> void submit(@Nonnull Callable<T> task,
+                           @Nonnull MemberSelector memberSelector,
+                           @Nullable ExecutionCallback<T> callback) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         submitToMember(task, members.get(selectedMember), callback);
     }
 
     @Override
-    public <T> void submitToMembers(Callable<T> task, MemberSelector memberSelector, MultiExecutionCallback callback) {
+    public <T> void submitToMembers(@Nonnull Callable<T> task,
+                                    @Nonnull MemberSelector memberSelector,
+                                    @Nonnull MultiExecutionCallback callback) {
         List<Member> members = selectMembers(memberSelector);
         submitToMembers(task, members, callback);
     }
 
     @Override
-    public void submitToAllMembers(Runnable command, MultiExecutionCallback callback) {
+    public void submitToAllMembers(@Nonnull Runnable command,
+                                   @Nonnull MultiExecutionCallback callback) {
         final Collection<Member> memberList = getContext().getClusterService().getMemberList();
         submitToMembers(command, memberList, callback);
     }
 
     @Override
-    public <T> void submitToAllMembers(Callable<T> task, MultiExecutionCallback callback) {
+    public <T> void submitToAllMembers(@Nonnull Callable<T> task,
+                                       @Nonnull MultiExecutionCallback callback) {
         final Collection<Member> memberList = getContext().getClusterService().getMemberList();
         submitToMembers(task, memberList, callback);
     }
 
     // submit random
 
+    @Nonnull
     @Override
-    public Future<?> submit(Runnable command) {
+    public Future<?> submit(@Nonnull Runnable command) {
         final Object partitionKey = getTaskPartitionKey(command);
         Data taskData = toData(command);
         if (partitionKey != null) {
@@ -257,8 +293,9 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return submitToRandomInternal(taskData, null, false);
     }
 
+    @Nonnull
     @Override
-    public <T> Future<T> submit(Runnable command, T result) {
+    public <T> Future<T> submit(@Nonnull Runnable command, T result) {
         final Object partitionKey = getTaskPartitionKey(command);
         Data taskData = toData(command);
         if (partitionKey != null) {
@@ -267,8 +304,9 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return submitToRandomInternal(taskData, result, false);
     }
 
+    @Nonnull
     @Override
-    public <T> Future<T> submit(Callable<T> task) {
+    public <T> Future<T> submit(@Nonnull Callable<T> task) {
         final Object partitionKey = getTaskPartitionKey(task);
         if (partitionKey != null) {
             return submitToKeyOwner(task, partitionKey);
@@ -277,7 +315,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     @Override
-    public <T> void submit(Runnable command, ExecutionCallback<T> callback) {
+    public <T> void submit(@Nonnull Runnable command,
+                           @Nullable ExecutionCallback<T> callback) {
         final Object partitionKey = getTaskPartitionKey(command);
         Data task = toData(command);
         if (partitionKey != null) {
@@ -288,7 +327,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     @Override
-    public <T> void submit(Callable<T> task, ExecutionCallback<T> callback) {
+    public <T> void submit(@Nonnull Callable<T> task, @Nullable ExecutionCallback<T> callback) {
         final Object partitionKey = getTaskPartitionKey(task);
         Data taskData = toData(task);
         if (partitionKey != null) {
@@ -301,17 +340,22 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     // submit to key
 
     @Override
-    public <T> Future<T> submitToKeyOwner(Callable<T> task, Object key) {
+    public <T> Future<T> submitToKeyOwner(@Nonnull Callable<T> task,
+                                          @Nonnull Object key) {
         return submitToKeyOwnerInternal(toData(task), key, null);
     }
 
     @Override
-    public void submitToKeyOwner(Runnable command, Object key, ExecutionCallback callback) {
+    public void submitToKeyOwner(@Nonnull Runnable command,
+                                 @Nonnull Object key,
+                                 @Nonnull ExecutionCallback callback) {
         submitToKeyOwnerInternal(toData(command), key, callback);
     }
 
     @Override
-    public <T> void submitToKeyOwner(Callable<T> task, Object key, ExecutionCallback<T> callback) {
+    public <T> void submitToKeyOwner(@Nonnull Callable<T> task,
+                                     @Nonnull Object key,
+                                     @Nullable ExecutionCallback<T> callback) {
         submitToKeyOwnerInternal(toData(task), key, callback);
     }
 
@@ -328,6 +372,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         invoke(request);
     }
 
+    @Nonnull
     @Override
     public List<Runnable> shutdownNow() {
         shutdown();
@@ -349,12 +394,15 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    public boolean awaitTermination(long timeout, @Nonnull TimeUnit unit) {
+        checkNotNull(unit, "unit must not be null");
         return false;
     }
 
+    @Nonnull
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    public <T> List<Future<T>> invokeAll(@Nonnull Collection<? extends Callable<T>> tasks) {
+        checkNotNull(tasks, "tasks must not be null");
         final List<Future<T>> futures = new ArrayList<>(tasks.size());
         final List<Future<T>> result = new ArrayList<>(tasks.size());
         for (Callable<T> task : tasks) {
@@ -368,20 +416,22 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return result;
     }
 
+    @Nonnull
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+    public <T> List<Future<T>> invokeAll(@Nonnull Collection<? extends Callable<T>> tasks,
+                                         long timeout, @Nonnull TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException, ExecutionException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks,
+                           long timeout, @Nonnull TimeUnit unit) {
         throw new UnsupportedOperationException();
     }
 
@@ -392,8 +442,12 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return null;
     }
 
-    private <T> Future<T> submitToKeyOwnerInternal(Data task, Object key, T defaultValue) {
+    private @Nonnull
+    <T> Future<T> submitToKeyOwnerInternal(@Nonnull Data task,
+                                           @Nonnull Object key,
+                                           T defaultValue) {
         checkNotNull(task, "task should not be null");
+        checkNotNull(key, "key should not be null");
 
         UUID uuid = getUUID();
         int partitionId = getPartitionId(key);
@@ -402,8 +456,11 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return checkSync(f, uuid, partitionId, false, defaultValue);
     }
 
-    private <T> Future<T> submitToKeyOwnerInternal(Data task, Object key, ExecutionCallback<T> callback) {
+    private <T> Future<T> submitToKeyOwnerInternal(@Nonnull Data task,
+                                                   @Nonnull Object key,
+                                                   @Nullable ExecutionCallback<T> callback) {
         checkNotNull(task, "task should not be null");
+        checkNotNull(key, "key should not be null");
         UUID uuid = getUUID();
         int partitionId = getPartitionId(key);
         ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, task);
@@ -418,7 +475,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return delegatingFuture;
     }
 
-    private <T> Future<T> submitToRandomInternal(Data task, T defaultValue, boolean preventSync) {
+    private @Nonnull
+    <T> Future<T> submitToRandomInternal(Data task, T defaultValue, boolean preventSync) {
         checkNotNull(task, "task should not be null");
 
         UUID uuid = getUUID();
@@ -437,10 +495,15 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
         InternalCompletableFuture<T> delegatingFuture = (InternalCompletableFuture<T>) checkSync(f, uuid, partitionId, false,
                 (T) null);
-        delegatingFuture.whenCompleteAsync(new ExecutionCallbackAdapter<>(callback));
+        if (callback != null) {
+            delegatingFuture.whenCompleteAsync(new ExecutionCallbackAdapter<>(callback));
+        }
     }
 
-    private <T> Future<T> submitToTargetInternal(Data task, Address address, T defaultValue, boolean preventSync) {
+    private <T> Future<T> submitToTargetInternal(@Nonnull Data task,
+                                                 Address address,
+                                                 T defaultValue,
+                                                 boolean preventSync) {
         checkNotNull(task, "task should not be null");
 
         UUID uuid = getUUID();
@@ -449,7 +512,9 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return checkSync(f, uuid, address, preventSync, defaultValue);
     }
 
-    private <T> void submitToTargetInternal(Data task, Address address, ExecutionCallback<T> callback) {
+    private <T> void submitToTargetInternal(@Nonnull Data task,
+                                            Address address,
+                                            @Nullable ExecutionCallback<T> callback) {
         checkNotNull(task, "task should not be null");
 
         UUID uuid = getUUID();
@@ -467,28 +532,32 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return "IExecutorService{" + "name='" + name + '\'' + '}';
     }
 
-    private <T> Future<T> checkSync(ClientInvocationFuture f, UUID uuid, Address address,
-                                    boolean preventSync, T defaultValue) {
+    private <T> Future<T> checkSync(ClientInvocationFuture f,
+                                    UUID uuid,
+                                    Address address,
+                                    boolean preventSync,
+                                    T defaultValue) {
         boolean sync = isSyncComputation(preventSync);
         if (sync) {
             Object response = retrieveResultFromMessage(f);
             Executor userExecutor = getContext().getExecutionService().getUserExecutor();
             return newCompletedFuture(response, getSerializationService(), userExecutor);
         } else {
-            return new IExecutorDelegatingFuture<T>(f, getContext(), uuid, defaultValue,
+            return new IExecutorDelegatingFuture<>(f, getContext(), uuid, defaultValue,
                     message -> ExecutorServiceSubmitToAddressCodec.decodeResponse(message).response, name, address);
         }
     }
 
-    private <T> Future<T> checkSync(ClientInvocationFuture f, UUID uuid, int partitionId,
-                                    boolean preventSync, T defaultValue) {
+    private @Nonnull
+    <T> Future<T> checkSync(ClientInvocationFuture f, UUID uuid, int partitionId,
+                            boolean preventSync, T defaultValue) {
         boolean sync = isSyncComputation(preventSync);
         if (sync) {
             Object response = retrieveResultFromMessage(f);
             Executor userExecutor = getContext().getExecutionService().getUserExecutor();
             return newCompletedFuture(response, getSerializationService(), userExecutor);
         } else {
-            return new IExecutorDelegatingFuture<T>(f, getContext(), uuid, defaultValue,
+            return new IExecutorDelegatingFuture<>(f, getContext(), uuid, defaultValue,
                     message -> ExecutorServiceSubmitToPartitionCodec.decodeResponse(message).response, name, partitionId);
         }
     }
@@ -533,10 +602,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     private List<Member> selectMembers(MemberSelector memberSelector) {
-        if (memberSelector == null) {
-            throw new IllegalArgumentException("memberSelector must not be null");
-        }
-        List<Member> selected = new ArrayList<Member>();
+        checkNotNull(memberSelector, "memberSelector must not be null");
+        List<Member> selected = new ArrayList<>();
         Collection<Member> members = getContext().getClusterService().getMemberList();
         for (Member member : members) {
             if (memberSelector.select(member)) {
@@ -576,7 +643,9 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         private final Map<Member, Object> values;
         private final AtomicInteger members;
 
-        private MultiExecutionCallbackWrapper(int memberSize, MultiExecutionCallback multiExecutionCallback) {
+        private MultiExecutionCallbackWrapper(int memberSize,
+                                              @Nonnull MultiExecutionCallback multiExecutionCallback) {
+            checkNotNull(multiExecutionCallback, "multiExecutionCallback must not be null");
             this.multiExecutionCallback = multiExecutionCallback;
             this.values = Collections.synchronizedMap(new HashMap<>(memberSize));
             this.members = new AtomicInteger(memberSize);
@@ -621,7 +690,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return UuidUtil.newUnsecureUUID();
     }
 
-    private Address getMemberAddress(Member member) {
+    private Address getMemberAddress(@Nonnull Member member) {
         Member m = getContext().getClusterService().getMember(member.getUuid());
         if (m == null) {
             throw new HazelcastException(member + " is not available!");
@@ -629,7 +698,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return m.getAddress();
     }
 
-    private int getPartitionId(Object key) {
+    private int getPartitionId(@Nonnull Object key) {
         ClientPartitionService partitionService = getContext().getPartitionService();
         return partitionService.getPartitionId(key);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionContextProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionContextProxy.java
@@ -37,6 +37,7 @@ import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.transaction.impl.TransactionalObjectKey;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -57,7 +58,8 @@ public class TransactionContextProxy implements ClientTransactionContext {
     private final Map<TransactionalObjectKey, TransactionalObject> txnObjectMap =
             new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
-    public TransactionContextProxy(ClientTransactionManagerServiceImpl transactionManager, TransactionOptions options) {
+    public TransactionContextProxy(@Nonnull ClientTransactionManagerServiceImpl transactionManager,
+                                   @Nonnull TransactionOptions options) {
         this.transactionManager = transactionManager;
         this.client = transactionManager.getClient();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionProxy.java
@@ -31,6 +31,8 @@ import com.hazelcast.internal.util.ThreadUtil;
 
 import java.util.UUID;
 
+import javax.annotation.Nonnull;
+
 import static com.hazelcast.transaction.impl.Transaction.State;
 import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
 import static com.hazelcast.transaction.impl.Transaction.State.COMMITTED;
@@ -55,7 +57,8 @@ final class TransactionProxy {
     private State state = NO_TXN;
     private long startTime;
 
-    TransactionProxy(HazelcastClientInstanceImpl client, TransactionOptions options, ClientConnection connection) {
+    TransactionProxy(HazelcastClientInstanceImpl client,
+                     @Nonnull TransactionOptions options, ClientConnection connection) {
         this.options = options;
         this.client = client;
         this.connection = connection;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientPartitionService.java
@@ -20,6 +20,8 @@ import com.hazelcast.partition.Partition;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.serialization.Data;
 
+import javax.annotation.Nonnull;
+
 /**
  * Partition service for Hazelcast clients.
  *
@@ -29,9 +31,9 @@ public interface ClientPartitionService {
 
     Address getPartitionOwner(int partitionId);
 
-    int getPartitionId(Data key);
+    int getPartitionId(@Nonnull Data key);
 
-    int getPartitionId(Object key);
+    int getPartitionId(@Nonnull Object key);
 
     int getPartitionCount();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientTransactionManagerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientTransactionManagerService.java
@@ -20,6 +20,7 @@ import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import javax.annotation.Nonnull;
 import javax.transaction.xa.Xid;
 
 /**
@@ -29,13 +30,13 @@ import javax.transaction.xa.Xid;
  */
 public interface ClientTransactionManagerService {
 
-    <T> T executeTransaction(TransactionalTask<T> task);
+    <T> T executeTransaction(@Nonnull TransactionalTask<T> task);
 
-    <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task);
+    <T> T executeTransaction(@Nonnull TransactionOptions options, @Nonnull TransactionalTask<T> task);
 
     TransactionContext newTransactionContext();
 
-    TransactionContext newTransactionContext(TransactionOptions options);
+    TransactionContext newTransactionContext(@Nonnull TransactionOptions options);
 
     /**
      * @param xid              branch qualifier

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientPartitionServiceImpl.java
@@ -42,6 +42,7 @@ import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.partition.PartitionLostListener;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.EventListener;
 import java.util.List;
@@ -276,7 +277,7 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
     }
 
     @Override
-    public int getPartitionId(Data key) {
+    public int getPartitionId(@Nonnull Data key) {
         final int pc = getPartitionCount();
         if (pc <= 0) {
             return 0;
@@ -286,7 +287,7 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
     }
 
     @Override
-    public int getPartitionId(Object key) {
+    public int getPartitionId(@Nonnull Object key) {
         final Data data = client.getSerializationService().toData(key);
         return getPartitionId(data);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientTransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientTransactionManagerServiceImpl.java
@@ -34,12 +34,14 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import javax.annotation.Nonnull;
 import javax.transaction.xa.Xid;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Set;
 
 import static com.hazelcast.internal.util.Clock.currentTimeMillis;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.StringUtil.timeToString;
 
 public class ClientTransactionManagerServiceImpl implements ClientTransactionManagerService {
@@ -62,17 +64,20 @@ public class ClientTransactionManagerServiceImpl implements ClientTransactionMan
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         return new TransactionContextProxy(this, options);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
         return executeTransaction(TransactionOptions.getDefault(), task);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
+        checkNotNull(options, "TransactionOptions must not be null!");
+        checkNotNull(task, "TransactionalTask is required!");
         final TransactionContext context = newTransactionContext(options);
         context.beginTransaction();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/MemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/MemberSelector.java
@@ -31,6 +31,7 @@ package com.hazelcast.cluster;
  *     }
  * }</pre>
  */
+@FunctionalInterface
 public interface MemberSelector {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -46,6 +46,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
@@ -54,11 +55,11 @@ import java.util.concurrent.ConcurrentMap;
  * Hazelcast instance. Each instance is a member and/or client in a Hazelcast cluster. When
  * you want to use Hazelcast's distributed data structures, you must first create an instance.
  * Multiple Hazelcast instances can be created on a single JVM.
- *
+ * <p>
  * Instances should be shut down explicitly. See the {@link #shutdown()} method.
  * If the instance is a client and you don't shut it down explicitly, it will continue to run and
  * even connect to another live member if the one it was connected fails.
- *
+ * <p>
  * Each Hazelcast instance has its own socket and threads.
  *
  * @see Hazelcast#newHazelcastInstance(Config config)
@@ -70,6 +71,7 @@ public interface HazelcastInstance {
      *
      * @return name of this Hazelcast instance
      */
+    @Nonnull
     String getName();
 
     /**
@@ -78,7 +80,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed queue
      * @return distributed queue instance with the specified name
      */
-    <E> IQueue<E> getQueue(String name);
+    @Nonnull
+    <E> IQueue<E> getQueue(@Nonnull String name);
 
     /**
      * Creates or returns the distributed topic instance with the specified name.
@@ -86,7 +89,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed topic
      * @return distributed topic instance with the specified name
      */
-    <E> ITopic<E> getTopic(String name);
+    @Nonnull
+    <E> ITopic<E> getTopic(@Nonnull String name);
 
     /**
      * Creates or returns the distributed set instance with the specified name.
@@ -94,7 +98,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed set
      * @return distributed set instance with the specified name
      */
-    <E> ISet<E> getSet(String name);
+    @Nonnull
+    <E> ISet<E> getSet(@Nonnull String name);
 
     /**
      * Creates or returns the distributed list instance with the specified name.
@@ -103,7 +108,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed list
      * @return distributed list instance with the specified name
      */
-    <E> IList<E> getList(String name);
+    @Nonnull
+    <E> IList<E> getList(@Nonnull String name);
 
     /**
      * Creates or returns the distributed map instance with the specified name.
@@ -111,7 +117,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed map
      * @return distributed map instance with the specified name
      */
-    <K, V> IMap<K, V> getMap(String name);
+    @Nonnull
+    <K, V> IMap<K, V> getMap(@Nonnull String name);
 
     /**
      * Creates or returns the replicated map instance with the specified name.
@@ -121,7 +128,8 @@ public interface HazelcastInstance {
      * @throws ReplicatedMapCantBeCreatedOnLiteMemberException if it is called on a lite member
      * @since 3.2
      */
-    <K, V> ReplicatedMap<K, V> getReplicatedMap(String name);
+    @Nonnull
+    <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name);
 
     /**
      * Creates or returns the distributed multimap instance with the specified name.
@@ -129,7 +137,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed multimap
      * @return distributed multimap instance with the specified name
      */
-    <K, V> MultiMap<K, V> getMultiMap(String name);
+    @Nonnull
+    <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name);
 
     /**
      * Creates or returns the distributed Ringbuffer instance with the specified name.
@@ -137,7 +146,8 @@ public interface HazelcastInstance {
      * @param name name of the distributed Ringbuffer
      * @return distributed RingBuffer instance with the specified name
      */
-    <E> Ringbuffer<E> getRingbuffer(String name);
+    @Nonnull
+    <E> Ringbuffer<E> getRingbuffer(@Nonnull String name);
 
     /**
      * Creates or returns the reliable topic instance with the specified name.
@@ -145,7 +155,8 @@ public interface HazelcastInstance {
      * @param name name of the reliable topic
      * @return the reliable topic
      */
-    <E> ITopic<E> getReliableTopic(String name);
+    @Nonnull
+    <E> ITopic<E> getReliableTopic(@Nonnull String name);
 
     /**
      * Returns the Cluster that this Hazelcast instance is part of.
@@ -155,6 +166,7 @@ public interface HazelcastInstance {
      *
      * @return the cluster that this Hazelcast instance is part of
      */
+    @Nonnull
     Cluster getCluster();
 
     /**
@@ -167,6 +179,7 @@ public interface HazelcastInstance {
      * @see Member
      * @see Client
      */
+    @Nonnull
     Endpoint getLocalEndpoint();
 
     /**
@@ -179,7 +192,8 @@ public interface HazelcastInstance {
      * @param name name of the executor service
      * @return the distributed executor service for the given name
      */
-    IExecutorService getExecutorService(String name);
+    @Nonnull
+    IExecutorService getExecutorService(@Nonnull String name);
 
     /**
      * Creates or returns the durable executor service for the given name.
@@ -191,7 +205,8 @@ public interface HazelcastInstance {
      * @param name name of the executor service
      * @return the durable executor service for the given name
      */
-    DurableExecutorService getDurableExecutorService(String name);
+    @Nonnull
+    DurableExecutorService getDurableExecutorService(@Nonnull String name);
 
     /**
      * Executes the given transactional task in current thread using default options
@@ -202,7 +217,7 @@ public interface HazelcastInstance {
      * @return result of the transactional task
      * @throws TransactionException if an error occurs during transaction.
      */
-    <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException;
+    <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException;
 
     /**
      * Executes the given transactional task in current thread using given options
@@ -214,7 +229,8 @@ public interface HazelcastInstance {
      * @return result of the transactional task
      * @throws TransactionException if an error occurs during transaction.
      */
-    <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException;
+    <T> T executeTransaction(@Nonnull TransactionOptions options,
+                             @Nonnull TransactionalTask<T> task) throws TransactionException;
 
     /**
      * Creates a new TransactionContext associated with the current thread using default options.
@@ -229,7 +245,7 @@ public interface HazelcastInstance {
      * @param options options for this transaction
      * @return new TransactionContext associated with the current thread
      */
-    TransactionContext newTransactionContext(TransactionOptions options);
+    TransactionContext newTransactionContext(@Nonnull TransactionOptions options);
 
     /**
      * Creates or returns a cluster-wide unique ID generator. Generated IDs are {@code long} primitive values
@@ -246,7 +262,8 @@ public interface HazelcastInstance {
      * @param name name of the {@link FlakeIdGenerator}
      * @return FlakeIdGenerator for the given name
      */
-    FlakeIdGenerator getFlakeIdGenerator(String name);
+    @Nonnull
+    FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name);
 
     /**
      * Returns all {@link DistributedObject}s, that is all maps, queues,
@@ -268,7 +285,7 @@ public interface HazelcastInstance {
      * @param distributedObjectListener instance listener
      * @return returns registration ID
      */
-    UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener);
+    UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener);
 
     /**
      * Removes the specified Distributed Object listener. Returns silently
@@ -277,13 +294,14 @@ public interface HazelcastInstance {
      * @param registrationId ID of listener registration
      * @return {@code true} if registration is removed, {@code false} otherwise
      */
-    boolean removeDistributedObjectListener(UUID registrationId);
+    boolean removeDistributedObjectListener(@Nonnull UUID registrationId);
 
     /**
      * Returns the configuration of this Hazelcast instance.
      *
      * @return configuration of this Hazelcast instance
      */
+    @Nonnull
     Config getConfig();
 
     /**
@@ -293,6 +311,7 @@ public interface HazelcastInstance {
      *
      * @return the partition service of this Hazelcast instance
      */
+    @Nonnull
     PartitionService getPartitionService();
 
     /**
@@ -303,6 +322,7 @@ public interface HazelcastInstance {
      *
      * @return the split brain protection service of this Hazelcast instance
      */
+    @Nonnull
     SplitBrainProtectionService getSplitBrainProtectionService();
 
     /**
@@ -311,6 +331,7 @@ public interface HazelcastInstance {
      *
      * @return the {@link ClientService} of this Hazelcast instance.
      */
+    @Nonnull
     ClientService getClientService();
 
     /**
@@ -321,6 +342,7 @@ public interface HazelcastInstance {
      *
      * @return the logging service of this Hazelcast instance
      */
+    @Nonnull
     LoggingService getLoggingService();
 
     /**
@@ -330,6 +352,7 @@ public interface HazelcastInstance {
      *
      * @return the lifecycle service for this instance
      */
+    @Nonnull
     LifecycleService getLifecycleService();
 
     /**
@@ -338,7 +361,9 @@ public interface HazelcastInstance {
      * @param <T>         type of the DistributedObject
      * @return DistributedObject created by the service
      */
-    <T extends DistributedObject> T getDistributedObject(String serviceName, String name);
+    @Nonnull
+    <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
+                                                         @Nonnull String name);
 
     /**
      * Returns a ConcurrentMap that can be used to add user-context to the HazelcastInstance. This can be used
@@ -351,14 +376,14 @@ public interface HazelcastInstance {
      *
      * @return a ConcurrentMap that can be used to add user-context to the HazelcastInstance.
      */
-    ConcurrentMap<String, Object> getUserContext();
+    @Nonnull ConcurrentMap<String, Object> getUserContext();
 
     /**
      * Gets xaResource which will participate in XATransaction.
      *
      * @return the xaResource
      */
-    HazelcastXAResource getXAResource();
+    @Nonnull HazelcastXAResource getXAResource();
 
     /**
      * Obtain the {@link ICacheManager} that provides access to JSR-107 (JCache) caches configured on a Hazelcast cluster.
@@ -382,7 +407,7 @@ public interface HazelcastInstance {
      * @param name the name of the estimator
      * @return a {@link CardinalityEstimator}
      */
-    CardinalityEstimator getCardinalityEstimator(String name);
+    @Nonnull CardinalityEstimator getCardinalityEstimator(@Nonnull String name);
 
     /**
      * Creates or returns a {@link PNCounter} with the given
@@ -396,7 +421,7 @@ public interface HazelcastInstance {
      * @param name the name of the PN counter
      * @return a {@link PNCounter}
      */
-    PNCounter getPNCounter(String name);
+    @Nonnull PNCounter getPNCounter(@Nonnull String name);
 
     /**
      * Creates or returns the {@link IScheduledExecutorService} scheduled executor service for the given name.
@@ -406,14 +431,14 @@ public interface HazelcastInstance {
      * @param name name of the executor service
      * @return the scheduled executor service for the given name
      */
-    IScheduledExecutorService getScheduledExecutorService(String name);
+    @Nonnull IScheduledExecutorService getScheduledExecutorService(@Nonnull String name);
 
     /**
      * Returns the CP subsystem that offers a set of in-memory linearizable data structures
      *
      * @return the CP subsystem that offers a set of in-memory linearizable data structures
      */
-    CPSubsystem getCPSubsystem();
+    @Nonnull CPSubsystem getCPSubsystem();
 
     /**
      * Shuts down this HazelcastInstance. For more information see {@link com.hazelcast.core.LifecycleService#shutdown()}.

--- a/hazelcast/src/main/java/com/hazelcast/core/IExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IExecutorService.java
@@ -21,6 +21,8 @@ import com.hazelcast.cluster.MemberSelector;
 import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.monitor.LocalExecutorStats;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -49,7 +51,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param memberSelector memberSelector
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    void execute(Runnable command, MemberSelector memberSelector);
+    void execute(@Nonnull Runnable command,
+                 @Nonnull MemberSelector memberSelector);
 
     /**
      * Executes a task on the owner of the specified key.
@@ -57,7 +60,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param command a task executed on the owner of the specified key
      * @param key     the specified key
      */
-    void executeOnKeyOwner(Runnable command, Object key);
+    void executeOnKeyOwner(@Nonnull Runnable command,
+                           @Nonnull Object key);
 
     /**
      * Executes a task on the specified member.
@@ -65,7 +69,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param command the task executed on the specified member
      * @param member  the specified member
      */
-    void executeOnMember(Runnable command, Member member);
+    void executeOnMember(@Nonnull Runnable command,
+                         @Nonnull Member member);
 
     /**
      * Executes a task on each of the specified members.
@@ -73,7 +78,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param command the task executed on the specified members
      * @param members the specified members
      */
-    void executeOnMembers(Runnable command, Collection<Member> members);
+    void executeOnMembers(@Nonnull Runnable command,
+                          @Nonnull Collection<Member> members);
 
     /**
      * Executes a task on each of the selected members.
@@ -82,14 +88,15 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param memberSelector memberSelector
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    void executeOnMembers(Runnable command, MemberSelector memberSelector);
+    void executeOnMembers(@Nonnull Runnable command,
+                          @Nonnull MemberSelector memberSelector);
 
     /**
      * Executes a task on all of the known cluster members.
      *
      * @param command a task executed  on all of the known cluster members
      */
-    void executeOnAllMembers(Runnable command);
+    void executeOnAllMembers(@Nonnull Runnable command);
 
     /**
      * Submits a task to a randomly selected member and returns a Future
@@ -101,7 +108,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @return a Future representing pending completion of the task
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    <T> Future<T> submit(Callable<T> task, MemberSelector memberSelector);
+    <T> Future<T> submit(@Nonnull Callable<T> task,
+                         @Nonnull MemberSelector memberSelector);
 
     /**
      * Submits a task to the owner of the specified key and returns a Future
@@ -112,7 +120,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>  the result type of callable
      * @return a Future representing pending completion of the task
      */
-    <T> Future<T> submitToKeyOwner(Callable<T> task, Object key);
+    <T> Future<T> submitToKeyOwner(@Nonnull Callable<T> task,
+                                   @Nonnull Object key);
 
     /**
      * Submits a task to the specified member and returns a Future
@@ -123,7 +132,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>    the result type of callable
      * @return a Future representing pending completion of the task
      */
-    <T> Future<T> submitToMember(Callable<T> task, Member member);
+    <T> Future<T> submitToMember(@Nonnull Callable<T> task,
+                                 @Nonnull Member member);
 
     /**
      * Submits a task to given members and returns
@@ -134,7 +144,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>     the result type of callable
      * @return map of Member-Future pairs representing pending completion of the task on each member
      */
-    <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, Collection<Member> members);
+    <T> Map<Member, Future<T>> submitToMembers(@Nonnull Callable<T> task,
+                                               @Nonnull Collection<Member> members);
 
     /**
      * Submits a task to selected members and returns a
@@ -146,7 +157,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @return map of Member-Future pairs representing pending completion of the task on each member
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, MemberSelector memberSelector);
+    <T> Map<Member, Future<T>> submitToMembers(@Nonnull Callable<T> task,
+                                               @Nonnull MemberSelector memberSelector);
 
     /**
      * Submits task to all cluster members and returns a
@@ -156,7 +168,7 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>  the result type of callable
      * @return map of Member-Future pairs representing pending completion of the task on each member
      */
-    <T> Map<Member, Future<T>> submitToAllMembers(Callable<T> task);
+    <T> Map<Member, Future<T>> submitToAllMembers(@Nonnull Callable<T> task);
 
     /**
      * Submits a task to a random member. Caller will be notified of the result of the task by
@@ -166,7 +178,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the response type of callback
      */
-    <T> void submit(Runnable task, ExecutionCallback<T> callback);
+    <T> void submit(@Nonnull Runnable task,
+                    @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits a task to randomly selected members. Caller will be notified for the result of the task by
@@ -178,7 +191,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>            the response type of callback
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    <T> void submit(Runnable task, MemberSelector memberSelector, ExecutionCallback<T> callback);
+    <T> void submit(@Nonnull Runnable task,
+                    @Nonnull MemberSelector memberSelector,
+                    @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits a task to the owner of the specified key. Caller will be notified for the result of the task by
@@ -189,7 +204,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the response type of callback
      */
-    <T> void submitToKeyOwner(Runnable task, Object key, ExecutionCallback<T> callback);
+    <T> void submitToKeyOwner(@Nonnull Runnable task,
+                              @Nonnull Object key,
+                              @Nonnull ExecutionCallback<T> callback);
 
     /**
      * Submits a task to the specified member. Caller will be notified for the result of the task by
@@ -200,7 +217,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the response type of callback
      */
-    <T> void submitToMember(Runnable task, Member member, ExecutionCallback<T> callback);
+    <T> void submitToMember(@Nonnull Runnable task,
+                            @Nonnull Member member,
+                            @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits a task to the specified members. Caller will be notified for the result of the each task by
@@ -211,7 +230,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param members  the specified members
      * @param callback callback
      */
-    void submitToMembers(Runnable task, Collection<Member> members, MultiExecutionCallback callback);
+    void submitToMembers(@Nonnull Runnable task,
+                         @Nonnull Collection<Member> members,
+                         @Nonnull MultiExecutionCallback callback);
 
     /**
      * Submits task to the selected members. Caller will be notified for the result of the each task by
@@ -223,7 +244,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback       callback
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    void submitToMembers(Runnable task, MemberSelector memberSelector, MultiExecutionCallback callback);
+    void submitToMembers(@Nonnull Runnable task,
+                         @Nonnull MemberSelector memberSelector,
+                         @Nonnull MultiExecutionCallback callback);
 
     /**
      * Submits task to all the cluster members. Caller will be notified for the result of each task by
@@ -233,7 +256,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param task     the task submitted to all the cluster members
      * @param callback callback
      */
-    void submitToAllMembers(Runnable task, MultiExecutionCallback callback);
+    void submitToAllMembers(@Nonnull Runnable task,
+                            @Nonnull MultiExecutionCallback callback);
 
     /**
      * Submits a task to a random member. Caller will be notified for the result of the task by
@@ -243,7 +267,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the result type of callable
      */
-    <T> void submit(Callable<T> task, ExecutionCallback<T> callback);
+    <T> void submit(@Nonnull Callable<T> task,
+                    @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits task to a randomly selected member. Caller will be notified for the result of the task by
@@ -255,7 +280,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>            the result type of callable
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    <T> void submit(Callable<T> task, MemberSelector memberSelector, ExecutionCallback<T> callback);
+    <T> void submit(@Nonnull Callable<T> task,
+                    @Nonnull MemberSelector memberSelector,
+                    @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits task to the owner of the specified key. Caller will be notified for the result of the task by
@@ -266,7 +293,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the result type of callable
      */
-    <T> void submitToKeyOwner(Callable<T> task, Object key, ExecutionCallback<T> callback);
+    <T> void submitToKeyOwner(@Nonnull Callable<T> task,
+                              @Nonnull Object key,
+                              @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits a task to the specified member. Caller will be notified for the result of the task by
@@ -277,7 +306,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the result type of callable
      */
-    <T> void submitToMember(Callable<T> task, Member member, ExecutionCallback<T> callback);
+    <T> void submitToMember(@Nonnull Callable<T> task,
+                            @Nonnull Member member,
+                            @Nullable ExecutionCallback<T> callback);
 
     /**
      * Submits a task to the specified members. Caller will be notified for the result of each task by
@@ -289,7 +320,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the result type of callable
      */
-    <T> void submitToMembers(Callable<T> task, Collection<Member> members, MultiExecutionCallback callback);
+    <T> void submitToMembers(@Nonnull Callable<T> task,
+                             @Nonnull Collection<Member> members,
+                             @Nonnull MultiExecutionCallback callback);
 
     /**
      * Submits task to the selected members. Caller will be notified for the result of each task by
@@ -302,7 +335,9 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param <T>            the result type of callable
      * @throws java.util.concurrent.RejectedExecutionException if no member is selected
      */
-    <T> void submitToMembers(Callable<T> task, MemberSelector memberSelector, MultiExecutionCallback callback);
+    <T> void submitToMembers(@Nonnull Callable<T> task,
+                             @Nonnull MemberSelector memberSelector,
+                             @Nonnull MultiExecutionCallback callback);
 
     /**
      * Submits task to all the cluster members. Caller will be notified for the result of the each task by
@@ -313,7 +348,8 @@ public interface IExecutorService extends ExecutorService, DistributedObject {
      * @param callback callback
      * @param <T>      the result type of callable
      */
-    <T> void submitToAllMembers(Callable<T> task, MultiExecutionCallback callback);
+    <T> void submitToAllMembers(@Nonnull Callable<T> task,
+                                @Nonnull MultiExecutionCallback callback);
 
     /**
      * Returns local statistics related to this executor service.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorService.java
@@ -19,6 +19,7 @@ package com.hazelcast.durableexecutor;
 import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.core.DistributedObject;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,8 +30,9 @@ import java.util.concurrent.RejectedExecutionException;
  * Durable implementation of {@link ExecutorService}.
  * DurableExecutor provides additional methods like executing tasks on a member who is owner of a specific key
  * DurableExecutor also provides a way to retrieve the result of an execution with the given taskId.
- * @see ExecutorService
  *
+ * @see ExecutorService
+ * <p>
  * Supports split brain protection {@link SplitBrainProtectionConfig} since 3.10 in cluster versions 3.10 and higher.
  */
 public interface DurableExecutorService extends ExecutorService, DistributedObject {
@@ -56,7 +58,8 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      *                                    scheduled for execution
      * @throws NullPointerException       if the task is null
      */
-    <T> DurableExecutorServiceFuture<T> submit(Callable<T> task);
+    @Nonnull
+    <T> DurableExecutorServiceFuture<T> submit(@Nonnull Callable<T> task);
 
     /**
      * Submits a Runnable task for execution and returns a Future
@@ -71,7 +74,8 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      *                                    scheduled for execution
      * @throws NullPointerException       if the task is null
      */
-    <T> DurableExecutorServiceFuture<T> submit(Runnable task, T result);
+    @Nonnull
+    <T> DurableExecutorServiceFuture<T> submit(@Nonnull Runnable task, T result);
 
     /**
      * Submits a Runnable task for execution and returns a Future
@@ -84,7 +88,9 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      *                                    scheduled for execution
      * @throws NullPointerException       if the task is null
      */
-    DurableExecutorServiceFuture<?> submit(Runnable task);
+    @Override
+    @Nonnull
+    DurableExecutorServiceFuture<?> submit(@Nonnull Runnable task);
 
     /**
      * Retrieves the result with the given taskId
@@ -117,7 +123,8 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      * @param command a task executed on the owner of the specified key
      * @param key     the specified key
      */
-    void executeOnKeyOwner(Runnable command, Object key);
+    void executeOnKeyOwner(@Nonnull Runnable command,
+                           @Nonnull Object key);
 
     /**
      * Submits a task to the owner of the specified key and returns a Future
@@ -127,7 +134,8 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      * @param key  the specified key
      * @return a Future representing pending completion of the task
      */
-    <T> DurableExecutorServiceFuture<T> submitToKeyOwner(Callable<T> task, Object key);
+    <T> DurableExecutorServiceFuture<T> submitToKeyOwner(@Nonnull Callable<T> task,
+                                                         @Nonnull Object key);
 
     /**
      * Submits a task to the owner of the specified key and returns a Future
@@ -137,5 +145,6 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      * @param key  the specified key
      * @return a Future representing pending completion of the task
      */
-    DurableExecutorServiceFuture<?> submitToKeyOwner(Runnable task, Object key);
+    DurableExecutorServiceFuture<?> submitToKeyOwner(@Nonnull Runnable task,
+                                                     @Nonnull Object key);
 }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -34,6 +34,7 @@ import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ContextMutexFactory;
 import com.hazelcast.internal.util.MapUtil;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
@@ -107,7 +108,8 @@ public class DistributedExecutorService implements ManagedService, RemoteService
         reset();
     }
 
-    public <T> void execute(String name, UUID uuid, T task, Operation op) {
+    public <T> void execute(String name, UUID uuid,
+                            @Nonnull T task, Operation op) {
         ExecutorConfig cfg = getOrFindExecutorConfig(name);
         if (cfg.isStatisticsEnabled()) {
             startPending(name);
@@ -250,7 +252,10 @@ public class DistributedExecutorService implements ManagedService, RemoteService
         private final long creationTime = Clock.currentTimeMillis();
         private final boolean statisticsEnabled;
 
-        private Processor(String name, UUID uuid, Callable callable, Operation op, boolean statisticsEnabled) {
+        private Processor(String name, UUID uuid,
+                          @Nonnull Callable callable,
+                          Operation op,
+                          boolean statisticsEnabled) {
             //noinspection unchecked
             super(callable);
             this.name = name;
@@ -260,7 +265,9 @@ public class DistributedExecutorService implements ManagedService, RemoteService
             this.statisticsEnabled = statisticsEnabled;
         }
 
-        private Processor(String name, UUID uuid, Runnable runnable, Operation op, boolean statisticsEnabled) {
+        private Processor(String name, UUID uuid,
+                          @Nonnull Runnable runnable,
+                          Operation op, boolean statisticsEnabled) {
             //noinspection unchecked
             super(runnable, null);
             this.name = name;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
@@ -16,11 +16,12 @@
 
 package com.hazelcast.executor.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.logging.ILogger;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.hazelcast.internal.util.MapUtil.createConcurrentHashMap;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
@@ -46,11 +48,15 @@ class ExecutionCallbackAdapterFactory {
     @SuppressWarnings("CanBeFinal")
     private volatile Boolean done = FALSE;
 
-    ExecutionCallbackAdapterFactory(ILogger logger, Collection<Member> members,
-                                    MultiExecutionCallback multiExecutionCallback) {
+    ExecutionCallbackAdapterFactory(@Nonnull ILogger logger,
+                                    @Nonnull Collection<Member> members,
+                                    @Nonnull MultiExecutionCallback multiExecutionCallback) {
+        checkNotNull(logger, "logger must not be null");
+        checkNotNull(members, "members must not be null");
+        checkNotNull(multiExecutionCallback, "multiExecutionCallback must not be null");
         this.multiExecutionCallback = multiExecutionCallback;
         this.responses = createConcurrentHashMap(members.size());
-        this.members = new HashSet<Member>(members);
+        this.members = new HashSet<>(members);
         this.logger = logger;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -42,6 +42,8 @@ import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -114,102 +116,119 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public void execute(Runnable command, MemberSelector memberSelector) {
+    public void execute(@Nonnull Runnable command,
+                        @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         executeOnMember(command, members.get(selectedMember));
     }
 
     @Override
-    public void executeOnMembers(Runnable command, MemberSelector memberSelector) {
+    public void executeOnMembers(@Nonnull Runnable command,
+                                 @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         executeOnMembers(command, members);
     }
 
     @Override
-    public <T> Future<T> submit(Callable<T> task, MemberSelector memberSelector) {
+    public <T> Future<T> submit(@Nonnull Callable<T> task,
+                                @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         return submitToMember(task, members.get(selectedMember));
     }
 
     @Override
-    public <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, MemberSelector memberSelector) {
+    public <T> Map<Member, Future<T>> submitToMembers(@Nonnull Callable<T> task,
+                                                      @Nonnull MemberSelector memberSelector) {
         List<Member> members = selectMembers(memberSelector);
         return submitToMembers(task, members);
     }
 
     @Override
-    public void submit(Runnable task, MemberSelector memberSelector, ExecutionCallback callback) {
+    public void submit(@Nonnull Runnable task,
+                       @Nonnull MemberSelector memberSelector,
+                       @Nullable ExecutionCallback callback) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         submitToMember(task, members.get(selectedMember), callback);
     }
 
     @Override
-    public void submitToMembers(Runnable task, MemberSelector memberSelector, MultiExecutionCallback callback) {
+    public void submitToMembers(@Nonnull Runnable task,
+                                @Nonnull MemberSelector memberSelector,
+                                @Nonnull MultiExecutionCallback callback) {
         List<Member> members = selectMembers(memberSelector);
         submitToMembers(task, members, callback);
     }
 
     @Override
-    public <T> void submit(Callable<T> task, MemberSelector memberSelector, ExecutionCallback<T> callback) {
+    public <T> void submit(@Nonnull Callable<T> task,
+                           @Nonnull MemberSelector memberSelector,
+                           @Nullable ExecutionCallback<T> callback) {
         List<Member> members = selectMembers(memberSelector);
         int selectedMember = random.nextInt(members.size());
         submitToMember(task, members.get(selectedMember), callback);
     }
 
     @Override
-    public <T> void submitToMembers(Callable<T> task, MemberSelector memberSelector, MultiExecutionCallback callback) {
+    public <T> void submitToMembers(@Nonnull Callable<T> task,
+                                    @Nonnull MemberSelector memberSelector,
+                                    @Nonnull MultiExecutionCallback callback) {
         List<Member> members = selectMembers(memberSelector);
         submitToMembers(task, members, callback);
     }
 
     @Override
-    public void execute(Runnable command) {
+    public void execute(@Nonnull Runnable command) {
         Callable<?> callable = createRunnableAdapter(command);
         submit(callable);
     }
 
-    private <T> RunnableAdapter<T> createRunnableAdapter(Runnable command) {
-        checkNotNull(command, "Command can't be null");
+    private <T> RunnableAdapter<T> createRunnableAdapter(@Nonnull Runnable command) {
+        checkNotNull(command, "Command must not be null");
 
-        return new RunnableAdapter<T>(command);
+        return new RunnableAdapter<>(command);
     }
 
     @Override
-    public void executeOnKeyOwner(Runnable command, Object key) {
+    public void executeOnKeyOwner(@Nonnull Runnable command,
+                                  @Nonnull Object key) {
         Callable<?> callable = createRunnableAdapter(command);
         submitToKeyOwner(callable, key);
     }
 
     @Override
-    public void executeOnMember(Runnable command, Member member) {
+    public void executeOnMember(@Nonnull Runnable command,
+                                @Nonnull Member member) {
         Callable<?> callable = createRunnableAdapter(command);
         submitToMember(callable, member);
     }
 
     @Override
-    public void executeOnMembers(Runnable command, Collection<Member> members) {
+    public void executeOnMembers(@Nonnull Runnable command,
+                                 @Nonnull Collection<Member> members) {
         Callable<?> callable = createRunnableAdapter(command);
         submitToMembers(callable, members);
     }
 
     @Override
-    public void executeOnAllMembers(Runnable command) {
+    public void executeOnAllMembers(@Nonnull Runnable command) {
         Callable<?> callable = createRunnableAdapter(command);
         submitToAllMembers(callable);
     }
 
+    @Nonnull
     @Override
-    public Future<?> submit(Runnable task) {
+    public Future<?> submit(@Nonnull Runnable task) {
         Callable<?> callable = createRunnableAdapter(task);
         return submit(callable);
     }
 
+    @Nonnull
     @Override
-    public <T> Future<T> submit(Runnable task, T result) {
-        checkNotNull(task, "task can't be null");
+    public <T> Future<T> submit(@Nonnull Runnable task, T result) {
+        checkNotNull(task, "task must not be null");
         checkNotShutdown();
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -230,7 +249,7 @@ public class ExecutorServiceProxy
             }
             return InternalCompletableFuture.newCompletedFuture(result);
         }
-        return new CancellableDelegatingFuture<T>(future, result, nodeEngine, uuid, partitionId);
+        return new CancellableDelegatingFuture<>(future, result, nodeEngine, uuid, partitionId);
     }
 
     private void checkNotShutdown() {
@@ -239,14 +258,19 @@ public class ExecutorServiceProxy
         }
     }
 
+    @Nonnull
     @Override
-    public <T> Future<T> submit(Callable<T> task) {
+    public <T> Future<T> submit(@Nonnull Callable<T> task) {
+        checkNotNull(task, "task must not be null");
         final int partitionId = getTaskPartitionId(task);
         return submitToPartitionOwner(task, partitionId, false);
     }
 
-    private <T> Future<T> submitToPartitionOwner(Callable<T> task, int partitionId, boolean preventSync) {
-        checkNotNull(task, "task can't be null");
+    private @Nonnull
+    <T> Future<T> submitToPartitionOwner(@Nonnull Callable<T> task,
+                                         int partitionId,
+                                         boolean preventSync) {
+        checkNotNull(task, "task must not be null");
         checkNotShutdown();
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -260,7 +284,7 @@ public class ExecutorServiceProxy
         if (sync) {
             return completedSynchronously(future, nodeEngine.getSerializationService());
         }
-        return new CancellableDelegatingFuture<T>(future, nodeEngine, uuid, partitionId);
+        return new CancellableDelegatingFuture<>(future, nodeEngine, uuid, partitionId);
     }
 
     /**
@@ -291,21 +315,26 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public <T> Future<T> submitToKeyOwner(Callable<T> task, Object key) {
+    public <T> Future<T> submitToKeyOwner(@Nonnull Callable<T> task,
+                                          @Nonnull Object key) {
+        checkNotNull(key, "key must not be null");
         NodeEngine nodeEngine = getNodeEngine();
         return submitToPartitionOwner(task, nodeEngine.getPartitionService().getPartitionId(key), false);
     }
 
     @Override
-    public <T> Future<T> submitToMember(Callable<T> task, Member member) {
-        checkNotNull(task, "task can't be null");
+    public <T> Future<T> submitToMember(@Nonnull Callable<T> task,
+                                        @Nonnull Member member) {
+        checkNotNull(task, "task must not be null");
+        checkNotNull(member, "member must not be null");
         checkNotShutdown();
 
         Data taskData = getNodeEngine().toData(task);
         return submitToMember(taskData, member);
     }
 
-    private  <T> Future<T> submitToMember(Data taskData, Member member) {
+    private <T> Future<T> submitToMember(@Nonnull Data taskData,
+                                         @Nonnull Member member) {
         NodeEngine nodeEngine = getNodeEngine();
         UUID uuid = newUnsecureUUID();
         Address target = member.getAddress();
@@ -317,12 +346,14 @@ public class ExecutorServiceProxy
         if (sync) {
             return completedSynchronously(future, nodeEngine.getSerializationService());
         }
-        return new CancellableDelegatingFuture<T>(future, nodeEngine, uuid, target);
+        return new CancellableDelegatingFuture<>(future, nodeEngine, uuid, target);
     }
 
     @Override
-    public <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, Collection<Member> members) {
-        checkNotNull(task, "task can't be null");
+    public <T> Map<Member, Future<T>> submitToMembers(@Nonnull Callable<T> task,
+                                                      @Nonnull Collection<Member> members) {
+        checkNotNull(task, "task must not be null");
+        checkNotNull(members, "members must not be null");
         checkNotShutdown();
         Data taskData = getNodeEngine().toData(task);
         Map<Member, Future<T>> futures = createHashMap(members.size());
@@ -333,43 +364,54 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public <T> Map<Member, Future<T>> submitToAllMembers(Callable<T> task) {
+    public <T> Map<Member, Future<T>> submitToAllMembers(@Nonnull Callable<T> task) {
         NodeEngine nodeEngine = getNodeEngine();
         return submitToMembers(task, nodeEngine.getClusterService().getMembers());
     }
 
     @Override
-    public void submit(Runnable task, ExecutionCallback callback) {
+    public void submit(@Nonnull Runnable task,
+                       @Nullable ExecutionCallback callback) {
         Callable<?> callable = createRunnableAdapter(task);
         submit(callable, callback);
     }
 
     @Override
-    public void submitToKeyOwner(Runnable task, Object key, ExecutionCallback callback) {
+    public void submitToKeyOwner(@Nonnull Runnable task,
+                                 @Nonnull Object key,
+                                 @Nonnull ExecutionCallback callback) {
         Callable<?> callable = createRunnableAdapter(task);
         submitToKeyOwner(callable, key, callback);
     }
 
     @Override
-    public void submitToMember(Runnable task, Member member, ExecutionCallback callback) {
+    public void submitToMember(@Nonnull Runnable task,
+                               @Nonnull Member member,
+                               @Nullable ExecutionCallback callback) {
         Callable<?> callable = createRunnableAdapter(task);
         submitToMember(callable, member, callback);
     }
 
     @Override
-    public void submitToMembers(Runnable task, Collection<Member> members, MultiExecutionCallback callback) {
+    public void submitToMembers(@Nonnull Runnable task,
+                                @Nonnull Collection<Member> members,
+                                @Nonnull MultiExecutionCallback callback) {
         Callable<?> callable = createRunnableAdapter(task);
         submitToMembers(callable, members, callback);
     }
 
     @Override
-    public void submitToAllMembers(Runnable task, MultiExecutionCallback callback) {
+    public void submitToAllMembers(@Nonnull Runnable task,
+                                   @Nonnull MultiExecutionCallback callback) {
         Callable<?> callable = createRunnableAdapter(task);
         submitToAllMembers(callable, callback);
     }
 
-    private <T> void submitToPartitionOwner(Callable<T> task, ExecutionCallback<T> callback, int partitionId) {
+    private <T> void submitToPartitionOwner(@Nonnull Callable<T> task,
+                                            @Nullable ExecutionCallback<T> callback,
+                                            int partitionId) {
         checkNotShutdown();
+        checkNotNull(task, "task must not be null");
 
         NodeEngine nodeEngine = getNodeEngine();
         Data taskData = nodeEngine.toData(task);
@@ -380,18 +422,27 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public <T> void submit(Callable<T> task, ExecutionCallback<T> callback) {
+    public <T> void submit(@Nonnull Callable<T> task,
+                           @Nullable ExecutionCallback<T> callback) {
         int partitionId = getTaskPartitionId(task);
         submitToPartitionOwner(task, callback, partitionId);
     }
 
     @Override
-    public <T> void submitToKeyOwner(Callable<T> task, Object key, ExecutionCallback<T> callback) {
+    public <T> void submitToKeyOwner(@Nonnull Callable<T> task,
+                                     @Nonnull Object key,
+                                     @Nullable ExecutionCallback<T> callback) {
+        checkNotNull(key, "key must not be null");
+        checkNotNull(task, "task must not be null");
+
         NodeEngine nodeEngine = getNodeEngine();
         submitToPartitionOwner(task, callback, nodeEngine.getPartitionService().getPartitionId(key));
     }
 
-    private  <T> void submitToMember(Data taskData, Member member, ExecutionCallback<T> callback) {
+    private <T> void submitToMember(@Nonnull Data taskData,
+                                    @Nonnull Member member,
+                                    @Nullable ExecutionCallback<T> callback) {
+        checkNotNull(member, "member must not be null");
         checkNotShutdown();
 
         NodeEngine nodeEngine = getNodeEngine();
@@ -405,7 +456,10 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public <T> void submitToMember(Callable<T> task, Member member, ExecutionCallback<T> callback) {
+    public <T> void submitToMember(@Nonnull Callable<T> task,
+                                   @Nonnull Member member,
+                                   @Nullable ExecutionCallback<T> callback) {
+        checkNotNull(task, "task must not be null");
         checkNotShutdown();
 
         Data taskData = getNodeEngine().toData(task);
@@ -418,10 +472,14 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public <T> void submitToMembers(Callable<T> task, Collection<Member> members, MultiExecutionCallback callback) {
+    public <T> void submitToMembers(@Nonnull Callable<T> task,
+                                    @Nonnull Collection<Member> members,
+                                    @Nonnull MultiExecutionCallback callback) {
+        checkNotNull(task, "task must not be null");
+        checkNotNull(members, "members must not be null");
         NodeEngine nodeEngine = getNodeEngine();
-        ExecutionCallbackAdapterFactory executionCallbackFactory = new ExecutionCallbackAdapterFactory(
-                nodeEngine.getLogger(ExecutionCallbackAdapterFactory.class), members, callback);
+        ILogger logger = nodeEngine.getLogger(ExecutionCallbackAdapterFactory.class);
+        ExecutionCallbackAdapterFactory executionCallbackFactory = new ExecutionCallbackAdapterFactory(logger, members, callback);
 
         Data taskData = nodeEngine.toData(task);
         for (Member member : members) {
@@ -430,16 +488,19 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public <T> void submitToAllMembers(Callable<T> task, MultiExecutionCallback callback) {
+    public <T> void submitToAllMembers(@Nonnull Callable<T> task,
+                                       @Nonnull MultiExecutionCallback callback) {
         NodeEngine nodeEngine = getNodeEngine();
         submitToMembers(task, nodeEngine.getClusterService().getMembers(), callback);
     }
 
+    @Nonnull
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+    public <T> List<Future<T>> invokeAll(@Nonnull Collection<? extends Callable<T>> tasks)
             throws InterruptedException {
-        List<Future<T>> futures = new ArrayList<Future<T>>(tasks.size());
-        List<Future<T>> result = new ArrayList<Future<T>>(tasks.size());
+        checkNotNull(tasks, "tasks must not be null");
+        List<Future<T>> futures = new ArrayList<>(tasks.size());
+        List<Future<T>> result = new ArrayList<>(tasks.size());
         for (Callable<T> task : tasks) {
             futures.add(submit(task));
         }
@@ -449,14 +510,16 @@ public class ExecutorServiceProxy
         return result;
     }
 
+    @Nonnull
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException {
+    public <T> List<Future<T>> invokeAll(@Nonnull Collection<? extends Callable<T>> tasks,
+                                         long timeout,
+                                         @Nonnull TimeUnit unit) {
         checkNotNull(unit, "unit must not be null");
         checkNotNull(tasks, "tasks must not be null");
 
         long timeoutNanos = unit.toNanos(timeout);
-        List<Future<T>> futures = new ArrayList<Future<T>>(tasks.size());
+        List<Future<T>> futures = new ArrayList<>(tasks.size());
         boolean done = false;
         try {
             for (Callable<T> task : tasks) {
@@ -515,15 +578,15 @@ public class ExecutorServiceProxy
         }
     }
 
+    @Nonnull
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException, ExecutionException {
+    public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks,
+                           long timeout, @Nonnull TimeUnit unit) {
         throw new UnsupportedOperationException();
     }
 
@@ -547,8 +610,8 @@ public class ExecutorServiceProxy
     }
 
     @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit)
-            throws InterruptedException {
+    public boolean awaitTermination(long timeout, @Nonnull TimeUnit unit) {
+        checkNotNull(unit, "unit must not be null");
         return false;
     }
 
@@ -557,7 +620,7 @@ public class ExecutorServiceProxy
         NodeEngine nodeEngine = getNodeEngine();
         Collection<Member> members = nodeEngine.getClusterService().getMembers();
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<Future> calls = new LinkedList<Future>();
+        Collection<Future> calls = new LinkedList<>();
 
         for (Member member : members) {
             Future f = submitShutdownOperation(operationService, member);
@@ -571,6 +634,7 @@ public class ExecutorServiceProxy
         return operationService.invokeOnTarget(getServiceName(), op, member.getAddress());
     }
 
+    @Nonnull
     @Override
     public List<Runnable> shutdownNow() {
         shutdown();
@@ -596,11 +660,9 @@ public class ExecutorServiceProxy
         return getNodeEngine().getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
     }
 
-    private List<Member> selectMembers(MemberSelector memberSelector) {
-        if (memberSelector == null) {
-            throw new IllegalArgumentException("memberSelector must not be null");
-        }
-        List<Member> selected = new ArrayList<Member>();
+    private List<Member> selectMembers(@Nonnull MemberSelector memberSelector) {
+        checkNotNull(memberSelector, "memberSelector must not be null");
+        List<Member> selected = new ArrayList<>();
         Collection<Member> members = getNodeEngine().getClusterService().getMembers();
         for (Member member : members) {
             if (memberSelector.select(member)) {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.impl.operationservice.NamedOperation;
 import com.hazelcast.spi.impl.operationservice.Offload;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -41,7 +42,9 @@ abstract class AbstractCallableTaskOperation extends Operation implements NamedO
     AbstractCallableTaskOperation() {
     }
 
-    AbstractCallableTaskOperation(String name, UUID uuid, Data callableData) {
+    AbstractCallableTaskOperation(String name,
+                                  UUID uuid,
+                                  @Nonnull Data callableData) {
         this.name = name;
         this.uuid = uuid;
         this.callableData = callableData;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CallableTaskOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 public final class CallableTaskOperation extends AbstractCallableTaskOperation
@@ -29,7 +30,9 @@ public final class CallableTaskOperation extends AbstractCallableTaskOperation
     public CallableTaskOperation() {
     }
 
-    public CallableTaskOperation(String name, UUID uuid, Data callableData) {
+    public CallableTaskOperation(String name,
+                                 UUID uuid,
+                                 @Nonnull Data callableData) {
         super(name, uuid, callableData);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 public final class MemberCallableTaskOperation extends AbstractCallableTaskOperation
@@ -32,7 +33,9 @@ public final class MemberCallableTaskOperation extends AbstractCallableTaskOpera
     public MemberCallableTaskOperation() {
     }
 
-    public MemberCallableTaskOperation(String name, UUID uuid, Data callableData) {
+    public MemberCallableTaskOperation(String name,
+                                       UUID uuid,
+                                       @Nonnull Data callableData) {
         super(name, uuid, callableData);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -241,6 +241,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
+        checkNotNull(options, "TransactionOptions must not be null!");
         TransactionManagerService transactionManagerService = node.getNodeEngine().getTransactionManagerService();
         return transactionManagerService.newTransactionContext(options);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -75,6 +75,7 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.impl.xa.XAService;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -158,68 +159,77 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         return managementService;
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return name;
     }
 
+    @Nonnull
     @Override
-    public <K, V> IMap<K, V> getMap(String name) {
+    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a map instance with a null name is not allowed!");
         return getDistributedObject(MapService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> IQueue<E> getQueue(String name) {
+    public <E> IQueue<E> getQueue(@Nonnull String name) {
         checkNotNull(name, "Retrieving a queue instance with a null name is not allowed!");
         return getDistributedObject(QueueService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getTopic(String name) {
+    public <E> ITopic<E> getTopic(@Nonnull String name) {
         checkNotNull(name, "Retrieving a topic instance with a null name is not allowed!");
         return getDistributedObject(TopicService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getReliableTopic(String name) {
+    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
         checkNotNull(name, "Retrieving a topic instance with a null name is not allowed!");
         return getDistributedObject(ReliableTopicService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> ISet<E> getSet(String name) {
+    public <E> ISet<E> getSet(@Nonnull String name) {
         checkNotNull(name, "Retrieving a set instance with a null name is not allowed!");
         return getDistributedObject(SetService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> IList<E> getList(String name) {
+    public <E> IList<E> getList(@Nonnull String name) {
         checkNotNull(name, "Retrieving a list instance with a null name is not allowed!");
         return getDistributedObject(ListService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> MultiMap<K, V> getMultiMap(String name) {
+    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a multi-map instance with a null name is not allowed!");
         return getDistributedObject(MultiMapService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> Ringbuffer<E> getRingbuffer(String name) {
+    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
         checkNotNull(name, "Retrieving a ringbuffer instance with a null name is not allowed!");
         return getDistributedObject(RingbufferService.SERVICE_NAME, name);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionalTask<T> task)
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task)
             throws TransactionException {
         return executeTransaction(TransactionOptions.getDefault(), task);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task)
-            throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
         TransactionManagerService transactionManagerService = node.getNodeEngine().getTransactionManagerService();
         return transactionManagerService.executeTransaction(options, task);
     }
@@ -230,31 +240,33 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         TransactionManagerService transactionManagerService = node.getNodeEngine().getTransactionManagerService();
         return transactionManagerService.newTransactionContext(options);
     }
 
+    @Nonnull
     @Override
-    public IExecutorService getExecutorService(String name) {
+    public IExecutorService getExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving an executor instance with a null name is not allowed!");
         return getDistributedObject(DistributedExecutorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public DurableExecutorService getDurableExecutorService(String name) {
+    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving a durable executor instance with a null name is not allowed!");
         return getDistributedObject(DistributedDurableExecutorService.SERVICE_NAME, name);
     }
 
     @Override
-    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a Flake ID-generator instance with a null name is not allowed!");
         return getDistributedObject(FlakeIdGeneratorService.SERVICE_NAME, name);
     }
 
     @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a replicated map instance with a null name is not allowed!");
         return getDistributedObject(ReplicatedMapService.SERVICE_NAME, name);
     }
@@ -264,11 +276,13 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         return hazelcastCacheManager;
     }
 
+    @Nonnull
     @Override
     public Cluster getCluster() {
         return node.getClusterService();
     }
 
+    @Nonnull
     @Override
     public Member getLocalEndpoint() {
         return node.getLocalMember();
@@ -280,36 +294,43 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         return proxyService.getAllDistributedObjects();
     }
 
+    @Nonnull
     @Override
     public Config getConfig() {
         return node.getConfig();
     }
 
+    @Nonnull
     @Override
     public ConcurrentMap<String, Object> getUserContext() {
         return userContext;
     }
 
+    @Nonnull
     @Override
     public PartitionService getPartitionService() {
         return node.getPartitionService().getPartitionServiceProxy();
     }
 
+    @Nonnull
     @Override
     public SplitBrainProtectionService getSplitBrainProtectionService() {
         return node.getNodeEngine().getSplitBrainProtectionService();
     }
 
+    @Nonnull
     @Override
     public ClientService getClientService() {
         return new ClientServiceProxy(node);
     }
 
+    @Nonnull
     @Override
     public LoggingService getLoggingService() {
         return node.getLoggingService();
     }
 
+    @Nonnull
     @Override
     public LifecycleServiceImpl getLifecycleService() {
         return lifecycleService;
@@ -320,21 +341,24 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         getLifecycleService().shutdown();
     }
 
+    @Nonnull
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
         ProxyService proxyService = node.getNodeEngine().getProxyService();
         return (T) proxyService.getDistributedObject(serviceName, name);
     }
 
     @Override
-    public UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
+        checkNotNull(distributedObjectListener, "DistributedObjectListener must not be null!");
         final ProxyService proxyService = node.getNodeEngine().getProxyService();
         return proxyService.addProxyListener(distributedObjectListener);
     }
 
     @Override
-    public boolean removeDistributedObjectListener(UUID registrationId) {
+    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
+        checkNotNull(registrationId, "Registration ID must not be null!");
         final ProxyService proxyService = node.getNodeEngine().getProxyService();
         return proxyService.removeProxyListener(registrationId);
     }
@@ -348,29 +372,34 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         return node.getNodeExtension().getMemoryStats();
     }
 
+    @Nonnull
     @Override
     public HazelcastXAResource getXAResource() {
         return getDistributedObject(XAService.SERVICE_NAME, XAService.SERVICE_NAME);
     }
 
+    @Nonnull
     @Override
-    public CardinalityEstimator getCardinalityEstimator(String name) {
+    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a cardinality estimator instance with a null name is not allowed!");
         return getDistributedObject(CardinalityEstimatorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public PNCounter getPNCounter(String name) {
+    public PNCounter getPNCounter(@Nonnull String name) {
         checkNotNull(name, "Retrieving a PN counter instance with a null name is not allowed!");
         return getDistributedObject(PNCounterService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public IScheduledExecutorService getScheduledExecutorService(String name) {
+    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving a scheduled executor instance with a null name is not allowed!");
         return getDistributedObject(DistributedScheduledExecutorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
     public CPSubsystem getCPSubsystem() {
         return cpSubsystem;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -52,6 +52,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
@@ -81,68 +82,79 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         name = original.getName();
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return name;
     }
 
+    @Nonnull
     @Override
-    public <K, V> IMap<K, V> getMap(String name) {
+    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
         return getOriginal().getMap(name);
     }
 
+    @Nonnull
     @Override
-    public <E> IQueue<E> getQueue(String name) {
+    public <E> IQueue<E> getQueue(@Nonnull String name) {
         return getOriginal().getQueue(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getTopic(String name) {
+    public <E> ITopic<E> getTopic(@Nonnull String name) {
         return getOriginal().getTopic(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getReliableTopic(String name) {
+    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
         return getOriginal().getReliableTopic(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ISet<E> getSet(String name) {
+    public <E> ISet<E> getSet(@Nonnull String name) {
         return getOriginal().getSet(name);
     }
 
+    @Nonnull
     @Override
-    public <E> IList<E> getList(String name) {
+    public <E> IList<E> getList(@Nonnull String name) {
         return getOriginal().getList(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> MultiMap<K, V> getMultiMap(String name) {
+    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
         return getOriginal().getMultiMap(name);
     }
 
+    @Nonnull
     @Override
-    public <E> Ringbuffer<E> getRingbuffer(String name) {
+    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
         return getOriginal().getRingbuffer(name);
     }
 
     @Override
-    public IExecutorService getExecutorService(String name) {
+    public IExecutorService getExecutorService(@Nonnull String name) {
         return getOriginal().getExecutorService(name);
     }
 
+    @Nonnull
     @Override
-    public DurableExecutorService getDurableExecutorService(String name) {
+    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
         return getOriginal().getDurableExecutorService(name);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
         return getOriginal().executeTransaction(task);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
         return getOriginal().executeTransaction(options, task);
     }
 
@@ -152,17 +164,17 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         return getOriginal().newTransactionContext(options);
     }
 
     @Override
-    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         return getOriginal().getFlakeIdGenerator(name);
     }
 
     @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         return getOriginal().getReplicatedMap(name);
     }
 
@@ -171,11 +183,13 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().getCacheManager();
     }
 
+    @Nonnull
     @Override
     public Cluster getCluster() {
         return getOriginal().getCluster();
     }
 
+    @Nonnull
     @Override
     public Member getLocalEndpoint() {
         return getOriginal().getLocalEndpoint();
@@ -186,77 +200,90 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().getDistributedObjects();
     }
 
+    @Nonnull
     @Override
     public Config getConfig() {
         return getOriginal().getConfig();
     }
 
+    @Nonnull
     @Override
     public PartitionService getPartitionService() {
         return getOriginal().getPartitionService();
     }
 
+    @Nonnull
     @Override
     public SplitBrainProtectionService getSplitBrainProtectionService() {
         return getOriginal().getSplitBrainProtectionService();
     }
 
+    @Nonnull
     @Override
     public ClientService getClientService() {
         return getOriginal().getClientService();
     }
 
+    @Nonnull
     @Override
     public LoggingService getLoggingService() {
         return getOriginal().getLoggingService();
     }
 
+    @Nonnull
     @Override
     public LifecycleService getLifecycleService() {
         final HazelcastInstanceImpl hz = original;
         return hz != null ? hz.getLifecycleService() : new TerminatedLifecycleService();
     }
 
+    @Nonnull
     @Override
-    public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
         return getOriginal().getDistributedObject(serviceName, name);
     }
 
     @Override
-    public UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
         return getOriginal().addDistributedObjectListener(distributedObjectListener);
     }
 
     @Override
-    public boolean removeDistributedObjectListener(UUID registrationId) {
+    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
         return getOriginal().removeDistributedObjectListener(registrationId);
     }
 
+    @Nonnull
     @Override
     public ConcurrentMap<String, Object> getUserContext() {
         return getOriginal().getUserContext();
     }
 
+    @Nonnull
     @Override
     public HazelcastXAResource getXAResource() {
         return getOriginal().getXAResource();
     }
 
+    @Nonnull
     @Override
-    public CardinalityEstimator getCardinalityEstimator(String name) {
+    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         return getOriginal().getCardinalityEstimator(name);
     }
 
+    @Nonnull
     @Override
-    public PNCounter getPNCounter(String name) {
+    public PNCounter getPNCounter(@Nonnull String name) {
         return getOriginal().getPNCounter(name);
     }
 
+    @Nonnull
     @Override
-    public IScheduledExecutorService getScheduledExecutorService(String name) {
+    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
         return getOriginal().getScheduledExecutorService(name);
     }
 
+    @Nonnull
     @Override
     public CPSubsystem getCPSubsystem() {
         return getOriginal().getCPSubsystem();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -67,6 +67,7 @@ import com.hazelcast.spi.partition.PartitionAwareService;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -936,12 +937,12 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
     }
 
     @Override
-    public final int getPartitionId(Data key) {
+    public final int getPartitionId(@Nonnull Data key) {
         return HashUtil.hashToIndex(key.getPartitionHash(), partitionCount);
     }
 
     @Override
-    public final int getPartitionId(Object key) {
+    public final int getPartitionId(@Nonnull Object key) {
         return getPartitionId(nodeEngine.toData(key));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -52,6 +52,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
@@ -73,53 +74,62 @@ class HazelcastOSGiInstanceImpl
         this.ownerService = ownerService;
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return delegatedInstance.getName();
     }
 
+    @Nonnull
     @Override
-    public <E> IQueue<E> getQueue(String name) {
+    public <E> IQueue<E> getQueue(@Nonnull String name) {
         return delegatedInstance.getQueue(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getTopic(String name) {
+    public <E> ITopic<E> getTopic(@Nonnull String name) {
         return delegatedInstance.getTopic(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ISet<E> getSet(String name) {
+    public <E> ISet<E> getSet(@Nonnull String name) {
         return delegatedInstance.getSet(name);
     }
 
+    @Nonnull
     @Override
-    public <E> IList<E> getList(String name) {
+    public <E> IList<E> getList(@Nonnull String name) {
         return delegatedInstance.getList(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> IMap<K, V> getMap(String name) {
+    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
         return delegatedInstance.getMap(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         return delegatedInstance.getReplicatedMap(name);
     }
 
+    @Nonnull
     @Override
-    public <K, V> MultiMap<K, V> getMultiMap(String name) {
+    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
         return delegatedInstance.getMultiMap(name);
     }
 
     @Override
-    public <E> Ringbuffer<E> getRingbuffer(String name) {
+    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
         return delegatedInstance.getRingbuffer(name);
     }
 
+    @Nonnull
     @Override
-    public <E> ITopic<E> getReliableTopic(String name) {
+    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
         return delegatedInstance.getReliableTopic(name);
     }
 
@@ -128,33 +138,38 @@ class HazelcastOSGiInstanceImpl
         return delegatedInstance.getCacheManager();
     }
 
+    @Nonnull
     @Override
     public Cluster getCluster() {
         return delegatedInstance.getCluster();
     }
 
+    @Nonnull
     @Override
     public Endpoint getLocalEndpoint() {
         return delegatedInstance.getLocalEndpoint();
     }
 
+    @Nonnull
     @Override
-    public IExecutorService getExecutorService(String name) {
+    public IExecutorService getExecutorService(@Nonnull String name) {
         return delegatedInstance.getExecutorService(name);
     }
 
+    @Nonnull
     @Override
-    public DurableExecutorService getDurableExecutorService(String name) {
+    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
         return delegatedInstance.getDurableExecutorService(name);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
         return delegatedInstance.executeTransaction(task);
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
         return delegatedInstance.executeTransaction(options, task);
     }
 
@@ -164,12 +179,12 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         return delegatedInstance.newTransactionContext(options);
     }
 
     @Override
-    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         return delegatedInstance.getFlakeIdGenerator(name);
     }
 
@@ -179,75 +194,88 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
-    public UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
         return delegatedInstance.addDistributedObjectListener(distributedObjectListener);
     }
 
     @Override
-    public boolean removeDistributedObjectListener(UUID registrationId) {
+    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
         return delegatedInstance.removeDistributedObjectListener(registrationId);
     }
 
+    @Nonnull
     @Override
     public Config getConfig() {
         return delegatedInstance.getConfig();
     }
 
+    @Nonnull
     @Override
     public PartitionService getPartitionService() {
         return delegatedInstance.getPartitionService();
     }
 
+    @Nonnull
     @Override
     public SplitBrainProtectionService getSplitBrainProtectionService() {
         return delegatedInstance.getSplitBrainProtectionService();
     }
 
+    @Nonnull
     @Override
     public ClientService getClientService() {
         return delegatedInstance.getClientService();
     }
 
+    @Nonnull
     @Override
     public LoggingService getLoggingService() {
         return delegatedInstance.getLoggingService();
     }
 
+    @Nonnull
     @Override
     public LifecycleService getLifecycleService() {
         return delegatedInstance.getLifecycleService();
     }
 
+    @Nonnull
     @Override
-    public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
         return delegatedInstance.getDistributedObject(serviceName, name);
     }
 
+    @Nonnull
     @Override
     public ConcurrentMap<String, Object> getUserContext() {
         return delegatedInstance.getUserContext();
     }
 
+    @Nonnull
     @Override
     public HazelcastXAResource getXAResource() {
         return delegatedInstance.getXAResource();
     }
 
+    @Nonnull
     @Override
-    public CardinalityEstimator getCardinalityEstimator(String name) {
+    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         return delegatedInstance.getCardinalityEstimator(name);
     }
 
+    @Nonnull
     @Override
-    public PNCounter getPNCounter(String name) {
+    public PNCounter getPNCounter(@Nonnull String name) {
         return delegatedInstance.getPNCounter(name);
     }
 
+    @Nonnull
     @Override
-    public IScheduledExecutorService getScheduledExecutorService(String name) {
+    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
         return delegatedInstance.getScheduledExecutorService(name);
     }
 
+    @Nonnull
     @Override
     public CPSubsystem getCPSubsystem() {
         return delegatedInstance.getCPSubsystem();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InvocationBuilder.java
@@ -23,6 +23,8 @@ import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
 
+import javax.annotation.Nullable;
+
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.spi.impl.operationservice.Operation.GENERIC_PARTITION_ID;
 
@@ -263,7 +265,8 @@ public abstract class InvocationBuilder {
      * @param executionCallback the new ExecutionCallback. If null is passed, the ExecutionCallback is unset.
      * @return the updated InvocationBuilder.
      */
-    public InvocationBuilder setExecutionCallback(ExecutionCallback<Object> executionCallback) {
+    public InvocationBuilder setExecutionCallback(
+            @Nullable ExecutionCallback<Object> executionCallback) {
         this.executionCallback = executionCallback;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionService.java
@@ -23,6 +23,7 @@ import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.internal.services.CoreService;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -92,7 +93,7 @@ public interface IPartitionService extends CoreService {
      * @return the partition ID
      * @throws NullPointerException if key is {@code null}
      */
-    int getPartitionId(Data key);
+    int getPartitionId(@Nonnull Data key);
 
     /**
      * Returns the partition ID for a given object.
@@ -100,7 +101,7 @@ public interface IPartitionService extends CoreService {
      * @param key the object key
      * @return the partition ID
      */
-    int getPartitionId(Object key);
+    int getPartitionId(@Nonnull Object key);
 
     /**
      * Returns the number of partitions.

--- a/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/SplitBrainProtectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/SplitBrainProtectionService.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.splitbrainprotection;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Split brain protection service can be used to trigger cluster split brain protections at any time.
  * Normally split brain protections are done when any change happens on the member list.
@@ -30,7 +33,8 @@ public interface SplitBrainProtectionService {
      * @throws IllegalArgumentException if no split brain protection found for given name
      * @throws NullPointerException     if splitBrainProtectionName is null
      */
-    SplitBrainProtection getSplitBrainProtection(String splitBrainProtectionName) throws IllegalArgumentException;
+    @Nonnull
+    SplitBrainProtection getSplitBrainProtection(@Nonnull String splitBrainProtectionName) throws IllegalArgumentException;
 
     /**
      * Ensures that the split brain protection with the given name is present.
@@ -48,7 +52,7 @@ public interface SplitBrainProtectionService {
      * @param requiredSplitBrainProtectionPermissionType type of split brain protection required
      * @throws SplitBrainProtectionException if split brain protection defined and not present
      */
-    void ensureNoSplitBrain(String splitBrainProtectionName,
-                            SplitBrainProtectionOn requiredSplitBrainProtectionPermissionType)
+    void ensureNoSplitBrain(@Nullable String splitBrainProtectionName,
+                            @Nonnull SplitBrainProtectionOn requiredSplitBrainProtectionPermissionType)
             throws SplitBrainProtectionException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/impl/SplitBrainProtectionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/impl/SplitBrainProtectionServiceImpl.java
@@ -16,16 +16,30 @@
 
 package com.hazelcast.splitbrainprotection.impl;
 
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.config.SplitBrainProtectionListenerConfig;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.internal.services.MemberAttributeServiceEvent;
+import com.hazelcast.internal.services.MembershipAwareService;
+import com.hazelcast.internal.services.MembershipServiceEvent;
+import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.internal.services.ServiceNamespaceAware;
+import com.hazelcast.internal.services.SplitBrainProtectionAwareService;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.executor.ExecutorType;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.EventService;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.impl.operationservice.NamedOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.splitbrainprotection.HeartbeatAware;
 import com.hazelcast.splitbrainprotection.PingAware;
 import com.hazelcast.splitbrainprotection.SplitBrainProtection;
@@ -33,33 +47,21 @@ import com.hazelcast.splitbrainprotection.SplitBrainProtectionEvent;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionFunction;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionListener;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
-import com.hazelcast.internal.services.MemberAttributeServiceEvent;
-import com.hazelcast.internal.services.MembershipAwareService;
-import com.hazelcast.internal.services.MembershipServiceEvent;
-import com.hazelcast.internal.services.ServiceNamespace;
-import com.hazelcast.internal.services.ServiceNamespaceAware;
-import com.hazelcast.internal.services.SplitBrainProtectionAwareService;
-import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
-import com.hazelcast.spi.impl.operationservice.NamedOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.internal.util.ExceptionUtil;
-import com.hazelcast.internal.util.executor.ExecutorType;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ_WRITE;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.WRITE;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * Service containing logic for cluster split brain protection.
@@ -228,13 +230,18 @@ public class SplitBrainProtectionServiceImpl implements EventPublishingService<S
         splitBrainProtection.ensureNoSplitBrain(op);
     }
 
-    public void ensureNoSplitBrain(String splitBrainProtectionName,
-                                   SplitBrainProtectionOn requiredSplitBrainProtectionPermissionType) {
+    public void ensureNoSplitBrain(@Nullable String splitBrainProtectionName,
+                                   @Nonnull SplitBrainProtectionOn requiredSplitBrainProtectionPermissionType) {
+        checkNotNull(requiredSplitBrainProtectionPermissionType,
+                "requiredSplitBrainProtectionPermissionType cannot be null!");
         if (isInactive() || splitBrainProtectionName == null) {
             return;
         }
 
         SplitBrainProtectionImpl definedSplitBrainProtection = splitBrainProtections.get(splitBrainProtectionName);
+        if (definedSplitBrainProtection == null) {
+            return;
+        }
         SplitBrainProtectionOn definedSplitBrainProtectionOn = definedSplitBrainProtection.getConfig().getProtectOn();
         switch (requiredSplitBrainProtectionPermissionType) {
             case WRITE:
@@ -328,8 +335,9 @@ public class SplitBrainProtectionServiceImpl implements EventPublishingService<S
         // They cannot change split brain protection state
     }
 
+    @Nonnull
     @Override
-    public SplitBrainProtection getSplitBrainProtection(String splitBrainProtectionName) {
+    public SplitBrainProtection getSplitBrainProtection(@Nonnull String splitBrainProtectionName) {
         checkNotNull(splitBrainProtectionName, "splitBrainProtectionName cannot be null!");
         SplitBrainProtection splitBrainProtection = splitBrainProtections.get(splitBrainProtectionName);
         if (splitBrainProtection == null) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionManagerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionManagerService.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.transaction;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public interface TransactionManagerService {
 
-    <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException;
+    <T> T executeTransaction(@Nonnull TransactionOptions options,
+                             @Nonnull TransactionalTask<T> task) throws TransactionException;
 
-    TransactionContext newTransactionContext(TransactionOptions options);
+    TransactionContext newTransactionContext(@Nonnull TransactionOptions options);
 
-    TransactionContext newClientTransactionContext(TransactionOptions options, UUID clientUuid);
+    TransactionContext newClientTransactionContext(@Nonnull TransactionOptions options,
+                                                   @Nullable UUID clientUuid);
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -35,6 +35,8 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionImpl.SuspendedTransactionImpl;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -46,10 +48,13 @@ final class TransactionContextImpl implements TransactionContext {
     private final NodeEngineImpl nodeEngine;
     private final TransactionWrapper transaction;
     private final Map<TransactionalObjectKey, TransactionalObject> txnObjectMap
-            = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
+            = new HashMap<>(2);
 
-    TransactionContextImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngineImpl nodeEngine,
-                           TransactionOptions options, UUID ownerUuid, boolean originatedFromClient) {
+    TransactionContextImpl(@Nonnull TransactionManagerServiceImpl transactionManagerService,
+                           @Nonnull NodeEngineImpl nodeEngine,
+                           @Nonnull TransactionOptions options,
+                           @Nullable UUID ownerUuid,
+                           boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
         this.transaction = new TransactionWrapper(
                 new TransactionImpl(transactionManagerService, nodeEngine, options, ownerUuid, originatedFromClient));

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -35,6 +35,8 @@ import com.hazelcast.transaction.impl.operations.ReplicateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.RollbackTxBackupLogOperation;
 import com.hazelcast.internal.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -92,13 +94,18 @@ public class TransactionImpl implements Transaction {
     private boolean backupLogsCreated;
     private boolean originatedFromClient;
 
-    public TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
-                           TransactionOptions options, UUID txOwnerUuid) {
+    public TransactionImpl(@Nonnull TransactionManagerServiceImpl transactionManagerService,
+                           @Nonnull NodeEngine nodeEngine,
+                           @Nonnull TransactionOptions options,
+                           @Nullable UUID txOwnerUuid) {
         this(transactionManagerService, nodeEngine, options, txOwnerUuid, false);
     }
 
-    public TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
-                           TransactionOptions options, UUID txOwnerUuid, boolean originatedFromClient) {
+    public TransactionImpl(@Nonnull TransactionManagerServiceImpl transactionManagerService,
+                           @Nonnull NodeEngine nodeEngine,
+                           @Nonnull TransactionOptions options,
+                           @Nullable UUID txOwnerUuid,
+                           boolean originatedFromClient) {
         this.transactionLog = new TransactionLog();
         this.transactionManagerService = transactionManagerService;
         this.nodeEngine = nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -16,24 +16,24 @@
 
 package com.hazelcast.transaction.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
-import com.hazelcast.internal.util.counters.Counter;
-import com.hazelcast.internal.util.counters.MwCounter;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.services.ClientAwareService;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.internal.services.ManagedService;
 import com.hazelcast.internal.services.MemberAttributeServiceEvent;
 import com.hazelcast.internal.services.MembershipAwareService;
 import com.hazelcast.internal.services.MembershipServiceEvent;
+import com.hazelcast.internal.util.counters.Counter;
+import com.hazelcast.internal.util.counters.MwCounter;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.transaction.TransactionContext;
@@ -43,6 +43,8 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.impl.operations.BroadcastTxRollbackOperation;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -57,14 +59,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import static com.hazelcast.transaction.impl.Transaction.State;
-import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
-import static com.hazelcast.transaction.impl.Transaction.State.COMMITTING;
-import static com.hazelcast.transaction.impl.Transaction.State.ROLLING_BACK;
 import static com.hazelcast.internal.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.internal.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.internal.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.transaction.impl.Transaction.State;
+import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
+import static com.hazelcast.transaction.impl.Transaction.State.COMMITTING;
+import static com.hazelcast.transaction.impl.Transaction.State.ROLLING_BACK;
 import static java.util.Collections.shuffle;
 
 public class TransactionManagerServiceImpl implements TransactionManagerService, ManagedService,
@@ -103,7 +105,9 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
     }
 
     @Override
-    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
+        checkNotNull(options, "TransactionOptions must not be null!");
         checkNotNull(task, "TransactionalTask is required!");
 
         TransactionContext context = newTransactionContext(options);
@@ -128,12 +132,13 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
     }
 
     @Override
-    public TransactionContext newTransactionContext(TransactionOptions options) {
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
         return new TransactionContextImpl(this, nodeEngine, options, null, false);
     }
 
     @Override
-    public TransactionContext newClientTransactionContext(TransactionOptions options, UUID clientUuid) {
+    public TransactionContext newClientTransactionContext(@Nonnull TransactionOptions options,
+                                                          @Nullable UUID clientUuid) {
         return new TransactionContextImpl(this, nodeEngine, options, clientUuid, true);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/AbstractCardinalityEstimatorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/AbstractCardinalityEstimatorNullTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cardinality;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractCardinalityEstimatorNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(c -> c.add(null));
+        assertThrowsNPE(c -> c.addAsync(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<CardinalityEstimator> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<CardinalityEstimator> method) {
+        try {
+            method.accept(getDriver().getCardinalityEstimator(""));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/MemberCardinalityEstimatorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/MemberCardinalityEstimatorNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cardinality;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic cardinality estimator methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberCardinalityEstimatorNullTest extends AbstractCardinalityEstimatorNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientHazelcastInstanceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientHazelcastInstanceNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.AbstractHazelcastInstanceNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Client implementation for basic hazelcast instance methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientHazelcastInstanceNullTest extends AbstractHazelcastInstanceNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cardinality;
+
+import com.hazelcast.cardinality.AbstractCardinalityEstimatorNullTest;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic cardinality estimator methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientCardinalityEstimatorNullTest extends AbstractCardinalityEstimatorNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.executor;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.executor.AbstractExecutorNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic IExecutor methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientExecutorNullTest extends AbstractExecutorNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExecuteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExecuteTest.java
@@ -201,7 +201,7 @@ public class ClientExecutorServiceExecuteTest {
         assertSizeEventually(CLUSTER_SIZE, map);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testExecuteOnMembers_whenSelectorNull() {
         IExecutorService service = client.getExecutorService(randomString());
         MemberSelector selector = null;

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.executor.durable;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.durableexecutor.AbstractDurableExecutorNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic IExecutor methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientDurableExecutorNullTest extends AbstractDurableExecutorNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/AbstractDurableExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/AbstractDurableExecutorNullTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.durableexecutor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+public abstract class AbstractDurableExecutorNullTest extends HazelcastTestSupport {
+
+    public static final String RANDOM_NAME = randomName();
+
+    @Test
+    public void testNullability() {
+        Runnable sampleRunnable = (Runnable & Serializable) () -> {
+        };
+        Callable<Object> sampleCallable = (Callable & Serializable) () -> "";
+
+        assertThrowsNPE(s -> s.submit((Callable) null));
+        assertThrowsNPE(s -> s.submit((Runnable) null, ""));
+        getDriver().getDurableExecutorService(RANDOM_NAME)
+                   .submit(sampleRunnable, null);
+        assertThrowsNPE(s -> s.submit((Runnable) null));
+        assertThrowsNPE(s -> s.executeOnKeyOwner((Runnable) null, ""));
+        assertThrowsNPE(s -> s.executeOnKeyOwner(sampleRunnable, null));
+        assertThrowsNPE(s -> s.submitToKeyOwner((Callable) null, ""));
+        getDriver().getDurableExecutorService(RANDOM_NAME)
+                   .submitToKeyOwner(sampleCallable, "");
+        assertThrowsNPE(s -> s.submitToKeyOwner((Runnable) null, ""));
+        assertThrowsNPE(s -> s.submitToKeyOwner(sampleRunnable, null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<DurableExecutorService> method) {
+        DurableExecutorService executorService = getDriver().getDurableExecutorService(RANDOM_NAME);
+        assertThrows(NullPointerException.class, () -> method.accept(executorService));
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/MemberDurableExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/MemberDurableExecutorNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.durableexecutor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic scheduled executor methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberDurableExecutorNullTest extends AbstractDurableExecutorNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/executor/AbstractExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/AbstractExecutorNullTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.executor;
+
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MemberSelector;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.MultiExecutionCallback;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+public abstract class AbstractExecutorNullTest extends HazelcastTestSupport {
+
+    public static final String RANDOM_NAME = randomName();
+
+    @Test
+    public void testNullability() {
+        Runnable sampleRunnable = (Runnable & Serializable) () -> {
+        };
+        Callable<Object> sampleCallable = (Callable & Serializable) () -> "";
+        Member sampleMember = getDriver().getCluster().getMembers().iterator().next();
+        Set<Member> sampleMembers = Collections.singleton(sampleMember);
+        MemberSelector sampleSelector = member -> true;
+        ExecutionCallback<Object> sampleCallback = new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+
+            }
+        };
+        MultiExecutionCallback sampleMultiExecutionCallback = new MultiExecutionCallback() {
+            @Override
+            public void onResponse(Member member, Object value) {
+
+            }
+
+            @Override
+            public void onComplete(Map<Member, Object> values) {
+
+            }
+        };
+
+        assertThrowsNPE(s -> s.execute((Runnable) null, sampleSelector));
+        assertThrowsNPE(s -> s.execute(sampleRunnable, null));
+        assertThrowsNPE(s -> s.executeOnKeyOwner(null, ""));
+        assertThrowsNPE(s -> s.executeOnKeyOwner(sampleRunnable, null));
+        assertThrowsNPE(s -> s.executeOnMember(null, sampleMember));
+        assertThrowsNPE(s -> s.executeOnMember(sampleRunnable, null));
+        assertThrowsNPE(s -> s.executeOnMembers(null, sampleMembers));
+        assertThrowsNPE(s -> s.executeOnMembers(sampleRunnable, (Collection<Member>) null));
+        assertThrowsNPE(s -> s.executeOnMembers(null, sampleSelector));
+        assertThrowsNPE(s -> s.executeOnMembers(sampleRunnable, (MemberSelector) null));
+        assertThrowsNPE(s -> s.executeOnAllMembers(null));
+
+        System.out.println("------------1");
+
+        assertThrowsNPE(s -> s.submit((Callable) null, sampleSelector));
+        assertThrowsNPE(s -> s.submit(sampleCallable, (MemberSelector) null));
+        assertThrowsNPE(s -> s.submitToKeyOwner((Callable) null, ""));
+        assertThrowsNPE(s -> s.submitToKeyOwner(sampleCallable, null));
+        assertThrowsNPE(s -> s.submitToMember((Callable) null, sampleMember));
+        assertThrowsNPE(s -> s.submitToMember(sampleCallable, null));
+        assertThrowsNPE(s -> s.submitToMembers((Callable) null, sampleMembers));
+        assertThrowsNPE(s -> s.submitToMembers(sampleCallable, (Collection<Member>) null));
+        assertThrowsNPE(s -> s.submitToMembers((Callable) null, sampleSelector));
+        assertThrowsNPE(s -> s.submitToMembers(sampleCallable, (MemberSelector) null));
+        assertThrowsNPE(s -> s.submitToAllMembers(null));
+
+        System.out.println("------------2");
+
+        assertThrowsNPE(s -> s.submit((Runnable) null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submit(sampleRunnable, (ExecutionCallback) null);
+
+        assertThrowsNPE(s -> s.submit((Runnable) null, sampleSelector, sampleCallback));
+        assertThrowsNPE(s -> s.submit(sampleRunnable, (MemberSelector) null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submit(sampleRunnable, sampleSelector, (ExecutionCallback) null);
+
+        assertThrowsNPE(s -> s.submitToKeyOwner((Runnable) null, "", sampleCallback));
+        assertThrowsNPE(s -> s.submitToKeyOwner(sampleRunnable, null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submitToKeyOwner(sampleRunnable, "", (ExecutionCallback) null);
+
+        assertThrowsNPE(s -> s.submitToMember((Runnable) null, sampleMember, sampleCallback));
+        assertThrowsNPE(s -> s.submitToMember(sampleRunnable, null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submitToMember(sampleRunnable, sampleMember, (ExecutionCallback) null);
+        assertThrowsNPE(s -> s.submitToMembers((Runnable) null, sampleMembers, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleRunnable, (Collection) null, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleRunnable, sampleMembers, (MultiExecutionCallback) null));
+
+        assertThrowsNPE(s -> s.submitToMembers((Runnable) null, sampleSelector, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleRunnable, (MemberSelector) null, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleRunnable, sampleSelector, (MultiExecutionCallback) null));
+
+        assertThrowsNPE(s -> s.submitToAllMembers((Runnable) null, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToAllMembers(sampleRunnable, null));
+
+        System.out.println("------------3");
+
+        assertThrowsNPE(s -> s.submit((Callable<Object>) null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submit(sampleCallable, (ExecutionCallback) null);
+
+        assertThrowsNPE(s -> s.submit((Callable) null, sampleSelector, sampleCallback));
+        assertThrowsNPE(s -> s.submit(sampleCallable, (MemberSelector) null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submit(sampleCallable, sampleSelector, (ExecutionCallback) null);
+
+        assertThrowsNPE(s -> s.submitToKeyOwner((Callable) null, "", sampleCallback));
+        assertThrowsNPE(s -> s.submitToKeyOwner(sampleCallable, null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submitToKeyOwner(sampleCallable, "", (ExecutionCallback) null);
+
+        assertThrowsNPE(s -> s.submitToMember((Callable) null, sampleMember, sampleCallback));
+        assertThrowsNPE(s -> s.submitToMember(sampleCallable, null, sampleCallback));
+        getDriver().getExecutorService(RANDOM_NAME)
+                   .submitToMember(sampleCallable, sampleMember, (ExecutionCallback) null);
+        assertThrowsNPE(s -> s.submitToMembers((Callable) null, sampleMembers, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleCallable, (Collection) null, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleCallable, sampleMembers, (MultiExecutionCallback) null));
+
+        assertThrowsNPE(s -> s.submitToMembers((Callable) null, sampleSelector, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleCallable, (MemberSelector) null, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToMembers(sampleCallable, sampleSelector, (MultiExecutionCallback) null));
+
+        assertThrowsNPE(s -> s.submitToAllMembers((Callable) null, sampleMultiExecutionCallback));
+        assertThrowsNPE(s -> s.submitToAllMembers(sampleCallable, null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<IExecutorService> method) {
+        IExecutorService executorService = getDriver().getExecutorService(RANDOM_NAME);
+        assertThrows(NullPointerException.class, () -> method.accept(executorService));
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/executor/MemberExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/MemberExecutorNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.executor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic scheduled executor methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberExecutorNullTest extends AbstractExecutorNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/AbstractHazelcastInstanceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/AbstractHazelcastInstanceNullTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.transaction.TransactionOptions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractHazelcastInstanceNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(c -> c.getQueue(null));
+        assertThrowsNPE(c -> c.getTopic(null));
+        assertThrowsNPE(c -> c.getSet(null));
+        assertThrowsNPE(c -> c.getList(null));
+        assertThrowsNPE(c -> c.getMap(null));
+        assertThrowsNPE(c -> c.getReplicatedMap(null));
+        assertThrowsNPE(c -> c.getMultiMap(null));
+        assertThrowsNPE(c -> c.getRingbuffer(null));
+        assertThrowsNPE(c -> c.getReliableTopic(null));
+        assertThrowsNPE(c -> c.getExecutorService(null));
+        assertThrowsNPE(c -> c.getDurableExecutorService(null));
+        assertThrowsNPE(c -> c.newTransactionContext(null));
+        assertThrowsNPE(c -> c.executeTransaction(null));
+        assertThrowsNPE(c -> c.executeTransaction(null, context -> null));
+        assertThrowsNPE(c -> c.executeTransaction(TransactionOptions.getDefault(), null));
+        assertThrowsNPE(c -> c.getFlakeIdGenerator(null));
+        assertThrowsNPE(c -> c.addDistributedObjectListener(null));
+        assertThrowsNPE(c -> c.removeDistributedObjectListener(null));
+        assertThrowsNPE(c -> c.getDistributedObject("", null));
+        assertThrowsNPE(c -> c.getDistributedObject(null, ""));
+        assertThrowsNPE(c -> c.getCardinalityEstimator(null));
+        assertThrowsNPE(c -> c.getPNCounter(null));
+        assertThrowsNPE(c -> c.getScheduledExecutorService(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<HazelcastInstance> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<HazelcastInstance> method) {
+        try {
+            method.accept(getDriver());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberHazelcastInstanceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberHazelcastInstanceNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberHazelcastInstanceNullTest extends AbstractHazelcastInstanceNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumServiceNullTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractQuorumServiceNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(c -> c.getSplitBrainProtection(null));
+        assertThrowsNPE(c -> c.ensureNoSplitBrain("dummyQuorum", null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<SplitBrainProtectionService> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<SplitBrainProtectionService> method) {
+        try {
+            method.accept(getDriver().getSplitBrainProtectionService());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/MemberQuorumServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/MemberQuorumServiceNullTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.SplitBrainProtectionConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberQuorumServiceNullTest extends AbstractQuorumServiceNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        SplitBrainProtectionConfig sbpc = new SplitBrainProtectionConfig("dummyQuorum", true);
+        instance = factory.newHazelcastInstance(new Config().addSplitBrainProtectionConfig(sbpc));
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/AbstractScheduledExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/AbstractScheduledExecutorNullTest.java
@@ -19,14 +19,11 @@ package com.hazelcast.scheduledexecutor;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.internal.util.ExceptionUtil;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -42,10 +39,6 @@ public abstract class AbstractScheduledExecutorNullTest extends HazelcastTestSup
         Callable<String> sampleCallable = () -> "";
         Member sampleMember = new MemberImpl();
         Set<Member> sampleMembers = Collections.singleton(sampleMember);
-
-        IScheduledExecutorService e = getDriver().getScheduledExecutorService(randomMapName());
-        IScheduledFuture<Object> f = e.getScheduledFuture(new ScheduledTaskHandlerImpl());
-        Map<Member, List<IScheduledFuture<Object>>> f2 = e.getAllScheduledFutures();
 
         assertThrowsNPE(s -> s.schedule((Runnable) null, 1, sampleTimeUnit));
         assertThrowsNPE(s -> s.schedule(sampleRunnable, 1, null));


### PR DESCRIPTION
Adds Nonnull and Nullable annotations to HazelcastInstance,
CardinalityEstimator, IExecutor, DurableExecutor, QuorumService and some
others.
Aligned some behaviour of client and member-side when it comes to
behaviour with null parameters.
Added FunctionalInterface to MemberSelector and cleaned up some JDK8
code.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3115