### PR TITLE
Add serialization compatibility tests for built-in objects (some marked with BinaryInterface)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.query.impl.getters.MultiResult;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Abstract class providing convenience for concrete implementations of an {@link Aggregator}
@@ -104,4 +105,20 @@ public abstract class AbstractAggregator<I, E, R> extends Aggregator<I, R> {
      */
     protected abstract void accumulateExtracted(I entry, E value);
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractAggregator<?, ?, ?> that = (AbstractAggregator<?, ?, ?>) o;
+        return attributePath.equals(that.attributePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributePath);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Objects;
 
 public final class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, BigDecimal, BigDecimal>
         implements IdentifiedDataSerializable {
@@ -82,5 +83,25 @@ public final class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, 
         this.attributePath = in.readUTF();
         this.sum = in.readObject();
         this.count = in.readLong();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BigDecimalAverageAggregator<?> that = (BigDecimalAverageAggregator<?>) o;
+        return count == that.count && Objects.equals(sum, that.sum);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum, count);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Objects;
 
 public final class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigDecimal, BigDecimal>
         implements IdentifiedDataSerializable {
@@ -75,4 +76,23 @@ public final class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigD
         this.sum = in.readObject();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BigDecimalSumAggregator<?> that = (BigDecimalSumAggregator<?>) o;
+        return Objects.equals(sum, that.sum);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 
 public final class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, BigInteger, BigDecimal>
         implements IdentifiedDataSerializable {
@@ -85,4 +86,23 @@ public final class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, 
         this.count = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BigIntegerAverageAggregator<?> that = (BigIntegerAverageAggregator<?>) o;
+        return count == that.count && Objects.equals(sum, that.sum);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum, count);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class CountAggregator<I> extends AbstractAggregator<I, Object, Long> implements IdentifiedDataSerializable {
     private long count;
@@ -70,5 +71,25 @@ public final class CountAggregator<I> extends AbstractAggregator<I, Object, Long
     public void readData(ObjectDataInput in) throws IOException {
         this.attributePath = in.readUTF();
         this.count = in.readLong();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        CountAggregator<?> that = (CountAggregator<?>) o;
+        return count == that.count;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), count);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -24,6 +24,7 @@ import com.hazelcast.util.MapUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
@@ -86,4 +87,23 @@ public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, 
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DistinctValuesAggregator<?, ?> that = (DistinctValuesAggregator<?, ?>) o;
+        return values.equals(that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), values);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Numbers;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class DoubleAverageAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
@@ -84,4 +85,23 @@ public final class DoubleAverageAggregator<I> extends AbstractAggregator<I, Numb
         this.count = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DoubleAverageAggregator<?> that = (DoubleAverageAggregator<?>) o;
+        return Double.compare(that.sum, sum) == 0 && count == that.count;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum, count);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Numbers;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class DoubleSumAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
@@ -75,4 +76,23 @@ public final class DoubleSumAggregator<I> extends AbstractAggregator<I, Number, 
         this.sum = in.readDouble();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DoubleSumAggregator<?> that = (DoubleSumAggregator<?>) o;
+        return Double.compare(that.sum, sum) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class FixedSumAggregator<I> extends AbstractAggregator<I, Number, Long> implements IdentifiedDataSerializable {
 
@@ -73,4 +74,23 @@ public final class FixedSumAggregator<I> extends AbstractAggregator<I, Number, L
         this.sum = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        FixedSumAggregator<?> that = (FixedSumAggregator<?>) o;
+        return sum == that.sum;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class FloatingPointSumAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
@@ -74,4 +75,23 @@ public final class FloatingPointSumAggregator<I> extends AbstractAggregator<I, N
         this.sum = in.readDouble();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        FloatingPointSumAggregator<?> that = (FloatingPointSumAggregator<?>) o;
+        return Double.compare(that.sum, sum) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Numbers;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class IntegerAverageAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
@@ -84,4 +85,23 @@ public final class IntegerAverageAggregator<I> extends AbstractAggregator<I, Num
         this.count = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        IntegerAverageAggregator<?> that = (IntegerAverageAggregator<?>) o;
+        return sum == that.sum && count == that.count;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum, count);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Numbers;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class IntegerSumAggregator<I> extends AbstractAggregator<I, Number, Long>
         implements IdentifiedDataSerializable {
@@ -75,4 +76,23 @@ public final class IntegerSumAggregator<I> extends AbstractAggregator<I, Number,
         this.sum = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        IntegerSumAggregator<?> that = (IntegerSumAggregator<?>) o;
+        return sum == that.sum;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Numbers;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class LongAverageAggregator<I> extends AbstractAggregator<I, Number, Double> implements IdentifiedDataSerializable {
 
@@ -83,4 +84,23 @@ public final class LongAverageAggregator<I> extends AbstractAggregator<I, Number
         this.count = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        LongAverageAggregator<?> that = (LongAverageAggregator<?>) o;
+        return sum == that.sum && count == that.count;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum, count);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Numbers;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class LongSumAggregator<I> extends AbstractAggregator<I, Number, Long> implements IdentifiedDataSerializable {
 
@@ -74,4 +75,23 @@ public final class LongSumAggregator<I> extends AbstractAggregator<I, Number, Lo
         this.sum = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        LongSumAggregator<?> that = (LongSumAggregator<?>) o;
+        return sum == that.sum;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Comparables;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class MaxAggregator<I, R extends Comparable> extends AbstractAggregator<I, R, R>
         implements IdentifiedDataSerializable {
@@ -88,4 +89,23 @@ public final class MaxAggregator<I, R extends Comparable> extends AbstractAggreg
         this.max = in.readObject();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MaxAggregator<?, ?> that = (MaxAggregator<?, ?>) o;
+        return Objects.equals(max, that.max);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), max);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxByAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxByAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Comparables;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class MaxByAggregator<I> extends AbstractAggregator<I, Comparable, I> implements IdentifiedDataSerializable {
 
@@ -92,4 +93,23 @@ public final class MaxByAggregator<I> extends AbstractAggregator<I, Comparable, 
         this.maxEntry = in.readObject();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MaxByAggregator<?> that = (MaxByAggregator<?>) o;
+        return Objects.equals(maxValue, that.maxValue) && Objects.equals(maxEntry, that.maxEntry);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), maxValue, maxEntry);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Comparables;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class MinAggregator<I, R extends Comparable> extends AbstractAggregator<I, R, R>
         implements IdentifiedDataSerializable {
@@ -88,4 +89,23 @@ public final class MinAggregator<I, R extends Comparable> extends AbstractAggreg
         this.min = in.readObject();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MinAggregator<?, ?> that = (MinAggregator<?, ?>) o;
+        return Objects.equals(min, that.min);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), min);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinByAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinByAggregator.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Comparables;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class MinByAggregator<I> extends AbstractAggregator<I, Comparable, I> implements IdentifiedDataSerializable {
 
@@ -92,4 +93,23 @@ public final class MinByAggregator<I> extends AbstractAggregator<I, Comparable, 
         this.minEntry = in.readObject();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MinByAggregator<?> that = (MinByAggregator<?>) o;
+        return Objects.equals(minValue, that.minValue) && Objects.equals(minEntry, that.minEntry);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), minValue, minEntry);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class NumberAverageAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
@@ -83,4 +84,23 @@ public final class NumberAverageAggregator<I> extends AbstractAggregator<I, Numb
         this.count = in.readLong();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        NumberAverageAggregator<?> that = (NumberAverageAggregator<?>) o;
+        return Double.compare(that.sum, sum) == 0 && count == that.count;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sum, count);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
@@ -23,6 +23,7 @@ import com.hazelcast.projection.Projection;
 import com.hazelcast.query.impl.Extractable;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkHasText;
@@ -87,4 +88,20 @@ public final class MultiAttributeProjection<I> implements Projection<I, Object[]
         this.attributePaths = in.readUTFArray();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MultiAttributeProjection<?> that = (MultiAttributeProjection<?>) o;
+        return Arrays.equals(attributePaths, that.attributePaths);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(attributePaths);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
@@ -23,6 +23,7 @@ import com.hazelcast.projection.Projection;
 import com.hazelcast.query.impl.Extractable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkHasText;
@@ -75,5 +76,22 @@ public final class SingleAttributeProjection<I, O> implements Projection<I, O>, 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         attributePath = in.readUTF();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SingleAttributeProjection<?, ?> that = (SingleAttributeProjection<?, ?>) o;
+        return Objects.equals(attributePath, that.attributePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributePath);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
@@ -16,10 +16,14 @@
 
 package com.hazelcast.nio.serialization.compatibility;
 
+import com.hazelcast.aggregation.Aggregators;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.projection.Projections;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.SampleTestObjects;
 
 import java.io.Externalizable;
 import java.io.Serializable;
@@ -85,6 +89,7 @@ class ReferenceObjects {
     static int anInt = 56789;
     static long aLong = -50992225L;
     static String aString;
+    static String anSqlString = "this > 5 AND this < 100";
 
     static {
         CharBuffer cb = CharBuffer.allocate(Character.MAX_VALUE);
@@ -150,6 +155,8 @@ class ReferenceObjects {
     static Serializable serializable = new AJavaSerialiazable(anInt, aFloat);
     static Externalizable externalizable = new AJavaExternalizable(anInt, aFloat);
 
+    static Comparable<SampleTestObjects.ValueType> aComparable = new SampleTestObjects.ValueType(aString);
+
     static ArrayList nonNullList = new ArrayList(asList(
             aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString, anInnerPortable,
             booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
@@ -210,6 +217,56 @@ class ReferenceObjects {
             serializable, externalizable,
             arrayList, linkedList, copyOnWriteArrayList, concurrentSkipListMap, concurrentHashMap, linkedHashMap, treeMap,
             hashSet, treeSet, linkedHashSet, copyOnWriteArraySet, concurrentSkipListSet, arrayDeque, linkedBlockingQueue,
-            arrayBlockingQueue, priorityBlockingQueue, delayQueue, synchronousQueue, linkedTransferQueue
+            arrayBlockingQueue, priorityBlockingQueue, delayQueue, synchronousQueue, linkedTransferQueue,
+
+            // predicates
+            Predicates.alwaysTrue(),
+            Predicates.alwaysFalse(),
+            Predicates.sql(anSqlString),
+            Predicates.equal(aString, aComparable),
+            Predicates.notEqual(aString, aComparable),
+            Predicates.greaterThan(aString, aComparable),
+            Predicates.between(aString, aComparable, aComparable),
+            Predicates.like(aString, aString),
+            Predicates.ilike(aString, aString),
+            Predicates.in(aString, aComparable, aComparable),
+            Predicates.regex(aString, aString),
+            Predicates.partitionPredicate(aComparable, Predicates.greaterThan(aString, aComparable)),
+            Predicates.and(Predicates.sql(anSqlString),
+                    Predicates.equal(aString, aComparable),
+                    Predicates.notEqual(aString, aComparable),
+                    Predicates.greaterThan(aString, aComparable),
+                    Predicates.greaterEqual(aString, aComparable)),
+            Predicates.or(Predicates.sql(anSqlString),
+                    Predicates.equal(aString, aComparable),
+                    Predicates.notEqual(aString, aComparable),
+                    Predicates.greaterThan(aString, aComparable),
+                    Predicates.greaterEqual(aString, aComparable)),
+            Predicates.instanceOf(aCustomStreamSerializable.getClass()),
+
+            // Aggregators
+            Aggregators.distinct(aString),
+            Aggregators.integerMax(aString),
+            Aggregators.maxBy(aString),
+            Aggregators.comparableMin(aString),
+            Aggregators.minBy(aString),
+            Aggregators.count(aString),
+            Aggregators.numberAvg(aString),
+            Aggregators.integerAvg(aString),
+            Aggregators.longAvg(aString),
+            Aggregators.doubleAvg(aString),
+            Aggregators.bigIntegerAvg(aString),
+            Aggregators.bigDecimalAvg(aString),
+            Aggregators.integerSum(aString),
+            Aggregators.longSum(aString),
+            Aggregators.doubleSum(aString),
+            Aggregators.fixedPointSum(aString),
+            Aggregators.floatingPointSum(aString),
+            Aggregators.bigDecimalSum(aString),
+
+            // projections
+            Projections.singleAttribute(aString),
+            Projections.multiAttribute(aString, aString, anSqlString),
+            Projections.identity()
     };
 }


### PR DESCRIPTION
Serialization compatibility tests for Predicates, Aggregators, Projections, etc. are added. This will fail if the user changes the serialization of any of these unchangeable objects. 