### PR TITLE
Assume execution on JDK<=11 for tests that use Whitebox.setInternalState

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTaskTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.codec.ClientCreateProxyCodec;
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -35,8 +36,10 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +54,7 @@ public class AbstractMessageTaskTest {
 
     @Before
     public void setup() {
+        assumeTrue("This test uses PowerMock Whitebox.setInternalState which fails in JDK >= 12", JavaVersion.isAtMost(JAVA_11));
         Node node = mock(Node.class);
         when(node.getConfig()).thenReturn(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -34,11 +35,13 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Random;
 
+import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -59,6 +62,7 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
     @Before
     public void before() throws Exception {
+        assumeTrue("This test uses PowerMock Whitebox.setInternalState which fails in JDK >= 12", JavaVersion.isAtMost(JAVA_11));
         byteOrder = BIG_ENDIAN;
         mockSerializationService = mock(InternalSerializationService.class);
         when(mockSerializationService.getByteOrder()).thenReturn(byteOrder);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
@@ -39,9 +40,11 @@ import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -67,6 +70,7 @@ public class ParallelPartitionScanExecutorTest {
 
     @Test
     public void execute_success() {
+        assumeTrue("This test uses PowerMock Whitebox.setInternalState which fails in JDK >= 12", JavaVersion.isAtMost(JAVA_11));
         IPartitionService partitionService = mock(IPartitionService.class);
         when(partitionService.getPartitionCount()).thenReturn(271);
         PartitionScanRunner runner = mock(PartitionScanRunner.class);


### PR DESCRIPTION
Since JDK 12, reflective access to `java.lang.reflect.Field.modifiers` is disallowed,
failing tests that use `Whitebox.setInternalState`. These tests will be
still executed in jobs running on JDK 8-11.

Fixes #15459 