### PR TITLE
frames read always zero on client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -56,11 +56,9 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
     public HandlerStatus onRead() {
         src.flip();
         try {
-            int messagesCreated = 0;
             while (src.hasRemaining()) {
                 boolean complete = message.readFrom(src);
                 if (!complete) {
-                    normalPacketsRead.inc(messagesCreated);
                     break;
                 }
 
@@ -69,7 +67,6 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
                     //HANDLE-MESSAGE
                     handleMessage(message);
                     message = ClientMessage.create();
-                    messagesCreated++;
                     continue;
                 }
 
@@ -97,7 +94,6 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
                 }
 
                 message = ClientMessage.create();
-                messagesCreated++;
             }
 
             return CLEAN;
@@ -109,6 +105,7 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
     private void handleMessage(ClientMessage message) {
         message.index(message.getDataOffset());
         message.setConnection(connection);
+        normalPacketsRead.inc();
         dst.accept(message);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoderTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,17 +41,17 @@ public class ClientMessageDecoderTest {
 
     private Consumer<ClientMessage> messageConsumer;
     private Connection connection;
-    private SwCounter counter;
+    private SwCounter normalPacketsRead;
     private ClientMessageDecoder decoder;
 
     @Before
     public void setup() {
         messageConsumer = mock(Consumer.class);
         connection = mock(Connection.class);
-        counter = SwCounter.newSwCounter();
+        normalPacketsRead = SwCounter.newSwCounter();
         connection = mock(Connection.class);
         decoder = new ClientMessageDecoder(connection, messageConsumer);
-        //decoder.setNormalPacketsRead(counter);
+        decoder.setNormalPacketsRead(normalPacketsRead);
     }
 
     @Test
@@ -68,5 +69,6 @@ public class ClientMessageDecoderTest {
         decoder.onRead();
 
         verify(messageConsumer).accept(any(ClientMessage.class));
+        assertEquals(1, normalPacketsRead.get());
     }
 }


### PR DESCRIPTION
fix #15479

no forward port is needed since the bug is resolved on 4.0
due to client protocol changes.