### PR TITLE
#15523 Fix exposure of operationExecutorQueueSize JMX attribute

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
@@ -52,7 +52,7 @@ public class OperationServiceMBean extends HazelcastMBean<InternalOperationServi
 
     @ManagedAnnotation("operationExecutorQueueSize")
     @ManagedDescription("The size of the operation executor queue")
-    int getOperationExecutorQueueSize() {
+    public int getOperationExecutorQueueSize() {
         return managedObject.getOperationExecutorQueueSize();
     }
 


### PR DESCRIPTION
Adds a `public` modifier to `OperationServiceMBean#getOperationExecutorQueueSize`, in common with the other attributes in this class, to fix JMX exposure.