### PR TITLE
Fix metrics non clientmode connection

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -135,8 +135,6 @@ public abstract class AbstractChannel implements Channel {
                 throw newEx;
             }
 
-            onConnect();
-
             if (logger.isFinestEnabled()) {
                 logger.finest("Successfully connected to: " + address + " using socket " + socketChannel.socket());
             }
@@ -147,13 +145,6 @@ public abstract class AbstractChannel implements Channel {
             IOUtil.closeResource(this);
             throw e;
         }
-    }
-
-    /**
-     * Template method that can be implemented when the {@link #connect(InetSocketAddress, int)}
-     * has completed.
-     */
-    protected void onConnect() {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -170,10 +170,13 @@ public interface Channel extends Closeable {
      * initialize the channel and to start with processing inbound and outbound data.
      *
      * This method is not threadsafe and should be made only once.
+     *
+     * This method should be called for clientMode and non clientMode channels. Otherwise
+     * the connection will not start to read from or write to the socket.
      */
     void start();
 
-      /**
+    /**
      * Connects the channel.
      *
      * This call should only be made once and is not threadsafe.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -85,13 +85,6 @@ public final class NioChannel extends AbstractChannel {
     }
 
     @Override
-    protected void onConnect() {
-        String metricsId = localSocketAddress() + "->" + remoteSocketAddress();
-        metricsRegistry.scanAndRegister(outboundPipeline, "tcp.connection[" + metricsId + "].out");
-        metricsRegistry.scanAndRegister(inboundPipeline, "tcp.connection[" + metricsId + "].in");
-    }
-
-    @Override
     public long lastReadTimeMillis() {
         return inboundPipeline.lastReadTimeMillis();
     }
@@ -103,6 +96,10 @@ public final class NioChannel extends AbstractChannel {
 
     @Override
     public void start() {
+        String metricsId = localSocketAddress() + "->" + remoteSocketAddress();
+        metricsRegistry.scanAndRegister(outboundPipeline, "tcp.connection[" + metricsId + "].out");
+        metricsRegistry.scanAndRegister(inboundPipeline, "tcp.connection[" + metricsId + "].in");
+
         try {
             // before starting the channel, the socketChannel need to be put in
             // non blocking mode since that is mandatory for the NioChannel.


### PR DESCRIPTION
Fix #15492

Updated metrics
```
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.bytesRead=173]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.completedMigrations=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.idleTimeMs=7058]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.normalFramesRead=3]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.opsInterested=1]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.opsReady=1]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.ownerId=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.priorityFramesRead=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.processCount=4]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].in.startedMigrations=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.bytesWritten=1578]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.completedMigrations=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.idleTimeMs=7055]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.normalFramesWritten=5]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.opsInterested=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.opsReady=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.ownerId=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.priorityFramesWritten=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.priorityWriteQueuePendingBytes=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.priorityWriteQueueSize=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.processCount=8]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.scheduled=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.startedMigrations=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.writeQueuePendingBytes=0]
30-08-2019 08:34:53 1567143293003 Metric[tcp.connection[/127.0.0.1:5701->/127.0.0.1:57837].out.writeQueueSize=0]
```