### PR TITLE
fix the fast forward to the endframe logic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -329,6 +329,10 @@ public final class ClientMessage extends LinkedList<ClientMessage.Frame> impleme
             return ClientMessage.isFlagSet(flags, END_DATA_STRUCTURE_FLAG);
         }
 
+        public boolean isBeginFrame() {
+            return ClientMessage.isFlagSet(flags, BEGIN_DATA_STRUCTURE_FLAG);
+        }
+
         public boolean isNullFrame() {
             return ClientMessage.isFlagSet(flags, IS_NULL_FLAG);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CodecUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CodecUtil.java
@@ -30,8 +30,17 @@ public final class CodecUtil {
     }
 
     public static void fastForwardToEndFrame(ListIterator<ClientMessage.Frame> iterator) {
-        for (ClientMessage.Frame frame = iterator.next(); !frame.isEndFrame(); ) {
+        // We are starting from 1 because of the BEGIN_FRAME we read
+        // in the beginning of the decode method
+        int numberOfExpectedEndFrames = 1;
+        ClientMessage.Frame frame;
+        while (numberOfExpectedEndFrames != 0) {
             frame = iterator.next();
+            if (frame.isEndFrame()) {
+                numberOfExpectedEndFrames--;
+            } else if (frame.isBeginFrame()) {
+                numberOfExpectedEndFrames++;
+            }
         }
     }
 


### PR DESCRIPTION
When we decode `custom-type-frames` we are fast forwarding to the end frame after reading the fields so that when we add new fields to that message in the future protocol versions, old members can skip reading those new fields. The problem is, we were just fast forwarding to the first end frame we would see. For example, if we add another `Address` field to the `Member` in the protocol version 2.1, old members would mistakenly try to fast forward to the end frame of the newly added `Address` field, leaving one `END_FRAME` unread, corrupting the possible iterations over that client message. With this PR, we are fast forwarding until we see an `END_FRAME` for each `BEGIN_FRAME` we saw after starting fast forwarding