### PR TITLE
Disabled some 3.x compatibility tests for now (#15457)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
@@ -46,7 +46,7 @@ public class HazelcastClientStarterTest {
     }
 
     @Test
-    @Ignore("To be enabled in 4.1 with with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
+    @Ignore("To be enabled in 4.1 with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
     public void testClientLifecycle() {
         memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
 
@@ -81,7 +81,7 @@ public class HazelcastClientStarterTest {
     }
 
     @Test
-    @Ignore("To be enabled in 4.1 with with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
+    @Ignore("To be enabled in 4.1 with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
     public void testAdvancedClientMap() {
         memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
         HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);

--- a/hazelcast/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
@@ -46,6 +46,7 @@ public class HazelcastClientStarterTest {
     }
 
     @Test
+    @Ignore("To be enabled in 4.1 with with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
     public void testClientLifecycle() {
         memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
 
@@ -80,6 +81,7 @@ public class HazelcastClientStarterTest {
     }
 
     @Test
+    @Ignore("To be enabled in 4.1 with with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
     public void testAdvancedClientMap() {
         memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
         HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastProxyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastProxyFactoryTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.starter.HazelcastAPIDelegatingClassloader;
 import com.hazelcast.test.starter.HazelcastProxyFactory;
 import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,6 +64,7 @@ public class HazelcastProxyFactoryTest {
     }
 
     @Test
+    @Ignore("To be enabled with 4.x instances - see https://github.com/hazelcast/hazelcast/issues/15457")
     public void testProxyHazelcastInstanceClasses_ofSameVersion_areSame() {
         HazelcastInstance hz1 = HazelcastStarter.newHazelcastInstance("3.8");
         HazelcastInstance hz2 = HazelcastStarter.newHazelcastInstance("3.8");


### PR DESCRIPTION
Ignore-d `HazelcastClientStarterTest.testAdvancedClientMap`, `HazelcastClientStarterTest.testClientLifecycle` and `HazelcastProxyFactoryTest.testProxyHazelcastInstanceClasses_ofSameVersion_areSame` until there are 4.x artifacts.

Fixes https://github.com/hazelcast/hazelcast/issues/15457