### PR TITLE
Fix fluent API for config classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -178,10 +178,12 @@ public class ClientConfig {
      *
      * @param configPatternMatcher the pattern matcher
      * @throws IllegalArgumentException if the pattern matcher is {@code null}
+     * @return this configuration
      */
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+    public ClientConfig setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
         Preconditions.isNotNull(configPatternMatcher, "configPatternMatcher");
         this.configPatternMatcher = configPatternMatcher;
+        return this;
     }
 
     /**
@@ -744,18 +746,20 @@ public class ClientConfig {
         return queryCacheConfigs;
     }
 
-    public void setQueryCacheConfigs(Map<String, Map<String, QueryCacheConfig>> queryCacheConfigs) {
+    public ClientConfig setQueryCacheConfigs(Map<String, Map<String, QueryCacheConfig>> queryCacheConfigs) {
         Preconditions.isNotNull(queryCacheConfigs, "queryCacheConfigs");
         this.queryCacheConfigs.clear();
         this.queryCacheConfigs.putAll(queryCacheConfigs);
+        return this;
     }
 
     public String getInstanceName() {
         return instanceName;
     }
 
-    public void setInstanceName(String instanceName) {
+    public ClientConfig setInstanceName(String instanceName) {
         this.instanceName = instanceName;
+        return this;
     }
 
     public ClientConnectionStrategyConfig getConnectionStrategyConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientFlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientFlakeIdGeneratorConfig.java
@@ -62,8 +62,9 @@ public class ClientFlakeIdGeneratorConfig {
      * Sets the name or name pattern for this config. Must not be modified after this
      * instance is added to {@link ClientConfig}.
      */
-    public void setName(String name) {
+    public ClientFlakeIdGeneratorConfig setName(String name) {
         this.name = name;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -103,9 +103,11 @@ public class ClientNetworkConfig {
      *
      * @param discoveryConfig the Discovery Provider SPI configuration
      * @throws java.lang.IllegalArgumentException if discoveryConfig is null
+     * @return this configuration
      */
-    public void setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+    public ClientNetworkConfig setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
         this.discoveryConfig = isNotNull(discoveryConfig, "discoveryConfig");
+        return this;
     }
 
     /**
@@ -446,9 +448,10 @@ public class ClientNetworkConfig {
         return cloudConfig;
     }
 
-    public void setCloudConfig(ClientCloudConfig cloudConfig) {
+    public ClientNetworkConfig setCloudConfig(ClientCloudConfig cloudConfig) {
         isNotNull(cloudConfig, "cloudConfig");
         this.cloudConfig = cloudConfig;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
@@ -176,8 +176,9 @@ public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
         }
     }
 
-    public void setProperties(Properties properties) {
+    public XmlClientFailoverConfigBuilder setProperties(Properties properties) {
         setPropertiesInternal(properties);
+        return this;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
@@ -115,8 +115,9 @@ public class YamlClientConfigBuilder extends AbstractYamlConfigBuilder {
         return clientConfig;
     }
 
-    public void setProperties(Properties properties) {
+    public YamlClientConfigBuilder setProperties(Properties properties) {
         setPropertiesInternal(properties);
+        return this;
     }
 
     void build(ClientConfig clientConfig, ClassLoader classLoader) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
@@ -118,8 +118,9 @@ public class YamlClientFailoverConfigBuilder extends AbstractYamlConfigBuilder {
         return clientFailoverConfig;
     }
 
-    public void setProperties(Properties properties) {
+    public YamlClientFailoverConfigBuilder setProperties(Properties properties) {
         setPropertiesInternal(properties);
+        return this;
     }
 
     void build(ClientFailoverConfig clientFailoverConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -426,7 +426,7 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+    public Config setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
@@ -446,7 +446,7 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public void setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
+    public Config setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AdvancedNetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AdvancedNetworkConfig.java
@@ -308,7 +308,7 @@ public class AdvancedNetworkConfig {
         }
 
         @Override
-        public void setPortCount(int portCount) {
+        public NetworkConfig setPortCount(int portCount) {
             throw new UnsupportedOperationException();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -496,9 +496,11 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> implements Spli
      *
      * @param disablePerEntryInvalidationEvents disables invalidation event sending behaviour if it is {@code true},
      *                                          otherwise enables it
+     * @return this configuration
      */
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheConfig<K, V> setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         this.disablePerEntryInvalidationEvents = disablePerEntryInvalidationEvents;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -210,7 +210,7 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
     }
 
     @Override
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheConfig<K, V> setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -563,9 +563,11 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
      * Sets the WAN target replication reference.
      *
      * @param wanReplicationRef the WAN target replication reference
+     * @return this configuration
      */
-    public void setWanReplicationRef(WanReplicationRef wanReplicationRef) {
+    public CacheSimpleConfig setWanReplicationRef(WanReplicationRef wanReplicationRef) {
         this.wanReplicationRef = wanReplicationRef;
+        return this;
     }
 
     /**
@@ -699,9 +701,11 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
      *
      * @param disablePerEntryInvalidationEvents Disables invalidation event sending behaviour if it is {@code true},
      *                                          otherwise enables it
+     * @return this configuration
      */
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheSimpleConfig setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         this.disablePerEntryInvalidationEvents = disablePerEntryInvalidationEvents;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -137,7 +137,7 @@ public class CacheSimpleConfigReadOnly extends CacheSimpleConfig {
     }
 
     @Override
-    public void setWanReplicationRef(WanReplicationRef wanReplicationRef) {
+    public CacheSimpleConfig setWanReplicationRef(WanReplicationRef wanReplicationRef) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
@@ -163,7 +163,7 @@ public class CacheSimpleConfigReadOnly extends CacheSimpleConfig {
     }
 
     @Override
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheSimpleConfig setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -61,16 +61,18 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
         return cacheEntryListenerFactory;
     }
 
-    public void setCacheEntryListenerFactory(String cacheEntryListenerFactory) {
+    public CacheSimpleEntryListenerConfig setCacheEntryListenerFactory(String cacheEntryListenerFactory) {
         this.cacheEntryListenerFactory = cacheEntryListenerFactory;
+        return this;
     }
 
     public String getCacheEntryEventFilterFactory() {
         return cacheEntryEventFilterFactory;
     }
 
-    public void setCacheEntryEventFilterFactory(String cacheEntryEventFilterFactory) {
+    public CacheSimpleEntryListenerConfig setCacheEntryEventFilterFactory(String cacheEntryEventFilterFactory) {
         this.cacheEntryEventFilterFactory = cacheEntryEventFilterFactory;
+        return this;
     }
 
     /**
@@ -89,9 +91,11 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
      * creates additional traffic. Default value is {@code false}.
      *
      * @param oldValueRequired {@code true} to have old value required, {@code false} otherwise
+     * @return this configuration
      */
-    public void setOldValueRequired(boolean oldValueRequired) {
+    public CacheSimpleEntryListenerConfig setOldValueRequired(boolean oldValueRequired) {
         this.oldValueRequired = oldValueRequired;
+        return this;
     }
 
     /**
@@ -109,9 +113,11 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
      *
      * @param synchronous {@code true} to have this cache entry listener implementation called in a synchronous manner,
      *                    {@code false} otherwise.
+     * @return this configuration
      */
-    public void setSynchronous(boolean synchronous) {
+    public CacheSimpleEntryListenerConfig setSynchronous(boolean synchronous) {
         this.synchronous = synchronous;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfigReadOnly.java
@@ -28,22 +28,22 @@ public class CacheSimpleEntryListenerConfigReadOnly extends CacheSimpleEntryList
     }
 
     @Override
-    public void setSynchronous(boolean synchronous) {
-        super.setSynchronous(synchronous);
-    }
-
-    @Override
-    public void setOldValueRequired(boolean oldValueRequired) {
+    public CacheSimpleEntryListenerConfig setSynchronous(boolean synchronous) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setCacheEntryEventFilterFactory(String cacheEntryEventFilterFactory) {
+    public CacheSimpleEntryListenerConfig setOldValueRequired(boolean oldValueRequired) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setCacheEntryListenerFactory(String cacheEntryListenerFactory) {
+    public CacheSimpleEntryListenerConfig setCacheEntryEventFilterFactory(String cacheEntryEventFilterFactory) {
+        throw new UnsupportedOperationException("This config is read-only");
+    }
+
+    @Override
+    public CacheSimpleEntryListenerConfig setCacheEntryListenerFactory(String cacheEntryListenerFactory) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -222,9 +222,11 @@ public abstract class CollectionConfig<T extends CollectionConfig>
      * Adds an item listener to this collection (listens for when items are added or removed).
      *
      * @param itemListenerConfig the item listener to add to this collection
+     * @return this configuration
      */
-    public void addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
+    public T addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
         getItemListenerConfigs().add(itemListenerConfig);
+        return (T) this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -220,12 +220,14 @@ public class Config {
      *
      * @param configPatternMatcher the pattern matcher
      * @throws IllegalArgumentException if the pattern matcher is {@code null}
+     * @return this configuration
      */
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+    public Config setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
         if (configPatternMatcher == null) {
             throw new IllegalArgumentException("ConfigPatternMatcher is not allowed to be null!");
         }
         this.configPatternMatcher = configPatternMatcher;
+        return this;
     }
 
     /**
@@ -274,9 +276,11 @@ public class Config {
      * attributes are exchanged with other members, e.g. on membership events.
      *
      * @param memberAttributeConfig the member attribute configuration
+     * @return this configuration
      */
-    public void setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
+    public Config setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
         this.memberAttributeConfig = memberAttributeConfig;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -73,8 +73,9 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
         return readonly;
     }
 
-    public void setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
+    public DiscoveryConfig setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
         this.discoveryServiceProvider = discoveryServiceProvider;
+        return this;
     }
 
     public DiscoveryServiceProvider getDiscoveryServiceProvider() {
@@ -85,16 +86,18 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
         return nodeFilter;
     }
 
-    public void setNodeFilter(NodeFilter nodeFilter) {
+    public DiscoveryConfig setNodeFilter(NodeFilter nodeFilter) {
         this.nodeFilter = nodeFilter;
+        return this;
     }
 
     public String getNodeFilterClass() {
         return nodeFilterClass;
     }
 
-    public void setNodeFilterClass(String nodeFilterClass) {
+    public DiscoveryConfig setNodeFilterClass(String nodeFilterClass) {
         this.nodeFilterClass = nodeFilterClass;
+        return this;
     }
 
     public boolean isEnabled() {
@@ -119,11 +122,13 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
      * Sets the strategy configurations for this discovery config.
      *
      * @param discoveryStrategyConfigs the strategy configurations
+     * @return this configuration
      */
-    public void setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+    public DiscoveryConfig setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
         this.discoveryStrategyConfigs = discoveryStrategyConfigs == null
                 ? new ArrayList<DiscoveryStrategyConfig>(1)
                 : discoveryStrategyConfigs;
+        return this;
     }
 
     /**
@@ -133,9 +138,11 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
      * remember when building custom {@link com.hazelcast.config.Config} instances.
      *
      * @param discoveryStrategyConfig the {@link DiscoveryStrategyConfig} to add
+     * @return this configuration
      */
-    public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+    public DiscoveryConfig addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         discoveryStrategyConfigs.add(discoveryStrategyConfig);
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
@@ -34,27 +34,27 @@ public class DiscoveryConfigReadOnly extends DiscoveryConfig {
     }
 
     @Override
-    public void setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
+    public DiscoveryConfig setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void setNodeFilter(NodeFilter nodeFilter) {
+    public DiscoveryConfig setNodeFilter(NodeFilter nodeFilter) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void setNodeFilterClass(String nodeFilterClass) {
+    public DiscoveryConfig setNodeFilterClass(String nodeFilterClass) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+    public DiscoveryConfig addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+    public DiscoveryConfig setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -94,12 +94,14 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
         return discoveryStrategyFactory;
     }
 
-    public void addProperty(String key, Comparable value) {
+    public DiscoveryStrategyConfig addProperty(String key, Comparable value) {
         properties.put(key, value);
+        return this;
     }
 
-    public void removeProperty(String key) {
+    public DiscoveryStrategyConfig removeProperty(String key) {
         properties.remove(key);
+        return this;
     }
 
     public DiscoveryStrategyConfig setProperties(Map<String, Comparable> properties) {

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
@@ -80,7 +80,7 @@ public class ListConfigReadOnly extends ListConfig {
     }
 
     @Override
-    public void addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
+    public ListConfig addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
         throw new UnsupportedOperationException("This config is read-only list: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -614,9 +614,11 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
 
     /**
      * Sets {@link QueryCacheConfig} instances to this {@code MapConfig}.
+     * @return this configuration
      */
-    public void setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
+    public MapConfig setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
         this.queryCacheConfigs = queryCacheConfigs;
+        return this;
     }
 
     public PartitioningStrategyConfig getPartitioningStrategyConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
@@ -268,7 +268,7 @@ public class MapConfigReadOnly extends MapConfig {
     }
 
     @Override
-    public void setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
+    public MapConfig setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
@@ -38,23 +38,26 @@ public class MemberAttributeConfig {
         return attributes;
     }
 
-    public void setAttributes(Map<String, String> attributes) {
+    public MemberAttributeConfig setAttributes(Map<String, String> attributes) {
         this.attributes.clear();
         if (attributes != null) {
             this.attributes.putAll(attributes);
         }
+        return this;
     }
 
     public String getAttribute(String key) {
         return attributes.get(key);
     }
 
-    public void setAttribute(String key, String value) {
+    public MemberAttributeConfig setAttribute(String key, String value) {
         this.attributes.put(key, value);
+        return this;
     }
 
-    public void removeAttribute(String key) {
+    public MemberAttributeConfig removeAttribute(String key) {
         attributes.remove(key);
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
@@ -31,17 +31,17 @@ public class MemberAttributeConfigReadOnly extends MemberAttributeConfig {
     }
 
     @Override
-    public void setAttribute(String key, String value) {
+    public MemberAttributeConfig setAttribute(String key, String value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void removeAttribute(String key) {
+    public MemberAttributeConfig removeAttribute(String key) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setAttributes(Map<String, String> attributes) {
+    public MemberAttributeConfig setAttributes(Map<String, String> attributes) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -120,12 +120,14 @@ public class NetworkConfig {
      *
      * @param portCount the maximum number of ports allowed to use
      * @see #setPortAutoIncrement(boolean) for more information
+     * @return this configuration
      */
-    public void setPortCount(int portCount) {
+    public NetworkConfig setPortCount(int portCount) {
         if (portCount < 1) {
             throw new IllegalArgumentException("port count can't be smaller than 0");
         }
         this.portCount = portCount;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
@@ -158,11 +158,13 @@ public class PredicateConfig implements IdentifiedDataSerializable {
      * If a className or implementation was set, it will be removed.
      *
      * @param sql sql string for this config
+     * @return this configuration
      */
-    public void setSql(String sql) {
+    public PredicateConfig setSql(String sql) {
         this.sql = sql;
         this.className = null;
         this.implementation = null;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
@@ -41,7 +41,7 @@ class PredicateConfigReadOnly extends PredicateConfig {
     }
 
     @Override
-    public void setSql(String sql) {
+    public PredicateConfig setSql(String sql) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -173,9 +173,11 @@ public class ReplicatedMapConfig
      *
      * @param asyncFillup {@code true} if the replicated map is available for reads before the initial
      *                    replication is completed, {@code false} otherwise
+     * @return this configuration
      */
-    public void setAsyncFillup(boolean asyncFillup) {
+    public ReplicatedMapConfig setAsyncFillup(boolean asyncFillup) {
         this.asyncFillup = asyncFillup;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
@@ -43,7 +43,7 @@ class ReplicatedMapConfigReadOnly extends ReplicatedMapConfig {
     }
 
     @Override
-    public void setAsyncFillup(boolean asyncFillup) {
+    public ReplicatedMapConfig setAsyncFillup(boolean asyncFillup) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/RestApiConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestApiConfig.java
@@ -118,11 +118,12 @@ public class RestApiConfig {
         return enabledGroups.contains(group);
     }
 
-    public void setEnabledGroups(Collection<RestEndpointGroup> groups) {
+    public RestApiConfig setEnabledGroups(Collection<RestEndpointGroup> groups) {
         enabledGroups.clear();
         if (groups != null) {
             enabledGroups.addAll(groups);
         }
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/RestServerEndpointConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestServerEndpointConfig.java
@@ -114,11 +114,12 @@ public class RestServerEndpointConfig
         return enabledGroups.contains(group);
     }
 
-    public void setEnabledGroups(Collection<RestEndpointGroup> groups) {
+    public RestServerEndpointConfig setEnabledGroups(Collection<RestEndpointGroup> groups) {
         enabledGroups.clear();
         if (groups != null) {
             enabledGroups.addAll(groups);
         }
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -57,8 +57,9 @@ public class SecurityConfig {
         return securityInterceptorConfigs;
     }
 
-    public void setSecurityInterceptorConfigs(final List<SecurityInterceptorConfig> securityInterceptorConfigs) {
+    public SecurityConfig setSecurityInterceptorConfigs(List<SecurityInterceptorConfig> securityInterceptorConfigs) {
         this.securityInterceptorConfigs = securityInterceptorConfigs;
+        return this;
     }
 
     public boolean isEnabled() {

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityInterceptorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityInterceptorConfig.java
@@ -42,15 +42,17 @@ public class SecurityInterceptorConfig {
         return className;
     }
 
-    public void setClassName(final String className) {
+    public SecurityInterceptorConfig setClassName(final String className) {
         this.className = className;
+        return this;
     }
 
     public SecurityInterceptor getImplementation() {
         return implementation;
     }
 
-    public void setImplementation(final SecurityInterceptor implementation) {
+    public SecurityInterceptorConfig setImplementation(final SecurityInterceptor implementation) {
         this.implementation = implementation;
+        return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ServerSocketEndpointConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServerSocketEndpointConfig.java
@@ -118,12 +118,14 @@ public class ServerSocketEndpointConfig
      *
      * @param portCount the maximum number of ports allowed to use
      * @see #setPortAutoIncrement(boolean) for more information
+     * @return this configuration
      */
-    public void setPortCount(int portCount) {
+    public ServerSocketEndpointConfig setPortCount(int portCount) {
         if (portCount < 1) {
             throw new IllegalArgumentException("port count can't be smaller than 0");
         }
         this.portCount = portCount;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
@@ -78,7 +78,7 @@ public class SetConfigReadOnly extends SetConfig {
     }
 
     @Override
-    public void addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
+    public SetConfig addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
         throw new UnsupportedOperationException("This config is read-only set: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -133,8 +133,8 @@ public class DynamicConfigurationAwareConfig extends Config {
     }
 
     @Override
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
-        staticConfig.setConfigPatternMatcher(configPatternMatcher);
+    public Config setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+        return staticConfig.setConfigPatternMatcher(configPatternMatcher);
     }
 
     @Override
@@ -153,8 +153,8 @@ public class DynamicConfigurationAwareConfig extends Config {
     }
 
     @Override
-    public void setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
-        staticConfig.setMemberAttributeConfig(memberAttributeConfig);
+    public Config setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
+        return staticConfig.setMemberAttributeConfig(memberAttributeConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -57,7 +57,7 @@ public class DynamicSecurityConfig extends SecurityConfig {
     }
 
     @Override
-    public void setSecurityInterceptorConfigs(List<SecurityInterceptorConfig> securityInterceptorConfigs) {
+    public SecurityConfig setSecurityInterceptorConfigs(List<SecurityInterceptorConfig> securityInterceptorConfigs) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 


### PR DESCRIPTION
Setters and other modification methods should try to return the same
instance for a fluent API.

Fixes: https://github.com/hazelcast/hazelcast/issues/11669
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3116