### PR TITLE
Protocol Specific Network Metrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/ProtocolType.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/ProtocolType.java
@@ -38,6 +38,7 @@ public enum ProtocolType {
     /**
      * Ordinals of this enum are used for IDS inside {@link EndpointQualifier}.
      * Do not re-arrange, only append new values at end.
+     * Names of this enum are used for stats sent to Management Center, do not rename.
      */
     MEMBER(1, Protocols.CLUSTER),
     CLIENT(1, Protocols.CLIENT_BINARY_NEW),

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -39,6 +39,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
+import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.monitor.LocalExecutorStats;
@@ -206,6 +207,10 @@ public class TimedMemberStateFactory {
         createWanSyncState(memberState);
 
         memberState.setClientStats(node.clientEngine.getClientStatistics());
+
+        Networking networking = node.getNetworkingService().getNetworking();
+        memberState.setInboundNetworkStats(networking.getInboundNetworkStats());
+        memberState.setOutboundNetworkStats(networking.getOutboundNetworkStats());
     }
 
     private void createHotRestartState(MemberStateImpl memberState) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.networking;
 
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.internal.networking.nio.NetworkStats;
 import com.hazelcast.internal.networking.nio.NioNetworking;
 
 import java.io.IOException;
@@ -67,4 +68,18 @@ public interface Networking {
      * Shuts down Networking.
      */
     void shutdown();
+
+    /**
+     * Gets network stats for outgoing traffic
+     *
+     * @return network stats for outgoing traffic per-protocol
+     */
+    NetworkStats getOutboundNetworkStats();
+
+    /**
+     * Gets network stats for incoming traffic
+     *
+     * @return network stats for incoming traffic per-protocol
+     */
+    NetworkStats getInboundNetworkStats();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NetworkStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NetworkStats.java
@@ -61,7 +61,7 @@ public class NetworkStats {
      * @param prefix          prefix for the probe names to be registered
      */
     void registerMetrics(MetricsRegistry metricsRegistry, String prefix) {
-        for (ProtocolType protocolType : ProtocolType.values()) {
+        for (final ProtocolType protocolType : ProtocolType.values()) {
             metricsRegistry.register(this, prefix + "." + protocolType.name(), ProbeLevel.INFO,
                     new LongProbeFunction<NetworkStats>() {
                         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NetworkStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NetworkStats.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeLevel;
+
+import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Stats per {@link ProtocolType} for a single direction of network traffic (inbound or outbound).
+ * <p>
+ * Stores number of bytes sent or received per {@link ProtocolType}
+ * depending on whether it is for inbound or outbound traffic. Works
+ * only when Advanced Networking is enabled and {@link com.hazelcast.config.EndpointConfig}
+ * is added for the {@link ProtocolType} in question.
+ **/
+public class NetworkStats {
+    private final EnumMap<ProtocolType, AtomicLong> bytesTransceived;
+
+    NetworkStats() {
+        bytesTransceived = new EnumMap<ProtocolType, AtomicLong>(ProtocolType.class);
+        for (ProtocolType protocolType : ProtocolType.values()) {
+            bytesTransceived.put(protocolType, new AtomicLong());
+        }
+    }
+
+    void setBytesTransceivedForProtocol(ProtocolType protocolType, long bytes) {
+        AtomicLong value = bytesTransceived.get(protocolType);
+        value.lazySet(bytes);
+    }
+
+    // used for tests only
+    public long getBytesTransceivedForProtocol(ProtocolType protocolType) {
+        return bytesTransceived.get(protocolType).get();
+    }
+
+    /**
+     * Dynamically registers probes for each protocol type. All registered probes will have the
+     * same prefix plus the protocol type as their names.
+     *
+     * @param metricsRegistry {@link MetricsRegistry} instance to register the probes on
+     * @param prefix          prefix for the probe names to be registered
+     */
+    void registerMetrics(MetricsRegistry metricsRegistry, String prefix) {
+        for (ProtocolType protocolType : ProtocolType.values()) {
+            metricsRegistry.register(this, prefix + "." + protocolType.name(), ProbeLevel.INFO,
+                    new LongProbeFunction<NetworkStats>() {
+                        @Override
+                        public long get(NetworkStats source) {
+                            return bytesTransceived.get(protocolType).get();
+                        }
+                    });
+        }
+    }
+
+    /**
+     * For serializing the stats before sending to Management Center.
+     *
+     * @return the JSON representation of this object
+     */
+    public JsonObject toJson() {
+        JsonObject bytesTransceivedJson = new JsonObject();
+        for (ProtocolType protocolType : ProtocolType.values()) {
+            bytesTransceivedJson.add(protocolType.name(), bytesTransceived.get(protocolType).get());
+        }
+
+        JsonObject result = new JsonObject();
+        result.add("bytesTransceived", bytesTransceivedJson);
+        return result;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NetworkStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NetworkStats.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class NetworkStats {
     private final EnumMap<ProtocolType, AtomicLong> bytesTransceived;
 
-    NetworkStats() {
+    public NetworkStats() {
         bytesTransceived = new EnumMap<ProtocolType, AtomicLong>(ProtocolType.class);
         for (ProtocolType protocolType : ProtocolType.values()) {
             bytesTransceived.put(protocolType, new AtomicLong());

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -40,12 +40,12 @@ public final class NioChannel extends AbstractChannel {
     // The close delays is needed for the TLS goodbye handshake to complete.
     NioInboundPipeline inboundPipeline;
     NioOutboundPipeline outboundPipeline;
+    final ProtocolType protocolType;
 
     private final Executor closeListenerExecutor;
     private final MetricsRegistry metricsRegistry;
     private final ChannelInitializer channelInitializer;
     private final NioChannelOptions config;
-    final ProtocolType protocolType;
 
     public NioChannel(SocketChannel socketChannel,
                       boolean clientMode,

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.networking.AbstractChannel;
 import com.hazelcast.internal.networking.ChannelInitializer;
@@ -44,17 +45,20 @@ public final class NioChannel extends AbstractChannel {
     private final MetricsRegistry metricsRegistry;
     private final ChannelInitializer channelInitializer;
     private final NioChannelOptions config;
+    final ProtocolType protocolType;
 
     public NioChannel(SocketChannel socketChannel,
                       boolean clientMode,
                       ChannelInitializer channelInitializer,
                       MetricsRegistry metricsRegistry,
-                      Executor closeListenerExecutor) {
+                      Executor closeListenerExecutor,
+                      ProtocolType protocolType) {
         super(socketChannel, clientMode);
         this.channelInitializer = channelInitializer;
         this.metricsRegistry = metricsRegistry;
         this.closeListenerExecutor = closeListenerExecutor;
         this.config = new NioChannelOptions(socketChannel.socket());
+        this.protocolType = protocolType;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -435,7 +435,7 @@ public abstract class NioPipeline implements MigratablePipeline, Runnable {
          */
         private static final class PublishableSwCounter {
             private final SwCounter counter = newSwCounter();
-            private long lastPublishedValue;
+            private volatile long lastPublishedValue;
 
             public long inc(long amount) {
                 return counter.inc(amount);

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -435,7 +435,7 @@ public abstract class NioPipeline implements MigratablePipeline, Runnable {
          */
         private static final class PublishableSwCounter {
             private final SwCounter counter = newSwCounter();
-            private long lastPublishedValue = 0;
+            private long lastPublishedValue;
 
             public long inc(long amount) {
                 return counter.inc(amount);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -86,8 +86,8 @@ public class MemberStateImpl implements MemberState {
     private HotRestartState hotRestartState = new HotRestartStateImpl();
     private ClusterHotRestartStatusDTO clusterHotRestartStatus = new ClusterHotRestartStatusDTO();
     private WanSyncState wanSyncState = new WanSyncStateImpl();
-    private NetworkStats inboundNetworkStats;
-    private NetworkStats outboundNetworkStats;
+    private NetworkStats inboundNetworkStats = new NetworkStats();
+    private NetworkStats outboundNetworkStats = new NetworkStats();
 
     public MemberStateImpl() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.management.dto.MXBeansDTO;
+import com.hazelcast.internal.networking.nio.NetworkStats;
 import com.hazelcast.monitor.HotRestartState;
 import com.hazelcast.monitor.LocalCacheStats;
 import com.hazelcast.monitor.LocalExecutorStats;
@@ -85,6 +86,8 @@ public class MemberStateImpl implements MemberState {
     private HotRestartState hotRestartState = new HotRestartStateImpl();
     private ClusterHotRestartStatusDTO clusterHotRestartStatus = new ClusterHotRestartStatusDTO();
     private WanSyncState wanSyncState = new WanSyncStateImpl();
+    private NetworkStats inboundNetworkStats;
+    private NetworkStats outboundNetworkStats;
 
     public MemberStateImpl() {
     }
@@ -316,6 +319,22 @@ public class MemberStateImpl implements MemberState {
         this.clientStats = clientStats;
     }
 
+    public NetworkStats getInboundNetworkStats() {
+        return inboundNetworkStats;
+    }
+
+    public void setInboundNetworkStats(NetworkStats inboundNetworkStats) {
+        this.inboundNetworkStats = inboundNetworkStats;
+    }
+
+    public NetworkStats getOutboundNetworkStats() {
+        return outboundNetworkStats;
+    }
+
+    public void setOutboundNetworkStats(NetworkStats outboundNetworkStats) {
+        this.outboundNetworkStats = outboundNetworkStats;
+    }
+
     @Override
     public JsonObject toJson() {
         final JsonObject root = new JsonObject();
@@ -378,6 +397,8 @@ public class MemberStateImpl implements MemberState {
             clientStatsObject.add(entry.getKey(), entry.getValue());
         }
         root.add("clientStats", clientStatsObject);
+        root.add("inboundNetworkStats", inboundNetworkStats.toJson());
+        root.add("outboundNetworkStats", outboundNetworkStats.toJson());
         return root;
     }
 
@@ -546,6 +567,8 @@ public class MemberStateImpl implements MemberState {
                 + ", wanSyncState=" + wanSyncState
                 + ", flakeIdStats=" + flakeIdGeneratorStats
                 + ", clientStats=" + clientStats
+                + ", inboundNetworkStats=" + inboundNetworkStats
+                + ", outboundNetworkStats=" + outboundNetworkStats
                 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
@@ -36,7 +36,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
 
     @Test
     public void testServices() {
-        HazelcastInstance hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance(smallInstanceConfig());
         TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
 
         hz.getMap("trial").put(1, 1);
@@ -53,7 +53,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
 
     @Test
     public void testSSL_defaultConfig() {
-        HazelcastInstance hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance(smallInstanceConfig());
         TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
@@ -74,7 +74,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         SSLConfig sslConfig = new SSLConfig();
         sslConfig.setEnabled(enabled);
 
-        Config config = getConfig();
+        Config config = smallInstanceConfig();
         config.getNetworkConfig().setSSLConfig(sslConfig);
 
         HazelcastInstance hz = createHazelcastInstance(config);
@@ -100,7 +100,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
     }
 
     private void testScripting(Boolean enabled) {
-        Config config = getConfig();
+        Config config = smallInstanceConfig();
         if (enabled != null) {
             config.getManagementCenterConfig().setScriptingEnabled(enabled);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AbstractAdvancedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AbstractAdvancedNetworkIntegrationTest.java
@@ -17,14 +17,18 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
+
+import org.junit.After;
+
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.After;
 
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 
@@ -91,4 +95,19 @@ public abstract class AbstractAdvancedNetworkIntegrationTest {
         return serverSocketConfig;
     }
 
+    void configureTcpIpConfig(Config config) {
+        JoinConfig join = config.getAdvancedNetworkConfig().getJoin();
+        join.getTcpIpConfig().addMember("127.0.0.1:" + NOT_OPENED_PORT).setEnabled(true);
+        join.getMulticastConfig().setEnabled(false);
+    }
+
+    Config prepareJoinConfigForSecondMember(int port) {
+        Config config = smallInstanceConfig();
+        config.getAdvancedNetworkConfig().setEnabled(true);
+        JoinConfig join = config.getAdvancedNetworkConfig().getJoin();
+        join.getTcpIpConfig().addMember("127.0.0.1:" + port).setEnabled(true);
+        join.getMulticastConfig().setEnabled(false);
+        config.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "3");
+        return config;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkStatsIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkStatsIntegrationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.instance.ProtocolType.MEMBER;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueAllTheTime;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetworkIntegrationTest {
+    private HazelcastInstance instance1;
+    private HazelcastInstance instance2;
+
+    @Test
+    public void testStats_advancedNetworkEnabled() {
+        Config config = createCompleteMultiSocketConfig();
+        configureTcpIpConfig(config);
+        enableMetrics(config);
+        instance1 = newHazelcastInstance(config);
+        instance2 = startSecondInstance();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue(getBytesReceived(instance1, MEMBER) > 0);
+                assertTrue(getBytesSent(instance1, MEMBER) > 0);
+                assertTrue(getBytesReceived(instance2, MEMBER) > 0);
+                assertTrue(getBytesSent(instance2, MEMBER) > 0);
+            }
+        });
+
+        assertNonMemberNetworkStatsAreZero(instance1);
+        assertNonMemberNetworkStatsAreZero(instance2);
+    }
+
+    @Test
+    public void testStats_advancedNetworkDisabled() {
+        instance1 = newHazelcastInstance(getUnisocketConfig(MEMBER_PORT));
+        instance2 = newHazelcastInstance(getUnisocketConfig(MEMBER_PORT + 1));
+        assertClusterSizeEventually(2, instance1, instance2);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertAllNetworkStatsAreZero(instance1);
+                assertAllNetworkStatsAreZero(instance2);
+            }
+        }, 30);
+    }
+
+    private Config getUnisocketConfig(int memberPort) {
+        Config config1 = smallInstanceConfig();
+        config1.getNetworkConfig().setPort(memberPort);
+        config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true)
+                .addMember("127.0.0.1:" + MEMBER_PORT)
+                .addMember("127.0.0.1:" + (MEMBER_PORT + 1));
+        return config1;
+    }
+
+    private void assertAllNetworkStatsAreZero(HazelcastInstance instance) {
+        assertEquals(0, getBytesReceived(instance, MEMBER));
+        assertEquals(0, getBytesSent(instance, MEMBER));
+        assertNonMemberNetworkStatsAreZero(instance);
+    }
+
+    private void assertNonMemberNetworkStatsAreZero(HazelcastInstance instance) {
+        for (ProtocolType protocolType : ProtocolType.values()) {
+            if (protocolType != MEMBER) {
+                assertEquals(0, getBytesReceived(instance, protocolType));
+                assertEquals(0, getBytesSent(instance, protocolType));
+            }
+        }
+    }
+
+    private long getBytesReceived(HazelcastInstance instance, ProtocolType protocolType) {
+        return getNode(instance)
+                .getNetworkingService()
+                .getNetworking()
+                .getInboundNetworkStats()
+                .getBytesTransceivedForProtocol(protocolType);
+    }
+
+    private long getBytesSent(HazelcastInstance instance, ProtocolType protocolType) {
+        return getNode(instance)
+                .getNetworkingService()
+                .getNetworking()
+                .getInboundNetworkStats()
+                .getBytesTransceivedForProtocol(protocolType);
+    }
+
+    private void enableMetrics(Config config) {
+        config.setProperty("hazelcast.diagnostics.enabled", "true");
+        config.setProperty("hazelcast.diagnostics.metric.level", "Info");
+        config.setProperty("hazelcast.diagnostics.metrics.period.seconds", "5");
+    }
+
+    private HazelcastInstance startSecondInstance() {
+        Config config = prepareJoinConfigForSecondMember(MEMBER_PORT);
+        enableMetrics(config);
+        HazelcastInstance newHzInstance = newHazelcastInstance(config);
+        int clusterSize = newHzInstance.getCluster().getMembers().size();
+        assertEquals(2, clusterSize);
+        return newHzInstance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkingCommunicationIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkingCommunicationIntegrationTest.java
@@ -21,13 +21,14 @@ import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.ascii.HTTPCommunicator;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
+
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.FailureMode;
 import net.spy.memcached.MemcachedClient;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -37,7 +38,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.Collections;
 
-import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -122,22 +122,6 @@ public class AdvancedNetworkingCommunicationIntegrationTest extends AbstractAdva
                 newHzInstance.shutdown();
             }
         }
-    }
-
-    private Config prepareJoinConfigForSecondMember(int port) {
-        Config config = smallInstanceConfig();
-        config.getAdvancedNetworkConfig().setEnabled(true);
-        JoinConfig join = config.getAdvancedNetworkConfig().getJoin();
-        join.getTcpIpConfig().addMember("127.0.0.1:" + port).setEnabled(true);
-        join.getMulticastConfig().setEnabled(false);
-        config.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "3");
-        return config;
-    }
-
-    private void configureTcpIpConfig(Config config) {
-        JoinConfig join = config.getAdvancedNetworkConfig().getJoin();
-        join.getTcpIpConfig().addMember("127.0.0.1:" + NOT_OPENED_PORT).setEnabled(true);
-        join.getMulticastConfig().setEnabled(false);
     }
 
     private void testRestCallFailsOnPort(HazelcastInstance hz, int port) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
@@ -20,7 +20,10 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
+import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.Networking;
+import com.hazelcast.internal.networking.nio.NetworkStats;
 import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -36,6 +39,8 @@ import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.util.executor.StripedRunnable;
 
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -345,7 +350,35 @@ class MockNetworkingService
 
     @Override
     public Networking getNetworking() {
-        return null;
+        return new Networking() {
+            @Override
+            public Channel register(EndpointQualifier endpointQualifier,
+                                    ChannelInitializerProvider channelInitializerProvider,
+                                    SocketChannel socketChannel,
+                                    boolean clientMode) throws IOException {
+                return null;
+            }
+
+            @Override
+            public void start() {
+                // NO-OP
+            }
+
+            @Override
+            public void shutdown() {
+                // NO-OP
+            }
+
+            @Override
+            public NetworkStats getOutboundNetworkStats() {
+                return new NetworkStats();
+            }
+
+            @Override
+            public NetworkStats getInboundNetworkStats() {
+                return new NetworkStats();
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
* Bytes send/received metrics for each ProtocolType are added as metrics
 and logged to diagnostics (only total, not per-thread or per-pipeline).
 * Bytes send/received are reported to Management Center.

 Note that this works only when advanced networking is enabled and an
 endpoint configuration is made for the specific protocol type (member,
 client, WAN etc.).

MC PR: https://github.com/hazelcast/management-center/pull/2062