### PR TITLE
Fix NPE NioNetworking shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -281,14 +281,10 @@ public final class NioNetworking implements Networking {
 
         NioInboundPipeline inboundPipeline = newInboundPipeline(channel);
         NioOutboundPipeline outboundPipeline = newOutboundPipeline(channel);
-
-        channels.add(channel);
-
         channel.init(inboundPipeline, outboundPipeline);
-
         ioBalancer.channelAdded(inboundPipeline, outboundPipeline);
-
         channel.addCloseListener(channelCloseListener);
+        channels.add(channel);
         return channel;
     }
 


### PR DESCRIPTION
Fix #15460

The cause was that the channel was added to the channels-set before
it was fully constructed.