### PR TITLE
Cache config protocol encoder

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -84,6 +84,8 @@
     <suppress checks="CyclomaticComplexity|ClassDataAbstractionCoupling"
               files="com[\\/]hazelcast[\\/]config[\\/]AbstractDomConfigProcessor"/>
     <suppress checks="ExecutableStatementCount" files="com[\\/]hazelcast[\\/]config[\\/]CacheConfig"/>
+    <suppress checks="ExecutableStatementCount"
+              files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]protocol[\\/]codec[\\/]holder[\\/]CacheConfigHolder"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]CacheSimpleConfig"/>
     <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]config[\\/]Config"/>
     <suppress checks="FileLength"

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -100,6 +100,9 @@ final class ClientCacheHelper {
             Future<ClientMessage> future = clientInvocation.invoke();
             final ClientMessage response = future.get();
             final CacheConfigHolder cacheConfigHolder = CacheCreateConfigCodec.decodeResponse(response).response;
+            if (cacheConfigHolder == null) {
+                return null;
+            }
             return cacheConfigHolder.asCacheConfig(serializationService);
         } catch (Exception e) {
             throw rethrow(e);

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -22,12 +22,13 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheCreateConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheGetConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheManagementConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.cluster.Member;
-import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.Address;
 import com.hazelcast.util.FutureUtil;
 
 import java.util.ArrayList;
@@ -65,8 +66,12 @@ final class ClientCacheHelper {
             ClientMessage responseMessage = future.get();
             SerializationService serializationService = client.getSerializationService();
 
-            Data responseData = CacheGetConfigCodec.decodeResponse(responseMessage).response;
-            return serializationService.toObject(responseData);
+            CacheConfigHolder cacheConfigHolder = CacheGetConfigCodec.decodeResponse(responseMessage).response;
+            if (cacheConfigHolder == null) {
+                return null;
+            }
+
+            return cacheConfigHolder.asCacheConfig(serializationService);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -88,13 +93,14 @@ final class ClientCacheHelper {
             String nameWithPrefix = newCacheConfig.getNameWithPrefix();
             int partitionId = client.getClientPartitionService().getPartitionId(nameWithPrefix);
 
-            Data configData = client.getSerializationService().toData(newCacheConfig);
-            ClientMessage request = CacheCreateConfigCodec.encodeRequest(configData, true);
+            InternalSerializationService serializationService = client.getSerializationService();
+            ClientMessage request = CacheCreateConfigCodec
+                    .encodeRequest(CacheConfigHolder.of(newCacheConfig, serializationService), true);
             ClientInvocation clientInvocation = new ClientInvocation(client, request, nameWithPrefix, partitionId);
             Future<ClientMessage> future = clientInvocation.invoke();
             final ClientMessage response = future.get();
-            final Data data = CacheCreateConfigCodec.decodeResponse(response).response;
-            return client.getSerializationService().toObject(data);
+            final CacheConfigHolder cacheConfigHolder = CacheCreateConfigCodec.decodeResponse(response).response;
+            return cacheConfigHolder.asCacheConfig(serializationService);
         } catch (Exception e) {
             throw rethrow(e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetConfigCodec.java
@@ -17,12 +17,19 @@
 package com.hazelcast.client.impl.protocol.codec;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.builtin.*;
+import com.hazelcast.client.impl.protocol.codec.builtin.CacheConfigHolderCodec;
+import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
+import com.hazelcast.client.impl.protocol.codec.builtin.StringCodec;
 
 import java.util.ListIterator;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.*;
-import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
+import static com.hazelcast.client.impl.protocol.ClientMessage.CORRELATION_ID_FIELD_OFFSET;
+import static com.hazelcast.client.impl.protocol.ClientMessage.PARTITION_ID_FIELD_OFFSET;
+import static com.hazelcast.client.impl.protocol.ClientMessage.TYPE_FIELD_OFFSET;
+import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.INT_SIZE_IN_BYTES;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.LONG_SIZE_IN_BYTES;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeInt;
 
 /**
  * TODO DOC
@@ -79,19 +86,18 @@ public final class CacheGetConfigCodec {
     public static class ResponseParameters {
 
         /**
-         * The cache configuration. Byte-array which is serialized from an object implementing
-         * javax.cache.configuration.Configuration interface.
+         * The cache configuration.
          */
-        public com.hazelcast.nio.serialization.Data response;
+        public com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder response;
     }
 
-    public static ClientMessage encodeResponse(com.hazelcast.nio.serialization.Data response) {
+    public static ClientMessage encodeResponse(com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder response) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
         clientMessage.add(initialFrame);
 
-        CodecUtil.encodeNullable(clientMessage, response, DataCodec::encode);
+        CodecUtil.encodeNullable(clientMessage, response, CacheConfigHolderCodec::encode);
         return clientMessage;
     }
 
@@ -100,7 +106,7 @@ public final class CacheGetConfigCodec {
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = CodecUtil.decodeNullable(iterator, DataCodec::decode);
+        response.response = CodecUtil.decodeNullable(iterator, CacheConfigHolderCodec::decode);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CacheConfigHolderCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CacheConfigHolderCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 public final class CacheConfigHolderCodec {
     private static final int BACKUP_COUNT_OFFSET = 0;
     private static final int ASYNC_BACKUP_COUNT_OFFSET = BACKUP_COUNT_OFFSET + Bits.INT_SIZE_IN_BYTES;
-    private static final int IS_READ_THROUGH_OFFSET = ASYNC_BACKUP_COUNT_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+    private static final int IS_READ_THROUGH_OFFSET = ASYNC_BACKUP_COUNT_OFFSET + Bits.INT_SIZE_IN_BYTES;
     private static final int IS_WRITE_THROUGH_OFFSET = IS_READ_THROUGH_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
     private static final int IS_STORE_BY_VALUE_OFFSET = IS_WRITE_THROUGH_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
     private static final int IS_MANAGEMENT_ENABLED_OFFSET = IS_STORE_BY_VALUE_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CacheConfigHolderCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CacheConfigHolderCodec.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder;
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.EvictionConfigHolder;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.HotRestartConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.WanReplicationRef;
+import com.hazelcast.nio.Bits;
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.List;
+import java.util.ListIterator;
+
+import static com.hazelcast.client.impl.protocol.ClientMessage.BEGIN_FRAME;
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_FRAME;
+import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.decodeNullable;
+import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.encodeNullable;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.decodeBoolean;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.decodeInt;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeBoolean;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeInt;
+
+public final class CacheConfigHolderCodec {
+    private static final int BACKUP_COUNT_OFFSET = 0;
+    private static final int ASYNC_BACKUP_COUNT_OFFSET = BACKUP_COUNT_OFFSET + Bits.INT_SIZE_IN_BYTES;
+    private static final int IS_READ_THROUGH_OFFSET = ASYNC_BACKUP_COUNT_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+    private static final int IS_WRITE_THROUGH_OFFSET = IS_READ_THROUGH_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+    private static final int IS_STORE_BY_VALUE_OFFSET = IS_WRITE_THROUGH_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+    private static final int IS_MANAGEMENT_ENABLED_OFFSET = IS_STORE_BY_VALUE_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+    private static final int IS_STATISTICS_ENABLED_OFFSET = IS_MANAGEMENT_ENABLED_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+    private static final int DISABLE_PER_ENTRY_INVALIDATION_EVENTS_OFFSET =
+            IS_STATISTICS_ENABLED_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+
+    private static final int INITIAL_FRAME_SIZE = DISABLE_PER_ENTRY_INVALIDATION_EVENTS_OFFSET + Bits.BOOLEAN_SIZE_IN_BYTES;
+
+    private CacheConfigHolderCodec() {
+    }
+
+    public static <K, V> void encode(ClientMessage clientMessage, CacheConfigHolder config) {
+        clientMessage.add(BEGIN_FRAME);
+
+        ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
+        encodeInt(initialFrame.content, BACKUP_COUNT_OFFSET, config.getBackupCount());
+        encodeInt(initialFrame.content, ASYNC_BACKUP_COUNT_OFFSET, config.getAsyncBackupCount());
+        encodeBoolean(initialFrame.content, IS_READ_THROUGH_OFFSET, config.isReadThrough());
+        encodeBoolean(initialFrame.content, IS_WRITE_THROUGH_OFFSET, config.isWriteThrough());
+        encodeBoolean(initialFrame.content, IS_STORE_BY_VALUE_OFFSET, config.isStoreByValue());
+        encodeBoolean(initialFrame.content, IS_MANAGEMENT_ENABLED_OFFSET, config.isManagementEnabled());
+        encodeBoolean(initialFrame.content, IS_STATISTICS_ENABLED_OFFSET, config.isStatisticsEnabled());
+        encodeBoolean(initialFrame.content, DISABLE_PER_ENTRY_INVALIDATION_EVENTS_OFFSET,
+                config.isDisablePerEntryInvalidationEvents());
+        clientMessage.add(initialFrame);
+
+        StringCodec.encode(clientMessage, config.getName());
+        encodeNullable(clientMessage, config.getManagerPrefix(), StringCodec::encode);
+        encodeNullable(clientMessage, config.getUriString(), StringCodec::encode);
+        StringCodec.encode(clientMessage, config.getInMemoryFormat());
+
+        EvictionConfigHolderCodec.encode(clientMessage, config.getEvictionConfigHolder());
+
+        encodeNullable(clientMessage, config.getWanReplicationRef(), WanReplicationRefCodec::encode);
+        StringCodec.encode(clientMessage, config.getKeyClassName());
+        StringCodec.encode(clientMessage, config.getValueClassName());
+        encodeNullable(clientMessage, config.getCacheLoaderFactory(), DataCodec::encode);
+        encodeNullable(clientMessage, config.getCacheWriterFactory(), DataCodec::encode);
+        encodeNullable(clientMessage, config.getExpiryPolicyFactory(), DataCodec::encode);
+        encodeNullable(clientMessage, config.getHotRestartConfig(), HotRestartConfigCodec::encode);
+        encodeNullable(clientMessage, config.getEventJournalConfig(), EventJournalConfigCodec::encode);
+        encodeNullable(clientMessage, config.getSplitBrainProtectionName(), StringCodec::encode);
+        ListMultiFrameCodec.encodeNullable(clientMessage, config.getListenerConfigurations(), DataCodec::encode);
+        MergePolicyConfigCodec.encode(clientMessage, config.getMergePolicyConfig());
+
+        clientMessage.add(END_FRAME);
+    }
+
+    public static CacheConfigHolder decode(ListIterator<ClientMessage.Frame> iterator) {
+        // begin frame
+        iterator.next();
+
+        ClientMessage.Frame initialFrame = iterator.next();
+        int backupCount = decodeInt(initialFrame.content, BACKUP_COUNT_OFFSET);
+        int asyncBackupCount = decodeInt(initialFrame.content, ASYNC_BACKUP_COUNT_OFFSET);
+        boolean isReadThrough = decodeBoolean(initialFrame.content, IS_READ_THROUGH_OFFSET);
+        boolean isWriteThrough = decodeBoolean(initialFrame.content, IS_WRITE_THROUGH_OFFSET);
+        boolean isStoreByValue = decodeBoolean(initialFrame.content, IS_STORE_BY_VALUE_OFFSET);
+        boolean isManagementEnabled = decodeBoolean(initialFrame.content, IS_MANAGEMENT_ENABLED_OFFSET);
+        boolean isStatisticsEnabled = decodeBoolean(initialFrame.content, IS_STATISTICS_ENABLED_OFFSET);
+        boolean disablePerEntryInvalidationEvents = decodeBoolean(initialFrame.content,
+                DISABLE_PER_ENTRY_INVALIDATION_EVENTS_OFFSET);
+
+        String name = StringCodec.decode(iterator);
+        String managerPrefix = decodeNullable(iterator, StringCodec::decode);
+        String uriString = decodeNullable(iterator, StringCodec::decode);
+        String inMemoryFormat = StringCodec.decode(iterator);
+
+        EvictionConfigHolder evictionConfigHolder = EvictionConfigHolderCodec.decode(iterator);
+
+        WanReplicationRef wanReplicationRef = decodeNullable(iterator, WanReplicationRefCodec::decode);
+
+        String keyClassName = StringCodec.decode(iterator);
+        String valueClassName = StringCodec.decode(iterator);
+
+        Data cacheLoaderFactory = decodeNullable(iterator, DataCodec::decode);
+        Data cacheWriterFactory = decodeNullable(iterator, DataCodec::decode);
+        Data expiryPolicyFactory = decodeNullable(iterator, DataCodec::decode);
+
+        HotRestartConfig hotRestartConfig = decodeNullable(iterator, HotRestartConfigCodec::decode);
+        EventJournalConfig eventJournalConfig = decodeNullable(iterator, EventJournalConfigCodec::decode);
+        String splitBrainProtectionName = decodeNullable(iterator, StringCodec::decode);
+        List<Data> listenerConfigurations = ListMultiFrameCodec.decodeNullable(iterator, DataCodec::decode);
+        MergePolicyConfig mergePolicyConfig = MergePolicyConfigCodec.decode(iterator);
+
+        return new CacheConfigHolder(name, managerPrefix, uriString, backupCount, asyncBackupCount, inMemoryFormat,
+                evictionConfigHolder, wanReplicationRef, keyClassName, valueClassName, cacheLoaderFactory, cacheWriterFactory,
+                expiryPolicyFactory, isReadThrough, isWriteThrough, isStoreByValue, isManagementEnabled, isStatisticsEnabled,
+                hotRestartConfig, eventJournalConfig, splitBrainProtectionName, listenerConfigurations, mergePolicyConfig,
+                disablePerEntryInvalidationEvents);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/MergePolicyConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/MergePolicyConfigCodec.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.nio.Bits;
+
+import java.util.ListIterator;
+
+import static com.hazelcast.client.impl.protocol.ClientMessage.BEGIN_FRAME;
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_FRAME;
+import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastForwardToEndFrame;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.decodeInt;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeInt;
+
+public final class MergePolicyConfigCodec {
+    private static final int BATCH_SIZE_OFFSET = 0;
+    private static final int INITIAL_FRAME_SIZE = BATCH_SIZE_OFFSET + Bits.INT_SIZE_IN_BYTES;
+
+    private MergePolicyConfigCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, MergePolicyConfig config) {
+        clientMessage.add(BEGIN_FRAME);
+        ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
+        encodeInt(initialFrame.content, BATCH_SIZE_OFFSET, config.getBatchSize());
+        clientMessage.add(initialFrame);
+        StringCodec.encode(clientMessage, config.getPolicy());
+        clientMessage.add(END_FRAME);
+    }
+
+    public static MergePolicyConfig decode(ListIterator<ClientMessage.Frame> iterator) {
+        // begin frame
+        iterator.next();
+        ClientMessage.Frame initialFrame = iterator.next();
+        int batchSize = decodeInt(initialFrame.content, BATCH_SIZE_OFFSET);
+        String policy = StringCodec.decode(iterator);
+        fastForwardToEndFrame(iterator);
+        return new MergePolicyConfig(policy, batchSize);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/holder/CacheConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/holder/CacheConfigHolder.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.holder;
+
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.EvictionConfigHolder;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.HotRestartConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.WanReplicationRef;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class CacheConfigHolder {
+    private String name;
+    private String managerPrefix;
+    private String uriString;
+    private int backupCount;
+    private int asyncBackupCount;
+    private String inMemoryFormat;
+    private EvictionConfigHolder evictionConfigHolder;
+    private WanReplicationRef wanReplicationRef;
+    private String keyClassName;
+    private String valueClassName;
+    private Data cacheLoaderFactory;
+    private Data cacheWriterFactory;
+    private Data expiryPolicyFactory;
+    private boolean isReadThrough;
+    private boolean isWriteThrough;
+    private boolean isStoreByValue;
+    private boolean isManagementEnabled;
+    private boolean isStatisticsEnabled;
+    private HotRestartConfig hotRestartConfig;
+    private EventJournalConfig eventJournalConfig;
+    private String splitBrainProtectionName;
+    private List<Data> listenerConfigurations;
+    private MergePolicyConfig mergePolicyConfig;
+    private boolean disablePerEntryInvalidationEvents;
+
+    public CacheConfigHolder(String name, String managerPrefix, String uriString, int backupCount, int asyncBackupCount,
+                             String inMemoryFormat, EvictionConfigHolder evictionConfigHolder,
+                             WanReplicationRef wanReplicationRef, String keyClassName, String valueClassName,
+                             Data cacheLoaderFactory, Data cacheWriterFactory, Data expiryPolicyFactory, boolean isReadThrough,
+                             boolean isWriteThrough, boolean isStoreByValue, boolean isManagementEnabled,
+                             boolean isStatisticsEnabled, HotRestartConfig hotRestartConfig,
+                             EventJournalConfig eventJournalConfig, String splitBrainProtectionName,
+                             List<Data> listenerConfigurations, MergePolicyConfig mergePolicyConfig,
+                             boolean disablePerEntryInvalidationEvents) {
+        this.name = name;
+        this.managerPrefix = managerPrefix;
+        this.uriString = uriString;
+        this.backupCount = backupCount;
+        this.asyncBackupCount = asyncBackupCount;
+        this.inMemoryFormat = inMemoryFormat;
+        this.evictionConfigHolder = evictionConfigHolder;
+        this.wanReplicationRef = wanReplicationRef;
+        this.keyClassName = keyClassName;
+        this.valueClassName = valueClassName;
+        this.cacheLoaderFactory = cacheLoaderFactory;
+        this.cacheWriterFactory = cacheWriterFactory;
+        this.expiryPolicyFactory = expiryPolicyFactory;
+        this.isReadThrough = isReadThrough;
+        this.isWriteThrough = isWriteThrough;
+        this.isStoreByValue = isStoreByValue;
+        this.isManagementEnabled = isManagementEnabled;
+        this.isStatisticsEnabled = isStatisticsEnabled;
+        this.hotRestartConfig = hotRestartConfig;
+        this.eventJournalConfig = eventJournalConfig;
+        this.splitBrainProtectionName = splitBrainProtectionName;
+        this.listenerConfigurations = listenerConfigurations;
+        this.mergePolicyConfig = mergePolicyConfig;
+        this.disablePerEntryInvalidationEvents = disablePerEntryInvalidationEvents;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getManagerPrefix() {
+        return managerPrefix;
+    }
+
+    public String getUriString() {
+        return uriString;
+    }
+
+    public int getBackupCount() {
+        return backupCount;
+    }
+
+    public int getAsyncBackupCount() {
+        return asyncBackupCount;
+    }
+
+    public String getInMemoryFormat() {
+        return inMemoryFormat;
+    }
+
+    public EvictionConfigHolder getEvictionConfigHolder() {
+        return evictionConfigHolder;
+    }
+
+    public WanReplicationRef getWanReplicationRef() {
+        return wanReplicationRef;
+    }
+
+    public String getKeyClassName() {
+        return keyClassName;
+    }
+
+    public String getValueClassName() {
+        return valueClassName;
+    }
+
+    public Data getCacheLoaderFactory() {
+        return cacheLoaderFactory;
+    }
+
+    public Data getCacheWriterFactory() {
+        return cacheWriterFactory;
+    }
+
+    public Data getExpiryPolicyFactory() {
+        return expiryPolicyFactory;
+    }
+
+    public boolean isReadThrough() {
+        return isReadThrough;
+    }
+
+    public boolean isWriteThrough() {
+        return isWriteThrough;
+    }
+
+    public boolean isStoreByValue() {
+        return isStoreByValue;
+    }
+
+    public boolean isManagementEnabled() {
+        return isManagementEnabled;
+    }
+
+    public boolean isStatisticsEnabled() {
+        return isStatisticsEnabled;
+    }
+
+    public HotRestartConfig getHotRestartConfig() {
+        return hotRestartConfig;
+    }
+
+    public EventJournalConfig getEventJournalConfig() {
+        return eventJournalConfig;
+    }
+
+    public String getSplitBrainProtectionName() {
+        return splitBrainProtectionName;
+    }
+
+    public List<Data> getListenerConfigurations() {
+        return listenerConfigurations;
+    }
+
+    public MergePolicyConfig getMergePolicyConfig() {
+        return mergePolicyConfig;
+    }
+
+    public boolean isDisablePerEntryInvalidationEvents() {
+        return disablePerEntryInvalidationEvents;
+    }
+
+    public <K, V> CacheConfig<K, V> asCacheConfig(SerializationService serializationService) {
+        CacheConfig<K, V> config = new CacheConfig();
+        config.setName(name);
+        config.setManagerPrefix(managerPrefix);
+        config.setUriString(uriString);
+        config.setBackupCount(backupCount);
+        config.setAsyncBackupCount(asyncBackupCount);
+        config.setInMemoryFormat(InMemoryFormat.valueOf(inMemoryFormat));
+        config.setEvictionConfig(evictionConfigHolder.asEvictionConfg(serializationService));
+        config.setWanReplicationRef(wanReplicationRef);
+        config.setKeyClassName(keyClassName);
+        config.setValueClassName(valueClassName);
+        config.setCacheLoaderFactory(serializationService.toObject(cacheLoaderFactory));
+        config.setCacheWriterFactory(serializationService.toObject(cacheWriterFactory));
+        config.setExpiryPolicyFactory(serializationService.toObject(expiryPolicyFactory));
+        config.setReadThrough(isReadThrough);
+        config.setWriteThrough(isWriteThrough);
+        config.setStoreByValue(isStoreByValue);
+        config.setManagementEnabled(isManagementEnabled);
+        config.setStatisticsEnabled(isStatisticsEnabled);
+        config.setHotRestartConfig(hotRestartConfig);
+        config.setEventJournalConfig(eventJournalConfig);
+        config.setSplitBrainProtectionName(splitBrainProtectionName);
+
+        if (listenerConfigurations != null && !listenerConfigurations.isEmpty()) {
+            config.setListenerConfigurations();
+            listenerConfigurations
+                    .forEach(listener -> config.addCacheEntryListenerConfiguration(serializationService.toObject(listener)));
+        }
+
+        config.setMergePolicyConfig(mergePolicyConfig);
+        config.setDisablePerEntryInvalidationEvents(disablePerEntryInvalidationEvents);
+
+        return config;
+    }
+
+    public static <K, V> CacheConfigHolder of(CacheConfig<K, V> config, SerializationService serializationService) {
+        if (config == null) {
+            return null;
+        }
+
+        List<Data> listenerConfigurations = null;
+        Set<CacheEntryListenerConfiguration<K, V>> entryListenerConfigurations = config.getListenerConfigurations();
+        if (entryListenerConfigurations != null && !entryListenerConfigurations.isEmpty()) {
+            listenerConfigurations = new ArrayList<>(entryListenerConfigurations.size());
+            final List<Data> configDatas = listenerConfigurations;
+            entryListenerConfigurations.forEach(listenerConfig -> configDatas.add(serializationService.toData(listenerConfig)));
+        }
+
+        return new CacheConfigHolder(config.getName(), config.getManagerPrefix(), config.getUriString(), config.getBackupCount(),
+                config.getAsyncBackupCount(), config.getInMemoryFormat().name(),
+                EvictionConfigHolder.of(config.getEvictionConfig(), serializationService), config.getWanReplicationRef(),
+                config.getKeyClassName(), config.getValueClassName(), serializationService.toData(config.getCacheLoaderFactory()),
+                serializationService.toData(config.getCacheWriterFactory()),
+                serializationService.toData(config.getExpiryPolicyFactory()), config.isReadThrough(), config.isWriteThrough(),
+                config.isStoreByValue(), config.isManagementEnabled(), config.isStatisticsEnabled(), config.getHotRestartConfig(),
+                config.getEventJournalConfig(), config.getSplitBrainProtectionName(), listenerConfigurations,
+                config.getMergePolicyConfig(), config.isDisablePerEntryInvalidationEvents());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetConfigMessageTask.java
@@ -19,11 +19,12 @@ package com.hazelcast.client.impl.protocol.task.cache;
 import com.hazelcast.cache.impl.operation.CacheGetConfigOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheGetConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder;
 import com.hazelcast.client.impl.protocol.task.AbstractAddressMessageTask;
+import com.hazelcast.config.CacheConfig;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
@@ -79,9 +80,9 @@ public class CacheGetConfigMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        Data responseData = nodeEngine.toData(response);
+        CacheConfig cacheConfig = (CacheConfig) response;
 
-        return CacheGetConfigCodec.encodeResponse(responseData);
+        return CacheGetConfigCodec.encodeResponse(CacheConfigHolder.of(cacheConfig, serializationService));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -17,7 +17,6 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.AddressUtil;
 
@@ -34,7 +33,6 @@ import static com.hazelcast.util.StringUtil.stringToBytes;
 /**
  * Represents an address of a member in the cluster.
  */
-@BinaryInterface
 public final class Address implements IdentifiedDataSerializable {
 
     private static final byte IPV4 = 4;

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.AddressUtil;
 
@@ -33,6 +34,7 @@ import static com.hazelcast.util.StringUtil.stringToBytes;
 /**
  * Represents an address of a member in the cluster.
  */
+@BinaryInterface
 public final class Address implements IdentifiedDataSerializable {
 
     private static final byte IPV4 = 4;


### PR DESCRIPTION
Serializing CacheConfig in the protocol instead of using Data in the protocol. CacheConfig changes will be more safe for compatibility when encoded using the client protocol rather that using binary serialized format between the server and the client.
    
Introduced CacheConfigHolder and CacheConfigHolderCodec. Updated the related message tasks.