### PR TITLE
Remove deprecated group properties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -31,8 +31,6 @@ import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.security.UsernamePasswordCredentials;
-import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.JsonUtil;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.version.Version;
@@ -364,12 +362,6 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     }
 
     private void handleManagementCenterUrlChange(HttpPostCommand command) throws UnsupportedEncodingException {
-        HazelcastProperties properties = textCommandService.getNode().getProperties();
-        if (! properties.getBoolean(GroupProperty.MC_URL_CHANGE_ENABLED)) {
-            logger.warning("Hazelcast property " + GroupProperty.MC_URL_CHANGE_ENABLED.getName() + " is deprecated.");
-            command.setResponse(HttpCommand.RES_503);
-            return;
-        }
         byte[] res;
         String[] strList = bytesToString(command.getData()).split("&");
         if (authenticate(command, strList[0], strList.length > 1 ? strList[1] : null)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -116,27 +116,15 @@ public class ClusterHeartbeatManager {
         heartbeatIntervalMillis = getHeartbeatInterval(hazelcastProperties);
         legacyIcmpCheckThresholdMillis = heartbeatIntervalMillis * HEART_BEAT_INTERVAL_FACTOR;
 
-        IcmpFailureDetectorConfig icmpFailureDetectorConfig
+        IcmpFailureDetectorConfig icmpConfig
                 = getActiveMemberNetworkConfig(node.config).getIcmpFailureDetectorConfig();
 
-        this.icmpTtl = icmpFailureDetectorConfig == null
-                ? hazelcastProperties.getInteger(GroupProperty.ICMP_TTL)
-                : icmpFailureDetectorConfig.getTtl();
-        this.icmpTimeoutMillis = icmpFailureDetectorConfig == null
-                ? (int) hazelcastProperties.getMillis(GroupProperty.ICMP_TIMEOUT)
-                : icmpFailureDetectorConfig.getTimeoutMilliseconds();
-        this.icmpIntervalMillis = icmpFailureDetectorConfig == null
-                ? (int) hazelcastProperties.getMillis(GroupProperty.ICMP_INTERVAL)
-                : icmpFailureDetectorConfig.getIntervalMilliseconds();
-        this.icmpMaxAttempts = icmpFailureDetectorConfig == null
-                ? hazelcastProperties.getInteger(GroupProperty.ICMP_MAX_ATTEMPTS)
-                : icmpFailureDetectorConfig.getMaxAttempts();
-        this.icmpEnabled = icmpFailureDetectorConfig == null
-                ? hazelcastProperties.getBoolean(GroupProperty.ICMP_ENABLED)
-                : icmpFailureDetectorConfig.isEnabled();
-        this.icmpParallelMode = icmpEnabled && (icmpFailureDetectorConfig == null
-                ? hazelcastProperties.getBoolean(GroupProperty.ICMP_PARALLEL_MODE)
-                : icmpFailureDetectorConfig.isParallelMode());
+        this.icmpTtl = icmpConfig != null ? icmpConfig.getTtl() : 0;
+        this.icmpTimeoutMillis = icmpConfig != null ? icmpConfig.getTimeoutMilliseconds() : 1000;
+        this.icmpIntervalMillis = icmpConfig != null ? icmpConfig.getIntervalMilliseconds() : 1000;
+        this.icmpMaxAttempts = icmpConfig != null ? icmpConfig.getMaxAttempts() : 3;
+        this.icmpEnabled = icmpConfig != null && icmpConfig.isEnabled();
+        this.icmpParallelMode = icmpEnabled && icmpConfig.isParallelMode();
 
         if (icmpTimeoutMillis > icmpIntervalMillis) {
             throw new IllegalStateException("ICMP timeout is set to a value greater than the ICMP interval, "
@@ -148,17 +136,15 @@ public class ClusterHeartbeatManager {
                     + MIN_ICMP_INTERVAL_MILLIS + "ms");
         }
 
-        this.icmpFailureDetector = createIcmpFailureDetectorIfNeeded(hazelcastProperties);
+        this.icmpFailureDetector = createIcmpFailureDetectorIfNeeded();
         heartbeatFailureDetector = createHeartbeatFailureDetector(hazelcastProperties);
     }
 
-    private PingFailureDetector createIcmpFailureDetectorIfNeeded(HazelcastProperties properties) {
+    private PingFailureDetector createIcmpFailureDetectorIfNeeded() {
         IcmpFailureDetectorConfig icmpFailureDetectorConfig
                 = getActiveMemberNetworkConfig(node.config).getIcmpFailureDetectorConfig();
 
-        boolean icmpEchoFailFast = icmpFailureDetectorConfig == null
-                ? properties.getBoolean(GroupProperty.ICMP_ECHO_FAIL_FAST)
-                : icmpFailureDetectorConfig.isFailFastOnStartup();
+        boolean icmpEchoFailFast = icmpFailureDetectorConfig == null || icmpFailureDetectorConfig.isFailFastOnStartup();
 
         if (icmpParallelMode) {
             if (icmpEchoFailFast) {
@@ -306,7 +292,7 @@ public class ClusterHeartbeatManager {
         Address masterAddress = clusterService.getMasterAddress();
         if (masterAddress == null) {
             logger.fine("Cannot send heartbeat complaint for " + senderMembersViewMetadata.getMemberAddress()
-                + ", master address is not set.");
+                    + ", master address is not set.");
             return;
         }
 
@@ -570,7 +556,7 @@ public class ClusterHeartbeatManager {
     }
 
     /**
-     * Pings the {@code member} if {@link GroupProperty#ICMP_ENABLED} is true and more than {@link #HEART_BEAT_INTERVAL_FACTOR}
+     * Pings the {@code member} if ICMP is enabled and more than {@link #HEART_BEAT_INTERVAL_FACTOR}
      * heartbeats have passed.
      */
     private void pingMemberIfRequired(long now, Member member) {
@@ -608,7 +594,9 @@ public class ClusterHeartbeatManager {
                 icmpParallelMode ? new PeriodicPingTask(member) : new PingTask(member));
     }
 
-    /** Send a {@link HeartbeatOp} to the {@code target}
+    /**
+     * Send a {@link HeartbeatOp} to the {@code target}
+     *
      * @param target target Member
      */
     private void sendHeartbeat(Member target) {
@@ -639,13 +627,6 @@ public class ClusterHeartbeatManager {
                 logger.warning("This node does not have a connection to " + member);
             }
         }
-    }
-
-    /**
-     * @return the {@code icmpFailureDetector} if configured, otherwise {@code null}
-     */
-    public PingFailureDetector getIcmpFailureDetector() {
-        return icmpFailureDetector;
     }
 
     /** Reset all heartbeats to the current cluster time. Called when system clock jump is detected. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -76,6 +76,8 @@ public class ClusterHeartbeatManager {
     private static final int HEART_BEAT_INTERVAL_FACTOR = 10;
     private static final int MAX_PING_RETRY_COUNT = 5;
     private static final long MIN_ICMP_INTERVAL_MILLIS = SECONDS.toMillis(1);
+    private static final int DEFAULT_ICMP_TIMEOUT_MILLIS = 1000;
+    private static final int DEFAULT_ICMP_INTERVAL_MILLIS = 1000;
 
     private final ILogger logger;
     private final Lock clusterServiceLock;
@@ -120,8 +122,8 @@ public class ClusterHeartbeatManager {
                 = getActiveMemberNetworkConfig(node.config).getIcmpFailureDetectorConfig();
 
         this.icmpTtl = icmpConfig != null ? icmpConfig.getTtl() : 0;
-        this.icmpTimeoutMillis = icmpConfig != null ? icmpConfig.getTimeoutMilliseconds() : 1000;
-        this.icmpIntervalMillis = icmpConfig != null ? icmpConfig.getIntervalMilliseconds() : 1000;
+        this.icmpTimeoutMillis = icmpConfig != null ? icmpConfig.getTimeoutMilliseconds() : DEFAULT_ICMP_TIMEOUT_MILLIS;
+        this.icmpIntervalMillis = icmpConfig != null ? icmpConfig.getIntervalMilliseconds() : DEFAULT_ICMP_INTERVAL_MILLIS;
         this.icmpMaxAttempts = icmpConfig != null ? icmpConfig.getMaxAttempts() : 3;
         this.icmpEnabled = icmpConfig != null && icmpConfig.isEnabled();
         this.icmpParallelMode = icmpEnabled && icmpConfig.isParallelMode();

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -45,18 +45,22 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public final class GroupProperty {
 
     /**
-     * Use this property to verify that Hazelcast nodes only join the cluster when their 'application' level configuration is the
-     * same.
+     * Use this property to verify that Hazelcast nodes only join the cluster
+     * when their 'application' level configuration is the same.
      * <p>
-     * If you have multiple machines, you want to make sure that each machine that joins the cluster
-     * has exactly the same 'application level' settings (such as settings that are not part of the Hazelcast configuration,
-     * maybe some file path). To prevent the machines with potentially different application level configuration from forming
-     * a cluster, you can set this property.
+     * If you have multiple machines, you want to make sure that each machine
+     * that joins the cluster has exactly the same 'application level' settings
+     * (such as settings that are not part of the Hazelcast configuration, maybe
+     * some file path). To prevent the machines with potentially different
+     * application level configuration from forming a cluster, you can set this
+     * property.
      * <p>
-     * You could use actual values, such as string paths, but you can also use an md5 hash. We make a guarantee
-     * that nodes will form a cluster (become a member) only if the token is an exact match. If this token is different, the
-     * member can't be started and therefore you will get the guarantee that all members in the cluster will have exactly the same
-     * application validation token.
+     * You could use actual values, such as string paths, but you can also use
+     * an md5 hash. We make a guarantee that nodes will form a cluster (become a
+     * member) only if the token is an exact match. If this token is different,
+     * the member can't be started and therefore you will get the guarantee that
+     * all members in the cluster will have exactly the same application validation
+     * token.
      * <p>
      * This validation token will be checked before a member joins the cluster.
      */
@@ -72,18 +76,22 @@ public final class GroupProperty {
     /**
      * For more detail see {@link #PARTITION_OPERATION_THREAD_COUNT}.
      *
-     * If this property is set to false, Hazelcast will default to 3.x style operation thread configuration
-     * whereby the sum of the number of partition threads and IO threads exceeds the number of cores.
+     * If this property is set to false, Hazelcast will default to 3.x style
+     * operation thread configuration whereby the sum of the number of partition
+     * threads and IO threads exceeds the number of cores.
      *
-     * If this property is set to true (default) Hazelcast will subtract the number of IO threads from the number
-     * of available processors and that will be the number of partition threads.
+     * If this property is set to true (default) Hazelcast will subtract the
+     * number of IO threads from the number of available processors and that will
+     * be the number of partition threads.
      *
-     * If explicit number of partition threads is configured, this property is irrelevant.
+     * If explicit number of partition threads is configured, this property is
+     * irrelevant.
      *
-     * This property favors the typical get/set type of application. Application that are number crunching or query
-     * heavy, will get a performance hit because not all cores will be busy with processing operations since there
-     * are less operation threads than processors. So for such applications it is best to explicitly disable this
-     * property.
+     * This property favors the typical get/set type of application. Application
+     * that are number crunching or query heavy, will get a performance hit
+     * because not all cores will be busy with processing operations since there
+     * are less operation threads than processors. So for such applications it
+     * is best to explicitly disable this property.
      */
     public static final HazelcastProperty PARTITION_OPERATION_THREAD_ISOLATED
             = new HazelcastProperty("hazelcast.operation.thread.isolated", new Function<HazelcastProperties, Boolean>() {
@@ -270,12 +278,8 @@ public final class GroupProperty {
      * smaller than 20, there will be 3+3 io threads, otherwise 4+4.
      */
     public static final HazelcastProperty IO_THREAD_COUNT
-            = new HazelcastProperty("hazelcast.io.thread.count", new Function<HazelcastProperties, Integer>() {
-        @Override
-        public Integer apply(HazelcastProperties properties) {
-            return Runtime.getRuntime().availableProcessors() >= 20 ? 4 : 3;
-        }
-    });
+            = new HazelcastProperty("hazelcast.io.thread.count",
+            properties -> Runtime.getRuntime().availableProcessors() >= 20 ? 4 : 3);
 
     /**
      * Controls the number of socket input threads. By default it is the same as {@link #IO_THREAD_COUNT}.
@@ -329,10 +333,6 @@ public final class GroupProperty {
     @SuppressWarnings("checkstyle:constantname")
     public static final HazelcastProperty PREFER_IPv4_STACK
             = new HazelcastProperty("hazelcast.prefer.ipv4.stack", true);
-
-    @Deprecated
-    public static final HazelcastProperty VERSION_CHECK_ENABLED
-            = new HazelcastProperty("hazelcast.version.check.enabled", true);
 
     public static final HazelcastProperty PHONE_HOME_ENABLED
             = new HazelcastProperty("hazelcast.phone.home.enabled", true);
@@ -553,79 +553,6 @@ public final class GroupProperty {
     public static final HazelcastProperty CLUSTER_SHUTDOWN_TIMEOUT_SECONDS
             = new HazelcastProperty("hazelcast.cluster.shutdown.timeout.seconds", 900, SECONDS);
 
-    /**
-     * If a member should be pinged when a sufficient amount of heartbeats have passed and the member has not sent any
-     * heartbeats. If the member is not reachable, it will be removed.
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_ENABLED
-            = new HazelcastProperty("hazelcast.icmp.enabled", false);
-
-    /**
-     * Run ICMP detection in parallel with the Heartbeat failure detector.
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_PARALLEL_MODE
-            = new HazelcastProperty("hazelcast.icmp.parallel.mode", true);
-
-    /**
-     * Enforce ICMP Echo Request mode for ping-detector. If OS is not supported,
-     * or not configured correctly as per reference-manual, hazelcast will fail to start.
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_ECHO_FAIL_FAST
-            = new HazelcastProperty("hazelcast.icmp.echo.fail.fast.on.startup", true);
-
-    /**
-     * Ping timeout in milliseconds. This cannot be more than the interval value. Should always be smaller.
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_TIMEOUT
-            = new HazelcastProperty("hazelcast.icmp.timeout", 1000, MILLISECONDS);
-
-    /**
-     * Interval between ping attempts in milliseconds. Default and min allowed, 1 second.
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_INTERVAL
-            = new HazelcastProperty("hazelcast.icmp.interval", 1000, MILLISECONDS);
-
-    /**
-     * Max ping attempts before suspecting a member
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_MAX_ATTEMPTS
-            = new HazelcastProperty("hazelcast.icmp.max.attempts", 3);
-
-    /**
-     * Ping TTL, the maximum number of hops the packets should go through or 0 for the default.
-     * Zero in this case means unlimited hops.
-     *
-     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
-     * This will be removed in future versions. Until this is done,
-     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
-     */
-    public static final HazelcastProperty ICMP_TTL
-            = new HazelcastProperty("hazelcast.icmp.ttl", 0);
-
     public static final HazelcastProperty INITIAL_MIN_CLUSTER_SIZE
             = new HazelcastProperty("hazelcast.initial.min.cluster.size", 0);
     public static final HazelcastProperty INITIAL_WAIT_SECONDS
@@ -686,13 +613,6 @@ public final class GroupProperty {
 
     public static final HazelcastProperty MC_MAX_VISIBLE_SLOW_OPERATION_COUNT
             = new HazelcastProperty("hazelcast.mc.max.visible.slow.operations.count", 10);
-    /**
-     * @deprecated Enable or disable the {@link com.hazelcast.config.RestEndpointGroup#CLUSTER_WRITE} group in
-     * {@link com.hazelcast.config.RestApiConfig} instead.
-     */
-    @Deprecated
-    public static final HazelcastProperty MC_URL_CHANGE_ENABLED
-            = new HazelcastProperty("hazelcast.mc.url.change.enabled", true);
 
     public static final HazelcastProperty CONNECTION_MONITOR_INTERVAL
             = new HazelcastProperty("hazelcast.connection.monitor.interval", 100, MILLISECONDS);
@@ -763,13 +683,6 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED
             = new HazelcastProperty("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false);
-
-    /**
-     * Property isn't used anymore.
-     */
-    @Deprecated
-    public static final HazelcastProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
-            = new HazelcastProperty("hazelcast.slow.invocation.detector.threshold.millis", -1, MILLISECONDS);
 
     public static final HazelcastProperty LOCK_MAX_LEASE_TIME_SECONDS
             = new HazelcastProperty("hazelcast.lock.max.lease.time.seconds", Long.MAX_VALUE, SECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -93,7 +93,8 @@ public class PhoneHome {
         }
         try {
             phoneHomeFuture = hazelcastNode.nodeEngine.getExecutionService()
-                                                      .scheduleWithRepetition("PhoneHome", () -> phoneHome(hazelcastNode, false), 0, 1, TimeUnit.DAYS);
+                                                      .scheduleWithRepetition("PhoneHome",
+                                                              () -> phoneHome(hazelcastNode, false), 0, 1, TimeUnit.DAYS);
         } catch (RejectedExecutionException e) {
             logger.warning("Could not schedule phone home task! Most probably Hazelcast failed to start.");
         }

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -16,16 +16,16 @@
 
 package com.hazelcast.util;
 
-import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.client.ClientType;
+import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
-import com.hazelcast.internal.management.ManagementCenterConnectionFactory;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.ManagementCenterConnectionFactory;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.GroupProperty;
 
@@ -41,6 +41,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -83,13 +84,7 @@ public class PhoneHome {
         logger = hazelcastNode.getLogger(PhoneHome.class);
     }
 
-    @SuppressWarnings("deprecation")
     public void check(final Node hazelcastNode) {
-        if (!hazelcastNode.getProperties().getBoolean(GroupProperty.VERSION_CHECK_ENABLED)) {
-            logger.warning(GroupProperty.VERSION_CHECK_ENABLED.getName() + " property is deprecated. Please use "
-                    + GroupProperty.PHONE_HOME_ENABLED.getName() + " instead to disable phone home.");
-            return;
-        }
         if (!hazelcastNode.getProperties().getBoolean(GroupProperty.PHONE_HOME_ENABLED)) {
             return;
         }
@@ -98,11 +93,7 @@ public class PhoneHome {
         }
         try {
             phoneHomeFuture = hazelcastNode.nodeEngine.getExecutionService()
-                    .scheduleWithRepetition("PhoneHome", new Runnable() {
-                        public void run() {
-                            phoneHome(hazelcastNode, false);
-                        }
-                    }, 0, 1, TimeUnit.DAYS);
+                                                      .scheduleWithRepetition("PhoneHome", () -> phoneHome(hazelcastNode, false), 0, 1, TimeUnit.DAYS);
         } catch (RejectedExecutionException e) {
             logger.warning("Could not schedule phone home task! Most probably Hazelcast failed to start.");
         }
@@ -144,7 +135,8 @@ public class PhoneHome {
      * Performs a phone request for {@code node} and returns the generated request
      * parameters. If {@code pretend} is {@code true}, only returns the parameters
      * without actually performing the request.
-     * @param node the node for which to make the phone home request
+     *
+     * @param node    the node for which to make the phone home request
      * @param pretend if {@code true}, do not perform the request
      * @return the generated request parameters
      */
@@ -280,7 +272,7 @@ public class PhoneHome {
             inputStream = connection.getInputStream();
             responseCode = connection.getResponseCode();
 
-            reader = new InputStreamReader(inputStream, "UTF-8");
+            reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
             JsonObject mcPhoneHomeInfoJson = Json.parse(reader).asObject();
             version = getString(mcPhoneHomeInfoJson, "mcVersion");
             license = getString(mcPhoneHomeInfoJson, "mcLicense", null);
@@ -322,7 +314,7 @@ public class PhoneHome {
     public static class PhoneHomeParameterCreator {
 
         private final StringBuilder builder;
-        private final Map<String, String> parameters = new HashMap<String, String>();
+        private final Map<String, String> parameters = new HashMap<>();
         private boolean hasParameterBefore;
 
         public PhoneHomeParameterCreator() {

--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -105,20 +105,6 @@ public class PhoneHomeTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    public void testScheduling_whenVersionCheckIsDisabled() {
-        Config config = new Config()
-                .setProperty(GroupProperty.VERSION_CHECK_ENABLED.getName(), "false");
-
-        HazelcastInstance hz = createHazelcastInstance(config);
-        Node node = getNode(hz);
-
-        PhoneHome phoneHome = new PhoneHome(node);
-        phoneHome.check(node);
-        assertNull(phoneHome.phoneHomeFuture);
-    }
-
-    @Test
     public void testScheduling_whenPhoneHomeIsDisabled() {
         Config config = new Config()
                 .setProperty(GroupProperty.PHONE_HOME_ENABLED.getName(), "false");


### PR DESCRIPTION
Removed some deprecated group properties, left some others which might
be more useful when deploying via docker & k8s.

Also fixed some warnings and rearranged some javadoc.