### PR TITLE
Removes unnecessary reflection from FilteringClassloader

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/util/FilteringClassLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FilteringClassLoader.java
@@ -21,7 +21,6 @@ import com.hazelcast.spi.annotation.PrivateApi;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -46,15 +45,12 @@ public class FilteringClassLoader extends ClassLoader {
     private ClassLoader delegatingClassLoader;
 
     public FilteringClassLoader(List<String> excludePackages, String enforcedSelfLoadingPackage) {
+        super(null);
         this.excludePackages = excludePackages;
         this.enforcedSelfLoadingPackage = enforcedSelfLoadingPackage;
 
         try {
-            Field parent = ClassLoader.class.getDeclaredField("parent");
-            parent.setAccessible(true);
-
-            delegatingClassLoader = (ClassLoader) parent.get(this);
-            parent.set(this, null);
+            delegatingClassLoader = ClassLoader.getSystemClassLoader();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The effects of reflective access can be achieved without reflection.

Related JDK12 change: https://bugs.openjdk.java.net/browse/JDK-8210522

Fixes #15459 