### PR TITLE
Renamed MapAttributeConfig and it's "extractor" field (#15547)

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -55,7 +55,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.MCMutualAuthConfig;
 import com.hazelcast.config.ManagementCenterConfig;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
@@ -1302,11 +1302,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 } else if ("attributes".equals(nodeName)) {
                     ManagedList<BeanDefinition> attributes = new ManagedList<BeanDefinition>();
                     for (Node attributeNode : childElements(childNode)) {
-                        BeanDefinitionBuilder attributeConfBuilder = createBeanBuilder(MapAttributeConfig.class);
+                        BeanDefinitionBuilder attributeConfBuilder = createBeanBuilder(AttributeConfig.class);
                         fillAttributeValues(attributeNode, attributeConfBuilder);
                         attributes.add(attributeConfBuilder.getBeanDefinition());
                     }
-                    mapConfigBuilder.addPropertyValue("mapAttributeConfigs", attributes);
+                    mapConfigBuilder.addPropertyValue("attributeConfigs", attributes);
                 } else if ("entry-listeners".equals(nodeName)) {
                     ManagedList listeners = parseListeners(childNode, EntryListenerConfig.class);
                     mapConfigBuilder.addPropertyValue("entryListenerConfigs", listeners);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -624,7 +624,7 @@
                                                 <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded">
                                                     <xs:complexType>
                                                         <xs:attribute name="name" type="xs:string" use="required"/>
-                                                        <xs:attribute name="extractor" type="xs:string" use="required"/>
+                                                        <xs:attribute name="extractor-class-name" type="xs:string" use="required"/>
                                                     </xs:complexType>
                                                 </xs:element>
                                             </xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -59,7 +59,7 @@ import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
@@ -345,12 +345,12 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
                 fail("unknown index!");
             }
         }
-        assertEquals(2, testMapConfig.getMapAttributeConfigs().size());
-        for (MapAttributeConfig attribute : testMapConfig.getMapAttributeConfigs()) {
+        assertEquals(2, testMapConfig.getAttributeConfigs().size());
+        for (AttributeConfig attribute : testMapConfig.getAttributeConfigs()) {
             if ("power".equals(attribute.getName())) {
-                assertEquals("com.car.PowerExtractor", attribute.getExtractor());
+                assertEquals("com.car.PowerExtractor", attribute.getExtractorClassName());
             } else if ("weight".equals(attribute.getName())) {
-                assertEquals("com.car.WeightExtractor", attribute.getExtractor());
+                assertEquals("com.car.WeightExtractor", attribute.getExtractorClassName());
             } else {
                 fail("unknown attribute!");
             }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -394,8 +394,8 @@
                     <hz:index attribute="age" ordered="true"/>
                 </hz:indexes>
                 <hz:attributes>
-                    <hz:attribute name="power" extractor="com.car.PowerExtractor"/>
-                    <hz:attribute name="weight" extractor="com.car.WeightExtractor"/>
+                    <hz:attribute name="power" extractor-class-name="com.car.PowerExtractor"/>
+                    <hz:attribute name="weight" extractor-class-name="com.car.WeightExtractor"/>
                 </hz:attributes>
                 <hz:split-brain-protection-ref>my-split-brain-protection</hz:split-brain-protection-ref>
                 <hz:merge-policy batch-size="2342">PassThroughMergePolicy</hz:merge-policy>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -149,7 +149,7 @@ public class ClientDynamicClusterConfig extends Config {
                 mapConfig.getMaxSizeConfig().getMaxSizePolicy().name(), mapConfig.getMaxSizeConfig().getSize(),
                 MapStoreConfigHolder.of(mapConfig.getMapStoreConfig(), serializationService),
                 NearCacheConfigHolder.of(mapConfig.getNearCacheConfig(), serializationService),
-                mapConfig.getWanReplicationRef(), mapConfig.getMapIndexConfigs(), mapConfig.getMapAttributeConfigs(),
+                mapConfig.getWanReplicationRef(), mapConfig.getMapIndexConfigs(), mapConfig.getAttributeConfigs(),
                 queryCacheConfigHolders, partitioningStrategyClassName, partitioningStrategy, mapConfig.getHotRestartConfig(),
                 mapConfig.getEventJournalConfig(), mapConfig.getMerkleTreeConfig(),
                 mapConfig.getMergePolicyConfig().getBatchSize(), mapConfig.getMetadataPolicy().getId());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMapConfigCodec.java
@@ -175,7 +175,7 @@ public final class DynamicConfigAddMapConfigCodec {
         /**
          * map attributes
          */
-        public java.util.List<com.hazelcast.config.MapAttributeConfig> mapAttributeConfigs;
+        public java.util.List<com.hazelcast.config.AttributeConfig> attributeConfigs;
 
         /**
          * configurations for query caches on this map
@@ -220,7 +220,7 @@ public final class DynamicConfigAddMapConfigCodec {
         public int metadataPolicy;
     }
 
-    public static ClientMessage encodeRequest(java.lang.String name, int backupCount, int asyncBackupCount, int timeToLiveSeconds, int maxIdleSeconds, java.lang.String evictionPolicy, boolean readBackupData, java.lang.String cacheDeserializedValues, java.lang.String mergePolicy, java.lang.String inMemoryFormat, java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> partitionLostListenerConfigs, boolean statisticsEnabled, java.lang.String splitBrainProtectionName, com.hazelcast.nio.serialization.Data mapEvictionPolicy, java.lang.String maxSizeConfigMaxSizePolicy, int maxSizeConfigSize, com.hazelcast.client.impl.protocol.task.dynamicconfig.MapStoreConfigHolder mapStoreConfig, com.hazelcast.client.impl.protocol.task.dynamicconfig.NearCacheConfigHolder nearCacheConfig, com.hazelcast.config.WanReplicationRef wanReplicationRef, java.util.Collection<com.hazelcast.config.MapIndexConfig> mapIndexConfigs, java.util.Collection<com.hazelcast.config.MapAttributeConfig> mapAttributeConfigs, java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.QueryCacheConfigHolder> queryCacheConfigs, java.lang.String partitioningStrategyClassName, com.hazelcast.nio.serialization.Data partitioningStrategyImplementation, com.hazelcast.config.HotRestartConfig hotRestartConfig, com.hazelcast.config.EventJournalConfig eventJournalConfig, com.hazelcast.config.MerkleTreeConfig merkleTreeConfig, int mergeBatchSize, int metadataPolicy) {
+    public static ClientMessage encodeRequest(java.lang.String name, int backupCount, int asyncBackupCount, int timeToLiveSeconds, int maxIdleSeconds, java.lang.String evictionPolicy, boolean readBackupData, java.lang.String cacheDeserializedValues, java.lang.String mergePolicy, java.lang.String inMemoryFormat, java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> partitionLostListenerConfigs, boolean statisticsEnabled, java.lang.String splitBrainProtectionName, com.hazelcast.nio.serialization.Data mapEvictionPolicy, java.lang.String maxSizeConfigMaxSizePolicy, int maxSizeConfigSize, com.hazelcast.client.impl.protocol.task.dynamicconfig.MapStoreConfigHolder mapStoreConfig, com.hazelcast.client.impl.protocol.task.dynamicconfig.NearCacheConfigHolder nearCacheConfig, com.hazelcast.config.WanReplicationRef wanReplicationRef, java.util.Collection<com.hazelcast.config.MapIndexConfig> mapIndexConfigs, java.util.Collection<com.hazelcast.config.AttributeConfig> attributeConfigs, java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.QueryCacheConfigHolder> queryCacheConfigs, java.lang.String partitioningStrategyClassName, com.hazelcast.nio.serialization.Data partitioningStrategyImplementation, com.hazelcast.config.HotRestartConfig hotRestartConfig, com.hazelcast.config.EventJournalConfig eventJournalConfig, com.hazelcast.config.MerkleTreeConfig merkleTreeConfig, int mergeBatchSize, int metadataPolicy) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
         clientMessage.setAcquiresResource(false);
@@ -251,7 +251,7 @@ public final class DynamicConfigAddMapConfigCodec {
         CodecUtil.encodeNullable(clientMessage, nearCacheConfig, NearCacheConfigHolderCodec::encode);
         CodecUtil.encodeNullable(clientMessage, wanReplicationRef, WanReplicationRefCodec::encode);
         ListMultiFrameCodec.encodeNullable(clientMessage, mapIndexConfigs, MapIndexConfigCodec::encode);
-        ListMultiFrameCodec.encodeNullable(clientMessage, mapAttributeConfigs, MapAttributeConfigCodec::encode);
+        ListMultiFrameCodec.encodeNullable(clientMessage, attributeConfigs, AttributeConfigCodec::encode);
         ListMultiFrameCodec.encodeNullable(clientMessage, queryCacheConfigs, QueryCacheConfigHolderCodec::encode);
         CodecUtil.encodeNullable(clientMessage, partitioningStrategyClassName, StringCodec::encode);
         CodecUtil.encodeNullable(clientMessage, partitioningStrategyImplementation, DataCodec::encode);
@@ -288,7 +288,7 @@ public final class DynamicConfigAddMapConfigCodec {
         request.nearCacheConfig = CodecUtil.decodeNullable(iterator, NearCacheConfigHolderCodec::decode);
         request.wanReplicationRef = CodecUtil.decodeNullable(iterator, WanReplicationRefCodec::decode);
         request.mapIndexConfigs = ListMultiFrameCodec.decodeNullable(iterator, MapIndexConfigCodec::decode);
-        request.mapAttributeConfigs = ListMultiFrameCodec.decodeNullable(iterator, MapAttributeConfigCodec::decode);
+        request.attributeConfigs = ListMultiFrameCodec.decodeNullable(iterator, AttributeConfigCodec::decode);
         request.queryCacheConfigs = ListMultiFrameCodec.decodeNullable(iterator, QueryCacheConfigHolderCodec::decode);
         request.partitioningStrategyClassName = CodecUtil.decodeNullable(iterator, StringCodec::decode);
         request.partitioningStrategyImplementation = CodecUtil.decodeNullable(iterator, DataCodec::decode);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/AttributeConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/AttributeConfigCodec.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.impl.protocol.codec.builtin;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 
 import java.util.ListIterator;
 
@@ -25,29 +25,29 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.BEGIN_FRAME;
 import static com.hazelcast.client.impl.protocol.ClientMessage.END_FRAME;
 import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastForwardToEndFrame;
 
-public final class MapAttributeConfigCodec {
+public final class AttributeConfigCodec {
 
-    private MapAttributeConfigCodec() {
+    private AttributeConfigCodec() {
     }
 
-    public static void encode(ClientMessage clientMessage, MapAttributeConfig config) {
+    public static void encode(ClientMessage clientMessage, AttributeConfig config) {
         clientMessage.add(BEGIN_FRAME);
 
         StringCodec.encode(clientMessage, config.getName());
-        StringCodec.encode(clientMessage, config.getExtractor());
+        StringCodec.encode(clientMessage, config.getExtractorClassName());
 
         clientMessage.add(END_FRAME);
     }
 
-    public static MapAttributeConfig decode(ListIterator<ClientMessage.Frame> iterator) {
+    public static AttributeConfig decode(ListIterator<ClientMessage.Frame> iterator) {
         // begin frame
         iterator.next();
 
         String name = StringCodec.decode(iterator);
-        String extractor = StringCodec.decode(iterator);
+        String extractorClassName = StringCodec.decode(iterator);
 
         fastForwardToEndFrame(iterator);
 
-        return new MapAttributeConfig(name, extractor);
+        return new AttributeConfig(name, extractorClassName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -71,7 +71,7 @@ public class AddMapConfigMessageTask
         config.setEventJournalConfig(parameters.eventJournalConfig);
         config.setHotRestartConfig(parameters.hotRestartConfig);
         config.setInMemoryFormat(InMemoryFormat.valueOf(parameters.inMemoryFormat));
-        config.setMapAttributeConfigs(parameters.mapAttributeConfigs);
+        config.setAttributeConfigs(parameters.attributeConfigs);
         config.setReadBackupData(parameters.readBackupData);
         config.setStatisticsEnabled(parameters.statisticsEnabled);
         if (parameters.mapEvictionPolicy != null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AttributeConfig.java
@@ -33,40 +33,40 @@ import static java.lang.String.format;
  *
  * @see com.hazelcast.query.extractor.ValueExtractor
  */
-public class MapAttributeConfig implements IdentifiedDataSerializable {
+public class AttributeConfig implements IdentifiedDataSerializable {
 
     private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9_]*$");
 
     private String name;
-    private String extractor;
+    private String extractorClassName;
 
-    private transient MapAttributeConfigReadOnly readOnly;
+    private transient AttributeConfigReadOnly readOnly;
 
     /**
-     * Creates an empty MapAttributeConfig.
+     * Creates an empty AttributeConfig.
      */
-    public MapAttributeConfig() {
+    public AttributeConfig() {
     }
 
     /**
-     * Creates a MapAttributeConfig with the given attribute and ordered setting.
+     * Creates a AttributeConfig with the given attribute and ordered setting.
      * <p>
      * Name may begin with an ascii letter [A-Za-z] or digit [0-9] and may contain ascii letters [A-Za-z], digits [0-9]
      * or underscores later on.
      *
-     * @param name      the name given to an attribute that is going to be extracted
-     * @param extractor full class name of the extractor used to extract the value of the attribute
+     * @param name               the name given to an attribute that is going to be extracted
+     * @param extractorClassName full class name of the extractor used to extract the value of the attribute
      * @see #setName(String)
-     * @see #setExtractor(String)
+     * @see #setExtractorClassName(String) (String)
      */
-    public MapAttributeConfig(String name, String extractor) {
+    public AttributeConfig(String name, String extractorClassName) {
         setName(name);
-        setExtractor(extractor);
+        setExtractorClassName(extractorClassName);
     }
 
-    public MapAttributeConfig(MapAttributeConfig config) {
+    public AttributeConfig(AttributeConfig config) {
         name = config.getName();
-        extractor = config.getExtractor();
+        extractorClassName = config.getExtractorClassName();
     }
 
     /**
@@ -75,9 +75,9 @@ public class MapAttributeConfig implements IdentifiedDataSerializable {
      * @return immutable version of this configuration
      * @deprecated this method will be removed in 4.0; it is meant for internal usage only
      */
-    public MapAttributeConfigReadOnly getAsReadOnly() {
+    public AttributeConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
-            readOnly = new MapAttributeConfigReadOnly(this);
+            readOnly = new AttributeConfigReadOnly(this);
         }
         return readOnly;
     }
@@ -97,11 +97,11 @@ public class MapAttributeConfig implements IdentifiedDataSerializable {
      * The name cannot be equal to any of the query constants.
      *
      * @param name the name of the attribute extracted by the extractor
-     * @return the updated MapAttributeConfig
+     * @return the updated AttributeConfig
      * @throws IllegalArgumentException if attribute is null,an empty or inappropriate string
      * @see QueryConstants
      */
-    public MapAttributeConfig setName(String name) {
+    public AttributeConfig setName(String name) {
         this.name = checkName(name);
         return this;
     }
@@ -133,28 +133,28 @@ public class MapAttributeConfig implements IdentifiedDataSerializable {
      * Gets the full class name of the extractor in a String format, e.g. {@code com.example.car.SpeedExtractor}.
      *
      * @return the full class name of the extractor in a String format
-     * @see #setExtractor(String)
+     * @see #setExtractorClassName(String) (String)
      */
-    public String getExtractor() {
-        return extractor;
+    public String getExtractorClassName() {
+        return extractorClassName;
     }
 
     /**
      * Sets the full class name of the extractor in a String format, e.g. {@code com.example.car.SpeedExtractor}.
      *
-     * @param extractor the full class name of the extractor in a String format
-     * @return the updated MapAttributeConfig
+     * @param extractorClassName the full class name of the extractor in a String format
+     * @return the updated AttributeConfig
      */
-    public MapAttributeConfig setExtractor(String extractor) {
-        this.extractor = checkHasText(extractor, "Map attribute extractor must contain text");
+    public AttributeConfig setExtractorClassName(String extractorClassName) {
+        this.extractorClassName = checkHasText(extractorClassName, "Map attribute extractor must contain text");
         return this;
     }
 
     @Override
     public String toString() {
-        return "MapAttributeConfig{"
+        return "AttributeConfig{"
                 + "name='" + name + '\''
-                + "extractor='" + extractor + '\''
+                + "extractorClassName='" + extractorClassName + '\''
                 + '}';
     }
 
@@ -171,13 +171,13 @@ public class MapAttributeConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeUTF(extractor);
+        out.writeUTF(extractorClassName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        extractor = in.readUTF();
+        extractorClassName = in.readUTF();
     }
 
     @Override
@@ -189,17 +189,18 @@ public class MapAttributeConfig implements IdentifiedDataSerializable {
             return false;
         }
 
-        MapAttributeConfig that = (MapAttributeConfig) o;
+        AttributeConfig that = (AttributeConfig) o;
         if (name != null ? !name.equals(that.name) : that.name != null) {
             return false;
         }
-        return extractor != null ? extractor.equals(that.extractor) : that.extractor == null;
+        return extractorClassName != null
+            ? extractorClassName.equals(that.extractorClassName) : that.extractorClassName == null;
     }
 
     @Override
     public int hashCode() {
         int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (extractor != null ? extractor.hashCode() : 0);
+        result = 31 * result + (extractorClassName != null ? extractorClassName.hashCode() : 0);
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AttributeConfigReadOnly.java
@@ -21,19 +21,19 @@ package com.hazelcast.config;
  *
  * @deprecated this class will be removed in 4.0; it is meant for internal usage only.
  */
-public class MapAttributeConfigReadOnly extends MapAttributeConfig {
+public class AttributeConfigReadOnly extends AttributeConfig {
 
-    public MapAttributeConfigReadOnly(MapAttributeConfig config) {
+    public AttributeConfigReadOnly(AttributeConfig config) {
         super(config);
     }
 
     @Override
-    public MapAttributeConfig setName(String attribute) {
+    public AttributeConfig setName(String attribute) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public MapAttributeConfig setExtractor(String type) {
+    public AttributeConfig setExtractorClassName(String extractorClassName) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -133,7 +133,7 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
         constructors[MAP_STORE_CONFIG] = arg -> new MapStoreConfig();
         constructors[MAP_PARTITION_LOST_LISTENER_CONFIG] = arg -> new MapPartitionLostListenerConfig();
         constructors[MAP_INDEX_CONFIG] = arg -> new MapIndexConfig();
-        constructors[MAP_ATTRIBUTE_CONFIG] = arg -> new MapAttributeConfig();
+        constructors[MAP_ATTRIBUTE_CONFIG] = arg -> new AttributeConfig();
         constructors[QUERY_CACHE_CONFIG] = arg -> new QueryCacheConfig();
         constructors[PREDICATE_CONFIG] = arg -> new PredicateConfig();
         constructors[PARTITION_STRATEGY_CONFIG] = arg -> new PartitioningStrategyConfig();

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -892,7 +892,7 @@ public class ConfigXmlGenerator {
             mapNearCacheConfigXmlGenerator(gen, m.getNearCacheConfig());
             wanReplicationConfigXmlGenerator(gen, m.getWanReplicationRef());
             mapIndexConfigXmlGenerator(gen, m);
-            mapAttributeConfigXmlGenerator(gen, m);
+            attributeConfigXmlGenerator(gen, m);
             entryListenerConfigXmlGenerator(gen, m);
             mapPartitionLostListenerConfigXmlGenerator(gen, m);
             mapPartitionStrategyConfigXmlGenerator(gen, m);
@@ -1114,11 +1114,11 @@ public class ConfigXmlGenerator {
         }
     }
 
-    private static void mapAttributeConfigXmlGenerator(XmlGenerator gen, MapConfig m) {
-        if (!m.getMapAttributeConfigs().isEmpty()) {
+    private static void attributeConfigXmlGenerator(XmlGenerator gen, MapConfig m) {
+        if (!m.getAttributeConfigs().isEmpty()) {
             gen.open("attributes");
-            for (MapAttributeConfig attributeCfg : m.getMapAttributeConfigs()) {
-                gen.node("attribute", attributeCfg.getName(), "extractor", attributeCfg.getExtractor());
+            for (AttributeConfig attributeCfg : m.getAttributeConfigs()) {
+                gen.node("attribute", attributeCfg.getName(), "extractor-class-name", attributeCfg.getExtractorClassName());
             }
             gen.close();
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -106,7 +106,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
     private List<EntryListenerConfig> entryListenerConfigs;
     private List<MapPartitionLostListenerConfig> partitionLostListenerConfigs;
     private List<MapIndexConfig> mapIndexConfigs;
-    private List<MapAttributeConfig> mapAttributeConfigs;
+    private List<AttributeConfig> attributeConfigs;
     private List<QueryCacheConfig> queryCacheConfigs;
     private PartitioningStrategyConfig partitioningStrategyConfig;
     private MetadataPolicy metadataPolicy = DEFAULT_METADATA_POLICY;
@@ -145,7 +145,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         this.partitionLostListenerConfigs =
                 new ArrayList<>(config.getPartitionLostListenerConfigs());
         this.mapIndexConfigs = new ArrayList<>(config.getMapIndexConfigs());
-        this.mapAttributeConfigs = new ArrayList<>(config.getMapAttributeConfigs());
+        this.attributeConfigs = new ArrayList<>(config.getAttributeConfigs());
         this.queryCacheConfigs = new ArrayList<>(config.getQueryCacheConfigs());
         this.partitioningStrategyConfig = config.partitioningStrategyConfig != null
                 ? new PartitioningStrategyConfig(config.getPartitioningStrategyConfig()) : null;
@@ -544,20 +544,20 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         return this;
     }
 
-    public MapConfig addMapAttributeConfig(MapAttributeConfig mapAttributeConfig) {
-        getMapAttributeConfigs().add(mapAttributeConfig);
+    public MapConfig addAttributeConfig(AttributeConfig attributeConfig) {
+        getAttributeConfigs().add(attributeConfig);
         return this;
     }
 
-    public List<MapAttributeConfig> getMapAttributeConfigs() {
-        if (mapAttributeConfigs == null) {
-            mapAttributeConfigs = new ArrayList<>();
+    public List<AttributeConfig> getAttributeConfigs() {
+        if (attributeConfigs == null) {
+            attributeConfigs = new ArrayList<>();
         }
-        return mapAttributeConfigs;
+        return attributeConfigs;
     }
 
-    public MapConfig setMapAttributeConfigs(List<MapAttributeConfig> mapAttributeConfigs) {
-        this.mapAttributeConfigs = mapAttributeConfigs;
+    public MapConfig setAttributeConfigs(List<AttributeConfig> attributeConfigs) {
+        this.attributeConfigs = attributeConfigs;
         return this;
     }
 
@@ -806,7 +806,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         if (!getMapIndexConfigs().equals(that.getMapIndexConfigs())) {
             return false;
         }
-        if (!getMapAttributeConfigs().equals(that.getMapAttributeConfigs())) {
+        if (!getAttributeConfigs().equals(that.getAttributeConfigs())) {
             return false;
         }
         if (!getQueryCacheConfigs().equals(that.getQueryCacheConfigs())) {
@@ -850,7 +850,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         result = 31 * result + (wanReplicationRef != null ? wanReplicationRef.hashCode() : 0);
         result = 31 * result + getEntryListenerConfigs().hashCode();
         result = 31 * result + getMapIndexConfigs().hashCode();
-        result = 31 * result + getMapAttributeConfigs().hashCode();
+        result = 31 * result + getAttributeConfigs().hashCode();
         result = 31 * result + getQueryCacheConfigs().hashCode();
         result = 31 * result + getPartitionLostListenerConfigs().hashCode();
         result = 31 * result + (statisticsEnabled ? 1 : 0);
@@ -885,7 +885,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
                 + ", wanReplicationRef=" + wanReplicationRef
                 + ", entryListenerConfigs=" + entryListenerConfigs
                 + ", mapIndexConfigs=" + mapIndexConfigs
-                + ", mapAttributeConfigs=" + mapAttributeConfigs
+                + ", attributeConfigs=" + attributeConfigs
                 + ", splitBrainProtectionName=" + splitBrainProtectionName
                 + ", queryCacheConfigs=" + queryCacheConfigs
                 + ", cacheDeserializedValues=" + cacheDeserializedValues
@@ -922,7 +922,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         writeNullableList(entryListenerConfigs, out);
         writeNullableList(partitionLostListenerConfigs, out);
         writeNullableList(mapIndexConfigs, out);
-        writeNullableList(mapAttributeConfigs, out);
+        writeNullableList(attributeConfigs, out);
         writeNullableList(queryCacheConfigs, out);
         out.writeBoolean(statisticsEnabled);
         out.writeObject(partitioningStrategyConfig);
@@ -953,7 +953,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         entryListenerConfigs = readNullableList(in);
         partitionLostListenerConfigs = readNullableList(in);
         mapIndexConfigs = readNullableList(in);
-        mapAttributeConfigs = readNullableList(in);
+        attributeConfigs = readNullableList(in);
         queryCacheConfigs = readNullableList(in);
         statisticsEnabled = in.readBoolean();
         partitioningStrategyConfig = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
@@ -263,7 +263,7 @@ public class MapConfigReadOnly extends MapConfig {
     }
 
     @Override
-    public MapConfig setMapAttributeConfigs(List<MapAttributeConfig> mapAttributeConfigs) {
+    public MapConfig setAttributeConfigs(List<AttributeConfig> attributeConfigs) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -1640,7 +1640,7 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             } else if ("indexes".equals(nodeName)) {
                 mapIndexesHandle(node, mapConfig);
             } else if ("attributes".equals(nodeName)) {
-                mapAttributesHandle(node, mapConfig);
+                attributesHandle(node, mapConfig);
             } else if ("entry-listeners".equals(nodeName)) {
                 handleEntryListeners(node, entryListenerConfig -> {
                     mapConfig.addEntryListenerConfig(entryListenerConfig);
@@ -1990,13 +1990,13 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         }
     }
 
-    protected void mapAttributesHandle(Node n, MapConfig mapConfig) {
+    protected void attributesHandle(Node n, MapConfig mapConfig) {
         for (Node extractorNode : childElements(n)) {
             if ("attribute".equals(cleanNodeName(extractorNode))) {
                 NamedNodeMap attrs = extractorNode.getAttributes();
-                String extractor = getTextContent(attrs.getNamedItem("extractor"));
+                String extractor = getTextContent(attrs.getNamedItem("extractor-class-name"));
                 String name = getTextContent(extractorNode);
-                mapConfig.addMapAttributeConfig(new MapAttributeConfig(name, extractor));
+                mapConfig.addAttributeConfig(new AttributeConfig(name, extractor));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -463,12 +463,12 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     }
 
     @Override
-    protected void mapAttributesHandle(Node n, MapConfig mapConfig) {
+    protected void attributesHandle(Node n, MapConfig mapConfig) {
         for (Node extractorNode : childElements(n)) {
             NamedNodeMap attrs = extractorNode.getAttributes();
-            String extractor = getTextContent(attrs.getNamedItem("extractor"));
+            String extractor = getTextContent(attrs.getNamedItem("extractor-class-name"));
             String name = extractorNode.getNodeName();
-            mapConfig.addMapAttributeConfig(new MapAttributeConfig(name, extractor));
+            mapConfig.addAttributeConfig(new AttributeConfig(name, extractor));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -130,7 +130,7 @@ public class MapContainer {
         initWanReplication(nodeEngine);
         ClassLoader classloader = mapServiceContext.getNodeEngine().getConfigClassLoader();
         this.extractors = Extractors.newBuilder(serializationService)
-                                    .setMapAttributeConfigs(mapConfig.getMapAttributeConfigs())
+                                    .setAttributeConfigs(mapConfig.getAttributeConfigs())
                                     .setClassLoader(classloader)
                                     .build();
         this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues(),

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueExtractor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueExtractor.java
@@ -29,21 +29,21 @@ import com.hazelcast.nio.serialization.Portable;
  * <p>
  * How to define a new custom attribute?
  * <code>
- * MapAttributeConfig attributeConfig = new MapAttributeConfig();
+ * AttributeConfig attributeConfig = new AttributeConfig();
  * extractorConfig.setName("currency");
- * extractorConfig.setExtractor("com.bank.CurrencyExtractor");
+ * extractorConfig.setExtractorClassName("com.bank.CurrencyExtractor");
  * </code>
  * <p>
  * How to register the newly-defined attribute in a configuration of a Map?
  * <code>
  * MapConfig mapConfig = (...);
- * mapConfig.addMapAttributeConfig(attributeConfig);
+ * mapConfig.addAttributeConfig(attributeConfig);
  * </code>
  * Extractors may be also defined in the XML configuration.
  * <pre>
  * &lt;map name="trades"&gt;
  *   &lt;attributes&gt;
- *     &lt;attribute extractor="com.bank.CurrencyExtractor"&gt;currency&lt;/attribute&gt;
+ *     &lt;attribute extractor-class-name="com.bank.CurrencyExtractor"&gt;currency&lt;/attribute&gt;
  *   &lt;/attributes&gt;
  * &lt;/map&gt;
  * </pre>

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.getters;
 
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.query.extractor.ValueExtractor;
 import com.hazelcast.util.StringUtil;
@@ -31,10 +31,10 @@ public final class ExtractorHelper {
     private ExtractorHelper() {
     }
 
-    static Map<String, ValueExtractor> instantiateExtractors(List<MapAttributeConfig> mapAttributeConfigs,
+    static Map<String, ValueExtractor> instantiateExtractors(List<AttributeConfig> attributeConfigs,
                                                              ClassLoader classLoader) {
-        Map<String, ValueExtractor> extractors = createHashMap(mapAttributeConfigs.size());
-        for (MapAttributeConfig config : mapAttributeConfigs) {
+        Map<String, ValueExtractor> extractors = createHashMap(attributeConfigs.size());
+        for (AttributeConfig config : attributeConfigs) {
             if (extractors.containsKey(config.getName())) {
                 throw new IllegalArgumentException("Could not add " + config
                         + ". Extractor for this attribute name already added.");
@@ -44,7 +44,7 @@ public final class ExtractorHelper {
         return extractors;
     }
 
-    static ValueExtractor instantiateExtractor(MapAttributeConfig config, ClassLoader classLoader) {
+    static ValueExtractor instantiateExtractor(AttributeConfig config, ClassLoader classLoader) {
         ValueExtractor extractor = null;
         if (classLoader != null) {
             try {
@@ -62,9 +62,9 @@ public final class ExtractorHelper {
         return extractor;
     }
 
-    private static ValueExtractor instantiateExtractorWithConfigClassLoader(MapAttributeConfig config, ClassLoader classLoader) {
+    private static ValueExtractor instantiateExtractorWithConfigClassLoader(AttributeConfig config, ClassLoader classLoader) {
         try {
-            Class<?> clazz = classLoader.loadClass(config.getExtractor());
+            Class<?> clazz = classLoader.loadClass(config.getExtractorClassName());
             Object extractor = clazz.newInstance();
             if (extractor instanceof ValueExtractor) {
                 return (ValueExtractor) extractor;
@@ -80,9 +80,9 @@ public final class ExtractorHelper {
         }
     }
 
-    private static ValueExtractor instantiateExtractorWithClassForName(MapAttributeConfig config) {
+    private static ValueExtractor instantiateExtractorWithClassForName(AttributeConfig config) {
         try {
-            Class<?> clazz = Class.forName(config.getExtractor());
+            Class<?> clazz = Class.forName(config.getExtractorClassName());
             Object extractor = clazz.newInstance();
             if (extractor instanceof ValueExtractor) {
                 return (ValueExtractor) extractor;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.getters;
 
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
@@ -56,11 +56,11 @@ public final class Extractors {
     private final EvictableGetterCache getterCache;
     private final DefaultArgumentParser argumentsParser;
 
-    private Extractors(List<MapAttributeConfig> mapAttributeConfigs,
+    private Extractors(List<AttributeConfig> attributeConfigs,
                        ClassLoader classLoader, InternalSerializationService ss) {
-        this.extractors = mapAttributeConfigs == null
+        this.extractors = attributeConfigs == null
                 ? Collections.<String, ValueExtractor>emptyMap()
-                : instantiateExtractors(mapAttributeConfigs, classLoader);
+                : instantiateExtractors(attributeConfigs, classLoader);
         this.getterCache = new EvictableGetterCache(MAX_CLASSES_IN_CACHE,
                 MAX_GETTERS_PER_CLASS_IN_CACHE, EVICTION_PERCENTAGE, false);
         this.argumentsParser = new DefaultArgumentParser();
@@ -163,7 +163,7 @@ public final class Extractors {
      */
     public static final class Builder {
         private ClassLoader classLoader;
-        private List<MapAttributeConfig> mapAttributeConfigs;
+        private List<AttributeConfig> attributeConfigs;
 
         private final InternalSerializationService ss;
 
@@ -171,8 +171,8 @@ public final class Extractors {
             this.ss = Preconditions.checkNotNull(ss);
         }
 
-        public Builder setMapAttributeConfigs(List<MapAttributeConfig> mapAttributeConfigs) {
-            this.mapAttributeConfigs = mapAttributeConfigs;
+        public Builder setAttributeConfigs(List<AttributeConfig> attributeConfigs) {
+            this.attributeConfigs = attributeConfigs;
             return this;
         }
 
@@ -185,7 +185,7 @@ public final class Extractors {
          * @return a new instance of Extractors
          */
         public Extractors build() {
-            return new Extractors(mapAttributeConfigs, classLoader, ss);
+            return new Extractors(attributeConfigs, classLoader, ss);
         }
     }
 }

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -2630,7 +2630,7 @@
     <xs:complexType name="map-attribute">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:attribute name="extractor" type="xs:string"/>
+                <xs:attribute name="extractor-class-name" type="xs:string"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1255,8 +1255,8 @@
         be set to false. Its default value is false.
         * <attributes>:
         You can define attributes that may be referenced in predicates, queries and indexes using this element's
-        <attribute> sub-elements. Each <attribute> has only the "extractor" attribute which you should define beforehand
-        by implementing Hazelcast's ValueExtractor class.
+        <attribute> sub-elements. Each <attribute> has only the "extractor-class-name" attribute which you should
+        define beforehand by implementing Hazelcast's ValueExtractor class.
         * <entry-listeners>:
             Adds listeners (listener classes) for the map entries using the <entry-listener> sub-elements. You can also set its
             attribute "include-value" to true if you want the entry event to contain the item values, and you can set its attribute
@@ -1321,7 +1321,7 @@
             <index ordered="true">age</index>
         </indexes>
         <attributes>
-            <attribute extractor="com.bank.CurrencyExtractor">currency</attribute>
+            <attribute extractor-class-name="com.bank.CurrencyExtractor">currency</attribute>
         </attributes>
         <entry-listeners>
             <entry-listener include-value="false" local="false">com.your-package.MyEntryListener</entry-listener>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -1240,8 +1240,8 @@ hazelcast:
   # be set to false. Its default value is false.
   # * "attributes":
   # You can define attributes that may be referenced in predicates, queries and indexes using this element's
-  # "attribute" sub-elements. Each "attribute" has only the "extractor" attribute which you should define beforehand
-  # by implementing Hazelcast's ValueExtractor class.
+  # "attribute" sub-elements. Each "attribute" has only the "extractor-class-name" attribute which you should define
+  # beforehand by implementing Hazelcast's ValueExtractor class.
   # * "entry-listeners":
   #     Adds listeners (listener classes) for the map entries using the "entry-listener" sub-elements. You can also set its
   #     attribute "include-value" to true if you want the entry event to contain the item values, and you can set its attribute
@@ -1313,7 +1313,7 @@ hazelcast:
           ordered: true
       attributes:
         currency:
-          extractor: com.bank.CurrencyExtractor
+          extractor-class-name: com.bank.CurrencyExtractor
       entry-listeners:
         - class-name: com.your-package.MyEntryListener
           include-value: false

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -40,7 +40,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.config.WanReplicationRef;
@@ -126,7 +126,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -198,8 +197,8 @@ public class ReferenceObjects {
         if (a instanceof MapIndexConfig && b instanceof MapIndexConfig) {
             return isEqual((MapIndexConfig) a, (MapIndexConfig) b);
         }
-        if (a instanceof MapAttributeConfig && b instanceof MapAttributeConfig) {
-            return isEqual((MapAttributeConfig) a, (MapAttributeConfig) b);
+        if (a instanceof AttributeConfig && b instanceof AttributeConfig) {
+            return isEqual((AttributeConfig) a, (AttributeConfig) b);
         }
         if (a instanceof QueryCacheConfigHolder && b instanceof QueryCacheConfigHolder) {
             return isEqual((QueryCacheConfigHolder) a, (QueryCacheConfigHolder) b);
@@ -355,7 +354,7 @@ public class ReferenceObjects {
                 : that.getAttribute() == null;
     }
 
-    public static boolean isEqual(MapAttributeConfig a, MapAttributeConfig that) {
+    public static boolean isEqual(AttributeConfig a, AttributeConfig that) {
         if (a == that) {
             return true;
         }
@@ -366,8 +365,8 @@ public class ReferenceObjects {
         if (a.getName() != null ? !a.getName().equals(that.getName()) : that.getName() != null) {
             return false;
         }
-        return a.getExtractor() != null ? a.getExtractor().equals(that.getExtractor())
-                : that.getExtractor() == null;
+        return a.getExtractorClassName() != null ? a.getExtractorClassName().equals(that.getExtractorClassName())
+                : that.getExtractorClassName() == null;
     }
 
     public static boolean isEqual(MapStoreConfigHolder a, MapStoreConfigHolder b) {
@@ -689,7 +688,7 @@ public class ReferenceObjects {
     public static NearCachePreloaderConfig nearCachePreloaderConfig;
     public static NearCacheConfigHolder nearCacheConfig;
     public static List<MapIndexConfig> mapIndexConfigs;
-    public static List<MapAttributeConfig> mapAttributeConfigs;
+    public static List<AttributeConfig> attributeConfigs;
     public static List<QueryCacheConfigHolder> queryCacheConfigs;
     public static TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig;
     public static HotRestartConfig hotRestartConfig;
@@ -749,8 +748,8 @@ public class ReferenceObjects {
         mapIndexConfigs = new ArrayList<MapIndexConfig>();
         mapIndexConfigs.add(new MapIndexConfig("attr", false));
 
-        mapAttributeConfigs = new ArrayList<MapAttributeConfig>();
-        mapAttributeConfigs.add(new MapAttributeConfig("attr", "com.hazelcast.AttributeExtractor"));
+        attributeConfigs = new ArrayList<AttributeConfig>();
+        attributeConfigs.add(new AttributeConfig("attr", "com.hazelcast.AttributeExtractor"));
 
         queryCacheConfigs = new ArrayList<QueryCacheConfigHolder>();
         QueryCacheConfigHolder queryCacheConfig = new QueryCacheConfigHolder();

--- a/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientUserCodeDeploymentConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
@@ -201,7 +201,7 @@ public class ClientUserCodeDeploymentTest extends HazelcastTestSupport {
         clientConfig.setUserCodeDeploymentConfig(clientUserCodeDeploymentConfig.setEnabled(true));
 
         Config config = createNodeConfig();
-        config.getMapConfig(mapName).addMapAttributeConfig(new MapAttributeConfig(attributeName, "usercodedeployment.CapitalizatingFirstnameExtractor"));
+        config.getMapConfig(mapName).addAttributeConfig(new AttributeConfig(attributeName, "usercodedeployment.CapitalizatingFirstnameExtractor"));
 
         factory.newHazelcastInstance(config);
         factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/config/AttributeConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AttributeConfigReadOnlyTest.java
@@ -25,19 +25,19 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class MapAttributeConfigReadOnlyTest {
+public class AttributeConfigReadOnlyTest {
 
-    private MapAttributeConfig getReadOnlyConfig() {
-        return new MapAttributeConfig().getAsReadOnly();
+    private AttributeConfig getReadOnlyConfig() {
+        return new AttributeConfig().getAsReadOnly();
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void setNameOfReadOnlyMapAttributeConfigShouldFail() throws Exception {
+    public void setNameOfReadOnlyAttributeConfigShouldFail() throws Exception {
         getReadOnlyConfig().setName("extractedName");
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void setExtractorOfReadOnlyMapAttributeConfigShouldFail() throws Exception {
-        getReadOnlyConfig().setExtractor("com.test.Extractor");
+    public void setExtractorOfReadOnlyAttributeConfigShouldFail() throws Exception {
+        getReadOnlyConfig().setExtractorClassName("com.test.Extractor");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/AttributeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AttributeConfigTest.java
@@ -31,88 +31,88 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class MapAttributeConfigTest {
+public class AttributeConfigTest {
 
     @Test
     public void empty() {
-        new MapAttributeConfig();
+        new AttributeConfig();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void nullName() {
-        new MapAttributeConfig(null, "com.class");
+        new AttributeConfig(null, "com.class");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void emptyName() {
-        new MapAttributeConfig("", "com.class");
+        new AttributeConfig("", "com.class");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void dotInName() {
-        new MapAttributeConfig("body.brain", "com.class");
+        new AttributeConfig("body.brain", "com.class");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void openingSquareBracketInName() {
-        new MapAttributeConfig("co[m", "com.test.Extractor");
+        new AttributeConfig("co[m", "com.test.Extractor");
     }
 
     public void closingSquareBracketInName() {
-        new MapAttributeConfig("co]m", "com.test.Extractor");
+        new AttributeConfig("co]m", "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void emptySquareBracketInName() {
-        new MapAttributeConfig("com[]", "com.test.Extractor");
+        new AttributeConfig("com[]", "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void bothSquareBracketInName() {
-        new MapAttributeConfig("com[007]", "com.test.Extractor");
+        new AttributeConfig("com[007]", "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void diactricsInName() {
-        new MapAttributeConfig("ąćżźć^∆Ō∑ęĺłęŌ", "com.test.Extractor");
+        new AttributeConfig("ąćżźć^∆Ō∑ęĺłęŌ", "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void spaceInName() {
-        new MapAttributeConfig("cool attribute", "com.test.Extractor");
+        new AttributeConfig("cool attribute", "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void queryConstantKeyAsName() {
-        new MapAttributeConfig(QueryConstants.KEY_ATTRIBUTE_NAME.value(), "com.test.Extractor");
+        new AttributeConfig(QueryConstants.KEY_ATTRIBUTE_NAME.value(), "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void queryConstantThisAsName() {
-        new MapAttributeConfig(QueryConstants.THIS_ATTRIBUTE_NAME.value(), "com.test.Extractor");
+        new AttributeConfig(QueryConstants.THIS_ATTRIBUTE_NAME.value(), "com.test.Extractor");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void nullExtractor() {
-        new MapAttributeConfig("iq", null);
+        new AttributeConfig("iq", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void emptyExtractor() {
-        new MapAttributeConfig("iq", "");
+        new AttributeConfig("iq", "");
     }
 
     @Test
     public void validDefinition() {
-        MapAttributeConfig config = new MapAttributeConfig("iq", "com.test.IqExtractor");
+        AttributeConfig config = new AttributeConfig("iq", "com.test.IqExtractor");
 
         assertEquals("iq", config.getName());
-        assertEquals("com.test.IqExtractor", config.getExtractor());
+        assertEquals("com.test.IqExtractor", config.getExtractorClassName());
     }
 
     @Test
     public void validToString() {
-        MapAttributeConfig config = new MapAttributeConfig("iq", "com.test.IqExtractor");
+        AttributeConfig config = new AttributeConfig("iq", "com.test.IqExtractor");
 
         String toString = config.toString();
 
@@ -122,13 +122,13 @@ public class MapAttributeConfigTest {
 
     @Test
     public void validReadOnly() {
-        MapAttributeConfig config = new MapAttributeConfig("iq", "com.test.IqExtractor");
+        AttributeConfig config = new AttributeConfig("iq", "com.test.IqExtractor");
 
-        MapAttributeConfigReadOnly readOnlyConfig = config.getAsReadOnly();
+        AttributeConfigReadOnly readOnlyConfig = config.getAsReadOnly();
 
-        assertThat(readOnlyConfig, instanceOf(MapAttributeConfigReadOnly.class));
+        assertThat(readOnlyConfig, instanceOf(AttributeConfigReadOnly.class));
         assertEquals("iq", readOnlyConfig.getName());
-        assertEquals("com.test.IqExtractor", readOnlyConfig.getExtractor());
+        assertEquals("com.test.IqExtractor", readOnlyConfig.getExtractorClassName());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -804,8 +804,8 @@ public class ConfigCompatibilityChecker {
                     && isCompatible(c1.getNearCacheConfig(), c2.getNearCacheConfig())
                     && isCompatible(c1.getWanReplicationRef(), c2.getWanReplicationRef())
                     && isCollectionCompatible(c1.getMapIndexConfigs(), c2.getMapIndexConfigs(), new MapIndexConfigChecker())
-                    && isCollectionCompatible(c1.getMapAttributeConfigs(), c2.getMapAttributeConfigs(),
-                    new MapAttributeConfigChecker())
+                    && isCollectionCompatible(c1.getAttributeConfigs(), c2.getAttributeConfigs(),
+                    new AttributeConfigChecker())
                     && isCollectionCompatible(c1.getEntryListenerConfigs(), c2.getEntryListenerConfigs(),
                     new EntryListenerConfigChecker())
                     && nullSafeEqual(c1.getPartitionLostListenerConfigs(), c2.getPartitionLostListenerConfigs())
@@ -884,12 +884,12 @@ public class ConfigCompatibilityChecker {
         }
     }
 
-    private static class MapAttributeConfigChecker extends ConfigChecker<MapAttributeConfig> {
+    private static class AttributeConfigChecker extends ConfigChecker<AttributeConfig> {
         @Override
-        boolean check(MapAttributeConfig c1, MapAttributeConfig c2) {
+        boolean check(AttributeConfig c1, AttributeConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getName(), c2.getName())
-                    && nullSafeEqual(c1.getExtractor(), c2.getExtractor());
+                    && nullSafeEqual(c1.getExtractorClassName(), c2.getExtractorClassName());
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -897,7 +897,7 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
-    public void testMapAttributesConfigWithStoreClass() {
+    public void testAttributesConfigWithStoreClass() {
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER)
@@ -925,7 +925,7 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
-    public void testMapAttributesConfigWithStoreFactory() {
+    public void testAttributesConfigWithStoreFactory() {
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER)
@@ -940,9 +940,9 @@ public class ConfigXmlGeneratorTest {
 
     @SuppressWarnings("deprecation")
     private void testMap(MapStoreConfig mapStoreConfig) {
-        MapAttributeConfig attrConfig = new MapAttributeConfig()
+        AttributeConfig attrConfig = new AttributeConfig()
                 .setName("power")
-                .setExtractor("com.car.PowerExtractor");
+                .setExtractorClassName("com.car.PowerExtractor");
 
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setSize(10)
@@ -1016,7 +1016,7 @@ public class ConfigXmlGeneratorTest {
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .addEntryListenerConfig(listenerConfig)
                 .setMapIndexConfigs(singletonList(mapIndexConfig))
-                .addMapAttributeConfig(attrConfig)
+                .addAttributeConfig(attrConfig)
                 .setPartitionLostListenerConfigs(singletonList(
                         new MapPartitionLostListenerConfig("partitionLostListener")));
 
@@ -1028,9 +1028,9 @@ public class ConfigXmlGeneratorTest {
         Config xmlConfig = getNewConfigViaXMLGenerator(config);
 
         MapConfig actualConfig = xmlConfig.getMapConfig("carMap");
-        MapAttributeConfig xmlAttrConfig = actualConfig.getMapAttributeConfigs().get(0);
+        AttributeConfig xmlAttrConfig = actualConfig.getAttributeConfigs().get(0);
         assertEquals(attrConfig.getName(), xmlAttrConfig.getName());
-        assertEquals(attrConfig.getExtractor(), xmlAttrConfig.getExtractor());
+        assertEquals(attrConfig.getExtractorClassName(), xmlAttrConfig.getExtractorClassName());
         assertEquals(expectedConfig, actualConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigReadOnlyTest.java
@@ -271,8 +271,8 @@ public class MapConfigReadOnlyTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void setMapAttributeConfigsOfReadOnlyMapConfigShouldFail() {
-        getReadOnlyConfig().setMapAttributeConfigs(singletonList(new MapAttributeConfig()));
+    public void setAttributeConfigsOfReadOnlyMapConfigShouldFail() {
+        getReadOnlyConfig().setAttributeConfigs(singletonList(new AttributeConfig()));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -2375,7 +2375,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "            <index ordered=\"true\">age</index>\n"
                 + "          </indexes>"
                 + "        <attributes>\n"
-                + "            <attribute extractor=\"com.bank.CurrencyExtractor\">currency</attribute>\n"
+                + "            <attribute extractor-class-name=\"com.bank.CurrencyExtractor\">currency</attribute>\n"
                 + "           </attributes>"
                 + "        <partition-lost-listeners>\n"
                 + "            <partition-lost-listener>com.your-package.YourPartitionLostListener</partition-lost-listener>\n"
@@ -2406,9 +2406,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(1, mapConfig.getMapIndexConfigs().size());
         assertEquals("age", mapConfig.getMapIndexConfigs().get(0).getAttribute());
         assertTrue(mapConfig.getMapIndexConfigs().get(0).isOrdered());
-        assertEquals(1, mapConfig.getMapAttributeConfigs().size());
-        assertEquals("com.bank.CurrencyExtractor", mapConfig.getMapAttributeConfigs().get(0).getExtractor());
-        assertEquals("currency", mapConfig.getMapAttributeConfigs().get(0).getName());
+        assertEquals(1, mapConfig.getAttributeConfigs().size());
+        assertEquals("com.bank.CurrencyExtractor", mapConfig.getAttributeConfigs().get(0).getExtractorClassName());
+        assertEquals("currency", mapConfig.getAttributeConfigs().get(0).getName());
         assertEquals(1, mapConfig.getPartitionLostListenerConfigs().size());
         assertEquals("com.your-package.YourPartitionLostListener", mapConfig.getPartitionLostListenerConfigs().get(0).getClassName());
         assertEquals(1, mapConfig.getEntryListenerConfigs().size());
@@ -2486,8 +2486,8 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
                 + "       <attributes>\n"
-                + "           <attribute extractor=\"com.car.PowerExtractor\">power</attribute>\n"
-                + "           <attribute extractor=\"com.car.WeightExtractor\">weight</attribute>\n"
+                + "           <attribute extractor-class-name=\"com.car.PowerExtractor\">power</attribute>\n"
+                + "           <attribute extractor-class-name=\"com.car.WeightExtractor\">weight</attribute>\n"
                 + "       </attributes>"
                 + "   </map>"
                 + HAZELCAST_END_TAG;
@@ -2495,9 +2495,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(xml);
         MapConfig mapConfig = config.getMapConfig("people");
 
-        assertFalse(mapConfig.getMapAttributeConfigs().isEmpty());
-        assertAttributeEqual("power", "com.car.PowerExtractor", mapConfig.getMapAttributeConfigs().get(0));
-        assertAttributeEqual("weight", "com.car.WeightExtractor", mapConfig.getMapAttributeConfigs().get(1));
+        assertFalse(mapConfig.getAttributeConfigs().isEmpty());
+        assertAttributeEqual("power", "com.car.PowerExtractor", mapConfig.getAttributeConfigs().get(0));
+        assertAttributeEqual("weight", "com.car.WeightExtractor", mapConfig.getAttributeConfigs().get(1));
     }
 
     @Override
@@ -2506,7 +2506,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
                 + "       <attributes>\n"
-                + "           <attribute extractor=\"com.car.WeightExtractor\"></attribute>\n"
+                + "           <attribute extractor-class-name=\"com.car.WeightExtractor\"></attribute>\n"
                 + "       </attributes>"
                 + "   </map>"
                 + HAZELCAST_END_TAG;
@@ -2514,9 +2514,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         buildConfig(xml);
     }
 
-    private static void assertAttributeEqual(String expectedName, String expectedExtractor, MapAttributeConfig attributeConfig) {
+    private static void assertAttributeEqual(String expectedName, String expectedExtractor, AttributeConfig attributeConfig) {
         assertEquals(expectedName, attributeConfig.getName());
-        assertEquals(expectedExtractor, attributeConfig.getExtractor());
+        assertEquals(expectedExtractor, attributeConfig.getExtractorClassName());
     }
 
     @Override
@@ -2525,7 +2525,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
                 + "       <attributes>\n"
-                + "           <attribute extractor=\"com.car.WeightExtractor\"/>\n"
+                + "           <attribute extractor-class-name=\"com.car.WeightExtractor\"/>\n"
                 + "       </attributes>"
                 + "   </map>"
                 + HAZELCAST_END_TAG;
@@ -2553,7 +2553,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
                 + "       <attributes>\n"
-                + "           <attribute extractor=\"\">weight</attribute>\n"
+                + "           <attribute extractor-class-name=\"\">weight</attribute>\n"
                 + "       </attributes>"
                 + "   </map>"
                 + HAZELCAST_END_TAG;

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -2421,7 +2421,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          ordered: true\n"
                 + "      attributes:\n"
                 + "        currency:\n"
-                + "          extractor: com.bank.CurrencyExtractor\n"
+                + "          extractor-class-name: com.bank.CurrencyExtractor\n"
                 + "      partition-lost-listeners:\n"
                 + "         - com.your-package.YourPartitionLostListener\n"
                 + "      entry-listeners:\n"
@@ -2449,9 +2449,9 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(1, mapConfig.getMapIndexConfigs().size());
         assertEquals("age", mapConfig.getMapIndexConfigs().get(0).getAttribute());
         assertTrue(mapConfig.getMapIndexConfigs().get(0).isOrdered());
-        assertEquals(1, mapConfig.getMapAttributeConfigs().size());
-        assertEquals("com.bank.CurrencyExtractor", mapConfig.getMapAttributeConfigs().get(0).getExtractor());
-        assertEquals("currency", mapConfig.getMapAttributeConfigs().get(0).getName());
+        assertEquals(1, mapConfig.getAttributeConfigs().size());
+        assertEquals("com.bank.CurrencyExtractor", mapConfig.getAttributeConfigs().get(0).getExtractorClassName());
+        assertEquals("currency", mapConfig.getAttributeConfigs().get(0).getName());
         assertEquals(1, mapConfig.getPartitionLostListenerConfigs().size());
         assertEquals("com.your-package.YourPartitionLostListener",
                 mapConfig.getPartitionLostListenerConfigs().get(0).getClassName());
@@ -2529,16 +2529,16 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    people:\n"
                 + "      attributes:\n"
                 + "        power:\n"
-                + "          extractor: com.car.PowerExtractor\n"
+                + "          extractor-class-name: com.car.PowerExtractor\n"
                 + "        weight:\n"
-                + "          extractor: com.car.WeightExtractor\n";
+                + "          extractor-class-name: com.car.WeightExtractor\n";
 
         Config config = buildConfig(yaml);
         MapConfig mapConfig = config.getMapConfig("people");
 
-        assertFalse(mapConfig.getMapAttributeConfigs().isEmpty());
-        assertAttributeEqual("power", "com.car.PowerExtractor", mapConfig.getMapAttributeConfigs().get(0));
-        assertAttributeEqual("weight", "com.car.WeightExtractor", mapConfig.getMapAttributeConfigs().get(1));
+        assertFalse(mapConfig.getAttributeConfigs().isEmpty());
+        assertAttributeEqual("power", "com.car.PowerExtractor", mapConfig.getAttributeConfigs().get(0));
+        assertAttributeEqual("weight", "com.car.WeightExtractor", mapConfig.getAttributeConfigs().get(1));
     }
 
     @Override
@@ -2549,14 +2549,14 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "  map:\n"
                 + "    people:\n"
                 + "      attributes:\n"
-                + "        - extractor: com.car.WeightExtractor\n";
+                + "        - extractor-class-name: com.car.WeightExtractor\n";
 
         buildConfig(yaml);
     }
 
-    private static void assertAttributeEqual(String expectedName, String expectedExtractor, MapAttributeConfig attributeConfig) {
+    private static void assertAttributeEqual(String expectedName, String expectedExtractor, AttributeConfig attributeConfig) {
         assertEquals(expectedName, attributeConfig.getName());
-        assertEquals(expectedExtractor, attributeConfig.getExtractor());
+        assertEquals(expectedExtractor, attributeConfig.getExtractorClassName());
     }
 
     @Override
@@ -2567,7 +2567,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "  map:\n"
                 + "   people:\n"
                 + "     attributes:\n"
-                + "       - extractor: com.car.WeightExtractor\n";
+                + "       - extractor-class-name: com.car.WeightExtractor\n";
         buildConfig(yaml);
     }
 
@@ -2592,7 +2592,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    people:\n"
                 + "      attributes:\n"
                 + "        weight:\n"
-                + "          extractor: \"\"\n";
+                + "          extractor-class-name: \"\"\n";
         buildConfig(yaml);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
@@ -133,7 +133,7 @@ public class DynamicConfigBouncingTest extends HazelcastTestSupport {
                 .addMapPartitionLostListenerConfig(new MapPartitionLostListenerConfig("foo.bar.Classname"))
                 .addMapIndexConfig(new MapIndexConfig("orderAttribute", true))
                 .addMapIndexConfig(new MapIndexConfig("unorderedAttribute", false))
-                .addMapAttributeConfig(new MapAttributeConfig("attribute", "foo.bar.ExtractorClass"))
+                .addAttributeConfig(new AttributeConfig("attribute", "foo.bar.ExtractorClass"))
                 .addQueryCacheConfig(queryCacheConfig)
                 .setStatisticsEnabled(false)
                 .setPartitioningStrategyConfig(new PartitioningStrategyConfig("foo.bar.Class"))

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -39,7 +39,7 @@ import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.LockConfig;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
@@ -866,7 +866,7 @@ public class DynamicConfigTest extends HazelcastTestSupport {
                 .setTimeToLiveSeconds(220)
                 .setMaxIdleSeconds(110)
                 .setSplitBrainProtectionName(randomString())
-                .addMapAttributeConfig(new MapAttributeConfig("attributeName", "com.attribute.extractor"))
+                .addAttributeConfig(new AttributeConfig("attributeName", "com.attribute.extractor"))
                 .addMapIndexConfig(new MapIndexConfig("attr", true))
                 .setMetadataPolicy(MetadataPolicy.OFF)
                 .setReadBackupData(true)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ExtractorsAndIndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ExtractorsAndIndexesTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
@@ -62,7 +62,7 @@ public class ExtractorsAndIndexesTest extends HazelcastTestSupport {
 
         Config config = new Config();
         config.getMapConfig(mapName).setInMemoryFormat(inMemoryFormat).addMapIndexConfig(new MapIndexConfig("last", true))
-              .addMapAttributeConfig(new MapAttributeConfig("generated", Extractor.class.getName()));
+              .addAttributeConfig(new AttributeConfig("generated", Extractor.class.getName()));
         config.getNativeMemoryConfig().setEnabled(true);
 
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "1");

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.querycache;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.EntryAdapter;
@@ -208,9 +208,9 @@ public class QueryCacheTest extends AbstractQueryCacheTestSupport {
     }
 
     @Test
-    public void testQueryCache_with_mapAttribute_inPredicate() {
+    public void testQueryCache_with_attribute_inPredicate() {
 
-        String MAP_ATTRIBUTE_NAME = "booleanMapAttribute";
+        String ATTRIBUTE_NAME = "booleanAttribute";
 
         Config config = new Config();
         config.getMapConfig(mapName)
@@ -218,12 +218,12 @@ public class QueryCacheTest extends AbstractQueryCacheTestSupport {
                         new QueryCacheConfig(cacheName)
                                 .setIncludeValue(true)
                                 .setPredicateConfig(// use map attribute in a predicate
-                                        new PredicateConfig(Predicates.equal(MAP_ATTRIBUTE_NAME, true))
+                                        new PredicateConfig(Predicates.equal(ATTRIBUTE_NAME, true))
                                 ))
-                .addMapAttributeConfig(
-                        new MapAttributeConfig()
-                                .setExtractor(EvenNumberEmployeeValueExtractor.class.getName())
-                                .setName(MAP_ATTRIBUTE_NAME));
+                .addAttributeConfig(
+                        new AttributeConfig()
+                                .setExtractorClassName(EvenNumberEmployeeValueExtractor.class.getName())
+                                .setName(ATTRIBUTE_NAME));
 
         IMap<Integer, Employee> map = getIMap(config);
         QueryCache<Integer, Employee> queryCache = map.getQueryCache(cacheName);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryPerformanceBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryPerformanceBenchmark.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.map.IMap;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
@@ -70,13 +70,13 @@ public class QueryPerformanceBenchmark extends HazelcastTestSupport {
     @Setup
     public void setup() {
         // object map
-        MapAttributeConfig nameWithExtractor = new MapAttributeConfig()
+        AttributeConfig nameWithExtractor = new AttributeConfig()
                 .setName("nameWithExtractor")
-                .setExtractor("com.hazelcast.query.impl.QueryPerformanceTest$NameExtractor");
+                .setExtractorClassName("com.hazelcast.query.impl.QueryPerformanceTest$NameExtractor");
 
-        MapAttributeConfig limbNameWithExtractor = new MapAttributeConfig()
+        AttributeConfig limbNameWithExtractor = new AttributeConfig()
                 .setName("limbNameWithExtractor")
-                .setExtractor("com.hazelcast.query.impl.QueryPerformanceTest$LimbNameExtractor");
+                .setExtractorClassName("com.hazelcast.query.impl.QueryPerformanceTest$LimbNameExtractor");
 
         MapConfig objectMapConfig = new MapConfig()
                 .setName("objectMap")
@@ -85,22 +85,22 @@ public class QueryPerformanceBenchmark extends HazelcastTestSupport {
         MapConfig objectMapWithExtractorConfig = new MapConfig()
                 .setName("objectMapWithExtractor")
                 .setInMemoryFormat(InMemoryFormat.OBJECT)
-                .addMapAttributeConfig(nameWithExtractor)
-                .addMapAttributeConfig(limbNameWithExtractor);
+                .addAttributeConfig(nameWithExtractor)
+                .addAttributeConfig(limbNameWithExtractor);
 
         // portable map
-        MapAttributeConfig portableNameWithExtractor = new MapAttributeConfig()
+        AttributeConfig portableNameWithExtractor = new AttributeConfig()
                 .setName("nameWithExtractor")
-                .setExtractor("com.hazelcast.query.impl.QueryPerformanceTest$PortableNameExtractor");
+                .setExtractorClassName("com.hazelcast.query.impl.QueryPerformanceTest$PortableNameExtractor");
 
-        MapAttributeConfig portableLimbNameWithExtractor = new MapAttributeConfig()
+        AttributeConfig portableLimbNameWithExtractor = new AttributeConfig()
                 .setName("limbNameWithExtractor")
-                .setExtractor("com.hazelcast.query.impl.QueryPerformanceTest$PortableLimbNameExtractor");
+                .setExtractorClassName("com.hazelcast.query.impl.QueryPerformanceTest$PortableLimbNameExtractor");
 
         MapConfig portableMapConfig = new MapConfig()
                 .setName("portableMapWithExtractor")
-                .addMapAttributeConfig(portableNameWithExtractor)
-                .addMapAttributeConfig(portableLimbNameWithExtractor);
+                .addAttributeConfig(portableNameWithExtractor)
+                .addAttributeConfig(portableLimbNameWithExtractor);
 
         // config
         Config config = new Config()

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.extractor;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -125,12 +125,12 @@ public abstract class AbstractExtractionTest extends AbstractExtractionSpecifica
      * reflection-based tests without any code changes and to use them with extractors.
      * In this way we avoid the name validation and can reuse the dot names
      */
-    public static class TestMapAttributeIndexConfig extends MapAttributeConfig {
+    public static class TestAttributeIndexConfig extends AttributeConfig {
 
         private String name;
 
         @Override
-        public MapAttributeConfig setName(String name) {
+        public AttributeConfig setName(String name) {
             this.name = name;
             return this;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.extractor.predicates;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
@@ -66,25 +66,25 @@ public class CollectionAllPredicatesExtractorTest extends CollectionAllPredicate
             public void doWithConfig(Config config, Multivalue mv) {
                 MapConfig mapConfig = config.getMapConfig("map");
 
-                MapAttributeConfig reducedNameAttribute = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig reducedNameAttribute = new TestAttributeIndexConfig();
                 reducedNameAttribute.setName(AbstractExtractionTest.parametrize("limb_[any].name", mv));
-                reducedNameAttribute.setExtractor("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$ReducedLimbNameExtractor");
-                mapConfig.addMapAttributeConfig(reducedNameAttribute);
+                reducedNameAttribute.setExtractorClassName("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$ReducedLimbNameExtractor");
+                mapConfig.addAttributeConfig(reducedNameAttribute);
 
-                MapAttributeConfig indexOneNameAttribute = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig indexOneNameAttribute = new TestAttributeIndexConfig();
                 indexOneNameAttribute.setName(AbstractExtractionTest.parametrize("limb_[1].name", mv));
-                indexOneNameAttribute.setExtractor("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$IndexOneLimbNameExtractor");
-                mapConfig.addMapAttributeConfig(indexOneNameAttribute);
+                indexOneNameAttribute.setExtractorClassName("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$IndexOneLimbNameExtractor");
+                mapConfig.addAttributeConfig(indexOneNameAttribute);
 
-                MapAttributeConfig reducedPowerAttribute = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig reducedPowerAttribute = new TestAttributeIndexConfig();
                 reducedPowerAttribute.setName(AbstractExtractionTest.parametrize("limb_[any].power", mv));
-                reducedPowerAttribute.setExtractor("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$ReducedLimbPowerExtractor");
-                mapConfig.addMapAttributeConfig(reducedPowerAttribute);
+                reducedPowerAttribute.setExtractorClassName("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$ReducedLimbPowerExtractor");
+                mapConfig.addAttributeConfig(reducedPowerAttribute);
 
-                MapAttributeConfig indexOnePowerAttribute = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig indexOnePowerAttribute = new TestAttributeIndexConfig();
                 indexOnePowerAttribute.setName(AbstractExtractionTest.parametrize("limb_[1].power", mv));
-                indexOnePowerAttribute.setExtractor("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$IndexOneLimbPowerExtractor");
-                mapConfig.addMapAttributeConfig(indexOnePowerAttribute);
+                indexOnePowerAttribute.setExtractorClassName("com.hazelcast.query.impl.extractor.predicates.CollectionAllPredicatesExtractorTest$IndexOneLimbPowerExtractor");
+                mapConfig.addAttributeConfig(indexOnePowerAttribute);
             }
         };
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.extractor.predicates;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
@@ -63,15 +63,15 @@ public class SingleValueAllPredicatesExtractorTest extends SingleValueAllPredica
             public void doWithConfig(Config config, Multivalue mv) {
                 MapConfig mapConfig = config.getMapConfig("map");
 
-                MapAttributeConfig iqConfig = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig iqConfig = new TestAttributeIndexConfig();
                 iqConfig.setName("brain.iq");
-                iqConfig.setExtractor("com.hazelcast.query.impl.extractor.predicates.SingleValueAllPredicatesExtractorTest$IqExtractor");
-                mapConfig.addMapAttributeConfig(iqConfig);
+                iqConfig.setExtractorClassName("com.hazelcast.query.impl.extractor.predicates.SingleValueAllPredicatesExtractorTest$IqExtractor");
+                mapConfig.addAttributeConfig(iqConfig);
 
-                MapAttributeConfig nameConfig = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig nameConfig = new TestAttributeIndexConfig();
                 nameConfig.setName("brain.name");
-                nameConfig.setExtractor("com.hazelcast.query.impl.extractor.predicates.SingleValueAllPredicatesExtractorTest$NameExtractor");
-                mapConfig.addMapAttributeConfig(nameConfig);
+                nameConfig.setExtractorClassName("com.hazelcast.query.impl.extractor.predicates.SingleValueAllPredicatesExtractorTest$NameExtractor");
+                mapConfig.addAttributeConfig(nameConfig);
             }
         };
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionWithExtractorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionWithExtractorsSpecTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.extractor.specification;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
@@ -179,10 +179,10 @@ public class ExtractionWithExtractorsSpecTest extends AbstractExtractionTest {
             public void doWithConfig(Config config, AbstractExtractionTest.Multivalue mv) {
                 MapConfig mapConfig = config.getMapConfig("map");
 
-                MapAttributeConfig tattoosCount = new AbstractExtractionTest.TestMapAttributeIndexConfig();
+                AttributeConfig tattoosCount = new TestAttributeIndexConfig();
                 tattoosCount.setName("tattoosCount");
-                tattoosCount.setExtractor("com.hazelcast.query.impl.extractor.specification.ExtractionWithExtractorsSpecTest$LimbTattoosCountExtractor");
-                mapConfig.addMapAttributeConfig(tattoosCount);
+                tattoosCount.setExtractorClassName("com.hazelcast.query.impl.extractor.specification.ExtractionWithExtractorsSpecTest$LimbTattoosCountExtractor");
+                mapConfig.addAttributeConfig(tattoosCount);
 
                 config.getSerializationConfig().addPortableFactory(ComplexTestDataStructure.PersonPortableFactory.ID, new ComplexTestDataStructure.PersonPortableFactory());
             }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.getters;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -69,8 +69,8 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractor() {
         // GIVEN
-        MapAttributeConfig config
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+        AttributeConfig config
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
 
         // WHEN
         ValueExtractor extractor = instantiateExtractor(config);
@@ -82,7 +82,7 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractor_notExistingClass() {
         // GIVEN
-        MapAttributeConfig config = new MapAttributeConfig("iq", "not.existing.class");
+        AttributeConfig config = new AttributeConfig("iq", "not.existing.class");
 
         // EXPECT
         expected.expect(IllegalArgumentException.class);
@@ -95,10 +95,10 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors() {
         // GIVEN
-        MapAttributeConfig iqExtractor
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
-        MapAttributeConfig nameExtractor
-                = new MapAttributeConfig("name", "com.hazelcast.query.impl.getters.ExtractorHelperTest$NameExtractor");
+        AttributeConfig iqExtractor
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+        AttributeConfig nameExtractor
+                = new AttributeConfig("name", "com.hazelcast.query.impl.getters.ExtractorHelperTest$NameExtractor");
 
         // WHEN
         Map<String, ValueExtractor> extractors =
@@ -112,10 +112,10 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors_withCustomClassLoader() {
         // GIVEN
-        MapAttributeConfig iqExtractor =
-                new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
-        MapAttributeConfig nameExtractor =
-                new MapAttributeConfig("name", "com.hazelcast.query.impl.getters.ExtractorHelperTest$NameExtractor");
+        AttributeConfig iqExtractor =
+                new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+        AttributeConfig nameExtractor =
+                new AttributeConfig("name", "com.hazelcast.query.impl.getters.ExtractorHelperTest$NameExtractor");
         Config config = new Config();
         // For other custom class loaders (from OSGi bundles, for example)
         ClassLoader customClassLoader = getClass().getClassLoader();
@@ -132,9 +132,9 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors_oneClassNotExisting() {
         // GIVEN
-        MapAttributeConfig iqExtractor
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
-        MapAttributeConfig nameExtractor = new MapAttributeConfig("name", "not.existing.class");
+        AttributeConfig iqExtractor
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+        AttributeConfig nameExtractor = new AttributeConfig("name", "not.existing.class");
 
         // EXPECT
         expected.expect(IllegalArgumentException.class);
@@ -147,10 +147,10 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors_duplicateExtractor() {
         // GIVEN
-        MapAttributeConfig iqExtractor
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
-        MapAttributeConfig iqExtractorDuplicate
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+        AttributeConfig iqExtractor
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+        AttributeConfig iqExtractorDuplicate
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
 
         // EXPECT
         expected.expect(IllegalArgumentException.class);
@@ -162,7 +162,7 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors_wrongType() {
         // GIVEN
-        MapAttributeConfig string = new MapAttributeConfig("iq", "java.lang.String");
+        AttributeConfig string = new AttributeConfig("iq", "java.lang.String");
 
         // EXPECT
         expected.expect(IllegalArgumentException.class);
@@ -174,8 +174,8 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors_initException() {
         // GIVEN
-        MapAttributeConfig string
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$InitExceptionExtractor");
+        AttributeConfig string
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$InitExceptionExtractor");
 
         // EXPECT
         expected.expect(IllegalArgumentException.class);
@@ -187,8 +187,8 @@ public class ExtractorHelperTest {
     @Test
     public void instantiate_extractors_accessException() {
         // GIVEN
-        MapAttributeConfig string
-                = new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$AccessExceptionExtractor");
+        AttributeConfig string
+                = new AttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$AccessExceptionExtractor");
 
         // EXPECT
         expected.expect(IllegalArgumentException.class);
@@ -265,13 +265,13 @@ public class ExtractorHelperTest {
         assertEquals("car.wheel[2].pressure", extractAttributeNameNameWithoutArguments("car.wheel[2].pressure[BAR]"));
     }
 
-    private ValueExtractor instantiateExtractor(MapAttributeConfig mapAttributeConfig) {
-        return ExtractorHelper.instantiateExtractor(mapAttributeConfig,
+    private ValueExtractor instantiateExtractor(AttributeConfig attributeConfig) {
+        return ExtractorHelper.instantiateExtractor(attributeConfig,
                 useClassloader ? this.getClass().getClassLoader() : null);
     }
 
-    private Map<String, ValueExtractor> instantiateExtractors(List<MapAttributeConfig> mapAttributeConfigs) {
-        return ExtractorHelper.instantiateExtractors(mapAttributeConfigs,
+    private Map<String, ValueExtractor> instantiateExtractors(List<AttributeConfig> attributeConfigs) {
+        return ExtractorHelper.instantiateExtractors(attributeConfigs,
                 useClassloader ? this.getClass().getClassLoader() : null);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.getters;
 
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.extractor.ValueCollector;
@@ -95,8 +95,8 @@ public class ExtractorsTest {
     @Test
     public void getGetter_extractor_cachingWorks() {
         // GIVEN
-        MapAttributeConfig config
-                = new MapAttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
+        AttributeConfig config
+                = new AttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
         Extractors extractors = createExtractors(config);
 
         // WHEN
@@ -108,10 +108,10 @@ public class ExtractorsTest {
         assertThat(getterFirstInvocation, instanceOf(ExtractorGetter.class));
     }
 
-    protected Extractors createExtractors(MapAttributeConfig config) {
+    protected Extractors createExtractors(AttributeConfig config) {
         Extractors.Builder builder = Extractors.newBuilder(ss);
         if (config != null) {
-            builder.setMapAttributeConfigs(singletonList(config));
+            builder.setAttributeConfigs(singletonList(config));
         }
         if (useClassloader) {
             builder.setClassLoader(this.getClass().getClassLoader());
@@ -122,8 +122,8 @@ public class ExtractorsTest {
     @Test
     public void extract_extractor_correctValue() {
         // GIVEN
-        MapAttributeConfig config
-                = new MapAttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
+        AttributeConfig config
+                = new AttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
         Extractors extractors = createExtractors(config);
 
         // WHEN

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
@@ -58,19 +58,19 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         Config config = new Config();
         MapConfig mapConfig = new MapConfig();
         mapConfig.setName("map");
-        mapConfig.addMapAttributeConfig(extractor("name",
+        mapConfig.addAttributeConfig(extractor("name",
                 "com.hazelcast.query.impl.predicates.NestedPredicateWithExtractorTest$BodyNameExtractor"));
-        mapConfig.addMapAttributeConfig(extractor("limbname",
+        mapConfig.addAttributeConfig(extractor("limbname",
                 "com.hazelcast.query.impl.predicates.NestedPredicateWithExtractorTest$LimbNameExtractor"));
         config.addMapConfig(mapConfig);
         HazelcastInstance instance = createHazelcastInstance(config);
         map = instance.getMap("map");
     }
 
-    private static MapAttributeConfig extractor(String name, String extractor) {
-        MapAttributeConfig extractorConfig = new MapAttributeConfig();
+    private static AttributeConfig extractor(String name, String extractor) {
+        AttributeConfig extractorConfig = new AttributeConfig();
         extractorConfig.setName(name);
-        extractorConfig.setExtractor(extractor);
+        extractorConfig.setExtractorClassName(extractor);
         return extractorConfig;
     }
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -353,8 +353,8 @@
         </indexes>
 
         <attributes>
-            <attribute extractor="com.example.CurrencyExtractor">currency</attribute>
-            <attribute extractor="com.example.AgeExtractor">age</attribute>
+            <attribute extractor-class-name="com.example.CurrencyExtractor">currency</attribute>
+            <attribute extractor-class-name="com.example.AgeExtractor">age</attribute>
         </attributes>
 
         <entry-listeners>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -336,9 +336,9 @@ hazelcast:
 
       attributes:
         currency:
-          extractor: com.example.CurrencyExtractor
+          extractor-class-name: com.example.CurrencyExtractor
         age:
-          extractor: com.example.AgeExtractor
+          extractor-class-name: com.example.AgeExtractor
 
       entry-listeners:
         - include-value: true


### PR DESCRIPTION
PR for task #15547:
1) `MapAttributeConfig` is renamed to `AttributeConfig`
2) `extractor` field is renamed to `extractorClassName`

Client protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/220