### PR TITLE
Rename SplitBrainProtection API method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/SplitBrainProtection.java
+++ b/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/SplitBrainProtection.java
@@ -25,6 +25,6 @@ public interface SplitBrainProtection {
      *
      * @return boolean whether the minimum cluster size property is satisfied
      */
-    boolean isMinimumClusterSizeSatisfied();
+    boolean hasMinimumSize();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/impl/SplitBrainProtectionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/impl/SplitBrainProtectionImpl.java
@@ -162,7 +162,7 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
     }
 
     @Override
-    public boolean isMinimumClusterSizeSatisfied() {
+    public boolean hasMinimumSize() {
         return splitBrainProtectionState == SplitBrainProtectionState.MIN_CLUSTER_SIZE_SATISFIED;
     }
 
@@ -256,7 +256,7 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
     }
 
     void ensureNoSplitBrain() {
-        if (!isMinimumClusterSizeSatisfied()) {
+        if (!hasMinimumSize()) {
             throw newSplitBrainProtectionException();
         }
     }
@@ -294,7 +294,7 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
     public String toString() {
         return "SplitBrainProtectionImpl{"
                 + "splitBrainProtectionName='" + splitBrainProtectionName + '\''
-                + ", isMinimumClusterSizeSatisfied=" + isMinimumClusterSizeSatisfied()
+                + ", isMinimumClusterSizeSatisfied=" + hasMinimumSize()
                 + ", minimumClusterSize=" + minimumClusterSize
                 + ", config=" + config
                 + ", splitBrainProtectionFunction=" + splitBrainProtectionFunction

--- a/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/impl/SplitBrainProtectionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/splitbrainprotection/impl/SplitBrainProtectionImpl.java
@@ -50,8 +50,8 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
 
     private enum SplitBrainProtectionState {
         INITIAL,
-        MIN_CLUSTER_SIZE_SATISFIED,
-        MIN_CLUSTER_SIZE_NOT_SATISFIED
+        HAS_MIN_CLUSTER_SIZE,
+        NO_MIN_CLUSTER_SIZE
     }
 
     private final NodeEngineImpl nodeEngine;
@@ -91,11 +91,11 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
      */
     void update(Collection<Member> members) {
         SplitBrainProtectionState previousSplitBrainProtectionState = splitBrainProtectionState;
-        SplitBrainProtectionState newSplitBrainProtectionState = SplitBrainProtectionState.MIN_CLUSTER_SIZE_NOT_SATISFIED;
+        SplitBrainProtectionState newSplitBrainProtectionState = SplitBrainProtectionState.NO_MIN_CLUSTER_SIZE;
         try {
             boolean present = splitBrainProtectionFunction.apply(members);
-            newSplitBrainProtectionState = present ? SplitBrainProtectionState.MIN_CLUSTER_SIZE_SATISFIED
-                    : SplitBrainProtectionState.MIN_CLUSTER_SIZE_NOT_SATISFIED;
+            newSplitBrainProtectionState = present ? SplitBrainProtectionState.HAS_MIN_CLUSTER_SIZE
+                    : SplitBrainProtectionState.NO_MIN_CLUSTER_SIZE;
         } catch (Exception e) {
             ILogger logger = nodeEngine.getLogger(SplitBrainProtectionService.class);
             logger.severe("Split brain protection function of split brain protection: "
@@ -105,7 +105,7 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
 
         splitBrainProtectionState = newSplitBrainProtectionState;
         if (previousSplitBrainProtectionState != newSplitBrainProtectionState) {
-            createAndPublishEvent(members, newSplitBrainProtectionState == SplitBrainProtectionState.MIN_CLUSTER_SIZE_SATISFIED);
+            createAndPublishEvent(members, newSplitBrainProtectionState == SplitBrainProtectionState.HAS_MIN_CLUSTER_SIZE);
         }
     }
 
@@ -163,7 +163,7 @@ public class SplitBrainProtectionImpl implements SplitBrainProtection {
 
     @Override
     public boolean hasMinimumSize() {
-        return splitBrainProtectionState == SplitBrainProtectionState.MIN_CLUSTER_SIZE_SATISFIED;
+        return splitBrainProtectionState == SplitBrainProtectionState.HAS_MIN_CLUSTER_SIZE;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/PartitionedCluster.java
@@ -145,7 +145,7 @@ public class PartitionedCluster {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertTrue(instance.getSplitBrainProtectionService().getSplitBrainProtection(splitBrainProtectionId).isMinimumClusterSizeSatisfied());
+                assertTrue(instance.getSplitBrainProtectionService().getSplitBrainProtection(splitBrainProtectionId).hasMinimumSize());
             }
         });
     }
@@ -154,7 +154,7 @@ public class PartitionedCluster {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertFalse(instance.getSplitBrainProtectionService().getSplitBrainProtection(splitBrainProtectionId).isMinimumClusterSizeSatisfied());
+                assertFalse(instance.getSplitBrainProtectionService().getSplitBrainProtection(splitBrainProtectionId).hasMinimumSize());
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/SplitBrainProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/SplitBrainProtectionTest.java
@@ -88,8 +88,8 @@ public class SplitBrainProtectionTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertTrue(splitBrainProtection1.isMinimumClusterSizeSatisfied());
-                assertFalse(splitBrainProtection2.isMinimumClusterSizeSatisfied());
+                assertTrue(splitBrainProtection1.hasMinimumSize());
+                assertFalse(splitBrainProtection2.hasMinimumSize());
             }
         });
     }
@@ -114,7 +114,7 @@ public class SplitBrainProtectionTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertTrue(splitBrainProtection.isMinimumClusterSizeSatisfied());
+                assertTrue(splitBrainProtection.hasMinimumSize());
             }
         });
     }
@@ -139,7 +139,7 @@ public class SplitBrainProtectionTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertTrue(splitBrainProtection.isMinimumClusterSizeSatisfied());
+                assertTrue(splitBrainProtection.hasMinimumSize());
             }
         });
     }
@@ -231,7 +231,7 @@ public class SplitBrainProtectionTest extends HazelcastTestSupport {
         } catch (Exception ignored) {
         }
         SplitBrainProtection splitBrainProtection = hazelcastInstance.getSplitBrainProtectionService().getSplitBrainProtection(splitBrainProtectionName);
-        assertFalse(splitBrainProtection.isMinimumClusterSizeSatisfied());
+        assertFalse(splitBrainProtection.hasMinimumSize());
     }
 
     @Test(expected = SplitBrainProtectionException.class)


### PR DESCRIPTION
Renamed isMinimumClusterSizeSatisfied() -> hasMinimumSize().