### PR TITLE
fixing NPE with null callback in ClientExecutorService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -81,12 +82,12 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
     }
 
     @Override
-    public void andThen(ExecutionCallback<V> callback) {
+    public void andThen(@Nonnull ExecutionCallback<V> callback) {
         future.andThen(new DelegatingExecutionCallback<V>(callback, deserializeResponse), userExecutor);
     }
 
     @Override
-    public void andThen(ExecutionCallback<V> callback, Executor executor) {
+    public void andThen(@Nonnull ExecutionCallback<V> callback, Executor executor) {
         future.andThen(new DelegatingExecutionCallback<V>(callback, deserializeResponse), executor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
@@ -410,7 +410,9 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
         ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
                 message -> ExecutorServiceSubmitToPartitionCodec.decodeResponse(message).response);
-        delegatingFuture.andThen(callback);
+        if (callback != null) {
+            delegatingFuture.andThen(callback);
+        }
         return delegatingFuture;
     }
 
@@ -453,7 +455,9 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         ClientInvocationFuture f = invokeOnTarget(request, address);
         ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
                 message -> ExecutorServiceSubmitToAddressCodec.decodeResponse(message).response);
-        delegatingFuture.andThen(callback);
+        if (callback != null) {
+            delegatingFuture.andThen(callback);
+        }
     }
 
     @Override


### PR DESCRIPTION
This was not causing any bug, we were seeing NullPointerException in the logs. That is why there is no tests. 