### PR TITLE
Execute client graceful shutdown tasks before marking as inactive

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientOutOfMemoryHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientOutOfMemoryHandler.java
@@ -65,7 +65,7 @@ public class ClientOutOfMemoryHandler extends DefaultOutOfMemoryHandler {
 
         private static void tryShutdown(HazelcastClientInstanceImpl client) {
             try {
-                client.doShutdown(false);
+                client.doShutdown();
             } catch (Throwable ignored) {
                 ignore(ignored);
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cp/internal/session/ClientProxySessionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cp/internal/session/ClientProxySessionManager.java
@@ -104,9 +104,8 @@ public class ClientProxySessionManager extends AbstractProxySessionManager {
         return new ClientDelegatingFuture<Object>(future, client.getSerializationService(), CLOSE_SESSION_RESPONSE_DECODER);
     }
 
-    @Override
-    public Map<RaftGroupId, ICompletableFuture<Object>> shutdown() {
-        Map<RaftGroupId, ICompletableFuture<Object>> futures = super.shutdown();
+    public void shutdownAndAwait() {
+        Map<RaftGroupId, ICompletableFuture<Object>> futures = shutdown();
 
         ILogger logger = client.getLoggingService().getLogger(getClass());
 
@@ -138,13 +137,10 @@ public class ClientProxySessionManager extends AbstractProxySessionManager {
                 Thread.sleep(SHUTDOWN_WAIT_SLEEP_MILLIS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return futures;
+                return;
             }
 
             remainingTimeNanos -= MILLISECONDS.toNanos(SHUTDOWN_WAIT_SLEEP_MILLIS);
         }
-
-        return futures;
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -791,10 +791,20 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         getLifecycleService().shutdown();
     }
 
-    public void doShutdown(boolean isGraceful) {
-        if (isGraceful) {
-            proxySessionManager.shutdown();
-        }
+    /**
+     * Called during graceful shutdown of client to safely clean up resources on server side.
+     * Shutdown process is blocked until this method returns.
+     * <p>
+     * Current list of cleanups:
+     * <ul>
+     * <li>Close of CP sessions</li>
+     * </ul>
+     */
+    void onGracefulShutdown() {
+        proxySessionManager.shutdownAndAwait();
+    }
+
+    public void doShutdown() {
         proxyManager.destroy();
         connectionManager.shutdown();
         clientConnectionStrategy.shutdown();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/LifecycleServiceImpl.java
@@ -137,12 +137,13 @@ public final class LifecycleServiceImpl implements LifecycleService {
 
     @Override
     public void shutdown() {
-        doShutdown(true);
+        client.onGracefulShutdown();
+        doShutdown();
     }
 
     @Override
     public void terminate() {
-        doShutdown(false);
+        doShutdown();
     }
 
     public void start() {
@@ -151,14 +152,14 @@ public final class LifecycleServiceImpl implements LifecycleService {
         fireLifecycleEvent(STARTED);
     }
 
-    private void doShutdown(boolean isGraceful) {
+    private void doShutdown() {
         if (!active.compareAndSet(true, false)) {
             return;
         }
 
         fireLifecycleEvent(SHUTTING_DOWN);
         HazelcastClient.shutdown(client.getName());
-        client.doShutdown(isGraceful);
+        client.doShutdown();
         fireLifecycleEvent(SHUTDOWN);
 
         shutdownExecutor();


### PR DESCRIPTION
Graceful shutdown tasks are needed to do cleanup of resources allocated
on server side. These resources are released after a HB timeout but during
a graceful shutdown, an immediate release is expected instead of a timeout.

But in some cases, missing connection etc, these request may retry.
If client is marked as inactive at that point, retry tasks will fail
without actually retrying. And that causes cleanup to fail.

Instead, we execute graceful shutdown tasks before marking client as inactive.

Fixes #15399
Fixes #15550

Backport of https://github.com/hazelcast/hazelcast/pull/15564