### PR TITLE
invalidate near client cache after execute on keys operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -106,14 +106,17 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.internal.journal.EventJournalReader;
+import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.internal.util.IterationType;
 import com.hazelcast.internal.util.collection.ImmutableInflatableSet;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.IMapEvent;
+import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.map.MapEvent;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.MapPartitionLostEvent;
@@ -125,11 +128,8 @@ import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
-import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
-import com.hazelcast.map.LocalMapStats;
-import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.PagingPredicate;
@@ -1622,13 +1622,23 @@ public class ClientMapProxy<K, V> extends ClientProxy
         if (keys.isEmpty()) {
             return InternalCompletableFuture.newCompletedFuture(Collections.emptyMap());
         }
+        Collection<Data> dataKeys = objectToDataCollection(keys, getSerializationService());
+        return submitToKeysInternal(keys, dataKeys, entryProcessor);
+    }
 
-        Collection<Data> dataCollection = objectToDataCollection(keys, getSerializationService());
-
-        ClientMessage request = MapExecuteOnKeysCodec.encodeRequest(name, toData(entryProcessor), dataCollection);
+    /**
+     * @param objectKeys not serialized key
+     * @param dataKeys   serialized keys
+     */
+    @Nonnull
+    protected <R> InternalCompletableFuture<Map<K, R>> submitToKeysInternal(@Nonnull Set<K> objectKeys,
+                                                                            @Nonnull Collection<Data> dataKeys,
+                                                                            @Nonnull EntryProcessor<K, V, R> entryProcessor) {
+        ClientMessage request = MapExecuteOnKeysCodec.encodeRequest(name, toData(entryProcessor), dataKeys);
         ClientInvocationFuture future = new ClientInvocation(getClient(), request, getName()).invoke();
-        return new ClientDelegatingFuture<>(future, getSerializationService(),
-                message -> prepareResult(MapExecuteOnKeysCodec.decodeResponse(message).response));
+        return new ClientDelegatingFuture<>(
+            future, getSerializationService(),
+            message -> prepareResult(MapExecuteOnKeysCodec.decodeResponse(message).response));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
@@ -481,6 +481,22 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         return localMapStats;
     }
 
+    /**
+     * Async version of {@link #executeOnKeys}.
+     */
+    public <R> InternalCompletableFuture<Map<K, R>> submitToKeys(@Nonnull Set<K> keys,
+                                                                 @Nonnull EntryProcessor<K, V, R> entryProcessor) {
+        checkNotNull(keys, NULL_KEY_IS_NOT_ALLOWED);
+
+        InternalCompletableFuture<Map<K, R>> response;
+        try {
+            response = super.submitToKeys(keys, entryProcessor);
+        } finally {
+            keys.forEach(this::invalidateNearCache);
+        }
+        return response;
+    }
+
     @Override
     public <R> R executeOnKeyInternal(Object key,
                                       EntryProcessor<K, V, R> entryProcessor) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/ExecuteOnKeyInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/ExecuteOnKeyInvalidationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache.invalidation;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ExecuteOnKeyInvalidationTest extends HazelcastTestSupport {
+
+  private final TestHazelcastFactory factory = new TestHazelcastFactory();
+  private HazelcastInstance client;
+
+  @Before
+  public void setUp() {
+    startHazelcastInstance();
+    client = clientWithNearCache();
+  }
+
+  @After
+  public void tearDown() {
+    factory.shutdownAll();
+  }
+
+  private HazelcastInstance clientWithNearCache() {
+    ClientConfig clientConfig = new ClientConfig().addNearCacheConfig(new NearCacheConfig("map"));
+    return factory.newHazelcastClient(clientConfig);
+  }
+
+  private void startHazelcastInstance() {
+    factory.newHazelcastInstance();
+  }
+
+  @Test
+  public void testExecuteOnKeysInvalidation_withNullOperationResult() {
+    IMap<String, String> map = client.getMap("map");
+    map.put("key", "old-value");
+    map.get("key");
+    map.executeOnKeys(
+        Collections.singleton("key"),
+        entry -> {
+          entry.setValue("new-value");
+          return null;
+        }
+    );
+    assertEquals("new-value", map.get("key"));
+  }
+
+  @Test
+  public void testExecuteOnKeysInvalidation_withOperationResult() {
+    IMap<String, String> map = client.getMap("map");
+    map.put("key", "old-value");
+    map.get("key");
+    map.executeOnKeys(
+        Collections.singleton("key"),
+        entry -> {
+          entry.setValue("new-value");
+          return "computation-result-of-on-key-execution";
+        }
+    );
+    assertEquals("new-value", map.get("key"));
+  }
+}


### PR DESCRIPTION
This PR is the fix for #15468. Due to the fact that result of computation was the `null` hazelcast hasn't send updated value to a client.

I included tests with `null` result and with not-`null` result different from new cache value

closes #15468