### PR TITLE
IMap.putAllAsync and performance improvement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -1739,10 +1739,10 @@ public class ClientMapProxy<K, V> extends ClientProxy
             @Override
             public void onResponse(ClientMessage response) {
                 if (counter.decrementAndGet() == 0) {
+                    finalizePutAll(map, entryMap);
                     if (future != null) {
                         future.setResult(null);
                     }
-                    finalizePutAll(map, entryMap);
                 }
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
@@ -541,20 +541,16 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected void putAllInternal(Map<? extends K, ? extends V> map, Map<Integer, List<Map.Entry<Data, Data>>> entryMap) {
-        try {
-            super.putAllInternal(map, entryMap);
-        } finally {
-            if (serializeKeys) {
-                for (List<Entry<Data, Data>> entries : entryMap.values()) {
-                    for (Entry<Data, Data> entry : entries) {
-                        invalidateNearCache(entry.getKey());
-                    }
+    protected void finalizePutAll(Map<? extends K, ? extends V> map, Map<Integer, List<Map.Entry<Data, Data>>> entryMap) {
+        if (serializeKeys) {
+            for (List<Entry<Data, Data>> entries : entryMap.values()) {
+                for (Entry<Data, Data> entry : entries) {
+                    invalidateNearCache(entry.getKey());
                 }
-            } else {
-                for (K key : map.keySet()) {
-                    invalidateNearCache(key);
-                }
+            }
+        } else {
+            for (K key : map.keySet()) {
+                invalidateNearCache(key);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
@@ -19,31 +19,30 @@ package com.hazelcast.core;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * HazelcastJsonValue is a wrapper for Json formatted strings. It is
- * preferred to store HazelcastJsonValue instead of Strings for Json
- * formatted strings. Users can run predicates/aggregations and use
- * indexes on the attributes of the underlying Json strings.
+ * HazelcastJsonValue is a wrapper for JSON formatted strings. It is preferred
+ * to store HazelcastJsonValue instead of Strings for JSON-formatted strings.
+ * It allows you to run predicates/aggregations and use indexes on the
+ * attributes of the underlying JSON strings.
  *
- * HazelcastJsonValue is queried using Hazelcast's querying language.
- * See {@link com.hazelcast.query.Predicates}.
+ * <p>HazelcastJsonValue can be queried for fields in Hazelcast's queries. See
+ * {@link com.hazelcast.query.Predicates}.
  *
- * In terms of querying, numbers in Json strings are treated as either
- * {@code Long} or {@code Double}. Strings, booleans and null are
+ * <p>When querying, numbers in JSON strings are treated as either
+ * {@code Long} or {@code Double}. Strings, booleans and nulls are
  * treated as their Java counterparts.
  *
- * HazelcastJsonValue keeps given string as it is. Strings are not
- * checked for being valid. Ill-formatted json strings may cause false
- * positive or false negative results in queries. {@code null} string
- * is not allowed.
+ * <p>HazelcastJsonValue stores the given string as is. It is not validated.
+ * Ill-formatted JSON strings may cause false positive or false negative
+ * results in queries. {@code null} string is not allowed.
  */
 public final class HazelcastJsonValue {
 
     private final String string;
 
     /**
-     * Creates a HazelcastJsonValue from given string.
+     * Creates a HazelcastJsonValue from the given string.
      *
-     * @param string a non null Json string
+     * @param string a non-null JSON string
      */
     public HazelcastJsonValue(String string) {
         this.string = checkNotNull(string);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/SimpleCompletedFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/SimpleCompletedFuture.java
@@ -63,6 +63,12 @@ public class SimpleCompletedFuture<E> implements InternalCompletableFuture<E> {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note: Since this future is always completed, the callback is executed
+     * immediately and in the calling thread.
+     */
     @SuppressWarnings("unchecked")
     @Override
     public void andThen(ExecutionCallback<E> callback) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.internal.util.SimpleCompletableFuture;
 import com.hazelcast.map.IMap;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
@@ -449,7 +450,18 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public void putAll(@Nonnull Map<? extends K, ? extends V> map) {
         checkNotNull(map, "Null argument map is not allowed");
-        putAllInternal(map);
+        putAllInternal(map, null);
+    }
+
+    /**
+     * This version does not support batching.
+     */
+    // used by jet
+    public ICompletableFuture<Void> putAllAsync(@Nonnull Map<? extends K, ? extends V> map) {
+        checkNotNull(map, "Null argument map is not allowed");
+        SimpleCompletableFuture<Void> future = new SimpleCompletableFuture<>(getNodeEngine());
+        putAllInternal(map, future);
+        return future;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -454,7 +454,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     /**
-     * This version does not support batching.
+     * This version does not support batching. Don't mutate the given map until the
+     * future completes.
      */
     // used by jet
     public ICompletableFuture<Void> putAllAsync(@Nonnull Map<? extends K, ? extends V> map) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -974,7 +974,7 @@ abstract class MapProxySupport<K, V>
             if (future == null) {
                 resultFuture.get();
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw rethrow(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -896,6 +896,9 @@ abstract class MapProxySupport<K, V>
         try {
             int mapSize = map.size();
             if (mapSize == 0) {
+                if (future != null) {
+                    future.setResult(null);
+                }
                 return;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -480,9 +480,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void invokePutAllOperationFactory(long size, int[] partitions, MapEntries[] entries) throws Exception {
+    protected void putAllVisitSerializedKeys(MapEntries[] entries) {
         try {
-            super.invokePutAllOperationFactory(size, partitions, entries);
+            super.putAllVisitSerializedKeys(entries);
         } finally {
             if (serializeKeys) {
                 for (MapEntries mapEntries : entries) {
@@ -498,13 +498,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     @Override
     protected void finalizePutAll(Map<?, ?> map) {
-        try {
-            super.finalizePutAll(map);
-        } finally {
-            if (!serializeKeys) {
-                for (Object key : map.keySet()) {
-                    invalidateNearCache(key);
-                }
+        if (!serializeKeys) {
+            for (Object key : map.keySet()) {
+                invalidateNearCache(key);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -481,15 +481,11 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     @Override
     protected void putAllVisitSerializedKeys(MapEntries[] entries) {
-        try {
-            super.putAllVisitSerializedKeys(entries);
-        } finally {
-            if (serializeKeys) {
-                for (MapEntries mapEntries : entries) {
-                    if (mapEntries != null) {
-                        for (int i = 0; i < mapEntries.size(); i++) {
-                            invalidateNearCache(mapEntries.getKey(i));
-                        }
+        if (serializeKeys) {
+            for (MapEntries mapEntries : entries) {
+                if (mapEntries != null) {
+                    for (int i = 0; i < mapEntries.size(); i++) {
+                        invalidateNearCache(mapEntries.getKey(i));
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostListener.java
@@ -23,38 +23,38 @@ import java.util.EventListener;
  * possible data loss when a partition loses a replica.
  * <p>
  * When the cluster is initialized, each node becomes owner of some of the
- * partitions, and backup of the some other partitions. We call owner of
- * partition "primary replica" and backup nodes "backup replicas".
+ * partitions and of a backup of some other partitions. We call the replica on the
+ * partition owner a "primary replica" and on the backup nodes "backup replicas".
  * Partition replicas are ordered. A primary replica node keeps all data
  * that is mapped to the partition. If a Hazelcast data structure is
  * configured with 1 backup, its data is put into the primary replica and
  * the first backup replica. Similarly, data of a Hazelcast data structure
  * that is configured with 2 backups is put into the primary replica, the
- * first backup replica, and the second backup replica. The idea is same
- * for higher backup counts.
+ * first backup replica and the second backup replica and so on.
  * <p>
  * When a node fails, primary replicas of its partitions are lost. In this
  * case, ownership of each partition owned by the unreachable node is
  * transferred to the first available backup node. After this point, other
  * backup nodes sync themselves from the new partition owner node in order
- * to populate the missing backup data. This sync is only happen when backup
+ * to populate the missing backup data. This sync only happens when backup
  * partition replica versions are not equal to the primary ones.
  * <p>
- * In this context, the partition loss detection algorithm works as
- * follows: {@link PartitionLostEvent#lostBackupCount} denotes the replica
- * index up to the which partition replicas are lost.
- * - 0 means that only the primary replica is lost. In other words, the node
+ * In this context the partition loss detection algorithm works as follows:
+ * {@link PartitionLostEvent#getLostBackupCount()} denotes the replica
+ * index up to which partition replicas are lost:<ul>
+ * <li>0 means that only the primary replica is lost. In other words, the node
  * which owns the partition is unreachable, hence removed from the cluster.
  * If there is a data structure configured with no backups, its data is
  * lost for this partition.
- * - 1 means that both the primary replica and the first backup replica are
+ * <li>1 means that both the primary replica and the first backup replica are
  * lost. In other words, the partition owner node and the first backup node
  * have became unreachable. If a data structure is configured with less
  * than 2 backups, its data is lost for this partition.
- * - The idea works same for higher backup counts.
+ * <li>The idea works same for higher backup counts.
+ * </ul>
  *
  * Please note that node failures that do not involve a primary replica
- * does not lead to partition lost events. For instance, if a backup node
+ * do not lead to partition lost events. For instance, if a backup node
  * crashes when owner of the partition is still alive, a partition lost
  * event is not fired. In this case, Hazelcast tries to assign a new backup
  * replica to populate the missing backup.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationService.java
@@ -38,6 +38,7 @@ import java.util.Map;
  * It also is possible to execute multiple operation on multiple partitions
  * using one of the invoke methods.
  */
+@SuppressWarnings("checkstyle:MethodCount")
 public interface OperationService {
     String SERVICE_NAME = "hz:impl:operationService";
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationService.java
@@ -205,6 +205,26 @@ public interface OperationService {
             String serviceName, OperationFactory operationFactory, Collection<Integer> partitions);
 
     /**
+     * Invokes a set of operations on selected set of partitions in an async way.
+     * <p>
+     * If the operations have sync backups, the returned {@link ICompletableFuture} does <b>not</b>
+     * wait for their completion. Instead, the {@link ICompletableFuture} is completed once the
+     * operations are completed on primary replicas of the given {@code partitions}.
+     *
+     * @param serviceName      the name of the service
+     * @param operationFactory the factory responsible for creating operations
+     * @param memberPartitions the partitions the operation should be executed on,
+     *                         grouped by owners
+     * @param <T>              type of result of operations returned by {@code operationFactory}
+     * @return a future returning a Map with partitionId as a key and the
+     *         outcome of the operation as a value.
+     */
+    <T> ICompletableFuture<Map<Integer, T>> invokeOnPartitionsAsync(
+            String serviceName,
+            OperationFactory operationFactory,
+            Map<Address, List<Integer>> memberPartitions);
+
+    /**
      * Invokes a set of operations on selected set of partitions.
      * <p>
      * This method blocks until all operations complete.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -419,7 +419,13 @@ public final class OperationServiceImpl implements MetricsProvider, LiveOperatio
     public <T> ICompletableFuture<Map<Integer, T>> invokeOnPartitionsAsync(
             String serviceName, OperationFactory operationFactory, Collection<Integer> partitions) {
 
-        Map<Address, List<Integer>> memberPartitions = getMemberPartitions(partitions);
+        return invokeOnPartitionsAsync(serviceName, operationFactory, getMemberPartitions(partitions));
+    }
+
+    @Override
+    public <T> ICompletableFuture<Map<Integer, T>> invokeOnPartitionsAsync(
+            String serviceName, OperationFactory operationFactory, Map<Address, List<Integer>> memberPartitions) {
+
         InvokeOnPartitions invokeOnPartitions =
                 new InvokeOnPartitions(this, serviceName, operationFactory, memberPartitions);
         return invokeOnPartitions.invokeAsync();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -67,7 +67,7 @@ import static com.hazelcast.spi.impl.operationservice.Operations.isJoinOperation
 import static com.hazelcast.spi.impl.operationservice.Operations.isWanReplicationOperation;
 import static com.hazelcast.spi.properties.GroupProperty.FAIL_ON_INDETERMINATE_OPERATION_STATE;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
-import static com.hazelcast.util.CollectionUtil.toIntegerList;
+import static com.hazelcast.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -428,7 +428,7 @@ public final class OperationServiceImpl implements MetricsProvider, LiveOperatio
     @Override
     public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory, int[] partitions)
             throws Exception {
-        return invokeOnPartitions(serviceName, operationFactory, toIntegerList(partitions));
+        return invokeOnPartitions(serviceName, operationFactory, asIntegerList(partitions));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.util;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
 
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -173,12 +174,18 @@ public final class CollectionUtil {
      * @return the list.
      * throws {@link NullPointerException} if array is null.
      */
-    public static List<Integer> toIntegerList(int[] array) {
-        List<Integer> result = new ArrayList<Integer>(array.length);
-        for (int partitionId : array) {
-            result.add(partitionId);
-        }
-        return result;
+    public static List<Integer> asIntegerList(int[] array) {
+        return new AbstractList<Integer>() {
+            @Override
+            public Integer get(int index) {
+                return array[index];
+            }
+
+            @Override
+            public int size() {
+                return array.length;
+            }
+        };
     }
 
     /** Returns an empty Collection if argument is null. **/

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -166,15 +166,14 @@ public final class CollectionUtil {
     }
 
     /**
-     * Converts an int array to an Integer {@link List}.
-     * <p>
-     * The returned collection can be modified after it is created; it isn't protected by an immutable wrapper.
+     * Adapts an int array to an Integer {@link List}.
      *
      * @param array the array
-     * @return the list.
-     * throws {@link NullPointerException} if array is null.
+     * @return the list
+     * @throws NullPointerException if array is null.
      */
     public static List<Integer> asIntegerList(int[] array) {
+        checkNotNull(array, "null array");
         return new AbstractList<Integer>() {
             @Override
             public Integer get(int index) {

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapEvent;
@@ -356,6 +357,17 @@ public class ClientMapTest extends HazelcastTestSupport {
         Future<String> future = map.removeAsync("key4");
         assertEquals("value4", future.get());
         assertEquals(9, map.size());
+    }
+
+    @Test
+    public void testAsyncPutAll()  {
+        IMap<String, String> map = createMap();
+        Map<String, String> tmpMap = new HashMap<>();
+        fillMap(tmpMap);
+        ICompletableFuture<Void> future = ((ClientMapProxy<String, String>) map).putAllAsync(tmpMap);
+        assertEqualsEventually(map::size, tmpMap.size());
+        assertTrue(future.isDone());
+        assertEquals(tmpMap, new HashMap<>(map));
     }
 
     @Test
@@ -980,7 +992,7 @@ public class ClientMapTest extends HazelcastTestSupport {
         return client.getMap(randomString());
     }
 
-    private void fillMap(IMap<String, String> map) {
+    private void fillMap(Map<String, String> map) {
         for (int i = 0; i < 10; i++) {
             map.put("key" + i, "value" + i);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.map.helpers.GenericEvent;
 import com.hazelcast.client.impl.proxy.ClientMapProxy;
+import com.hazelcast.client.map.helpers.GenericEvent;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapStoreConfig;
@@ -68,6 +68,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -357,6 +358,18 @@ public class ClientMapTest extends HazelcastTestSupport {
         Future<String> future = map.removeAsync("key4");
         assertEquals("value4", future.get());
         assertEquals(9, map.size());
+    }
+
+    @Test
+    public void testPutAllEmpty() {
+        IMap<Integer, Integer> map = createMap();
+        map.putAll(emptyMap());
+    }
+
+    @Test
+    public void tstPutAllAsyncEmpty() {
+        IMap<Integer, Integer> map = createMap();
+        ((ClientMapProxy<Integer, Integer>) map).putAllAsync(emptyMap());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -73,6 +73,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
+import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertArrayEquals;
@@ -934,6 +935,18 @@ public class BasicMapTest extends HazelcastTestSupport {
         } catch (ExecutionException e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void testPutAllEmpty() {
+        IMap<Integer, Integer> map = getInstance().getMap("testPutAllEmpty");
+        map.putAll(emptyMap());
+    }
+
+    @Test
+    public void tstPutAllAsyncEmpty() {
+        IMap<Integer, Integer> map = getInstance().getMap("testPutAllEmpty");
+        ((MapProxyImpl<Integer, Integer>) map).putAllAsync(emptyMap());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -1045,7 +1045,7 @@ public class BasicMapTest extends HazelcastTestSupport {
         }
         ICompletableFuture<Void> future = ((MapProxyImpl<Integer, Integer>) map).putAllAsync(mm);
         assertEqualsEventually(map::size, size);
-        assertTrue(future.isDone());
+        assertTrueEventually(() -> assertTrue(future.isDone()));
         for (int i = 0; i < size; i++) {
             assertEquals(i, map.get(i).intValue());
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -24,9 +24,9 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastJsonValue;
-import java.util.function.BiFunction;
-
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.internal.json.Json;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
@@ -71,6 +71,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -1030,6 +1031,23 @@ public class BasicMapTest extends HazelcastTestSupport {
         assertEquals(size, map1.size());
         for (int i = 0; i < size; i++) {
             assertEquals(i, map1.get(i).intValue());
+        }
+    }
+
+    @Test
+    public void testPutAllAsync() {
+        int size = 10000;
+
+        IMap<Integer, Integer> map = instances[0].getMap("testPutAllAsync");
+        Map<Integer, Integer> mm = new HashMap<Integer, Integer>();
+        for (int i = 0; i < size; i++) {
+            mm.put(i, i);
+        }
+        ICompletableFuture<Void> future = ((MapProxyImpl<Integer, Integer>) map).putAllAsync(mm);
+        assertEqualsEventually(map::size, size);
+        assertTrue(future.isDone());
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, map.get(i).intValue());
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
@@ -122,7 +122,7 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     public void testPutAll() {
         Map<String, String> businessObjects = new HashMap<>();
         for (int i = 0; i < 100; i++) {
-            map.put("k" + i, "v" + i);
+            businessObjects.put("k" + i, "v" + i);
         }
         map.putAll(businessObjects);
         for (int i = 0; i < 100; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
@@ -42,7 +42,7 @@ import static com.hazelcast.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.util.CollectionUtil.nullToEmpty;
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
-import static com.hazelcast.util.CollectionUtil.toIntegerList;
+import static com.hazelcast.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.util.CollectionUtil.toLongArray;
 import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_LIST;
@@ -241,18 +241,18 @@ public class CollectionUtilTest extends HazelcastTestSupport {
 
     @Test(expected = NullPointerException.class)
     public void testToIntegerList_whenNull() {
-        toIntegerList(null);
+        asIntegerList(null);
     }
 
     @Test
     public void testToIntegerList_whenEmpty() {
-        List<Integer> result = toIntegerList(new int[0]);
+        List<Integer> result = asIntegerList(new int[0]);
         assertEquals(0, result.size());
     }
 
     @Test
     public void testToIntegerList_whenNotEmpty() {
-        List<Integer> result = toIntegerList(new int[]{1, 2, 3, 4});
+        List<Integer> result = asIntegerList(new int[]{1, 2, 3, 4});
         assertEquals(asList(1, 2, 3, 4), result);
     }
 


### PR DESCRIPTION
Add an async version of `IMap.putAll()`. For member-to-member case, execute operations for members in parallel (this is the performance improvement).

Code is mostly shared for sync/async version, except for the result handling: in one case we block for all the subfutures, in the other case we create a new future that's completed when subfutures complete. The async version on member doesn't support batching.

Feature will be used by Jet. Until release we have a clone of this method in Jet code.

Contains grammar fixes as usual, in a separate commit.