### PR TITLE
Builtin DistinctValuesAggregator and MultiAttributeProjection return type fix for non-java clients

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregators.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregators.java
@@ -20,6 +20,7 @@ import com.hazelcast.aggregation.impl.BigDecimalAverageAggregator;
 import com.hazelcast.aggregation.impl.BigDecimalSumAggregator;
 import com.hazelcast.aggregation.impl.BigIntegerAverageAggregator;
 import com.hazelcast.aggregation.impl.BigIntegerSumAggregator;
+import com.hazelcast.aggregation.impl.CanonicalizingHashSet;
 import com.hazelcast.aggregation.impl.CountAggregator;
 import com.hazelcast.aggregation.impl.DistinctValuesAggregator;
 import com.hazelcast.aggregation.impl.DoubleAverageAggregator;
@@ -38,7 +39,6 @@ import com.hazelcast.aggregation.impl.NumberAverageAggregator;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Set;
 
 /**
  * A utility class to create basic {@link com.hazelcast.aggregation.Aggregator} instances.
@@ -95,9 +95,9 @@ public final class Aggregators {
      * @param <R> type of the return object.
      * @return an aggregator that calculates the distinct set of input values.
      * Accepts null input values.
-     * Aggregation result type is a Set of R.
+     * Aggregation result type is a CanonicalizingHashSet of R.
      */
-    public static <I, R> Aggregator<I, Set<R>> distinct() {
+    public static <I, R> Aggregator<I, CanonicalizingHashSet<R>> distinct() {
         return new DistinctValuesAggregator<I, R>();
     }
 
@@ -107,9 +107,9 @@ public final class Aggregators {
      * @param <R> type of the return object.
      * @return an aggregator that calculates the distinct set of input values extracted from the given attributePath.
      * Accepts null input values and null extracted values.
-     * Aggregation result type is a Set of R.
+     * Aggregation result type is a CanonicalizingHashSet of R.
      */
-    public static <I, R> Aggregator<I, Set<R>> distinct(String attributePath) {
+    public static <I, R> Aggregator<I, CanonicalizingHashSet<R>> distinct(String attributePath) {
         return new DistinctValuesAggregator<I, R>(attributePath);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregators.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregators.java
@@ -20,7 +20,6 @@ import com.hazelcast.aggregation.impl.BigDecimalAverageAggregator;
 import com.hazelcast.aggregation.impl.BigDecimalSumAggregator;
 import com.hazelcast.aggregation.impl.BigIntegerAverageAggregator;
 import com.hazelcast.aggregation.impl.BigIntegerSumAggregator;
-import com.hazelcast.aggregation.impl.CanonicalizingHashSet;
 import com.hazelcast.aggregation.impl.CountAggregator;
 import com.hazelcast.aggregation.impl.DistinctValuesAggregator;
 import com.hazelcast.aggregation.impl.DoubleAverageAggregator;
@@ -39,6 +38,7 @@ import com.hazelcast.aggregation.impl.NumberAverageAggregator;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Set;
 
 /**
  * A utility class to create basic {@link com.hazelcast.aggregation.Aggregator} instances.
@@ -95,10 +95,10 @@ public final class Aggregators {
      * @param <R> type of the return object.
      * @return an aggregator that calculates the distinct set of input values.
      * Accepts null input values.
-     * Aggregation result type is a CanonicalizingHashSet of R.
+     * Aggregation result type is a Set of R.
      */
-    public static <I, R> Aggregator<I, CanonicalizingHashSet<R>> distinct() {
-        return new DistinctValuesAggregator<I, R>();
+    public static <I, R> Aggregator<I, Set<R>> distinct() {
+        return new DistinctValuesAggregator<>();
     }
 
     /**
@@ -107,10 +107,10 @@ public final class Aggregators {
      * @param <R> type of the return object.
      * @return an aggregator that calculates the distinct set of input values extracted from the given attributePath.
      * Accepts null input values and null extracted values.
-     * Aggregation result type is a CanonicalizingHashSet of R.
+     * Aggregation result type is a Set of R.
      */
-    public static <I, R> Aggregator<I, CanonicalizingHashSet<R>> distinct(String attributePath) {
-        return new DistinctValuesAggregator<I, R>(attributePath);
+    public static <I, R> Aggregator<I, Set<R>> distinct(String attributePath) {
+        return new DistinctValuesAggregator<>(attributePath);
     }
 
     // ---------------------------------------------------------------------------------------------------------

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -24,7 +24,6 @@ import com.hazelcast.util.MapUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.Set;
 import java.util.Objects;
 import java.util.Set;
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -28,7 +28,8 @@ import java.util.Objects;
 import java.util.Set;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
-public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, R, Set<R>> implements IdentifiedDataSerializable {
+public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, R, CanonicalizingHashSet<R>>
+        implements IdentifiedDataSerializable {
 
     private CanonicalizingHashSet<R> values = new CanonicalizingHashSet<R>();
 
@@ -53,7 +54,7 @@ public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, 
     }
 
     @Override
-    public Set<R> aggregate() {
+    public CanonicalizingHashSet<R> aggregate() {
         return values;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -24,14 +24,16 @@ import com.hazelcast.util.MapUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.Objects;
 import java.util.Set;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
-public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, R, CanonicalizingHashSet<R>>
+public final class DistinctValuesAggregator<I, R>
+        extends AbstractAggregator<I, R, Set<R>>
         implements IdentifiedDataSerializable {
 
-    private CanonicalizingHashSet<R> values = new CanonicalizingHashSet<R>();
+    private CanonicalizingHashSet<R> values = new CanonicalizingHashSet<>();
 
     public DistinctValuesAggregator() {
         super();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayStreamSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+
+import java.io.IOException;
+
+/**
+ * The {@link Object[]} serializer
+ */
+public class ArrayStreamSerializer implements StreamSerializer<Object[]> {
+    @Override
+    public void write(ObjectDataOutput out, Object[] object) throws IOException {
+        out.writeInt(object.length);
+        for (int i = 0; i < object.length; i++) {
+            out.writeObject(object[i]);
+        }
+    }
+
+    @Override
+    public Object[] read(ObjectDataInput in) throws IOException {
+        int length = in.readInt();
+        Object[] objects = new Object[length];
+        for (int i = 0; i < length; i++) {
+            objects[i] = in.readObject();
+        }
+        return objects;
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public int getTypeId() {
+        return SerializationConstants.JAVA_DEFAULT_TYPE_ARRAY;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -79,51 +79,53 @@ public final class SerializationConstants {
     public static final int JAVA_DEFAULT_TYPE_ENUM = -26;
 
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_LIST = -27;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY = -27;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -28;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_LIST = -28;
 
-    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_LIST = -29;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -29;
 
-
-    public static final int JAVA_DEFAULT_TYPE_HASH_MAP = -30;
-
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_MAP = -31;
-
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_HASH_MAP = -32;
-
-    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_MAP = -33;
-
-    public static final int JAVA_DEFAULT_TYPE_TREE_MAP = -34;
+    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_LIST = -30;
 
 
-    public static final int JAVA_DEFAULT_TYPE_HASH_SET = -35;
+    public static final int JAVA_DEFAULT_TYPE_HASH_MAP = -31;
 
-    public static final int JAVA_DEFAULT_TYPE_TREE_SET = -36;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_MAP = -32;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_SET = -37;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_HASH_MAP = -33;
 
-    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_SET = -38;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_MAP = -34;
 
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_SET = -39;
+    public static final int JAVA_DEFAULT_TYPE_TREE_MAP = -35;
 
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_DEQUE = -40;
+    public static final int JAVA_DEFAULT_TYPE_HASH_SET = -36;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_BLOCKING_QUEUE = -41;
+    public static final int JAVA_DEFAULT_TYPE_TREE_SET = -37;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_BLOCKING_QUEUE = -42;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_SET = -38;
 
-    public static final int JAVA_DEFAULT_TYPE_PRIORITY_BLOCKING_QUEUE = -43;
+    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_SET = -39;
 
-    public static final int JAVA_DEFAULT_TYPE_DELAY_QUEUE = -44;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_SET = -40;
 
-    public static final int JAVA_DEFAULT_TYPE_SYNCHRONOUS_QUEUE = -45;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_TRANSFER_QUEUE = -46;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_DEQUE = -41;
+
+    public static final int JAVA_DEFAULT_TYPE_LINKED_BLOCKING_QUEUE = -42;
+
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_BLOCKING_QUEUE = -43;
+
+    public static final int JAVA_DEFAULT_TYPE_PRIORITY_BLOCKING_QUEUE = -44;
+
+    public static final int JAVA_DEFAULT_TYPE_DELAY_QUEUE = -45;
+
+    public static final int JAVA_DEFAULT_TYPE_SYNCHRONOUS_QUEUE = -46;
+
+    public static final int JAVA_DEFAULT_TYPE_LINKED_TRANSFER_QUEUE = -47;
 
     // NUMBER OF CONSTANT SERIALIZERS...
-    public static final int CONSTANT_SERIALIZERS_LENGTH = 47;
+    public static final int CONSTANT_SERIALIZERS_LENGTH = 48;
 
     // ------------------------------------------------------------
     // JAVA SERIALIZATION

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -198,6 +198,8 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         registerConstant(BigDecimal.class, new BigDecimalSerializer());
         registerConstant(Enum.class, new EnumSerializer());
 
+        registerConstant(Object[].class, new ArrayStreamSerializer());
+
         registerConstant(ArrayList.class, new ArrayListStreamSerializer());
         registerConstant(LinkedList.class, new LinkedListStreamSerializer());
         registerConstant(CopyOnWriteArrayList.class, new CopyOnWriteArrayListStreamSerializer());

--- a/hazelcast/src/main/java/com/hazelcast/projection/Projections.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/Projections.java
@@ -20,6 +20,8 @@ import com.hazelcast.projection.impl.IdentityProjection;
 import com.hazelcast.projection.impl.MultiAttributeProjection;
 import com.hazelcast.projection.impl.SingleAttributeProjection;
 
+import java.util.ArrayList;
+
 /**
  * A utility class to create basic {@link com.hazelcast.projection.Projection} instances.
  *

--- a/hazelcast/src/main/java/com/hazelcast/projection/Projections.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/Projections.java
@@ -20,8 +20,6 @@ import com.hazelcast.projection.impl.IdentityProjection;
 import com.hazelcast.projection.impl.MultiAttributeProjection;
 import com.hazelcast.projection.impl.SingleAttributeProjection;
 
-import java.util.ArrayList;
-
 /**
  * A utility class to create basic {@link com.hazelcast.projection.Projection} instances.
  *

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.aggregation.impl.CanonicalizingHashSet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -50,12 +51,12 @@ public class DistinctAggregationTest {
         List<String> values = repeatTimes(3, sampleStrings());
         Set<String> expectation = new HashSet<String>(values);
 
-        Aggregator<Map.Entry<String, String>, Set<String>> aggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> aggregation = Aggregators.distinct();
         for (String value : values) {
             aggregation.accumulate(createEntryWithValue(value));
         }
 
-        Aggregator<Map.Entry<String, String>, Set<String>> resultAggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> resultAggregation = Aggregators.distinct();
         resultAggregation.combine(aggregation);
         Set<String> result = resultAggregation.aggregate();
 
@@ -69,18 +70,17 @@ public class DistinctAggregationTest {
         values.add(null);
         Set<String> expectation = new HashSet<String>(values);
 
-        Aggregator<Map.Entry<String, String>, Set<String>> aggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> aggregation = Aggregators.distinct();
         for (String value : values) {
             aggregation.accumulate(createEntryWithValue(value));
         }
 
-        Aggregator<Map.Entry<String, String>, Set<String>> resultAggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> resultAggregation = Aggregators.distinct();
         resultAggregation.combine(aggregation);
         Set<String> result = resultAggregation.aggregate();
 
         assertThat(result, is(equalTo(expectation)));
     }
-
 
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testCountAggregator_withAttributePath() {
@@ -89,12 +89,12 @@ public class DistinctAggregationTest {
         List<Person> values = repeatTimes(3, Arrays.asList(people));
         Set<Double> expectation = new HashSet<Double>(Arrays.asList(ages));
 
-        Aggregator<Map.Entry<Person, Person>, Set<Double>> aggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> aggregation = Aggregators.distinct("age");
         for (Person value : values) {
             aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
-        Aggregator<Map.Entry<Person, Person>, Set<Double>> resultAggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> resultAggregation = Aggregators.distinct("age");
         resultAggregation.combine(aggregation);
         Set<Double> result = resultAggregation.aggregate();
 
@@ -108,12 +108,12 @@ public class DistinctAggregationTest {
         List<Person> values = repeatTimes(3, Arrays.asList(people));
         Set<Double> expectation = new HashSet<Double>(Arrays.asList(ages));
 
-        Aggregator<Map.Entry<Person, Person>, Set<Double>> aggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> aggregation = Aggregators.distinct("age");
         for (Person value : values) {
             aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
-        Aggregator<Map.Entry<Person, Person>, Set<Double>> resultAggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> resultAggregation = Aggregators.distinct("age");
         resultAggregation.combine(aggregation);
         Set<Double> result = resultAggregation.aggregate();
 

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aggregation;
 
-import com.hazelcast.aggregation.impl.CanonicalizingHashSet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -51,12 +50,12 @@ public class DistinctAggregationTest {
         List<String> values = repeatTimes(3, sampleStrings());
         Set<String> expectation = new HashSet<String>(values);
 
-        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> aggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, Set<String>> aggregation = Aggregators.distinct();
         for (String value : values) {
             aggregation.accumulate(createEntryWithValue(value));
         }
 
-        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> resultAggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, Set<String>> resultAggregation = Aggregators.distinct();
         resultAggregation.combine(aggregation);
         Set<String> result = resultAggregation.aggregate();
 
@@ -70,12 +69,12 @@ public class DistinctAggregationTest {
         values.add(null);
         Set<String> expectation = new HashSet<String>(values);
 
-        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> aggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, Set<String>> aggregation = Aggregators.distinct();
         for (String value : values) {
             aggregation.accumulate(createEntryWithValue(value));
         }
 
-        Aggregator<Map.Entry<String, String>, CanonicalizingHashSet<String>> resultAggregation = Aggregators.distinct();
+        Aggregator<Map.Entry<String, String>, Set<String>> resultAggregation = Aggregators.distinct();
         resultAggregation.combine(aggregation);
         Set<String> result = resultAggregation.aggregate();
 
@@ -89,12 +88,12 @@ public class DistinctAggregationTest {
         List<Person> values = repeatTimes(3, Arrays.asList(people));
         Set<Double> expectation = new HashSet<Double>(Arrays.asList(ages));
 
-        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> aggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, Set<Double>> aggregation = Aggregators.distinct("age");
         for (Person value : values) {
             aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
-        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> resultAggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, Set<Double>> resultAggregation = Aggregators.distinct("age");
         resultAggregation.combine(aggregation);
         Set<Double> result = resultAggregation.aggregate();
 
@@ -108,12 +107,12 @@ public class DistinctAggregationTest {
         List<Person> values = repeatTimes(3, Arrays.asList(people));
         Set<Double> expectation = new HashSet<Double>(Arrays.asList(ages));
 
-        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> aggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, Set<Double>> aggregation = Aggregators.distinct("age");
         for (Person value : values) {
             aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
-        Aggregator<Map.Entry<Person, Person>, CanonicalizingHashSet<Double>> resultAggregation = Aggregators.distinct("age");
+        Aggregator<Map.Entry<Person, Person>, Set<Double>> resultAggregation = Aggregators.distinct("age");
         resultAggregation.combine(aggregation);
         Set<Double> result = resultAggregation.aggregate();
 

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -136,6 +136,16 @@ public class MapProjectionTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void projection_3Nodes_multiAttribute() {
+        IMap<String, Person> map = getMapWithNodeCount(3);
+        populateMapWithPersons(map);
+
+        Collection<Object[]> result = map.project(Projections.multiAttribute("age", "state"));
+
+        assertThat(result, containsInAnyOrder(new Object[]{1.0d, "NY"}, new Object[]{4.0d, "DC"}, new Object[]{7.0d, "OH"}));
+    }
+
+    @Test
     public void projection_1Node_objectValue_withPredicate() {
         IMap<String, Person> map = getMapWithNodeCount(1);
         populateMapWithPersons(map);
@@ -185,14 +195,15 @@ public class MapProjectionTest extends HazelcastTestSupport {
     }
 
     private void populateMapWithPersons(IMap<String, Person> map) {
-        map.put("key1", new Person(1.0d));
-        map.put("key2", new Person(4.0d));
-        map.put("key3", new Person(7.0d));
+        map.put("key1", new Person(1.0d, "NY"));
+        map.put("key2", new Person(4.0d, "DC"));
+        map.put("key3", new Person(7.0d, "OH"));
     }
 
     public static class Person implements DataSerializable {
 
         public double age;
+        public String state;
 
         public Person() {
         }
@@ -201,14 +212,21 @@ public class MapProjectionTest extends HazelcastTestSupport {
             this.age = age;
         }
 
+        public Person(double age, String state) {
+            this.age = age;
+            this.state = state;
+        }
+
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeDouble(age);
+            out.writeUTF(state);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             age = in.readDouble();
+            state = in.readUTF();
         }
     }
 


### PR DESCRIPTION
Fixes the DistinctValuesAggregator return object to be compatible with non-java clients (returns the IdentifiedDataSerializable CanonicalizingHashSet object).

Fixes the MultiAttributeProjection return object array to be compatible with non-java clients. Added a built-in serializer for Object[] so that it can be serialized by Hazelcast serialization and no-need for Java serialization.

fixes https://github.com/hazelcast/hazelcast/issues/10104