### PR TITLE
Executor service message task should not block the partition thread

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -425,7 +425,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         ClientMessage request =
                 ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, toData(task), partitionId);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
-        return checkSync(f, uuid, partitionId, preventSync, defaultValue);
+        return checkSync(f, uuid, preventSync, defaultValue);
     }
 
     private <T> void submitToKeyOwnerInternal(Callable<T> task, Object key, ExecutionCallback<T> callback) {
@@ -449,7 +449,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         ClientMessage request =
                 ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, toData(task), partitionId);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
-        return checkSync(f, uuid, partitionId, preventSync, defaultValue);
+        return checkSync(f, uuid, preventSync, defaultValue);
     }
 
     private <T> void submitToRandomInternal(Callable<T> task, ExecutionCallback<T> callback) {
@@ -472,7 +472,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         String uuid = getUUID();
         ClientMessage request = ExecutorServiceSubmitToAddressCodec.encodeRequest(name, uuid, taskData, address);
         ClientInvocationFuture f = invokeOnTarget(request, address);
-        return checkSync(f, uuid, address, preventSync, defaultValue);
+        return checkSync(f, uuid, preventSync, defaultValue);
     }
 
     private <T> void submitToTargetInternal(Data taskData, Address address, ExecutionCallback<T> callback) {
@@ -490,8 +490,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return "IExecutorService{" + "name='" + name + '\'' + '}';
     }
 
-    private <T> Future<T> checkSync(ClientInvocationFuture f, String uuid, Address address,
-                                    boolean preventSync, T defaultValue) {
+    private <T> Future<T> checkSync(ClientInvocationFuture f, String uuid, boolean preventSync, T defaultValue) {
         boolean sync = isSyncComputation(preventSync);
         if (sync) {
             Object response = retrieveResultFromMessage(f);
@@ -499,20 +498,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
             return new CompletedFuture<T>(getSerializationService(), response, userExecutor);
         } else {
             return new IExecutorDelegatingFuture<T>(f, getContext(), uuid, defaultValue,
-                    SUBMIT_TO_ADDRESS_DECODER, name, address);
-        }
-    }
-
-    private <T> Future<T> checkSync(ClientInvocationFuture f, String uuid, int partitionId,
-                                    boolean preventSync, T defaultValue) {
-        boolean sync = isSyncComputation(preventSync);
-        if (sync) {
-            Object response = retrieveResultFromMessage(f);
-            Executor userExecutor = getContext().getExecutionService().getUserExecutor();
-            return new CompletedFuture<T>(getSerializationService(), response, userExecutor);
-        } else {
-            return new IExecutorDelegatingFuture<T>(f, getContext(), uuid, defaultValue,
-                    SUBMIT_TO_PARTITION_DECODER, name, partitionId);
+                    SUBMIT_TO_ADDRESS_DECODER, name);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
@@ -44,31 +44,15 @@ public final class IExecutorDelegatingFuture<V> extends ClientDelegatingFuture<V
 
     private final ClientContext context;
     private final String uuid;
-    private final Address target;
-    private final int partitionId;
     private final String objectName;
 
     IExecutorDelegatingFuture(ClientInvocationFuture future, ClientContext context,
                               String uuid, V defaultValue,
-                              ClientMessageDecoder resultDecoder, String objectName, Address address) {
+                              ClientMessageDecoder resultDecoder, String objectName) {
         super(future, context.getSerializationService(), resultDecoder, defaultValue);
         this.context = context;
         this.uuid = uuid;
-        this.partitionId = -1;
         this.objectName = objectName;
-        this.target = address;
-    }
-
-    IExecutorDelegatingFuture(ClientInvocationFuture future, ClientContext context,
-                              String uuid, V defaultValue,
-                              ClientMessageDecoder resultDecoder, String objectName, int partitionId) {
-        super(future, context.getSerializationService(), resultDecoder, defaultValue);
-        this.context = context;
-        this.uuid = uuid;
-        this.partitionId = partitionId;
-        this.objectName = objectName;
-        this.target = null;
-
     }
 
     @Override
@@ -93,19 +77,13 @@ public final class IExecutorDelegatingFuture<V> extends ClientDelegatingFuture<V
     private boolean invokeCancelRequest(boolean mayInterruptIfRunning) throws InterruptedException, ExecutionException {
         waitForRequestToBeSend();
 
+        Address target = getFuture().getInvocation().getSendConnection().getEndPoint();
+
         HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
-        if (partitionId > -1) {
-            ClientMessage request =
-                    ExecutorServiceCancelOnPartitionCodec.encodeRequest(uuid, partitionId, mayInterruptIfRunning);
-            ClientInvocation clientInvocation = new ClientInvocation(client, request, objectName, partitionId);
-            ClientInvocationFuture f = clientInvocation.invoke();
-            return ExecutorServiceCancelOnPartitionCodec.decodeResponse(f.get()).response;
-        } else {
-            ClientMessage request = ExecutorServiceCancelOnAddressCodec.encodeRequest(uuid, target, mayInterruptIfRunning);
-            ClientInvocation clientInvocation = new ClientInvocation(client, request, objectName, target);
-            ClientInvocationFuture f = clientInvocation.invoke();
-            return ExecutorServiceCancelOnAddressCodec.decodeResponse(f.get()).response;
-        }
+        ClientMessage request = ExecutorServiceCancelOnAddressCodec.encodeRequest(uuid, target, mayInterruptIfRunning);
+        ClientInvocation clientInvocation = new ClientInvocation(client, request, objectName, target);
+        ClientInvocationFuture f = clientInvocation.invoke();
+        return ExecutorServiceCancelOnAddressCodec.decodeResponse(f.get()).response;
     }
 
     private void waitForRequestToBeSend() throws InterruptedException {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/AbstractExecutorServiceCancelMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/AbstractExecutorServiceCancelMessageTask.java
@@ -21,58 +21,21 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.instance.Node;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.InternalCompletableFuture;
-import com.hazelcast.spi.InvocationBuilder;
 
-import java.net.UnknownHostException;
 import java.security.Permission;
-import java.util.concurrent.ExecutionException;
-
-import static java.lang.Thread.currentThread;
 
 public abstract class AbstractExecutorServiceCancelMessageTask<P> extends AbstractCallableMessageTask<P>
         implements BlockingMessageTask {
-
-    private static final int CANCEL_TRY_COUNT = 50;
-    private static final int CANCEL_TRY_PAUSE_MILLIS = 250;
 
     public AbstractExecutorServiceCancelMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
-        InvocationBuilder builder = createInvocationBuilder();
-        builder.setTryCount(CANCEL_TRY_COUNT).setTryPauseMillis(CANCEL_TRY_PAUSE_MILLIS);
-        InternalCompletableFuture future = builder.invoke();
-        boolean result = false;
-        try {
-            result = (Boolean) future.get();
-        } catch (InterruptedException e) {
-            currentThread().interrupt();
-            logException(e);
-        } catch (ExecutionException e) {
-            logException(e);
-        }
-        return result;
-    }
-
-
-    protected abstract InvocationBuilder createInvocationBuilder() throws UnknownHostException;
-
-    private void logException(Exception e) {
-        ILogger logger = nodeEngine.getLogger(AbstractExecutorServiceCancelMessageTask.class);
-        logger.warning(e);
-    }
-
-
-    @Override
     public String getServiceName() {
         return DistributedExecutorService.SERVICE_NAME;
     }
-
 
     @Override
     public Permission getRequiredPermission() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
@@ -19,13 +19,8 @@ package com.hazelcast.client.impl.protocol.task.executorservice;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceCancelOnAddressCodec;
 import com.hazelcast.executor.impl.DistributedExecutorService;
-import com.hazelcast.executor.impl.operations.CancellationOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.InvocationBuilder;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-
-import java.net.UnknownHostException;
 
 public class ExecutorServiceCancelOnAddressMessageTask
         extends AbstractExecutorServiceCancelMessageTask<ExecutorServiceCancelOnAddressCodec.RequestParameters> {
@@ -35,13 +30,10 @@ public class ExecutorServiceCancelOnAddressMessageTask
     }
 
     @Override
-    protected InvocationBuilder createInvocationBuilder() throws UnknownHostException {
-        final InternalOperationService operationService = nodeEngine.getOperationService();
-        final String serviceName = DistributedExecutorService.SERVICE_NAME;
-        CancellationOperation op = new CancellationOperation(parameters.uuid, parameters.interrupt);
-        return operationService.createInvocationBuilder(serviceName, op, parameters.address);
+    protected Object call() throws Exception {
+        DistributedExecutorService service = getService(getServiceName());
+        return service.cancel(parameters.uuid, parameters.interrupt);
     }
-
 
     @Override
     protected ExecutorServiceCancelOnAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnPartitionMessageTask.java
@@ -19,13 +19,8 @@ package com.hazelcast.client.impl.protocol.task.executorservice;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceCancelOnPartitionCodec;
 import com.hazelcast.executor.impl.DistributedExecutorService;
-import com.hazelcast.executor.impl.operations.CancellationOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.InvocationBuilder;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-
-import java.net.UnknownHostException;
 
 public class ExecutorServiceCancelOnPartitionMessageTask
         extends AbstractExecutorServiceCancelMessageTask<ExecutorServiceCancelOnPartitionCodec.RequestParameters> {
@@ -35,11 +30,9 @@ public class ExecutorServiceCancelOnPartitionMessageTask
     }
 
     @Override
-    protected InvocationBuilder createInvocationBuilder() throws UnknownHostException {
-        final InternalOperationService operationService = nodeEngine.getOperationService();
-        final String serviceName = DistributedExecutorService.SERVICE_NAME;
-        CancellationOperation op = new CancellationOperation(parameters.uuid, parameters.interrupt);
-        return operationService.createInvocationBuilder(serviceName, op, parameters.partitionId);
+    protected Object call() throws Exception {
+        DistributedExecutorService service = getService(getServiceName());
+        return service.cancel(parameters.uuid, parameters.interrupt);
     }
 
     @Override


### PR DESCRIPTION
Added a new test which verifies that executor service cancel operation does not block the partition thread.
    
Solution:
    1. The executor service cancel task uses the client invoked member to cancel the ongoing task.
    
    2. The executor cancel cancel task now works in the blocking executor (for both partition and address based requests).

fixes https://github.com/hazelcast/hazelcast/issues/15497
