### PR TITLE
Fixes HazelcastManifestTransformerTest interactions expected for JDK 13+

### DIFF
--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.buildutils;
 
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -96,6 +97,9 @@ public class HazelcastManifestTransformerTest {
         verify(os).putNextEntry(any(JarEntry.class));
         verify(os, atLeastOnce()).write(anyInt());
         verify(os, atLeastOnce()).flush();
+        if (JavaVersion.isAtLeast(JavaVersion.JAVA_13)) {
+            verify(os, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
+        }
         verifyNoMoreInteractions(os);
     }
 }


### PR DESCRIPTION
Implementation of `java.util.jar.Attributes.writeMain` changed in JDK 13
resulting in additional `JarOutputStream.write` invocations

Fixes #15535 