### PR TITLE
Publish metrics to MC and JMX

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.Client;
+import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.config.ConfigPatternMatcher;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.MetricsConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.QueryCacheConfig;
@@ -34,6 +35,7 @@ import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.internal.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -108,6 +110,7 @@ public class ClientConfig {
     private final Map<String, ClientFlakeIdGeneratorConfig> flakeIdGeneratorConfigMap;
     private final Set<String> labels;
     private final ConcurrentMap<String, Object> userContext;
+    private MetricsConfig metricsConfig = new MetricsConfig();
 
     public ClientConfig() {
         listenerConfigs = new LinkedList<>();
@@ -169,6 +172,7 @@ public class ClientConfig {
         }
         labels = new HashSet<>(config.labels);
         userContext = new ConcurrentHashMap<>(config.userContext);
+        metricsConfig = new MetricsConfig(config.metricsConfig);
     }
 
     /**
@@ -960,6 +964,24 @@ public class ClientConfig {
         return userContext.equals(that.userContext);
     }
 
+    /**
+     * Returns the metrics collection config.
+     */
+    @Nonnull
+    public MetricsConfig getMetricsConfig() {
+        return metricsConfig;
+    }
+
+    /**
+     * Sets the metrics collection config.
+     */
+    @Nonnull
+    public ClientConfig setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
+        Preconditions.checkNotNull(metricsConfig, "metricsConfig");
+        this.metricsConfig = metricsConfig;
+        return this;
+    }
+
     @Override
     @SuppressWarnings({"checkstyle:npathcomplexity"})
     public int hashCode() {
@@ -985,6 +1007,7 @@ public class ClientConfig {
         result = 31 * result + flakeIdGeneratorConfigMap.hashCode();
         result = 31 * result + labels.hashCode();
         result = 31 * result + userContext.hashCode();
+        result = 31 * result + metricsConfig.hashCode();
         return result;
     }
 
@@ -1010,6 +1033,7 @@ public class ClientConfig {
                 + ", userCodeDeploymentConfig=" + userCodeDeploymentConfig
                 + ", flakeIdGeneratorConfigMap=" + flakeIdGeneratorConfigMap
                 + ", labels=" + labels
+                + ", metricsConfig=" + metricsConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -62,6 +62,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.MetricsConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NetworkConfig;
@@ -87,6 +88,7 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.Data;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
@@ -121,7 +123,7 @@ public class ClientDynamicClusterConfig extends Config {
                 adaptListenerConfigs(mapConfig.getPartitionLostListenerConfigs());
         List<QueryCacheConfigHolder> queryCacheConfigHolders = null;
         if (mapConfig.getQueryCacheConfigs() != null && !mapConfig.getQueryCacheConfigs().isEmpty()) {
-            queryCacheConfigHolders = new ArrayList<QueryCacheConfigHolder>(mapConfig.getQueryCacheConfigs().size());
+            queryCacheConfigHolders = new ArrayList<>(mapConfig.getQueryCacheConfigs().size());
             for (QueryCacheConfig config : mapConfig.getQueryCacheConfigs()) {
                 queryCacheConfigHolders.add(QueryCacheConfigHolder.of(config, serializationService));
             }
@@ -1041,6 +1043,19 @@ public class ClientDynamicClusterConfig extends Config {
     public Config setCPSubsystemConfig(CPSubsystemConfig cpSubsystemConfig) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
+
+    @Override
+    @Nonnull
+    public Config setMetricsConfig(MetricsConfig metricsConfig) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    @Nonnull
+    public MetricsConfig getMetricsConfig() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
 
     @Override
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -255,6 +255,9 @@ public final class FailoverClientConfigSupport {
         if (notEqual(mainConfig.getUserContext(), alternativeConfig.getUserContext())) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "userContext");
         }
+        if (notEqual(mainConfig.getMetricsConfig(), alternativeConfig.getMetricsConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "metricsConfig");
+        }
     }
 
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -77,6 +77,7 @@ import com.hazelcast.client.impl.protocol.task.map.MapPutWithMaxIdleMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapSetTtlMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapSetWithMaxIdleMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.Pre38MapAddNearCacheEntryListenerMessageTask;
+import com.hazelcast.client.impl.protocol.task.metrics.ReadMetricsMessageTask;
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorGetAllScheduledMessageTask;
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorShutdownMessageTask;
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorSubmitToAddressMessageTask;
@@ -2232,6 +2233,13 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 return new ReleasePermitsMessageTask(clientMessage, node, connection);
             }
         });
+        factories.put(com.hazelcast.client.impl.protocol.codec.MetricsReadMetricsCodec.REQUEST_MESSAGE_TYPE,
+                new MessageTaskFactory() {
+                    @Override
+                    public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                        return new ReadMetricsMessageTask(clientMessage, node, connection);
+                    }
+                });
     }
 
     @SuppressFBWarnings({"MS_EXPOSE_REP", "EI_EXPOSE_REP"})

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/metrics/ReadMetricsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/metrics/ReadMetricsMessageTask.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.metrics;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MetricsReadMetricsCodec;
+import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.metrics.impl.MetricsService;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer;
+import com.hazelcast.internal.metrics.managementcenter.ReadMetricsOperation;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.security.Permission;
+import java.util.Map;
+
+public class ReadMetricsMessageTask extends AbstractInvocationMessageTask<MetricsReadMetricsCodec.RequestParameters> {
+
+    public ReadMetricsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected InvocationBuilder getInvocationBuilder(Operation op) {
+        return nodeEngine.getOperationService().createInvocationBuilder(getServiceName(),
+                op, nodeEngine.getThisAddress());
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        // readMetrics requests are sent to member identified by address, but we want it by member UUID.
+        // After a member restart, the address remains, but UUID changes. If the local member has different
+        // UUID from the intended one, fail.
+        if (!parameters.uuid.equals(nodeEngine.getLocalMember().getUuid())) {
+            // do not throw RetryableException here
+            throw new IllegalArgumentException(
+                    "Requested metrics for member " + parameters.uuid
+                            + ", but local member is " + nodeEngine.getLocalMember().getUuid()
+            );
+        }
+        return new ReadMetricsOperation(parameters.fromSequence);
+    }
+
+    @Override
+    protected MetricsReadMetricsCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MetricsReadMetricsCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        ConcurrentArrayRingbuffer.RingbufferSlice<Map.Entry<Long, byte[]>> responsex
+                = (ConcurrentArrayRingbuffer.RingbufferSlice<Map.Entry<Long, byte[]>>) response;
+        return MetricsReadMetricsCodec.encodeResponse(responsex.elements(), responsex.nextSequence());
+    }
+
+    @Override
+    public String getServiceName() {
+        return MetricsService.SERVICE_NAME;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return null;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "readMetrics";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[0];
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/metrics/ReadMetricsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/metrics/ReadMetricsMessageTask.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
+import java.util.List;
 import java.util.Map;
 
 public class ReadMetricsMessageTask extends AbstractInvocationMessageTask<MetricsReadMetricsCodec.RequestParameters> {
@@ -64,9 +65,12 @@ public class ReadMetricsMessageTask extends AbstractInvocationMessageTask<Metric
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        ConcurrentArrayRingbuffer.RingbufferSlice<Map.Entry<Long, byte[]>> responsex
+        ConcurrentArrayRingbuffer.RingbufferSlice<Map.Entry<Long, byte[]>> ringbufferSlice
                 = (ConcurrentArrayRingbuffer.RingbufferSlice<Map.Entry<Long, byte[]>>) response;
-        return MetricsReadMetricsCodec.encodeResponse(responsex.elements(), responsex.nextSequence());
+
+        List<Map.Entry<Long, byte[]>> elements = ringbufferSlice.elements();
+        long nextSequence = ringbufferSlice.nextSequence();
+        return MetricsReadMetricsCodec.encodeResponse(elements, nextSequence);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -43,6 +43,7 @@ import com.hazelcast.internal.config.RingbufferConfigReadOnly;
 import com.hazelcast.internal.config.ScheduledExecutorConfigReadOnly;
 import com.hazelcast.internal.config.SetConfigReadOnly;
 import com.hazelcast.internal.config.TopicConfigReadOnly;
+import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.map.IMap;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
@@ -50,6 +51,7 @@ import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.security.jsm.HazelcastRuntimePermission;
 import com.hazelcast.topic.ITopic;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URL;
 import java.util.EventListener;
@@ -173,6 +175,8 @@ public class Config {
     private boolean liteMember;
 
     private CPSubsystemConfig cpSubsystemConfig = new CPSubsystemConfig();
+
+    private MetricsConfig metricsConfig = new MetricsConfig();
 
     public Config() {
     }
@@ -2800,6 +2804,24 @@ public class Config {
         return this;
     }
 
+    /**
+     * Returns the metrics collection config.
+     */
+    @Nonnull
+    public MetricsConfig getMetricsConfig() {
+        return metricsConfig;
+    }
+
+    /**
+     * Sets the metrics collection config.
+     */
+    @Nonnull
+    public Config setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
+        Preconditions.checkNotNull(metricsConfig, "metricsConfig");
+        this.metricsConfig = metricsConfig;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "Config{"
@@ -2823,6 +2845,7 @@ public class Config {
                 + ", crdtReplicationConfig=" + crdtReplicationConfig
                 + ", advancedNetworkConfig=" + advancedNetworkConfig
                 + ", cpSubsystemConfig=" + cpSubsystemConfig
+                + ", metricsConfig=" + metricsConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigSections.java
@@ -63,7 +63,8 @@ enum ConfigSections {
     CRDT_REPLICATION("crdt-replication", false),
     PN_COUNTER("pn-counter", true),
     ADVANCED_NETWORK("advanced-network", false),
-    CP_SUBSYSTEM("cp-subsystem", false);
+    CP_SUBSYSTEM("cp-subsystem", false),
+    METRICS("metrics", false);
 
     final String name;
     final boolean multipleOccurrence;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1447,7 +1447,10 @@ public class ConfigXmlGenerator {
 
     private static void metricsConfig(XmlGenerator gen, Config config) {
         MetricsConfig metricsConfig = config.getMetricsConfig();
-        gen.open("metrics", "enabled", metricsConfig.isEnabled(), "jmx-enabled", metricsConfig.isJmxEnabled())
+        gen.open("metrics",
+                "enabled", metricsConfig.isEnabled(),
+                "mc-enabled", metricsConfig.isMcEnabled(),
+                "jmx-enabled", metricsConfig.isJmxEnabled())
            .node("collection-interval-seconds", metricsConfig.getCollectionIntervalSeconds())
            .node("retention-seconds", metricsConfig.getRetentionSeconds())
            .node("metrics-for-data-structures", metricsConfig.isMetricsForDataStructuresEnabled())

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -160,6 +160,7 @@ public class ConfigXmlGenerator {
         pnCounterXmlGenerator(gen, config);
         splitBrainProtectionXmlGenerator(gen, config);
         cpSubsystemConfig(gen, config);
+        metricsConfig(gen, config);
         userCodeDeploymentConfig(gen, config);
 
         xml.append("</hazelcast>");
@@ -1442,6 +1443,16 @@ public class ConfigXmlGenerator {
         }
 
         gen.close().close();
+    }
+
+    private static void metricsConfig(XmlGenerator gen, Config config) {
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        gen.open("metrics", "enabled", metricsConfig.isEnabled(), "jmx-enabled", metricsConfig.isJmxEnabled())
+           .node("collection-interval-seconds", metricsConfig.getCollectionIntervalSeconds())
+           .node("retention-seconds", metricsConfig.getRetentionSeconds())
+           .node("metrics-for-data-structures", metricsConfig.isMetricsForDataStructuresEnabled())
+           .node("minimum-level", metricsConfig.getMinimumLevel())
+           .close();
     }
 
     private static void userCodeDeploymentConfig(XmlGenerator gen, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -2876,10 +2876,22 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     private void handleMetrics(Node node) {
         MetricsConfig metricsConfig = config.getMetricsConfig();
-        boolean enabled = getBooleanValue(getAttribute(node, "enabled"));
-        metricsConfig.setEnabled(enabled);
-        boolean jmxEnabled = getBooleanValue(getAttribute(node, "jmx-enabled"));
-        metricsConfig.setJmxEnabled(jmxEnabled);
+
+        NamedNodeMap attributes = node.getAttributes();
+        for (int a = 0; a < attributes.getLength(); a++) {
+            Node att = attributes.item(a);
+            if ("enabled".equals(att.getNodeName())) {
+                boolean enabled = getBooleanValue(getAttribute(node, "enabled"));
+                metricsConfig.setEnabled(enabled);
+            } else if ("mc-enabled".equals(att.getNodeName())) {
+                boolean enabled = getBooleanValue(getAttribute(node, "mc-enabled"));
+                metricsConfig.setMcEnabled(enabled);
+            } else if ("jmx-enabled".equals(att.getNodeName())) {
+                boolean enabled = getBooleanValue(getAttribute(node, "jmx-enabled"));
+                metricsConfig.setJmxEnabled(enabled);
+            }
+        }
+
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             String value = getTextContent(child).trim();

--- a/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
@@ -39,6 +39,7 @@ public class MetricsConfig {
     public static final int DEFAULT_METRICS_RETENTION_SECONDS = 5;
 
     private boolean enabled = true;
+    private boolean mcEnabled = true;
     private boolean jmxEnabled = true;
     private int retentionSeconds = DEFAULT_METRICS_RETENTION_SECONDS;
     private boolean metricsForDataStructuresEnabled;
@@ -50,6 +51,7 @@ public class MetricsConfig {
 
     public MetricsConfig(MetricsConfig metricsConfig) {
         this.enabled = metricsConfig.enabled;
+        this.mcEnabled = metricsConfig.mcEnabled;
         this.jmxEnabled = metricsConfig.jmxEnabled;
         this.retentionSeconds = metricsConfig.retentionSeconds;
         this.metricsForDataStructuresEnabled = metricsConfig.metricsForDataStructuresEnabled;
@@ -76,7 +78,43 @@ public class MetricsConfig {
     }
 
     /**
+     * Returns whether metrics will be exposed to Hazelcast Management
+     * Center. If enabled, Hazelcast Management Center will be able to read
+     * out the recorder metrics from this member. It's enabled by default.
+     * <p/>
+     * This configuration acts as a fine-tuning option beyond
+     * enabling/disabling the Metrics collection entirely via the {@link #enabled}
+     * master switch.
+     *
+     * @return true if exporting to Hazelcast Management Center is enabled.
+     * @see #isEnabled()
+     */
+    public boolean isMcEnabled() {
+        return mcEnabled;
+    }
+
+    /**
+     * Enables exposing metrics to Hazelcast Management Center. If enabled,
+     * Hazelcast Management Center will be able to read out the recorded
+     * metrics from this member. It's enabled by default.
+     * <p/>
+     * This configuration acts as a fine-tuning option beyond
+     * enabling/disabling the Metrics collection entirely via the {@link #enabled}
+     * master switch.
+     *
+     * @see #setEnabled(boolean)
+     */
+    public MetricsConfig setMcEnabled(boolean mcEnabled) {
+        this.mcEnabled = mcEnabled;
+        return this;
+    }
+
+    /**
      * Returns whether metrics will be exposed through JMX MBeans.
+     * <p/>
+     * This configuration acts as a fine-tuning option beyond
+     * enabling/disabling the Metrics collection entirely via the {@link #enabled}
+     * master switch.
      */
     public boolean isJmxEnabled() {
         return jmxEnabled;
@@ -86,6 +124,10 @@ public class MetricsConfig {
      * Enables metrics exposure through JMX. It's enabled by default. Metric
      * values are collected in the {@linkplain #setCollectionIntervalSeconds
      * metric collection interval} and written to a set of MBeans.
+     * <p/>
+     * This configuration acts as a fine-tuning option beyond
+     * enabling/disabling the Metrics collection entirely via the {@link #enabled}
+     * master switch.
      */
     public MetricsConfig setJmxEnabled(boolean jmxEnabled) {
         this.jmxEnabled = jmxEnabled;
@@ -141,7 +183,7 @@ public class MetricsConfig {
      * Sets whether statistics for data structures are added to metrics.
      * It's disabled by default.
      * <p/>
-     * Note that enabling the data structures metrics also set {@link #minimumLevel}
+     * Note that enabling the data structures metrics also sets {@link #minimumLevel}
      * to {@link ProbeLevel#INFO}.
      *
      * @see #setMinimumLevel(ProbeLevel)
@@ -193,6 +235,9 @@ public class MetricsConfig {
         if (enabled != that.enabled) {
             return false;
         }
+        if (mcEnabled != that.mcEnabled) {
+            return false;
+        }
         if (jmxEnabled != that.jmxEnabled) {
             return false;
         }
@@ -211,6 +256,7 @@ public class MetricsConfig {
     @Override
     public final int hashCode() {
         int result = (enabled ? 1 : 0);
+        result = 31 * result + (mcEnabled ? 1 : 0);
         result = 31 * result + (jmxEnabled ? 1 : 0);
         result = 31 * result + retentionSeconds;
         result = 31 * result + (metricsForDataStructuresEnabled ? 1 : 0);
@@ -223,6 +269,7 @@ public class MetricsConfig {
     public String toString() {
         return "MetricsConfig{"
                 + "enabled=" + enabled
+                + ", mcEnabled=" + mcEnabled
                 + ", jmxEnabled=" + jmxEnabled
                 + ", retentionSeconds=" + retentionSeconds
                 + ", metricsForDataStructuresEnabled=" + metricsForDataStructuresEnabled

--- a/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
@@ -222,6 +222,7 @@ public class MetricsConfig {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:NPathComplexity")
     public final boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
@@ -44,7 +44,7 @@ public class MetricsConfig {
     private int retentionSeconds = DEFAULT_METRICS_RETENTION_SECONDS;
     private boolean metricsForDataStructuresEnabled;
     private int intervalSeconds = DEFAULT_METRICS_COLLECTION_SECONDS;
-    private ProbeLevel minimumLevel = ProbeLevel.MANDATORY;
+    private ProbeLevel minimumLevel = ProbeLevel.INFO;
 
     public MetricsConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetricsConfig.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.internal.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Configuration options specific to metrics collection.
+ *
+ * @since 4.0
+ */
+public class MetricsConfig {
+
+    /**
+     * Default collection interval for metrics
+     */
+    public static final int DEFAULT_METRICS_COLLECTION_SECONDS = 5;
+
+    /**
+     * Default retention period for metrics.
+     */
+    public static final int DEFAULT_METRICS_RETENTION_SECONDS = 5;
+
+    private boolean enabled = true;
+    private boolean jmxEnabled = true;
+    private int retentionSeconds = DEFAULT_METRICS_RETENTION_SECONDS;
+    private boolean metricsForDataStructuresEnabled;
+    private int intervalSeconds = DEFAULT_METRICS_COLLECTION_SECONDS;
+    private ProbeLevel minimumLevel = ProbeLevel.MANDATORY;
+
+    public MetricsConfig() {
+    }
+
+    public MetricsConfig(MetricsConfig metricsConfig) {
+        this.enabled = metricsConfig.enabled;
+        this.jmxEnabled = metricsConfig.jmxEnabled;
+        this.retentionSeconds = metricsConfig.retentionSeconds;
+        this.metricsForDataStructuresEnabled = metricsConfig.metricsForDataStructuresEnabled;
+        this.intervalSeconds = metricsConfig.intervalSeconds;
+        this.minimumLevel = metricsConfig.minimumLevel;
+    }
+
+    /**
+     * Sets whether metrics collection should be enabled for the node. If
+     * enabled, Hazelcast Management Center will be able to connect to this
+     * member. It's enabled by default.
+     */
+    @Nonnull
+    public MetricsConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns if metrics collection is enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Returns whether metrics will be exposed through JMX MBeans.
+     */
+    public boolean isJmxEnabled() {
+        return jmxEnabled;
+    }
+
+    /**
+     * Enables metrics exposure through JMX. It's enabled by default. Metric
+     * values are collected in the {@linkplain #setCollectionIntervalSeconds
+     * metric collection interval} and written to a set of MBeans.
+     */
+    public MetricsConfig setJmxEnabled(boolean jmxEnabled) {
+        this.jmxEnabled = jmxEnabled;
+        return this;
+    }
+
+    /**
+     * Sets the number of seconds the metrics will be retained on the
+     * instance. By default, metrics are retained for 5 seconds (that is for
+     * one collection of metrics values, if default {@linkplain
+     * #setCollectionIntervalSeconds(int) collection interval} is used). More
+     * retention means more heap memory, but allows for longer client hiccups
+     * without losing a value (for example to restart the Management Center).
+     * <p>
+     * This setting applies only to Management Center metrics API. It
+     * doesn't affect how metrics are exposed through JMX.
+     */
+    @Nonnull
+    public MetricsConfig setRetentionSeconds(int retentionSeconds) {
+        Preconditions.checkPositive(intervalSeconds, "retentionSeconds must be positive");
+        this.retentionSeconds = retentionSeconds;
+        return this;
+    }
+
+    /**
+     * Returns the number of seconds the metrics will be retained on the
+     * instance.
+     */
+    public int getRetentionSeconds() {
+        return retentionSeconds;
+    }
+
+    /**
+     * Sets the metrics collection interval in seconds. The same interval is
+     * used for collection for Management Center and for JMX publisher. By default,
+     * metrics are collected every 5 seconds.
+     */
+    @Nonnull
+    public MetricsConfig setCollectionIntervalSeconds(int intervalSeconds) {
+        Preconditions.checkPositive(intervalSeconds, "intervalSeconds must be positive");
+        this.intervalSeconds = intervalSeconds;
+        return this;
+    }
+
+    /**
+     * Returns the metrics collection interval.
+     */
+    public int getCollectionIntervalSeconds() {
+        return this.intervalSeconds;
+    }
+
+    /**
+     * Sets whether statistics for data structures are added to metrics.
+     * It's disabled by default.
+     * <p/>
+     * Note that enabling the data structures metrics also set {@link #minimumLevel}
+     * to {@link ProbeLevel#INFO}.
+     *
+     * @see #setMinimumLevel(ProbeLevel)
+     */
+    @Nonnull
+    public MetricsConfig setMetricsForDataStructuresEnabled(boolean metricsForDataStructuresEnabled) {
+        this.metricsForDataStructuresEnabled = metricsForDataStructuresEnabled;
+        return setMinimumLevel(ProbeLevel.INFO);
+    }
+
+    /**
+     * Returns if statistics for data structures are added to metrics.
+     */
+    public boolean isMetricsForDataStructuresEnabled() {
+        return metricsForDataStructuresEnabled;
+    }
+
+    /**
+     * Sets the minimum probe level to be collected.
+     *
+     * @param minimumLevel The minimum level to be collected
+     */
+    public MetricsConfig setMinimumLevel(ProbeLevel minimumLevel) {
+        this.minimumLevel = minimumLevel;
+        return this;
+    }
+
+    /**
+     * Returns the minimum probe level to be collected.
+     *
+     * @return the minimum probe level
+     */
+    @Nonnull
+    public ProbeLevel getMinimumLevel() {
+        return minimumLevel;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof MetricsConfig)) {
+            return false;
+        }
+
+        MetricsConfig that = (MetricsConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (jmxEnabled != that.jmxEnabled) {
+            return false;
+        }
+        if (retentionSeconds != that.retentionSeconds) {
+            return false;
+        }
+        if (metricsForDataStructuresEnabled != that.metricsForDataStructuresEnabled) {
+            return false;
+        }
+        if (intervalSeconds != that.intervalSeconds) {
+            return false;
+        }
+        return minimumLevel == that.minimumLevel;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (jmxEnabled ? 1 : 0);
+        result = 31 * result + retentionSeconds;
+        result = 31 * result + (metricsForDataStructuresEnabled ? 1 : 0);
+        result = 31 * result + intervalSeconds;
+        result = 31 * result + (minimumLevel != null ? minimumLevel.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MetricsConfig{"
+                + "enabled=" + enabled
+                + ", jmxEnabled=" + jmxEnabled
+                + ", retentionSeconds=" + retentionSeconds
+                + ", metricsForDataStructuresEnabled=" + metricsForDataStructuresEnabled
+                + ", intervalSeconds=" + intervalSeconds
+                + ", minimumLevel=" + minimumLevel
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.diagnostics;
 
-import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
@@ -43,28 +42,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  */
 @SuppressWarnings("WeakerAccess")
 public class Diagnostics {
-
-    /**
-     * The minimum level for probes is MANDATORY, but it can be changed to INFO
-     * or DEBUG. A lower level will increase memory usage (probably just a few
-     * 100KB) and provides much greater detail on what is going on inside a
-     * HazelcastInstance.
-     * <p>
-     * By default only mandatory probes are being tracked
-     */
-    public static final HazelcastProperty METRICS_LEVEL
-            = new HazelcastProperty("hazelcast.diagnostics.metric.level", ProbeLevel.MANDATORY.name());
-
-    /**
-     * If metrics should be tracked on distributed data structures like IMap,
-     * IQueue etc.
-     * <p>
-     * By default, these data structures are not tracked, but in a future release
-     * this will probably be changed to {@code true}.
-     */
-    public static final HazelcastProperty METRICS_DISTRIBUTED_DATASTRUCTURES
-            = new HazelcastProperty("hazelcast.diagnostics.metric.distributed.datastructures", false);
-
 
     /**
      * Use the {@link Diagnostics} to see internal performance metrics and cluster
@@ -127,7 +104,7 @@ public class Diagnostics {
     public static final HazelcastProperty FILENAME_PREFIX
             = new HazelcastProperty("hazelcast.diagnostics.filename.prefix");
 
-    final AtomicReference<DiagnosticsPlugin[]> staticTasks = new AtomicReference<DiagnosticsPlugin[]>(
+    final AtomicReference<DiagnosticsPlugin[]> staticTasks = new AtomicReference<>(
             new DiagnosticsPlugin[0]
     );
     final String baseFileName;
@@ -139,8 +116,7 @@ public class Diagnostics {
 
     DiagnosticsLogFile diagnosticsLogFile;
 
-    private final ConcurrentMap<Class<? extends DiagnosticsPlugin>, DiagnosticsPlugin> pluginsMap
-            = new ConcurrentHashMap<Class<? extends DiagnosticsPlugin>, DiagnosticsPlugin>();
+    private final ConcurrentMap<Class<? extends DiagnosticsPlugin>, DiagnosticsPlugin> pluginsMap = new ConcurrentHashMap<>();
     private final boolean enabled;
 
     private ScheduledExecutorService scheduler;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -35,8 +36,9 @@ public class MetricsPlugin extends DiagnosticsPlugin {
      * The period in seconds the {@link MetricsPlugin} runs.
      * <p>
      * The MetricsPlugin periodically writes the contents of the MetricsRegistry
-     * to the logfile. For debugging purposes make sure the
-     * {@link Diagnostics#METRICS_LEVEL} is set to debug.
+     * to the logfile. For debugging purposes make sure the minimum metrics
+     * level is set to {@link com.hazelcast.internal.metrics.ProbeLevel#DEBUG}
+     * with {@link com.hazelcast.config.MetricsConfig#setMinimumLevel(ProbeLevel)}.
      * <p>
      * This plugin is very cheap to use.
      * <p>

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -35,6 +35,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.MetricsConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NetworkConfig;
@@ -1150,6 +1151,18 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config setCPSubsystemConfig(CPSubsystemConfig cpSubsystemConfig) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Nonnull
+    @Override
+    public MetricsConfig getMetricsConfig() {
+        return staticConfig.getMetricsConfig();
+    }
+
+    @Nonnull
+    @Override
+    public Config setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsPublisher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Represents an object which publishes a set of metrics to some destination.
+ */
+public interface MetricsPublisher {
+
+    /**
+     * Publish the given metric with a long value.
+     */
+    void publishLong(String name, long value);
+
+    /**
+     * Publish the given metric with a double value.
+     */
+    void publishDouble(String name, double value);
+
+    /**
+     * Callback is called after all metrics are published for a given
+     * metric collection round.
+     */
+    default void whenComplete() {
+    }
+
+    /**
+     * Perform any necessary cleanup before shutdown.
+     */
+    default void shutdown() {
+    }
+
+    /**
+     * Name of the publisher, only used for debugging purposes.
+     */
+    String name();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LiveOperationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LiveOperationRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.operationservice.LiveOperations;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LiveOperationRegistry {
+    // memberAddress -> callId -> operation
+    private final ConcurrentHashMap<Address, Map<Long, Operation>> liveOperations = new ConcurrentHashMap<>();
+
+    public void register(Operation operation) {
+        Map<Long, Operation> callIds = liveOperations.computeIfAbsent(operation.getCallerAddress(),
+                (key) -> new ConcurrentHashMap<>());
+        if (callIds.putIfAbsent(operation.getCallId(), operation) != null) {
+            throw new IllegalStateException("Duplicate operation during registration of operation=" + operation);
+        }
+    }
+
+    public void deregister(Operation operation) {
+        Map<Long, Operation> operations = liveOperations.get(operation.getCallerAddress());
+
+        if (operations == null) {
+            throw new IllegalStateException("Missing address during de-registration of operation=" + operation);
+        }
+
+        if (operations.remove(operation.getCallId()) == null) {
+            throw new IllegalStateException("Missing operation during de-registration of operation=" + operation);
+        }
+    }
+
+    public void populate(LiveOperations liveOperations) {
+        this.liveOperations.forEach((key, value) -> value.keySet().forEach(callId -> liveOperations.add(key, callId)));
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.config.MetricsConfig;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.jmx.JmxPublisher;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
+import com.hazelcast.internal.metrics.managementcenter.ManagementCenterPublisher;
+import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
+import com.hazelcast.internal.services.ManagedService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.impl.operationservice.LiveOperations;
+import com.hazelcast.spi.impl.operationservice.LiveOperationsTracker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
+import static com.hazelcast.internal.util.MapUtil.entry;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Service collecting the Metrics periodically and publishes them via
+ * {@link MetricsPublisher}s.
+ *
+ * @since 4.0
+ */
+public class MetricsService implements ManagedService, LiveOperationsTracker {
+    public static final String SERVICE_NAME = "hz:impl:metricsService";
+
+    private final NodeEngineImpl nodeEngine;
+    private final ILogger logger;
+    private final MetricsConfig config;
+    private final LiveOperationRegistry liveOperationRegistry;
+    // Holds futures for pending read metrics operations
+    private final ConcurrentMap<CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>>, Long>
+            pendingReads = new ConcurrentHashMap<>();
+    private final ProbeRenderer probeRenderer = new PublisherProbeRenderer();
+
+    /**
+     * Ringbuffer which stores a bounded history of metrics. For each round of collection,
+     * the metrics are compressed into a blob and stored along with the timestamp,
+     * with the format (timestamp, byte[])
+     */
+    private ConcurrentArrayRingbuffer<Map.Entry<Long, byte[]>> metricsJournal;
+    private volatile ScheduledFuture<?> scheduledFuture;
+
+    private final List<MetricsPublisher> publishers;
+
+    private final Supplier<MetricsRegistry> metricsRegistrySupplier;
+
+    public MetricsService(NodeEngine nodeEngine) {
+        this(nodeEngine, ((NodeEngineImpl) nodeEngine)::getMetricsRegistry);
+    }
+
+    public MetricsService(NodeEngine nodeEngine, Supplier<MetricsRegistry> metricsRegistrySupplier) {
+        this.nodeEngine = (NodeEngineImpl) nodeEngine;
+        this.logger = nodeEngine.getLogger(getClass());
+        this.config = nodeEngine.getConfig().getMetricsConfig();
+        this.liveOperationRegistry = new LiveOperationRegistry();
+        this.metricsRegistrySupplier = metricsRegistrySupplier;
+        this.publishers = new CopyOnWriteArrayList<>();
+    }
+
+    @Override
+    public void init(NodeEngine nodeEngine, Properties properties) {
+        this.publishers.addAll(getPublishers());
+
+        if (publishers.isEmpty()) {
+            return;
+        }
+
+        logger.fine("Configuring metrics collection, collection interval=" + config.getCollectionIntervalSeconds()
+                + " seconds, retention=" + config.getRetentionSeconds() + " seconds, publishers="
+                + publishers.stream().map(MetricsPublisher::name).collect(joining(", ", "[", "]")));
+
+        ExecutionService executionService = nodeEngine.getExecutionService();
+        scheduledFuture = executionService.scheduleWithRepetition("MetricsPublisher", this::collectMetrics, 1,
+                config.getCollectionIntervalSeconds(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * Register a custom {@link MetricsPublisher} implementation with a register
+     * function that takes {@link NodeEngine} as input letting the caller to
+     * optionally initialize the publisher returned from the function.
+     *
+     * @param registerFunction The function that returns with the {@link MetricsPublisher}
+     *                         instance.
+     */
+    public void registerPublisher(Function<NodeEngine, MetricsPublisher> registerFunction) {
+        MetricsPublisher publisher = registerFunction.apply(nodeEngine);
+        publishers.add(publisher);
+    }
+
+    // visible for testing
+    void collectMetrics() {
+        collectMetrics(probeRenderer);
+    }
+
+    // visible for testing
+    void collectMetrics(ProbeRenderer probeRenderer) {
+        metricsRegistrySupplier.get().render(probeRenderer);
+        for (MetricsPublisher publisher : publishers) {
+            try {
+                publisher.whenComplete();
+            } catch (Exception e) {
+                logger.severe("Error completing publication for publisher " + publisher, e);
+            }
+        }
+    }
+
+    public LiveOperationRegistry getLiveOperationRegistry() {
+        return liveOperationRegistry;
+    }
+
+    @Override
+    public void populate(LiveOperations liveOperations) {
+        liveOperationRegistry.populate(liveOperations);
+    }
+
+    /**
+     * Read metrics from the journal from the given sequence.
+     *
+     * @param startSequence The sequence start reading the metrics with.
+     */
+    public CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> readMetrics(long startSequence) {
+        if (!config.isEnabled()) {
+            throw new IllegalArgumentException("Metrics collection is not enabled");
+        }
+        CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future = new CompletableFuture<>();
+        future.whenComplete(withTryCatch(logger, (s, e) -> pendingReads.remove(future)));
+        pendingReads.put(future, startSequence);
+
+        tryCompleteRead(future, startSequence);
+
+        return future;
+    }
+
+    private void tryCompleteRead(CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future, long sequence) {
+        try {
+            RingbufferSlice<Map.Entry<Long, byte[]>> slice = metricsJournal.copyFrom(sequence);
+            if (!slice.isEmpty()) {
+                future.complete(slice);
+            }
+        } catch (Exception e) {
+            logger.severe("Error reading from metrics journal, sequence: " + sequence, e);
+            future.completeExceptionally(e);
+        }
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void shutdown(boolean terminate) {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+        }
+
+        for (MetricsPublisher publisher : publishers) {
+            try {
+                publisher.shutdown();
+            } catch (Exception e) {
+                logger.warning("Error shutting down metrics publisher " + publisher.name(), e);
+            }
+        }
+    }
+
+    private List<MetricsPublisher> getPublishers() {
+        List<MetricsPublisher> publishers = new ArrayList<>();
+        if (config.isEnabled()) {
+            int journalSize = Math.max(
+                    1, (int) Math.ceil((double) config.getRetentionSeconds() / config.getCollectionIntervalSeconds())
+            );
+            metricsJournal = new ConcurrentArrayRingbuffer<>(journalSize);
+            ManagementCenterPublisher publisher = new ManagementCenterPublisher(this.nodeEngine.getLoggingService(),
+                    (blob, ts) -> {
+                        metricsJournal.add(entry(ts, blob));
+                        pendingReads.forEach(this::tryCompleteRead);
+                    }
+            );
+            publishers.add(publisher);
+        }
+
+        if (config.isJmxEnabled()) {
+            publishers.add(new JmxPublisher(nodeEngine.getHazelcastInstance().getName(), "com.hazelcast"));
+        }
+
+        return publishers;
+    }
+
+    /**
+     * A probe renderer which renders the metrics to all the given publishers.
+     */
+    private class PublisherProbeRenderer implements ProbeRenderer {
+        @Override
+        public void renderLong(String name, long value) {
+            for (MetricsPublisher publisher : publishers) {
+                try {
+                    publisher.publishLong(name, value);
+                } catch (Exception e) {
+                    logError(name, value, publisher, e);
+                }
+            }
+        }
+
+        @Override
+        public void renderDouble(String name, double value) {
+            for (MetricsPublisher publisher : publishers) {
+                try {
+                    publisher.publishDouble(name, value);
+                } catch (Exception e) {
+                    logError(name, value, publisher, e);
+                }
+            }
+        }
+
+        @Override
+        public void renderException(String name, Exception e) {
+            logger.warning("Error when rendering '" + name + '\'', e);
+        }
+
+        @Override
+        public void renderNoValue(String name) {
+            // noop
+        }
+
+        private void logError(String name, Object value, MetricsPublisher publisher, Exception e) {
+            logger.fine("Error publishing metric to: " + publisher.name() + ", metric=" + name + ", value=" + value, e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.jmx;
+
+import com.hazelcast.config.MetricsConfig;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.metrics.MetricsUtil;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+
+import static com.hazelcast.internal.util.MapUtil.entry;
+
+/**
+ * Renderer to create, register and unregister mBeans for metrics as they are
+ * rendered.
+ */
+public class JmxPublisher implements MetricsPublisher {
+
+    private final MBeanServer platformMBeanServer;
+    private final String instanceNameEscaped;
+
+    /**
+     * key: metric name, value: MetricData
+     */
+    private final Map<String, MetricData> metricNameToMetricData = new HashMap<>();
+    /**
+     * key: jmx object name, value: mBean
+     */
+    private final Map<ObjectName, MetricsMBean> mBeans = new HashMap<>();
+
+    private volatile boolean isShutdown;
+    private final Function<String, MetricData> createMetricDataFunction;
+    private final Function<? super ObjectName, ? extends MetricsMBean> createMBeanFunction;
+
+    public JmxPublisher(String instanceName, String domainPrefix) {
+        platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        instanceNameEscaped = escapeObjectNameValue(instanceName);
+        createMetricDataFunction = n -> new MetricData(n, instanceNameEscaped, domainPrefix);
+        createMBeanFunction = objectName -> {
+            MetricsMBean bean = new MetricsMBean();
+            try {
+                platformMBeanServer.registerMBean(bean, objectName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return bean;
+        };
+    }
+
+    @Override
+    public String name() {
+        return "JMX Publisher";
+    }
+
+    @Override
+    public void publishLong(String metricName, long value) {
+        publishNumber(metricName, value);
+    }
+
+    @Override
+    public void publishDouble(String metricName, double value) {
+        publishNumber(metricName, value);
+    }
+
+    private void publishNumber(String metricName, Number value) {
+        MetricData metricData = metricNameToMetricData.computeIfAbsent(metricName, createMetricDataFunction);
+        assert !metricData.wasPresent : "metric '" + metricName + "' was rendered twice";
+        metricData.wasPresent = true;
+        MetricsMBean mBean = mBeans.computeIfAbsent(metricData.objectName, createMBeanFunction);
+        if (isShutdown) {
+            unregisterMBeanIgnoreError(metricData.objectName);
+        }
+        mBean.setMetricValue(metricData.metric, metricData.unit, value);
+    }
+
+    private void unregisterMBeanIgnoreError(ObjectName objectName) {
+        try {
+            platformMBeanServer.unregisterMBean(objectName);
+        } catch (InstanceNotFoundException ignored) {
+            // Unregistration can by racy, we unregister from multiple places.
+        } catch (MBeanRegistrationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void whenComplete() {
+        // remove metrics that weren't present in current rendering
+        for (Iterator<MetricData> iterator = metricNameToMetricData.values().iterator(); iterator.hasNext(); ) {
+            MetricData metricData = iterator.next();
+            if (!metricData.wasPresent) {
+                iterator.remove();
+                // remove the metric from the bean
+                MetricsMBean mBean = mBeans.get(metricData.objectName);
+                mBean.removeMetric(metricData.metric);
+                // remove entire bean if no metric is left
+                if (mBean.numAttributes() == 0) {
+                    mBeans.remove(metricData.objectName);
+                    unregisterMBeanIgnoreError(metricData.objectName);
+                }
+            } else {
+                metricData.wasPresent = false;
+            }
+        }
+    }
+
+    // package-visible for test
+    @SuppressWarnings("checkstyle:BooleanExpressionComplexity")
+    static String escapeObjectNameValue(String name) {
+        if (name.indexOf(',') < 0
+                && name.indexOf('=') < 0
+                && name.indexOf(':') < 0
+                && name.indexOf('*') < 0
+                && name.indexOf('?') < 0
+                && name.indexOf('\"') < 0
+                && name.indexOf('\n') < 0) {
+            return name;
+        }
+        return "\"" + name
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("*", "\\*")
+                .replace("?", "\\?")
+                + '"';
+    }
+
+    private static class MetricData {
+        ObjectName objectName;
+        String metric;
+        String unit;
+        boolean wasPresent;
+
+        /**
+         * See {@link MetricsConfig#setJmxEnabled(boolean)}.
+         */
+        @SuppressWarnings("checkstyle:ExecutableStatementCount")
+        MetricData(String metricName, String instanceNameEscaped, String domainPrefix) {
+            List<Entry<String, String>> tagsList = metricName.startsWith("[") && metricName.endsWith("]")
+                    ? MetricsUtil.parseMetricName(metricName)
+                    : parseOldMetricName(metricName);
+            StringBuilder mBeanTags = new StringBuilder();
+            String module = null;
+            metric = "metric";
+            unit = "unknown";
+            int tag = 0;
+
+            for (Entry<String, String> entry : tagsList) {
+                switch (entry.getKey()) {
+                    case "unit":
+                        unit = entry.getValue();
+                        break;
+                    case "module":
+                        module = entry.getValue();
+                        break;
+                    case "metric":
+                        metric = entry.getValue();
+                        break;
+                    default:
+                        if (mBeanTags.length() > 0) {
+                            mBeanTags.append(',');
+                        }
+                        mBeanTags.append("tag")
+                                 .append(tag++)
+                                 .append('=');
+                        if (entry.getKey().length() == 0) {
+                            // key is empty for old metric names (see parseOldMetricName)
+                            mBeanTags.append(escapeObjectNameValue(entry.getValue()));
+                        } else {
+                            // We add both key and value to the value: the key carries semantic value, we
+                            // want to see it in the UI.
+                            mBeanTags.append(escapeObjectNameValue(entry.getKey() + '=' + entry.getValue()));
+                        }
+                }
+            }
+            assert metric != null : "metric == null";
+
+            StringBuilder objectNameStr = new StringBuilder(mBeanTags.length() + (1 << 3 << 3));
+            objectNameStr.append(domainPrefix);
+            if (module != null) {
+                objectNameStr.append('.').append(module);
+            }
+            objectNameStr.append(":type=Metrics");
+            objectNameStr.append(",instance=").append(instanceNameEscaped);
+            if (mBeanTags.length() > 0) {
+                objectNameStr.append(',').append(mBeanTags);
+            }
+            try {
+                // We use the ObjectName(String) constructor, not the one with Hashtable, because
+                // this one preserves the tag order which is important for the tree structure in UI tools.
+                objectName = new ObjectName(objectNameStr.toString());
+            } catch (MalformedObjectNameException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static List<Entry<String, String>> parseOldMetricName(String name) {
+            List<Entry<String, String>> res = new ArrayList<>();
+            boolean inBracket = false;
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < name.length(); i++) {
+                char ch = name.charAt(i);
+                if (ch == '.' && !inBracket) {
+                    if (builder.length() > 0) {
+                        res.add(entry("", builder.toString()));
+                    }
+                    builder.setLength(0);
+                } else {
+                    builder.append(ch);
+                    if (ch == '[') {
+                        inBracket = true;
+                    } else if (ch == ']') {
+                        inBracket = false;
+                    }
+                }
+            }
+            // the trailing entry will be marked as `metric` tag
+            if (builder.length() > 0) {
+                res.add(entry("metric", builder.toString()));
+            }
+            return res;
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        isShutdown = true;
+        ObjectName name;
+        try {
+            name = new ObjectName("com.hazelcast*" + ":instance=" + instanceNameEscaped + ",type=Metrics,*");
+        } catch (MalformedObjectNameException e) {
+            throw new RuntimeException("Exception when unregistering JMX beans", e);
+        }
+
+        for (ObjectName bean : platformMBeanServer.queryNames(name, null)) {
+            unregisterMBeanIgnoreError(bean);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
@@ -94,7 +94,7 @@ public class ConcurrentArrayRingbuffer<E> {
         return new RingbufferSlice<>(result, tail);
     }
 
-    public synchronized int getCapacity() {
+    public int getCapacity() {
         return capacity;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
@@ -16,11 +16,6 @@
 
 package com.hazelcast.internal.metrics.managementcenter;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -123,15 +118,11 @@ public class ConcurrentArrayRingbuffer<E> {
         return (int) (sequence % ringItems.length);
     }
 
-    public static final class RingbufferSlice<E> implements IdentifiedDataSerializable {
+    public static final class RingbufferSlice<E> {
         // we use Object[] (instead of E[]) because we have only serializer for Object[], not for
         // subtypes.
         private Object[] elements;
         private long nextSequence;
-
-        // for deserialization
-        public RingbufferSlice() {
-        }
 
         private RingbufferSlice(E[] elements, long nextSequence) {
             this.elements = elements;
@@ -157,28 +148,6 @@ public class ConcurrentArrayRingbuffer<E> {
          */
         public long nextSequence() {
             return nextSequence;
-        }
-
-        @Override
-        public int getFactoryId() {
-            return MetricsDataSerializerHook.FACTORY_ID;
-        }
-
-        @Override
-        public int getClassId() {
-            return MetricsDataSerializerHook.RINGBUFFER_SLICE;
-        }
-
-        @Override
-        public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeObject(elements);
-            out.writeLong(nextSequence);
-        }
-
-        @Override
-        public void readData(ObjectDataInput in) throws IOException {
-            elements = in.readObject();
-            nextSequence = in.readLong();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.lang.System.arraycopy;
+
+public class ConcurrentArrayRingbuffer<E> {
+
+    private static final Object[] EMPTY_ARRAY = {};
+
+    private final E[] ringItems;
+    /**
+     * Head is the sequence where oldest item is found
+     */
+    private long head;
+    /**
+     * Tail is the sequence where next item will be added
+     */
+    private long tail;
+    private final int capacity;
+
+    @SuppressWarnings("unchecked")
+    public ConcurrentArrayRingbuffer(int capacity) {
+        this.capacity = capacity;
+        this.ringItems = (E[]) new Object[capacity];
+    }
+
+    /**
+     * Appends an item to the ring buffer. If size == capacity, also drops the
+     * oldest item.
+     */
+    public synchronized void add(E item) {
+        if (tail - capacity == head) {
+            head++;
+        }
+        ringItems[toIndex(tail++)] = item;
+    }
+
+    public synchronized void clear() {
+        Arrays.fill(ringItems, null);
+        head = tail;
+    }
+
+    public synchronized E get(long sequence) {
+        checkSequence(sequence);
+        return ringItems[toIndex(sequence)];
+    }
+
+    /**
+     * Copies all the items from the given {@code sequence} up to the
+     * tail. If the item at the sequence number is already dropped, start from
+     * the oldest item.
+     *
+     * @throws IllegalArgumentException If the sequence is in the future.
+     */
+    public synchronized RingbufferSlice<E> copyFrom(long sequence) {
+        sequence = Math.max(sequence, head);
+        if (sequence == tail) {
+            return new RingbufferSlice(EMPTY_ARRAY, tail);
+        }
+        checkSequence(sequence);
+        E[] result = (E[]) new Object[(int) (tail - sequence)];
+        int startPoint = toIndex(sequence);
+        int endPoint = toIndex(tail);
+        if (startPoint >= endPoint) {
+            arraycopy(ringItems, startPoint, result, 0, capacity - startPoint);
+            arraycopy(ringItems, 0, result, capacity - startPoint, endPoint);
+        } else {
+            arraycopy(ringItems, startPoint, result, 0, endPoint - startPoint);
+        }
+        return new RingbufferSlice<>(result, tail);
+    }
+
+    public synchronized int getCapacity() {
+        return capacity;
+    }
+
+    public synchronized long size() {
+        return tail - head;
+    }
+
+    public synchronized boolean isEmpty() {
+        return tail == head;
+    }
+
+    private void checkSequence(long sequence) {
+        if (sequence >= tail) {
+            throw new IllegalArgumentException("sequence:" + sequence
+                    + " is too large. The current tail is:" + tail);
+        }
+
+        if (sequence < head) {
+            throw new IllegalArgumentException("sequence:" + sequence
+                    + " is too small. The current headSequence is:" + head
+                    + " tailSequence is:" + tail);
+        }
+    }
+
+    private int toIndex(long sequence) {
+        return (int) (sequence % ringItems.length);
+    }
+
+    public static final class RingbufferSlice<E> implements IdentifiedDataSerializable {
+        // we use Object[] (instead of E[]) because we have only serializer for Object[], not for
+        // subtypes.
+        private Object[] elements;
+        private long nextSequence;
+
+        // for deserialization
+        public RingbufferSlice() {
+        }
+
+        private RingbufferSlice(E[] elements, long nextSequence) {
+            this.elements = elements;
+            this.nextSequence = nextSequence;
+        }
+
+        public List<E> elements() {
+            return (List<E>) Arrays.asList(elements);
+        }
+
+        public Stream<E> stream() {
+            return (Stream<E>) Arrays.stream(elements);
+        }
+
+        public boolean isEmpty() {
+            return elements.length == 0;
+        }
+
+        /**
+         * The tail, this is the sequence where next call to {@link
+         * ConcurrentArrayRingbuffer#copyFrom}
+         * should start.
+         */
+        public long nextSequence() {
+            return nextSequence;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return MetricsDataSerializerHook.FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return MetricsDataSerializerHook.RINGBUFFER_SLICE;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeObject(elements);
+            out.writeLong(nextSequence);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            elements = in.readObject();
+            nextSequence = in.readLong();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ManagementCenterPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ManagementCenterPublisher.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+
+import javax.annotation.Nonnull;
+import java.util.function.ObjLongConsumer;
+
+/**
+ * Renderer to serialize metrics to byte[] to be read by Management Center.
+ * Additionally, it converts legacy metric names to {@code [metric=<oldName>]}.
+ */
+public class ManagementCenterPublisher implements MetricsPublisher {
+
+    private final ILogger logger;
+    private final ObjLongConsumer<byte[]> consumer;
+    private final MetricsCompressor compressor;
+
+    public ManagementCenterPublisher(@Nonnull LoggingService loggingService, @Nonnull ObjLongConsumer<byte[]> writeFn) {
+        this.consumer = writeFn;
+        this.logger = loggingService.getLogger(getClass());
+        this.compressor = new MetricsCompressor();
+    }
+
+    @Override
+    public String name() {
+        return "Management Center Publisher";
+    }
+
+    @Override
+    public void publishLong(String name, long value) {
+        compressor.addLong(name, value);
+    }
+
+    @Override
+    public void publishDouble(String name, double value) {
+        compressor.addDouble(name, value);
+    }
+
+    @Override
+    public void whenComplete() {
+        int count = compressor.count();
+        byte[] blob = compressor.getBlobAndReset();
+        consumer.accept(blob, System.currentTimeMillis());
+        logger.finest(String.format("Collected %,d metrics, %,d bytes", count, blob.length));
+    }
+
+    public int getCount() {
+        return compressor.count();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/Metric.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/Metric.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+public class Metric {
+
+    private final String key;
+    private final long value;
+
+    Metric(String key, long value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public long value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return key + "=" + value;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsCompressor.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import com.hazelcast.internal.nio.Bits;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
+
+import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricNamePart;
+import static java.lang.Math.multiplyExact;
+
+/**
+ * Helper class for compressing metrics into a byte[] blob to be read by
+ * various consumers. The consumer itself is passed in as a parameter.
+ * <p>
+ * Most efficient when the metrics to be compressed are fed in sorted by
+ * name. It will work even if this condition is violated, but it won't
+ * nearly be as efficient.
+ * <p>
+ * Before compressing it also converts legacy metric names to
+ * {@code [metric=<oldName>]}.
+ * <p>
+ * The utility is optimized to repeatedly compress similar set of metrics: it
+ * reuses the buffer and keeps it about 10% bigger than what was needed the
+ * last time.
+ */
+public class MetricsCompressor {
+
+    @SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:TrailingComment"})
+    private static final int INITIAL_BUFFER_SIZE = 2 << 11; // 2kB
+    private static final int SIZE_FACTOR_NUMERATOR = 11;
+    private static final int SIZE_FACTOR_DENOMINATOR = 10;
+
+    private static final int BITS_IN_BYTE = 8;
+    private static final int BYTE_MASK = 0xff;
+
+    private static final short SHORT_BITS = BITS_IN_BYTE * Bits.SHORT_SIZE_IN_BYTES;
+    // required precision after the decimal point for doubles
+    private static final int CONVERSION_PRECISION = 4;
+    // coefficient for converting doubles to long
+    private static final double DOUBLE_TO_LONG = Math.pow(10, CONVERSION_PRECISION);
+
+    private static final short BINARY_FORMAT_VERSION = 1;
+
+    private DataOutputStream dos;
+    private MorePublicByteArrayOutputStream baos = new MorePublicByteArrayOutputStream(INITIAL_BUFFER_SIZE);
+    private String lastName;
+    private int count;
+
+    public MetricsCompressor() {
+        reset(INITIAL_BUFFER_SIZE);
+    }
+
+    public void addLong(String name, long value) {
+        try {
+            writeName(name);
+            dos.writeLong(value);
+        } catch (IOException e) {
+            // should never be thrown
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void addDouble(String name, double value) {
+        try {
+            writeName(name);
+            // convert to long with specified precision
+            dos.writeLong(Math.round(value * DOUBLE_TO_LONG));
+        } catch (IOException e) {
+            // should never be thrown
+            throw new RuntimeException(e);
+        }
+    }
+
+    public byte[] getBlobAndReset() {
+        byte[] blob = getRenderedBlob();
+        reset(blob.length * SIZE_FACTOR_NUMERATOR / SIZE_FACTOR_DENOMINATOR);
+        return blob;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    private void writeName(String name) throws IOException {
+        // Metric name should have the form "[tag1=value1,tag2=value2,...]". If it is not
+        // enclosed in "[]", we convert it to "[metric=originalName]".
+        if (!name.startsWith("[") || !name.endsWith("]")) {
+            name = "[metric=" + escapeMetricNamePart(name) + ']';
+        }
+
+        if (name.length() >= 1 << SHORT_BITS) {
+            throw new RuntimeException("metric name too long: " + name);
+        }
+        // count number of shared characters
+        int equalPrefixLength = 0;
+        int shorterLen = Math.min(name.length(), lastName.length());
+        while (equalPrefixLength < shorterLen
+                && name.charAt(equalPrefixLength) == lastName.charAt(equalPrefixLength)) {
+            equalPrefixLength++;
+        }
+        dos.writeShort(equalPrefixLength);
+        dos.writeUTF(name.substring(equalPrefixLength));
+        lastName = name;
+        count++;
+    }
+
+    private void reset(int estimatedBytes) {
+        Deflater compressor = new Deflater();
+        compressor.setLevel(Deflater.BEST_SPEED);
+        // shrink the `baos` if capacity is more than 50% larger than the estimated size
+        if (baos.capacity() > multiplyExact(estimatedBytes, 3) / 2) {
+            baos = new MorePublicByteArrayOutputStream(estimatedBytes);
+        }
+        baos.reset();
+        baos.write((BINARY_FORMAT_VERSION >>> BITS_IN_BYTE) & BYTE_MASK);
+        baos.write(BINARY_FORMAT_VERSION & BYTE_MASK);
+        dos = new DataOutputStream(new DeflaterOutputStream(baos, compressor));
+        count = 0;
+        lastName = "";
+    }
+
+    private byte[] getRenderedBlob() {
+        try {
+            dos.close();
+        } catch (IOException e) {
+            // should never be thrown
+            throw new RuntimeException(e);
+        }
+        return baos.toByteArray();
+    }
+
+    @SuppressWarnings("checkstyle:AnonInnerLength")
+    public static Iterator<Metric> decompressingIterator(byte[] bytes) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        int version = (bais.read() << BITS_IN_BYTE) + bais.read();
+        if (version != BINARY_FORMAT_VERSION) {
+            throw new RuntimeException("Incorrect format, expected version " + BINARY_FORMAT_VERSION
+                    + ", got " + version);
+        }
+        DataInputStream dis = new DataInputStream(new InflaterInputStream(bais));
+
+        return new Iterator<Metric>() {
+            String lastName = "";
+            Metric next;
+
+            {
+                moveNext();
+            }
+
+            @Override
+            public boolean hasNext() {
+                return next != null;
+            }
+
+            @Override
+            public Metric next() {
+                try {
+                    return next;
+                } finally {
+                    moveNext();
+                }
+            }
+
+            private void moveNext() {
+                try {
+                    int equalPrefixLen;
+                    try {
+                        equalPrefixLen = dis.readUnsignedShort();
+                    } catch (EOFException ignored) {
+                        next = null;
+                        dis.close();
+                        return;
+                    }
+                    lastName = lastName.substring(0, equalPrefixLen) + dis.readUTF();
+                    next = new Metric(lastName, dis.readLong());
+                } catch (IOException e) {
+                    // unexpected EOFException can occur here
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    private static class MorePublicByteArrayOutputStream extends ByteArrayOutputStream {
+        MorePublicByteArrayOutputStream(int size) {
+            super(size);
+        }
+
+        int capacity() {
+            return buf.length;
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHook.java
@@ -30,8 +30,6 @@ public final class MetricsDataSerializerHook implements DataSerializerHook {
 
     static final int READ_METRICS = 1;
 
-    static final int RINGBUFFER_SLICE = 2;
-
     @Override
     public int getFactoryId() {
         return FACTORY_ID;
@@ -48,8 +46,6 @@ public final class MetricsDataSerializerHook implements DataSerializerHook {
             switch (typeId) {
                 case READ_METRICS:
                     return new ReadMetricsOperation();
-                case RINGBUFFER_SLICE:
-                    return new ConcurrentArrayRingbuffer.RingbufferSlice<>();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHook.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.METRICS_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.METRICS_DS_FACTORY_ID;
+
+public final class MetricsDataSerializerHook implements DataSerializerHook {
+
+    public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(METRICS_DS_FACTORY, METRICS_DS_FACTORY_ID);
+
+    static final int READ_METRICS = 1;
+
+    static final int RINGBUFFER_SLICE = 2;
+
+    @Override
+    public int getFactoryId() {
+        return FACTORY_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        return new Factory();
+    }
+
+    private static class Factory implements DataSerializableFactory {
+        @Override
+        public IdentifiedDataSerializable create(int typeId) {
+            switch (typeId) {
+                case READ_METRICS:
+                    return new ReadMetricsOperation();
+                case RINGBUFFER_SLICE:
+                    return new ConcurrentArrayRingbuffer.RingbufferSlice<>();
+                default:
+                    throw new IllegalArgumentException("Unknown type id " + typeId);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsResultSet.java
@@ -16,25 +16,17 @@
 
 package com.hazelcast.internal.metrics.managementcenter;
 
-import javax.annotation.Nonnull;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.hazelcast.internal.metrics.managementcenter.MetricsCompressor.decompressingIterator;
 
 public class MetricsResultSet {
 
     private final long nextSequence;
-    private final List<MetricsCollection> collections;
+    private final List<Map.Entry<Long, byte[]>> collections;
 
-    public MetricsResultSet(long nextSequence, List<Map.Entry<java.lang.Long, byte[]>> collections) {
-        //        this.nextSequence = slice.nextSequence();
+    public MetricsResultSet(long nextSequence, List<Map.Entry<Long, byte[]>> collections) {
         this.nextSequence = nextSequence;
-        this.collections = collections.stream()
-                                      .map(e -> new MetricsCollection(e.getKey(), e.getValue()))
-                                      .collect(Collectors.toList());
+        this.collections = collections;
     }
 
     /**
@@ -44,36 +36,8 @@ public class MetricsResultSet {
         return nextSequence;
     }
 
-    public List<MetricsCollection> collections() {
+    public List<Map.Entry<Long, byte[]>> collections() {
         return collections;
-    }
-
-    /**
-     * Deserializing iterator for reading metrics
-     */
-    public static final class MetricsCollection implements Iterable<Metric> {
-
-        private final long timestamp;
-        private final byte[] bytes;
-
-        private MetricsCollection(long timestamp, byte[] bytes) {
-            this.timestamp = timestamp;
-            this.bytes = bytes;
-        }
-
-        public long timestamp() {
-            return timestamp;
-        }
-
-        public int sizeInBytes() {
-            return bytes.length;
-        }
-
-        @Nonnull
-        @Override
-        public Iterator<Metric> iterator() {
-            return decompressingIterator(bytes);
-        }
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/MetricsResultSet.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.internal.metrics.managementcenter.MetricsCompressor.decompressingIterator;
+
+public class MetricsResultSet {
+
+    private final long nextSequence;
+    private final List<MetricsCollection> collections;
+
+    public MetricsResultSet(long nextSequence, List<Map.Entry<java.lang.Long, byte[]>> collections) {
+        //        this.nextSequence = slice.nextSequence();
+        this.nextSequence = nextSequence;
+        this.collections = collections.stream()
+                                      .map(e -> new MetricsCollection(e.getKey(), e.getValue()))
+                                      .collect(Collectors.toList());
+    }
+
+    /**
+     * The next sequence to read from.
+     */
+    public long nextSequence() {
+        return nextSequence;
+    }
+
+    public List<MetricsCollection> collections() {
+        return collections;
+    }
+
+    /**
+     * Deserializing iterator for reading metrics
+     */
+    public static final class MetricsCollection implements Iterable<Metric> {
+
+        private final long timestamp;
+        private final byte[] bytes;
+
+        private MetricsCollection(long timestamp, byte[] bytes) {
+            this.timestamp = timestamp;
+            this.bytes = bytes;
+        }
+
+        public long timestamp() {
+            return timestamp;
+        }
+
+        public int sizeInBytes() {
+            return bytes.length;
+        }
+
+        @Nonnull
+        @Override
+        public Iterator<Metric> iterator() {
+            return decompressingIterator(bytes);
+        }
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ReadMetricsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ReadMetricsOperation.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import com.hazelcast.internal.metrics.impl.MetricsService;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+
+import static com.hazelcast.internal.util.ExceptionUtil.peel;
+import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
+
+public class ReadMetricsOperation extends Operation implements ReadonlyOperation, IdentifiedDataSerializable {
+
+    private long offset;
+
+    public ReadMetricsOperation() {
+    }
+
+    public ReadMetricsOperation(long offset) {
+        this.offset = offset;
+    }
+
+    @Override
+    public void beforeRun() {
+        MetricsService service = getService();
+        service.getLiveOperationRegistry().register(this);
+    }
+
+    @Override
+    public void run() {
+        ILogger logger = getNodeEngine().getLogger(getClass());
+        MetricsService service = getService();
+        CompletableFuture<RingbufferSlice<Entry<Long, byte[]>>> future = service.readMetrics(offset);
+        future.whenComplete(withTryCatch(logger, (slice, error) -> doSendResponse(error != null ? peel(error) : slice)));
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
+    }
+
+    @Override
+    public Object getResponse() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServiceName() {
+        return MetricsService.SERVICE_NAME;
+    }
+
+    private void doSendResponse(Object value) {
+        try {
+            sendResponse(value);
+        } finally {
+            final MetricsService service = getService();
+            service.getLiveOperationRegistry().deregister(this);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MetricsDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return MetricsDataSerializerHook.READ_METRICS;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeLong(offset);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        offset = in.readLong();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -18,13 +18,13 @@ package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.monitor.LocalInstanceStats;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
-import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 
@@ -68,8 +68,8 @@ public class StatisticsAwareMetricsSet {
     // it will register it.
     private final class Task implements Runnable {
         private final MetricsRegistry metricsRegistry;
-        private Set<LocalInstanceStats> previousStats = new HashSet<LocalInstanceStats>();
-        private Set<LocalInstanceStats> currentStats = new HashSet<LocalInstanceStats>();
+        private Set<LocalInstanceStats> previousStats = new HashSet<>();
+        private Set<LocalInstanceStats> currentStats = new HashSet<>();
 
         private Task(MetricsRegistry metricsRegistry) {
             this.metricsRegistry = metricsRegistry;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -57,7 +57,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
     private static final String FACTORY_ID = "com.hazelcast.DataSerializerHook";
 
     private final Version version = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
-    private final Int2ObjectHashMap<DataSerializableFactory> factories = new Int2ObjectHashMap<DataSerializableFactory>();
+    private final Int2ObjectHashMap<DataSerializableFactory> factories = new Int2ObjectHashMap<>();
 
     DataSerializableSerializer(Map<Integer, ? extends DataSerializableFactory> dataSerializableFactories,
                                ClassLoader classLoader) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -22,24 +22,24 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.memory.GlobalMemoryAccessorRegistry;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.InputOutputFactory;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationClassNameFilter;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPoolFactoryImpl;
-import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.nio.serialization.ClassNameFilter;
-import com.hazelcast.internal.serialization.SerializationClassNameFilter;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.nio.serialization.ClassDefinition;
+import com.hazelcast.nio.serialization.ClassNameFilter;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.SerializerHook;
+import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.internal.util.StringUtil;
 
 import java.nio.ByteOrder;
 import java.util.HashMap;
@@ -60,12 +60,11 @@ public class DefaultSerializationServiceBuilder implements SerializationServiceB
     private static final String BYTE_ORDER_OVERRIDE_PROPERTY = "hazelcast.serialization.byteOrder";
     private static final int DEFAULT_OUT_BUFFER_SIZE = 4 * 1024;
 
-    protected final Map<Integer, DataSerializableFactory> dataSerializableFactories =
-            new HashMap<Integer, DataSerializableFactory>();
+    protected final Map<Integer, DataSerializableFactory> dataSerializableFactories = new HashMap<>();
 
-    protected final Map<Integer, PortableFactory> portableFactories = new HashMap<Integer, PortableFactory>();
+    protected final Map<Integer, PortableFactory> portableFactories = new HashMap<>();
 
-    protected final Set<ClassDefinition> classDefinitions = new HashSet<ClassDefinition>();
+    protected final Set<ClassDefinition> classDefinitions = new HashSet<>();
 
     protected ClassLoader classLoader;
     protected SerializationConfig config;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -149,6 +149,9 @@ public final class FactoryIdHelper {
     public static final String PN_COUNTER_DS_FACTORY = "hazelcast.serialization.ds.pn_counter";
     public static final int PN_COUNTER_DS_FACTORY_ID = -48;
 
+    public static final String METRICS_DS_FACTORY = "hazelcast.serialization.metrics";
+    public static final int METRICS_DS_FACTORY_ID = -49;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MapUtil.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.util;
 
 import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -92,6 +93,13 @@ public final class MapUtil {
      */
     public static boolean isNullOrEmpty(Map map) {
         return map == null || map.isEmpty();
+    }
+
+    /**
+     * Returns a {@code Map.Entry} with the given key and value.
+     */
+    public static <K, V> Map.Entry<K, V> entry(K k, V v) {
+        return new SimpleImmutableEntry<>(k, v);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -38,6 +38,7 @@ import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.metrics.impl.MetricsService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
@@ -162,6 +163,7 @@ public final class ServiceManagerImpl implements ServiceManager {
         registerService(PNCounterService.SERVICE_NAME, new PNCounterService());
         registerService(CRDTReplicationMigrationService.SERVICE_NAME, new CRDTReplicationMigrationService());
         registerService(DistributedScheduledExecutorService.SERVICE_NAME, new DistributedScheduledExecutorService());
+        registerService(MetricsService.SERVICE_NAME, new MetricsService(nodeEngine));
         registerCacheServiceIfAvailable();
         readServiceDescriptors();
     }

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -55,4 +55,4 @@ com.hazelcast.cp.internal.datastructures.lock.RaftLockDataSerializerHook
 com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreDataSerializerHook
 com.hazelcast.cp.internal.datastructures.RaftDataServiceDataSerializerHook
 com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchDataSerializerHook
-
+com.hazelcast.internal.metrics.managementcenter.MetricsDataSerializerHook

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -73,6 +73,7 @@
                 <xs:element name="pn-counter" type="pn-counter" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="advanced-network" type="advanced-network" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="cp-subsystem" type="cp-subsystem" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -4533,4 +4534,25 @@
             </xs:element>
         </xs:all>
     </xs:complexType>
+
+    <xs:complexType name="metrics">
+        <xs:all>
+            <xs:element name="collection-interval-seconds" type="xs:unsignedInt" default="5" minOccurs="0"/>
+            <xs:element name="retention-seconds" type="xs:unsignedInt" default="5" minOccurs="0"/>
+            <xs:element name="metrics-for-data-structures" type="xs:boolean" default="false" minOccurs="0"/>
+            <xs:element name="minimum-level" type="metric-minimum-level" default="MANDATORY" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+        <xs:attribute name="jmx-enabled" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:simpleType name="metric-minimum-level">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="MANDATORY"/>
+            <xs:enumeration value="INFO"/>
+            <xs:enumeration value="DEBUG"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -4542,8 +4542,40 @@
             <xs:element name="metrics-for-data-structures" type="xs:boolean" default="false" minOccurs="0"/>
             <xs:element name="minimum-level" type="metric-minimum-level" default="MANDATORY" minOccurs="0"/>
         </xs:all>
-        <xs:attribute name="enabled" type="xs:boolean" default="true"/>
-        <xs:attribute name="jmx-enabled" type="xs:boolean" default="true"/>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Master-switch for the metrics system. Controls whether
+                    the metrics are collected and publishers are enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mc-enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls whether the metrics collected are exposed to
+                    Hazelcast Management Center. It is enabled by default.
+                    Please note that the metrics are polled by the
+                    Hazelcast Management Center, hence the members need to
+                    buffer the collected metrics between two polls. The aim
+                    for this switch is to reduce memory consumption of the
+                    metrics system if the Hazelcast Management Center is not
+                    used.
+                    In order to expose the metrics, the metrics system need
+                    to be enabled via the enabled master-switch attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="jmx-enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls whether the metrics collected are exposed to
+                    through JMX. It is enabled by default.
+                    In order to expose the metrics, the metrics system need
+                    to be enabled via the enabled master-switch attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="metric-minimum-level">

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -4540,7 +4540,7 @@
             <xs:element name="collection-interval-seconds" type="xs:unsignedInt" default="5" minOccurs="0"/>
             <xs:element name="retention-seconds" type="xs:unsignedInt" default="5" minOccurs="0"/>
             <xs:element name="metrics-for-data-structures" type="xs:boolean" default="false" minOccurs="0"/>
-            <xs:element name="minimum-level" type="metric-minimum-level" default="MANDATORY" minOccurs="0"/>
+            <xs:element name="minimum-level" type="metric-minimum-level" default="INFO" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="enabled" type="xs:boolean" default="true">
             <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3209,7 +3209,7 @@
         <collection-interval-seconds>10</collection-interval-seconds>
         <retention-seconds>30</retention-seconds>
         <metrics-for-data-structures>true</metrics-for-data-structures>
-        <minimum-level>INFO</minimum-level>
+        <minimum-level>DEBUG</minimum-level>
     </metrics>
 
 </hazelcast>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3205,7 +3205,7 @@
         </locks>
     </cp-subsystem>
 
-    <metrics enabled="false" jmx-enabled="false">
+    <metrics enabled="false" mc-enabled="false" jmx-enabled="false">
         <collection-interval-seconds>10</collection-interval-seconds>
         <retention-seconds>30</retention-seconds>
         <metrics-for-data-structures>true</metrics-for-data-structures>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3205,4 +3205,11 @@
         </locks>
     </cp-subsystem>
 
+    <metrics enabled="false" jmx-enabled="false">
+        <collection-interval-seconds>10</collection-interval-seconds>
+        <retention-seconds>30</retention-seconds>
+        <metrics-for-data-structures>true</metrics-for-data-structures>
+        <minimum-level>INFO</minimum-level>
+    </metrics>
+
 </hazelcast>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3153,4 +3153,4 @@ hazelcast:
     collection-interval-seconds: 10
     retention-seconds: 30
     metrics-for-data-structures: true
-    minimum-level: INFO
+    minimum-level: DEBUG

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3145,3 +3145,11 @@ hazelcast:
         lock-acquire-limit: 1
       lock2:
         lock-acquire-limit: 2
+
+  metrics:
+    enabled: false
+    jmx-enabled: false
+    collection-interval-seconds: 10
+    retention-seconds: 30
+    metrics-for-data-structures: true
+    minimum-level: INFO

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3148,6 +3148,7 @@ hazelcast:
 
   metrics:
     enabled: false
+    mc-enabled: false
     jmx-enabled: false
     collection-interval-seconds: 10
     retention-seconds: 30

--- a/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
@@ -43,7 +43,7 @@ public class FailoverConfigTest {
 
     @Test
     public void testAllClientConfigsAreHandledInMultipleClientConfigSupport() {
-        Set<String> allClientConfigMethods = new HashSet<String>();
+        Set<String> allClientConfigMethods = new HashSet<>();
         Collections.addAll(allClientConfigMethods, "setProperty", "getProperty", "getClassLoader", "getProperties",
                 "setProperties", "getLabels", "getGroupConfig", "getSecurityConfig", "isSmartRouting", "setSmartRouting",
                 "getSocketInterceptorConfig", "setSocketInterceptorConfig", "getConnectionAttemptPeriod",
@@ -62,7 +62,7 @@ public class FailoverConfigTest {
                 "setQueryCacheConfigs", "getInstanceName", "setInstanceName", "getConnectionStrategyConfig",
                 "setConnectionStrategyConfig", "getUserCodeDeploymentConfig", "setUserCodeDeploymentConfig",
                 "getOrCreateQueryCacheConfig", "getOrNullQueryCacheConfig", "addLabel", "setLabels",
-                "setUserContext", "getUserContext", "equals", "hashCode", "toString");
+                "setUserContext", "getUserContext", "setMetricsConfig", "getMetricsConfig", "equals", "hashCode", "toString");
         Method[] declaredMethods = ClientConfig.class.getDeclaredMethods();
         for (Method method : declaredMethods) {
             String methodName = method.getName();
@@ -75,7 +75,7 @@ public class FailoverConfigTest {
 
     @Test
     public void testAllClientNetworkConfigsAreHandledInMultipleClientConfigSupport() {
-        Set<String> allClientNetworkConfigMethods = new HashSet<String>();
+        Set<String> allClientNetworkConfigMethods = new HashSet<>();
         Collections.addAll(allClientNetworkConfigMethods, "isSmartRouting", "setSmartRouting", "getSocketInterceptorConfig",
                 "setSocketInterceptorConfig", "getConnectionAttemptPeriod", "setConnectionAttemptPeriod",
                 "getConnectionAttemptLimit", "setConnectionAttemptLimit", "getConnectionTimeout", "setConnectionTimeout",

--- a/hazelcast/src/test/java/com/hazelcast/client/metrics/ReadMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/metrics/ReadMetricsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.metrics;
+
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.managementcenter.MetricsResultSet;
+import com.hazelcast.internal.util.UuidUtil;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.MemberVersion;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.StreamSupport;
+
+import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ReadMetricsTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void when_readMetricsAsync() {
+        Config conf = getConfig();
+        conf.getMetricsConfig()
+            .setEnabled(true)
+            .setCollectionIntervalSeconds(1);
+
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(conf);
+        HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(hazelcastFactory.newHazelcastClient());
+        Member member = instance.getCluster().getLocalMember();
+
+        AtomicLong nextSequence = new AtomicLong();
+        assertTrueEventually(() -> {
+            MetricsResultSet result = client.readMetricsAsync(member, nextSequence.get()).get();
+            nextSequence.set(result.nextSequence());
+            // call should not return empty result - it should wait until a result is available
+            assertFalse("empty result", result.collections().isEmpty());
+            assertTrue(StreamSupport.stream(result.collections().get(0).spliterator(), false)
+                                    .anyMatch(m -> m.key().equals("[metric=operation.queueSize]"))
+            );
+        });
+    }
+
+    @Test
+    public void when_invalidUUID() throws ExecutionException, InterruptedException {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(getConfig());
+        HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(hazelcastFactory.newHazelcastClient());
+        Address addr = instance.getCluster().getLocalMember().getAddress();
+        MemberVersion ver = instance.getCluster().getLocalMember().getVersion();
+        MemberImpl member = new MemberImpl(addr, ver, false, UuidUtil.newUnsecureUUID());
+
+        exception.expectCause(Matchers.instanceOf(IllegalArgumentException.class));
+        client.readMetricsAsync(member, 0).get();
+    }
+
+    @Test
+    public void when_metricsDisabled() throws ExecutionException, InterruptedException {
+        Config cfg = getConfig();
+        cfg.getMetricsConfig().setEnabled(false);
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(cfg);
+        HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(hazelcastFactory.newHazelcastClient());
+
+        exception.expectCause(Matchers.instanceOf(IllegalArgumentException.class));
+        client.readMetricsAsync(instance.getCluster().getLocalMember(), 0).get();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -539,6 +539,8 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
 
     public abstract void testCPSubsystemConfig();
 
+    public abstract void testMetricsConfig();
+
     protected static void assertAwsConfig(AwsConfig aws) {
         assertEquals("sample-access-key", aws.getProperties().get("access-key"));
         assertEquals("sample-secret-key", aws.getProperties().get("secret-key"));

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -541,6 +541,12 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
 
     public abstract void testMetricsConfig();
 
+    public abstract void testMetricsConfigMasterSwitchDisabled();
+
+    public abstract void testMetricsConfigMcDisabled();
+
+    public abstract void testMetricsConfigJmxDisabled();
+
     protected static void assertAwsConfig(AwsConfig aws) {
         assertEquals("sample-access-key", aws.getProperties().get("access-key"));
         assertEquals("sample-secret-key", aws.getProperties().get("secret-key"));

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -639,6 +639,30 @@ public class ConfigCompatibilityChecker {
         }
     }
 
+    public static class MetricsConfigChecker extends ConfigChecker<MetricsConfig> {
+
+        @Override
+        boolean check(MetricsConfig c1, MetricsConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+
+            return c1.isEnabled() == c2.isEnabled() && c1.isJmxEnabled() == c2.isJmxEnabled()
+                    && c1.getCollectionIntervalSeconds() == c2.getCollectionIntervalSeconds()
+                    && c1.getRetentionSeconds() == c2.getRetentionSeconds()
+                    && c1.isMetricsForDataStructuresEnabled() == c2.isMetricsForDataStructuresEnabled()
+                    && c1.getMinimumLevel() == c2.getMinimumLevel();
+        }
+
+        @Override
+        MetricsConfig getDefault(Config c) {
+            return c.getMetricsConfig();
+        }
+    }
+
     private static class CacheSimpleConfigChecker extends ConfigChecker<CacheSimpleConfig> {
         @Override
         boolean check(CacheSimpleConfig c1, CacheSimpleConfig c2) {

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -650,7 +650,9 @@ public class ConfigCompatibilityChecker {
                 return false;
             }
 
-            return c1.isEnabled() == c2.isEnabled() && c1.isJmxEnabled() == c2.isJmxEnabled()
+            return c1.isEnabled() == c2.isEnabled()
+                    && c1.isMcEnabled() == c2.isMcEnabled()
+                    && c1.isJmxEnabled() == c2.isJmxEnabled()
                     && c1.getCollectionIntervalSeconds() == c2.getCollectionIntervalSeconds()
                     && c1.getRetentionSeconds() == c2.getRetentionSeconds()
                     && c1.isMetricsForDataStructuresEnabled() == c2.isMetricsForDataStructuresEnabled()

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.ConfigCompatibilityChecker.CPSubsystemConfigChecker;
+import com.hazelcast.config.ConfigCompatibilityChecker.MetricsConfigChecker;
 import com.hazelcast.config.ConfigCompatibilityChecker.SplitBrainProtectionConfigChecker;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
@@ -51,6 +52,7 @@ import static com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.T
 import static com.hazelcast.config.ConfigCompatibilityChecker.checkEndpointConfigCompatible;
 import static com.hazelcast.config.ConfigXmlGenerator.MASK_FOR_SENSITIVE_DATA;
 import static com.hazelcast.instance.ProtocolType.MEMBER;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.test.HazelcastTestSupport.randomName;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -1300,6 +1302,23 @@ public class ConfigXmlGeneratorTest {
         CPSubsystemConfig generatedConfig = getNewConfigViaXMLGenerator(config).getCPSubsystemConfig();
         assertTrue(generatedConfig + " should be compatible with " + config.getCPSubsystemConfig(),
                 new CPSubsystemConfigChecker().check(config.getCPSubsystemConfig(), generatedConfig));
+    }
+
+    @Test
+    public void testMetricsConfig() {
+        Config config = new Config();
+
+        config.getMetricsConfig()
+              .setEnabled(false)
+              .setJmxEnabled(false)
+              .setCollectionIntervalSeconds(10)
+              .setRetentionSeconds(11)
+              .setMetricsForDataStructuresEnabled(true)
+              .setMinimumLevel(DEBUG);
+
+        MetricsConfig generatedConfig = getNewConfigViaXMLGenerator(config).getMetricsConfig();
+        assertTrue(generatedConfig + " should be compatible with " + config.getMetricsConfig(),
+                new MetricsConfigChecker().check(config.getMetricsConfig(), generatedConfig));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1310,6 +1310,7 @@ public class ConfigXmlGeneratorTest {
 
         config.getMetricsConfig()
               .setEnabled(false)
+              .setMcEnabled(false)
               .setJmxEnabled(false)
               .setCollectionIntervalSeconds(10)
               .setRetentionSeconds(11)

--- a/hazelcast/src/test/java/com/hazelcast/config/MetricsConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MetricsConfigTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MetricsConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
+        EqualsVerifier.forClass(MetricsConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+
+    @Test
+    public void testCloneEquals() {
+        // create MetricsConfig with non-defaults
+        MetricsConfig original = new MetricsConfig()
+                .setEnabled(false)
+                .setJmxEnabled(false)
+                .setRetentionSeconds(1)
+                .setCollectionIntervalSeconds(1)
+                .setMetricsForDataStructuresEnabled(true)
+                .setMinimumLevel(ProbeLevel.DEBUG);
+
+        MetricsConfig clone = new MetricsConfig(original);
+
+        assertEquals(original.hashCode(), clone.hashCode());
+        assertEquals(original, clone);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -62,6 +62,7 @@ import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
 import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.config.XmlYamlConfigBuilderEqualsTest.readResourceToString;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -3338,5 +3339,26 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + HAZELCAST_END_TAG;
 
         return buildConfig(xml);
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "<metrics enabled=\"false\" jmx-enabled=\"false\">\n"
+                + "  <collection-interval-seconds>10</collection-interval-seconds>\n"
+                + "  <retention-seconds>11</retention-seconds>\n"
+                + "  <metrics-for-data-structures>true</metrics-for-data-structures>\n"
+                + "  <minimum-level>DEBUG</minimum-level>\n"
+                + "</metrics>"
+                + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.isJmxEnabled());
+        assertEquals(10, metricsConfig.getCollectionIntervalSeconds());
+        assertEquals(11, metricsConfig.getRetentionSeconds());
+        assertTrue(metricsConfig.isMetricsForDataStructuresEnabled());
+        assertEquals(DEBUG, metricsConfig.getMinimumLevel());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3345,7 +3345,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testMetricsConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<metrics enabled=\"false\" jmx-enabled=\"false\">\n"
+                + "<metrics enabled=\"false\" mc-enabled=\"false\" jmx-enabled=\"false\">\n"
                 + "  <collection-interval-seconds>10</collection-interval-seconds>\n"
                 + "  <retention-seconds>11</retention-seconds>\n"
                 + "  <metrics-for-data-structures>true</metrics-for-data-structures>\n"
@@ -3355,10 +3355,50 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = new InMemoryXmlConfig(xml);
         MetricsConfig metricsConfig = config.getMetricsConfig();
         assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.isMcEnabled());
         assertFalse(metricsConfig.isJmxEnabled());
         assertEquals(10, metricsConfig.getCollectionIntervalSeconds());
         assertEquals(11, metricsConfig.getRetentionSeconds());
         assertTrue(metricsConfig.isMetricsForDataStructuresEnabled());
         assertEquals(DEBUG, metricsConfig.getMinimumLevel());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigMasterSwitchDisabled() {
+        String xml = HAZELCAST_START_TAG
+                + "<metrics enabled=\"false\"/>"
+                + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertTrue(metricsConfig.isMcEnabled());
+        assertTrue(metricsConfig.isJmxEnabled());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigMcDisabled() {
+        String xml = HAZELCAST_START_TAG
+                + "<metrics mc-enabled=\"false\"/>"
+                + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertTrue(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.isMcEnabled());
+        assertTrue(metricsConfig.isJmxEnabled());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigJmxDisabled() {
+        String xml = HAZELCAST_START_TAG
+                + "<metrics jmx-enabled=\"false\"/>"
+                + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertTrue(metricsConfig.isEnabled());
+        assertTrue(metricsConfig.isMcEnabled());
+        assertFalse(metricsConfig.isJmxEnabled());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -59,6 +59,7 @@ import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
 import static com.hazelcast.config.WanQueueFullBehavior.DISCARD_AFTER_MUTATION;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.config.XmlYamlConfigBuilderEqualsTest.readResourceToString;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -3388,4 +3389,25 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals("/mnt/optane", yamlConfig.getNativeMemoryConfig().getPersistentMemoryDirectory());
     }
 
+    @Override
+    @Test
+    public void testMetricsConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  metrics:\n"
+                + "    enabled: false\n"
+                + "    jmx-enabled: false\n"
+                + "    collection-interval-seconds: 10\n"
+                + "    retention-seconds: 11\n"
+                + "    metrics-for-data-structures: true\n"
+                + "    minimum-level: DEBUG";
+        Config config = new InMemoryYamlConfig(yaml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.isJmxEnabled());
+        assertEquals(10, metricsConfig.getCollectionIntervalSeconds());
+        assertEquals(11, metricsConfig.getRetentionSeconds());
+        assertTrue(metricsConfig.isMetricsForDataStructuresEnabled());
+        assertEquals(DEBUG, metricsConfig.getMinimumLevel());
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3396,6 +3396,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "hazelcast:\n"
                 + "  metrics:\n"
                 + "    enabled: false\n"
+                + "    mc-enabled: false\n"
                 + "    jmx-enabled: false\n"
                 + "    collection-interval-seconds: 10\n"
                 + "    retention-seconds: 11\n"
@@ -3404,10 +3405,54 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = new InMemoryYamlConfig(yaml);
         MetricsConfig metricsConfig = config.getMetricsConfig();
         assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.isMcEnabled());
         assertFalse(metricsConfig.isJmxEnabled());
         assertEquals(10, metricsConfig.getCollectionIntervalSeconds());
         assertEquals(11, metricsConfig.getRetentionSeconds());
         assertTrue(metricsConfig.isMetricsForDataStructuresEnabled());
         assertEquals(DEBUG, metricsConfig.getMinimumLevel());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigMasterSwitchDisabled() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  metrics:\n"
+                + "    enabled: false";
+        Config config = new InMemoryYamlConfig(yaml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertTrue(metricsConfig.isMcEnabled());
+        assertTrue(metricsConfig.isJmxEnabled());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigMcDisabled() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  metrics:\n"
+                + "    mc-enabled: false";
+        Config config = new InMemoryYamlConfig(yaml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertTrue(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.isMcEnabled());
+        assertTrue(metricsConfig.isJmxEnabled());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigJmxDisabled() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  metrics:\n"
+                + "    jmx-enabled: false";
+        Config config = new InMemoryYamlConfig(yaml);
+        MetricsConfig metricsConfig = config.getMetricsConfig();
+        assertTrue(metricsConfig.isEnabled());
+        assertTrue(metricsConfig.isMcEnabled());
+        assertFalse(metricsConfig.isJmxEnabled());
+
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ConcurrentArrayRingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ConcurrentArrayRingbufferTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class ConcurrentArrayRingbufferTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private ConcurrentArrayRingbuffer<Integer> rb = new ConcurrentArrayRingbuffer<>(3);
+
+    @Test
+    public void test() {
+        assertEquals(0, rb.size());
+        assertTrue(rb.isEmpty());
+        assertEquals(emptyList(), rb.copyFrom(0).elements());
+        rb.add(1);
+        assertEquals(1, rb.size());
+        assertFalse(rb.isEmpty());
+        assertEquals(singletonList(1), rb.copyFrom(0).elements());
+        rb.add(2);
+        assertEquals(2, rb.size());
+        assertEquals(asList(1, 2), rb.copyFrom(0).elements());
+        rb.add(3);
+        assertEquals(3, rb.size());
+        assertEquals(asList(1, 2, 3), rb.copyFrom(0).elements());
+        rb.add(4);
+        assertEquals(3, rb.size());
+        for (int i = 5; i < 8; i++) {
+            assertEquals(IntStream.range(i - rb.getCapacity(), i).boxed().collect(toList()),
+                    rb.copyFrom(0).elements());
+            rb.add(i);
+            assertEquals(3, rb.size());
+        }
+    }
+
+    @Test
+    public void when_sequenceTooHigh_then_fail() {
+        exception.expect(IllegalArgumentException.class);
+        rb.get(0);
+    }
+
+    @Test
+    public void when_sequenceTooLow_then_fail() {
+        exception.expect(IllegalArgumentException.class);
+        rb.get(-1);
+    }
+
+    @Test
+    public void test_get() {
+        rb.add(1);
+        assertEquals(1, (int) rb.get(0));
+        rb.add(2);
+        assertEquals(1, (int) rb.get(0));
+        assertEquals(2, (int) rb.get(1));
+        rb.add(3);
+        assertEquals(1, (int) rb.get(0));
+        assertEquals(2, (int) rb.get(1));
+        assertEquals(3, (int) rb.get(2));
+        rb.add(4);
+        assertEquals(2, (int) rb.get(1));
+        assertEquals(3, (int) rb.get(2));
+        assertEquals(4, (int) rb.get(3));
+    }
+
+    @Test
+    public void test_clear() {
+        test();
+        rb.clear();
+        test();
+    }
+
+    @Test
+    public void test_copyFromSequence() {
+        rb.add(1);
+        rb.add(2);
+        ConcurrentArrayRingbuffer.RingbufferSlice result = rb.copyFrom(0);
+        rb.add(3);
+        result = rb.copyFrom(result.nextSequence());
+        assertEquals(singletonList(3), result.elements());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LiveOperationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LiveOperationRegistryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.operationservice.CallsPerMember;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.OperationAccessor;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class LiveOperationRegistryTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private LiveOperationRegistry r = new LiveOperationRegistry();
+
+    @Test
+    public void when_registerDuplicateCallId_then_exception() throws UnknownHostException {
+        r.register(createOperation("1.2.3.4", 1234, 2222L));
+
+        // this should not fail
+        r.register(createOperation("1.2.3.4", 1234, 2223L));
+
+        // adding a duplicate, expecting failure
+        exception.expect(IllegalStateException.class);
+        r.register(createOperation("1.2.3.4", 1234, 2222L));
+    }
+
+    @Test
+    public void test_registerAndDeregister() throws UnknownHostException {
+        Operation op1 = createOperation("1.2.3.4", 1234, 2222L);
+        Operation op2 = createOperation("1.2.3.4", 1234, 2223L);
+
+        r.register(op1);
+        r.register(op2);
+        r.deregister(op1);
+        r.deregister(op2);
+    }
+
+    @Test
+    public void when_deregisterNotExistingAddress_then_fail() throws UnknownHostException {
+        Operation op1 = createOperation("1.2.3.4", 1234, 2222L);
+        exception.expect(IllegalStateException.class);
+        r.deregister(op1);
+    }
+
+    @Test
+    public void when_deregisterNotExistingCallId_then_fail() throws UnknownHostException {
+        r.register(createOperation("1.2.3.4", 1234, 2222L));
+        exception.expect(IllegalStateException.class);
+        r.deregister(createOperation("1.2.3.4", 1234, 2223L));
+    }
+
+    @Test
+    public void testPopulate() throws UnknownHostException {
+        r.register(createOperation("1.2.3.4", 1234, 2223L));
+        r.register(createOperation("1.2.3.4", 1234, 2222L));
+        r.register(createOperation("1.2.3.3", 1234, 2222L));
+
+        CallsPerMember liveOperations = new CallsPerMember(new Address("1.2.3.3", 1234));
+        r.populate(liveOperations);
+
+        Set<Address> addresses = liveOperations.addresses();
+        assertEquals(addresses.size(), 2);
+        assertTrue(addresses.contains(new Address("1.2.3.4", 1234)));
+        assertTrue(addresses.contains(new Address("1.2.3.3", 1234)));
+        long[] runningOperations = liveOperations.toOpControl(new Address("1.2.3.4", 1234)).runningOperations();
+        assertTrue(Arrays.equals(new long[]{2222, 2223}, runningOperations)
+                || Arrays.equals(new long[]{2223, 2222}, runningOperations));
+        runningOperations = liveOperations.toOpControl(new Address("1.2.3.3", 1234)).runningOperations();
+        assertArrayEquals(new long[]{2222}, runningOperations);
+        //callIds.
+    }
+
+    private Operation createOperation(String host, int port, long callId) throws UnknownHostException {
+        Operation op = mock(Operation.class);
+        Address address = new Address(host, port);
+
+        OperationAccessor.setCallerAddress(op, address);
+        OperationAccessor.setCallId(op, callId);
+        return op;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
+import com.hazelcast.internal.metrics.managementcenter.MetricsResultSet;
+import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MetricsServiceTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private Node nodeMock;
+    @Mock
+    private HazelcastInstance hzMock;
+    @Mock
+    private NodeEngineImpl nodeEngineMock;
+    @Mock
+    private LoggingService loggingServiceMock;
+    @Mock
+    private ILogger loggerMock;
+    @Mock
+    private ProbeRenderer probeRendererMock;
+
+    private MetricsRegistry metricsRegistry;
+    private TestProbeSource testProbeSource;
+    private final Config config = new Config();
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        config.getMetricsConfig().setCollectionIntervalSeconds(10);
+        metricsRegistry = new MetricsRegistryImpl(loggerMock, ProbeLevel.INFO);
+
+        when(nodeMock.getLogger(any(Class.class))).thenReturn(loggerMock);
+        when(nodeMock.getLogger(any(String.class))).thenReturn(loggerMock);
+        when(nodeEngineMock.getNode()).thenReturn(nodeMock);
+        when(nodeEngineMock.getConfig()).thenReturn(config);
+        when(nodeEngineMock.getLoggingService()).thenReturn(loggingServiceMock);
+        when(nodeEngineMock.getLogger(any(Class.class))).thenReturn(loggerMock);
+        when(nodeEngineMock.getMetricsRegistry()).thenReturn(metricsRegistry);
+        when(nodeEngineMock.getHazelcastInstance()).thenReturn(hzMock);
+        when(hzMock.getName()).thenReturn("mockInstance");
+
+        ExecutionServiceImpl executionService = new ExecutionServiceImpl(nodeEngineMock);
+        when(nodeEngineMock.getExecutionService()).thenReturn(executionService);
+
+        when(loggingServiceMock.getLogger(any(Class.class))).thenReturn(loggerMock);
+
+        testProbeSource = new TestProbeSource();
+
+        metricsRegistry.scanAndRegister(testProbeSource, "test");
+    }
+
+    @Test
+    public void testUpdatesRenderedInOrder() {
+        MetricsService metricsService = new MetricsService(nodeEngineMock, () -> metricsRegistry);
+        metricsService.init(nodeEngineMock, new Properties());
+
+        testProbeSource.update(1, 1.5D);
+        metricsService.collectMetrics(probeRendererMock);
+
+        testProbeSource.update(2, 5.5D);
+        metricsService.collectMetrics(probeRendererMock);
+
+        InOrder inOrder = inOrder(probeRendererMock);
+        inOrder.verify(probeRendererMock).renderDouble("test.doubleValue", 1.5D);
+        inOrder.verify(probeRendererMock).renderLong("test.longValue", 1);
+        inOrder.verify(probeRendererMock).renderDouble("test.doubleValue", 5.5D);
+        inOrder.verify(probeRendererMock).renderLong("test.longValue", 2);
+    }
+
+    @Test
+    public void testReadMetricsReadsLastTwoCollections() throws Exception {
+        // configure metrics to keep the result of the last 2 collection cycles
+        config.getMetricsConfig()
+              .setRetentionSeconds(2)
+              .setCollectionIntervalSeconds(1);
+
+        MetricsService metricsService = new MetricsService(nodeEngineMock, () -> metricsRegistry);
+        metricsService.init(nodeEngineMock, new Properties());
+
+        testProbeSource.update(1, 1.5D);
+        metricsService.collectMetrics();
+
+        testProbeSource.update(2, 5.5D);
+        metricsService.collectMetrics();
+
+        MetricConsumer metricConsumerMock = mock(MetricConsumer.class);
+        InOrder inOrder = inOrder(metricConsumerMock);
+
+        readMetrics(metricsService, 0, metricConsumerMock);
+
+        inOrder.verify(metricConsumerMock).consumeDouble(1.5D);
+        inOrder.verify(metricConsumerMock).consumeLong(1);
+        inOrder.verify(metricConsumerMock).consumeDouble(5.5D);
+        inOrder.verify(metricConsumerMock).consumeLong(2);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadMetricsReadsOnlyLastCollection() throws Exception {
+        // configure metrics to keep the result only of the last collection cycle
+        config.getMetricsConfig()
+              .setRetentionSeconds(1)
+              .setCollectionIntervalSeconds(5);
+
+        MetricsService metricsService = new MetricsService(nodeEngineMock, () -> metricsRegistry);
+        metricsService.init(nodeEngineMock, new Properties());
+
+        // this collection will be dropped
+        testProbeSource.update(1, 1.5D);
+        metricsService.collectMetrics();
+
+        testProbeSource.update(2, 5.5D);
+        metricsService.collectMetrics();
+
+        MetricConsumer metricConsumerMock = mock(MetricConsumer.class);
+        InOrder inOrder = inOrder(metricConsumerMock);
+
+        readMetrics(metricsService, 0, metricConsumerMock);
+
+        inOrder.verify(metricConsumerMock).consumeDouble(5.5D);
+        inOrder.verify(metricConsumerMock).consumeLong(2);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadMetricsThrowsOnFutureSequence() throws Exception {
+        MetricsService metricsService = new MetricsService(nodeEngineMock, () -> metricsRegistry);
+        metricsService.init(nodeEngineMock, new Properties());
+
+        MetricConsumer metricConsumerMock = mock(MetricConsumer.class);
+
+        long futureSequence = 42;
+        long headSequence = 0;
+
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(Is.is(CoreMatchers.instanceOf(IllegalArgumentException.class)));
+        expectedException.expectMessage(Long.toString(futureSequence));
+        expectedException.expectMessage(Long.toString(headSequence));
+        readMetrics(metricsService, futureSequence, metricConsumerMock);
+    }
+
+    @Test
+    public void testWithCustomPublisher() {
+        MetricsPublisher publisherMock = mock(MetricsPublisher.class);
+        MetricsService metricsService = new MetricsService(nodeEngineMock, () -> metricsRegistry);
+        metricsService.init(nodeEngineMock, new Properties());
+        metricsService.registerPublisher(nodeEngine -> publisherMock);
+
+        metricsService.collectMetrics();
+
+        verify(publisherMock, atLeastOnce()).publishDouble(anyString(), anyDouble());
+        verify(publisherMock, atLeastOnce()).publishLong(anyString(), anyLong());
+    }
+
+    private void readMetrics(MetricsService metricsService, long sequence, MetricConsumer metricConsumer)
+            throws InterruptedException, java.util.concurrent.ExecutionException {
+        CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future = metricsService.readMetrics(sequence);
+        RingbufferSlice<Map.Entry<Long, byte[]>> ringbufferSlice = future.get();
+
+        MetricsResultSet metricsResultSet = new MetricsResultSet(ringbufferSlice.nextSequence(), ringbufferSlice.elements());
+
+        metricsResultSet.collections().forEach(coll -> coll.forEach(metric -> {
+            if (metric.key().contains("test.longValue")) {
+                metricConsumer.consumeLong(metric.value());
+            } else if (metric.key().contains("test.doubleValue")) {
+                metricConsumer.consumeDouble(metric.value() / 10_000D);
+            }
+        }));
+    }
+
+    private static class TestProbeSource {
+        @Probe
+        private long longValue;
+
+        @Probe
+        private double doubleValue;
+
+        private void update(long longValue, double doubleValue) {
+            this.longValue = longValue;
+            this.doubleValue = doubleValue;
+        }
+
+    }
+
+    private interface MetricConsumer {
+        void consumeLong(long value);
+
+        void consumeDouble(double value);
+    }
+
+    private static class CustomMetricsPublisher implements MetricsPublisher {
+
+        @Override
+        public void publishLong(String name, long value) {
+
+        }
+
+        @Override
+        public void publishDouble(String name, double value) {
+
+        }
+
+        @Override
+        public void whenComplete() {
+
+        }
+
+        @Override
+        public void shutdown() {
+
+        }
+
+        @Override
+        public String name() {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
@@ -215,7 +215,7 @@ public class MetricsServiceTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testNoCollectionIfMetricsEnabledAndMcJmxDisabledButCustomPublisherRegistered() {
+    public void testMetricsCollectedIfMetricsEnabledAndMcJmxDisabledButCustomPublisherRegistered() {
         config.getMetricsConfig()
               .setEnabled(true)
               .setMcEnabled(false)
@@ -226,9 +226,7 @@ public class MetricsServiceTest extends HazelcastTestSupport {
         metricsService.init(nodeEngineMock, new Properties());
         metricsService.registerPublisher(nodeEngine -> publisherMock);
 
-        //        metricsService.collectMetrics();
-
-        HazelcastTestSupport.assertTrueEventually(() -> {
+        assertTrueEventually(() -> {
             verify(publisherMock, atLeastOnce()).publishDouble(anyString(), anyDouble());
             verify(publisherMock, atLeastOnce()).publishLong(anyString(), anyLong());
         });

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
+import com.hazelcast.internal.metrics.managementcenter.Metric;
+import com.hazelcast.internal.metrics.managementcenter.MetricsResultSet;
+import com.hazelcast.internal.metrics.managementcenter.ReadMetricsOperation;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ReadMetricsOperationTest extends HazelcastTestSupport {
+
+    @Test
+    public void testMetricsPresent_map() {
+        Config config = new Config();
+        config.getMetricsConfig()
+              .setEnabled(true)
+              .setMetricsForDataStructuresEnabled(true);
+
+        HazelcastInstance hzInstance = createHazelcastInstance(config);
+        IMap<Object, Object> map = hzInstance.getMap("map");
+        map.put("key", "value");
+
+        NodeEngineImpl nodeEngine = getNode(hzInstance).getNodeEngine();
+        OperationServiceImpl operationService = nodeEngine.getOperationService();
+
+        AtomicLong nextSequence = new AtomicLong();
+        assertTrueEventually(() -> {
+            long sequence = nextSequence.get();
+            ReadMetricsOperation readMetricsOperation = new ReadMetricsOperation(sequence);
+            InternalCompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future = operationService
+                    .invokeOnTarget(MetricsService.SERVICE_NAME, readMetricsOperation, nodeEngine.getThisAddress());
+
+            RingbufferSlice<Map.Entry<Long, byte[]>> ringbufferSlice = future.get();
+
+            MetricsResultSet metricsResultSet = new MetricsResultSet(ringbufferSlice.nextSequence(), ringbufferSlice.elements());
+            nextSequence.set(metricsResultSet.nextSequence());
+
+            boolean mapMetric = false;
+            for (MetricsResultSet.MetricsCollection coll : metricsResultSet.collections()) {
+                for (Metric metric : coll) {
+                    mapMetric |= metric.key().contains("map[");
+                }
+            }
+            assertTrue(mapMetric);
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationTest.java
@@ -34,9 +34,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.internal.metrics.managementcenter.MetricsCompressor.decompressingIterator;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -70,8 +73,11 @@ public class ReadMetricsOperationTest extends HazelcastTestSupport {
             nextSequence.set(metricsResultSet.nextSequence());
 
             boolean mapMetric = false;
-            for (MetricsResultSet.MetricsCollection coll : metricsResultSet.collections()) {
-                for (Metric metric : coll) {
+            List<Map.Entry<Long, byte[]>> collections = metricsResultSet.collections();
+            for (Map.Entry<Long, byte[]> entry : collections) {
+                Iterator<Metric> metricIterator = decompressingIterator(entry.getValue());
+                while (metricIterator.hasNext()) {
+                    Metric metric = metricIterator.next();
                     mapMetric |= metric.key().contains("map[");
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.jmx;
+
+import com.hazelcast.internal.metrics.MetricsUtil;
+import com.hazelcast.internal.util.BiTuple;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.internal.util.BiTuple.of;
+import static com.hazelcast.internal.util.MapUtil.entry;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class JmxPublisherTest {
+
+    private static final String MODULE_NAME = "moduleA";
+
+    private ObjectName objectNameNoModule;
+    private ObjectName objectNameWithModule;
+
+    private JmxPublisher jmxPublisher;
+    private MBeanServer platformMBeanServer;
+    private String domainPrefix;
+
+    @Before
+    public void before() throws Exception {
+        domainPrefix = "domain" + ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
+        jmxPublisher = new JmxPublisher("inst1", domainPrefix);
+        platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        objectNameNoModule = new ObjectName(domainPrefix + ":*");
+        objectNameWithModule = new ObjectName(domainPrefix + "." + MODULE_NAME + ":*");
+        try {
+            assertMBeans(emptyList());
+        } catch (AssertionError e) {
+            throw new AssertionError("JMX beans used by this test are already registered", e);
+        }
+    }
+
+    @After
+    public void after() throws Exception {
+        // unregister all beans in domains used in the test to not interfere with other tests
+        try {
+            for (ObjectInstance instance : queryOurInstances()) {
+                platformMBeanServer.unregisterMBean(instance.getObjectName());
+            }
+        } catch (InstanceNotFoundException ignored) {
+        }
+    }
+
+    @Test
+    public void when_singleMetricOldFormat() throws Exception {
+        jmxPublisher.publishLong("a.b.c", 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("c", 1L)))));
+    }
+
+    @Test
+    public void when_trailingPeriodOldFormat_doNotFail() throws Exception {
+        jmxPublisher.publishLong("a.b.", 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("metric", 1L)))));
+    }
+
+    @Test
+    public void when_twoDotsOldFormat_doNotFail() throws Exception {
+        jmxPublisher.publishLong("a.b..c", 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("c", 1L)))));
+    }
+
+    @Test
+    public void when_metricTagMissingNewFormat_then_useDefault() throws Exception {
+        jmxPublisher.publishLong("a.b.", 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("metric", 1L)))));
+    }
+
+    @Test
+    public void when_singleMetricNewFormat() throws Exception {
+        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=c]", 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
+                        singletonList(entry("c", 1L)))));
+    }
+
+    @Test
+    public void when_singleMetricNewFormatWithModule() throws Exception {
+        jmxPublisher.publishLong("[tag1=a,module=" + MODULE_NAME + ",metric=c]", 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + "." + MODULE_NAME + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
+                        singletonList(entry("c", 1L)))));
+    }
+
+    @Test
+    public void when_moreMetricsOldFormat() throws Exception {
+        jmxPublisher.publishLong("a.b.c", 1L);
+        jmxPublisher.publishLong("a.b.d", 2L);
+        jmxPublisher.publishLong("a.c.a", 3L);
+        jmxPublisher.publishLong("a", 4L);
+        assertMBeans(asList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b",
+                        asList(entry("c", 1L), entry("d", 2L))),
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=c",
+                        singletonList(entry("a", 3L))),
+                of(domainPrefix + ":type=Metrics,instance=inst1",
+                        singletonList(entry("a", 4L)))
+        ));
+    }
+
+    @Test
+    public void when_moreMetricsNewFormat() throws Exception {
+        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=c]", 1L);
+        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=d]", 2L);
+        jmxPublisher.publishLong("[module=" + MODULE_NAME + ",tag1=a,tag2=b,metric=d]", 5L);
+        jmxPublisher.publishLong("[tag1=a,tag2=c,metric=a]", 3L);
+        jmxPublisher.publishLong("[metric=a]", 4L);
+        assertMBeans(asList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
+                        asList(entry("c", 1L), entry("d", 2L))),
+                of(domainPrefix + "." + MODULE_NAME + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
+                        singletonList(entry("d", 5L))),
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=c\"",
+                        singletonList(entry("a", 3L))),
+                of(domainPrefix + ":type=Metrics,instance=inst1",
+                        singletonList(entry("a", 4L)))
+        ));
+    }
+
+    @Test
+    public void when_metricNotRendered_then_mBeanRemoved() throws Exception {
+        jmxPublisher.publishLong("[tag1=a,metric=b]", 1L);
+        jmxPublisher.publishLong("[tag1=a,metric=c]", 2L);
+        jmxPublisher.whenComplete();
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
+                        asList(entry("b", 1L), entry("c", 2L)))
+        ));
+
+        jmxPublisher.publishLong("[tag1=a,metric=b]", 1L);
+        jmxPublisher.whenComplete();
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
+                        singletonList(entry("b", 1L)))
+        ));
+
+        jmxPublisher.whenComplete();
+        assertMBeans(emptyList());
+    }
+
+    @Test
+    public void when_badCharacters1_then_escaped() throws Exception {
+        // this is a test that the test works with plain input
+        when_badCharacters_then_escaped("aaa");
+    }
+
+    @Test
+    public void when_badCharacters2_then_escaped() throws Exception {
+        // backslash is special in quoted value, but not in unquoted
+        when_badCharacters_then_escaped("\\");
+    }
+
+    @Test
+    public void when_badCharacters3_then_escaped() throws Exception {
+        // colon is special in unquoted value, but not in quoted
+        when_badCharacters_then_escaped(":");
+    }
+
+    @Test
+    public void when_badCharacters4_then_escaped() throws Exception {
+        // a text containing characters that need to be escaped in quoted value
+        when_badCharacters_then_escaped("\\w\n\\");
+    }
+
+    @Test
+    public void when_badCharacters5_then_escaped() throws Exception {
+        // * and ? can be validly a part of unquoted or quoted value, but they are pattern matchers
+        // and we want to treat them literally
+        when_badCharacters_then_escaped("?*");
+    }
+
+    private void when_badCharacters_then_escaped(String badText) throws Exception {
+        // we must be able to work with any crazy user input
+        System.out.println("badText: " + badText);
+        jmxPublisher.publishLong(badText + ".metric", 1L);
+        jmxPublisher.publishLong("[tag1=a,metric=" + MetricsUtil.escapeMetricNamePart(badText) + "]", 2L);
+        jmxPublisher.whenComplete();
+
+        assertMBeans(asList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=" + JmxPublisher.escapeObjectNameValue(badText),
+                        singletonList(entry("metric", 1L))),
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
+                        singletonList(entry(badText, 2L)))
+        ));
+    }
+
+    private void assertMBeans(List<BiTuple<String, List<Entry<String, Number>>>> expected) throws Exception {
+        Set<ObjectInstance> instances = queryOurInstances();
+        Map<ObjectName, ObjectInstance> instanceMap =
+                instances.stream().collect(Collectors.toMap(ObjectInstance::getObjectName, Function.identity()));
+
+        assertEquals("actual: " + instances, expected.size(), instances.size());
+
+        for (BiTuple<String, List<Entry<String, Number>>> entry : expected) {
+            ObjectName on = new ObjectName(entry.element1);
+            assertTrue("name: " + on + " not in instances " + instances, instanceMap.containsKey(on));
+            for (Entry<String, Number> attribute : entry.element2) {
+                assertEquals("Attribute '" + attribute.getKey() + "' of '" + on + "' doesn't match",
+                        attribute.getValue(), platformMBeanServer.getAttribute(on, attribute.getKey()));
+            }
+        }
+    }
+
+    private Set<ObjectInstance> queryOurInstances() {
+        Set<ObjectInstance> instances = new HashSet<>();
+        instances.addAll(platformMBeanServer.queryMBeans(objectNameNoModule, null));
+        instances.addAll(platformMBeanServer.queryMBeans(objectNameWithModule, null));
+        return instances;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHookTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHookTest.java
@@ -33,9 +33,9 @@ public class MetricsDataSerializerHookTest {
     @Test
     public void testExistingTypes() {
         MetricsDataSerializerHook hook = new MetricsDataSerializerHook();
-        IdentifiedDataSerializable rbSlice = hook.createFactory()
-                                                 .create(MetricsDataSerializerHook.RINGBUFFER_SLICE);
-        assertTrue(rbSlice instanceof ConcurrentArrayRingbuffer.RingbufferSlice);
+        IdentifiedDataSerializable readMetricsOperation = hook.createFactory()
+                                                              .create(MetricsDataSerializerHook.READ_METRICS);
+        assertTrue(readMetricsOperation instanceof ReadMetricsOperation);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHookTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/managementcenter/MetricsDataSerializerHookTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.managementcenter;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MetricsDataSerializerHookTest {
+
+    @Test
+    public void testExistingTypes() {
+        MetricsDataSerializerHook hook = new MetricsDataSerializerHook();
+        IdentifiedDataSerializable rbSlice = hook.createFactory()
+                                                 .create(MetricsDataSerializerHook.RINGBUFFER_SLICE);
+        assertTrue(rbSlice instanceof ConcurrentArrayRingbuffer.RingbufferSlice);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidType() {
+        MetricsDataSerializerHook hook = new MetricsDataSerializerHook();
+        hook.createFactory().create(999);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
@@ -275,7 +275,7 @@ public class HazelcastPropertiesTest {
     public void getEnum_default() {
         ProbeLevel level = config.getMetricsConfig().getMinimumLevel();
 
-        assertEquals(ProbeLevel.MANDATORY, level);
+        assertEquals(ProbeLevel.INFO, level);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.properties;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -265,36 +264,18 @@ public class HazelcastPropertiesTest {
 
     @Test
     public void getEnum() {
-        config.setProperty(Diagnostics.METRICS_LEVEL.getName(), ProbeLevel.DEBUG.toString());
-        HazelcastProperties properties = new HazelcastProperties(config);
+        config.getMetricsConfig().setMinimumLevel(ProbeLevel.DEBUG);
 
-        ProbeLevel level = properties.getEnum(Diagnostics.METRICS_LEVEL, ProbeLevel.class);
+        ProbeLevel level = config.getMetricsConfig().getMinimumLevel();
 
         assertEquals(ProbeLevel.DEBUG, level);
     }
 
     @Test
     public void getEnum_default() {
-        ProbeLevel level = defaultProperties.getEnum(Diagnostics.METRICS_LEVEL, ProbeLevel.class);
+        ProbeLevel level = config.getMetricsConfig().getMinimumLevel();
 
         assertEquals(ProbeLevel.MANDATORY, level);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void getEnum_nonExistingEnum() {
-        config.setProperty(Diagnostics.METRICS_LEVEL.getName(), "notExist");
-        HazelcastProperties properties = new HazelcastProperties(config);
-        properties.getEnum(Diagnostics.METRICS_LEVEL, ProbeLevel.class);
-    }
-
-    @Test
-    public void getEnum_ignoredName() {
-        config.setProperty(Diagnostics.METRICS_LEVEL.getName(), "dEbUg");
-        HazelcastProperties properties = new HazelcastProperties(config);
-
-        ProbeLevel level = properties.getEnum(Diagnostics.METRICS_LEVEL, ProbeLevel.class);
-
-        assertEquals(ProbeLevel.DEBUG, level);
     }
 
     @Test


### PR DESCRIPTION
Metrics are recorded to a ringbuffer that Management Center can read out
by using `ReadMetricsMessageTask`. The task reads the metrics recorded
since the last seen sequence number. The next sequence number that MC
can continue reading the Metrics with is returned in the response. The
ringbuffer, the `ReadMetricsOperation` and the task are almost identical
copies of the similar Jet classes.

Besides the described mechanism used for recording and publishing,
configuring the metrics system has also changed. Before this commit,
metrics could be configured with JVM arguments, now it can be done with
`MetricsConfig` both on the member and on the client side. This
configuration is shared with the diagnostic's `MetricsPlugin`.

The client protocol changes required for the `ReadMetricsMessageTask` is
also included in this commit.