### PR TITLE
Added check for AbstractChannel.connect

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -116,6 +116,10 @@ public abstract class AbstractChannel implements Channel {
     @Override
     public void connect(InetSocketAddress address, int timeoutMillis) throws IOException {
         try {
+            if (!clientMode) {
+                throw new IllegalStateException("Can't call connect on a Channel that isn't in clientMode");
+            }
+
             checkNotNull(address, "address");
             checkNotNegative(timeoutMillis, "timeoutMillis can't be negative");
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -189,6 +189,7 @@ public interface Channel extends Closeable {
      *
      * @param address       the address to connect to.
      * @param timeoutMillis the timeout in millis, or 0 if waiting indefinitely.
+     * @throws IllegalStateException if the connection is not in clientMode.
      * @throws IOException if connecting fails.
      */
     void connect(InetSocketAddress address, int timeoutMillis) throws IOException;


### PR DESCRIPTION
This method should only be called when the AbstractChannel is in
clientMode.

fixes https://github.com/hazelcast/hazelcast/issues/15493