### PR TITLE
Fix possible metrics (de)registration livelock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -290,7 +290,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
             Collections.sort(sorted, COMPARATOR);
             sortedInstances = new SortedProbeInstances(modCountLocal, sorted);
             // if some other thread sorted in the meantime, ignore our sorting
-            this.sortedProbeInstances.compareAndSet(sortedInstancesOld, sortedInstancesOld);
+            this.sortedProbeInstances.compareAndSet(sortedInstancesOld, sortedInstances);
         } else {
             sortedInstances = sortedInstancesOld;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -283,16 +283,19 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     List<ProbeInstance> getSortedProbeInstances() {
         long modCountLocal = modCount.get();
-        SortedProbeInstances sortedProbeInstances = this.sortedProbeInstances.get();
-        if (sortedProbeInstances.mod < modCountLocal) {
+        final SortedProbeInstances sortedInstancesOld = this.sortedProbeInstances.get();
+        final SortedProbeInstances sortedInstances;
+        if (sortedInstancesOld.mod < modCountLocal) {
             List<ProbeInstance> sorted = new ArrayList<>(probeInstances.values());
             Collections.sort(sorted, COMPARATOR);
-            sortedProbeInstances = new SortedProbeInstances(modCountLocal, sorted);
+            sortedInstances = new SortedProbeInstances(modCountLocal, sorted);
             // if some other thread sorted in the meantime, ignore our sorting
-            this.sortedProbeInstances.compareAndSet(sortedProbeInstances, sortedProbeInstances);
+            this.sortedProbeInstances.compareAndSet(sortedInstancesOld, sortedInstancesOld);
+        } else {
+            sortedInstances = sortedInstancesOld;
         }
         // let's use whatever sorted version we have, it's non-null
-        return sortedProbeInstances.probeInstances;
+        return sortedInstances.probeInstances;
     }
 
     private void render(ProbeRenderer renderer, ProbeInstance probeInstance) {

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -98,7 +98,7 @@ if [ -z "$ADDRESS" ]; then
     ADDRESS="127.0.0.1"
 fi
 
-command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit -1; }
+command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit 255; }
 
 URL_BASE="${URL_SCHEME}://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster"
 CURL_CMD="curl $CURL_ARGS"

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -122,7 +122,7 @@ class TestClientRegistry {
             try {
                 HazelcastInstance instance = nodeRegistry.getInstance(address);
                 if (instance == null) {
-                    throw new IOException("Can not connected to " + address + ": instance does not exist");
+                    throw new IOException("Can not connect to " + address + ": instance does not exist");
                 }
                 Address localAddress = new Address(host, ports.incrementAndGet());
                 LockPair lockPair = getLockPair(address);


### PR DESCRIPTION
The `incrementMod` method used a get+CAS in an infinite loop. This is
prone to a livelock when many threads contend to run it. The commit
updates this with incrementing an AtomicInteger which uses the CPU's
fetch-and-add instruction and should not be susceptible to this.

Fixes #15503