### PR TITLE
Remove the old client handling code from MapRemoveAllMessageTask

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
@@ -16,19 +16,13 @@
 
 package com.hazelcast.client.impl.protocol.task.map;
 
-import com.hazelcast.client.impl.operations.OperationFactoryWrapper;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveAllCodec;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.instance.impl.Node;
-import com.hazelcast.map.impl.MapContainer;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.security.permission.ActionConstants;
@@ -44,7 +38,6 @@ import java.util.Map;
 
 import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static java.util.Collections.singletonList;
 
 public class MapRemoveAllMessageTask extends AbstractMapAllPartitionsMessageTask<MapRemoveAllCodec.RequestParameters> {
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
@@ -62,66 +62,42 @@ public class MapRemoveAllMessageTask extends AbstractMapAllPartitionsMessageTask
         }
 
         int partitionId = clientMessage.getPartitionId();
-        boolean invokedOnPartition = partitionId != -1;
-        if (!invokedOnPartition) {
-            // We got an old client which is sending -1 as a partition ID in its messages
-            // while still using partition predicates.
-
-            PartitionPredicate partitionPredicate = (PartitionPredicate) predicate;
-            MapService mapService = getService(getServiceName());
-            MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-            MapContainer mapContainer = mapServiceContext.getMapContainer(parameters.name);
-            PartitioningStrategy partitioningStrategy = mapContainer.getPartitioningStrategy();
-            Data partitionKey = serializationService.toData(partitionPredicate.getPartitionKey(), partitioningStrategy);
-            partitionId = nodeEngine.getPartitionService().getPartitionId(partitionKey);
-        }
 
         OperationFactory operationFactory = createOperationFactory();
         OperationServiceImpl operationService = nodeEngine.getOperationService();
-        if (invokedOnPartition) {
-            // We are running on a partition thread now and we are not allowed
-            // to call invokeOnPartitions(Async) on operation service because of
-            // that.
 
-            Operation operation;
-            if (operationFactory instanceof PartitionAwareOperationFactory) {
-                // If operation factory is partition-aware, we should utilize this to our advantage
-                // since for the on-heap storages this may speed up the operation via indexes
-                // (see PartitionWideEntryWithPredicateOperationFactory.createFactoryOnRunner).
+        // We are running on a partition thread now and we are not allowed
+        // to call invokeOnPartitions(Async) on operation service because of
+        // that.
 
-                PartitionAwareOperationFactory partitionAwareOperationFactory = (PartitionAwareOperationFactory) operationFactory;
-                partitionAwareOperationFactory = partitionAwareOperationFactory
-                        .createFactoryOnRunner(nodeEngine, new int[]{partitionId});
-                operation = partitionAwareOperationFactory.createPartitionOperation(partitionId);
-            } else {
-                operation = operationFactory.createOperation();
-            }
-
-            final int thisPartitionId = partitionId;
-            operation.setCallerUuid(endpoint.getUuid());
-            ICompletableFuture<Object> future = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
-            future.andThen(new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object response) {
-                    MapRemoveAllMessageTask.this.onResponse(Collections.singletonMap(thisPartitionId, response));
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    MapRemoveAllMessageTask.this.onFailure(t);
-                }
-            });
-        } else {
-            // invokeOnPartitionsAsync is used intentionally here, instead of asyncInvokeOnPartition,
-            // since the later one doesn't support PartitionAwareOperationFactory, which we need to use
-            // to speed up the removal operation using global indexes
+        Operation operation;
+        if (operationFactory instanceof PartitionAwareOperationFactory) {
+            // If operation factory is partition-aware, we should utilize this to our advantage
+            // since for the on-heap storages this may speed up the operation via indexes
             // (see PartitionWideEntryWithPredicateOperationFactory.createFactoryOnRunner).
 
-            operationFactory = new OperationFactoryWrapper(operationFactory, endpoint.getUuid());
-            ICompletableFuture<Map<Integer, Object>> future =
-                    operationService.invokeOnPartitionsAsync(getServiceName(), operationFactory, singletonList(partitionId));
-            future.andThen(this);
+            PartitionAwareOperationFactory partitionAwareOperationFactory = (PartitionAwareOperationFactory) operationFactory;
+            partitionAwareOperationFactory = partitionAwareOperationFactory
+                    .createFactoryOnRunner(nodeEngine, new int[]{partitionId});
+            operation = partitionAwareOperationFactory.createPartitionOperation(partitionId);
+        } else {
+            operation = operationFactory.createOperation();
         }
+
+        final int thisPartitionId = partitionId;
+        operation.setCallerUuid(endpoint.getUuid());
+        ICompletableFuture<Object> future = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
+        future.andThen(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                MapRemoveAllMessageTask.this.onResponse(Collections.singletonMap(thisPartitionId, response));
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                MapRemoveAllMessageTask.this.onFailure(t);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Removed the old client handling code from message task when IMap removeAll is used with PartitionPredicate.