### PR TITLE
Moving Tuple classes out from CP package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -32,7 +32,7 @@ import com.hazelcast.cp.internal.raftop.metadata.CreateRaftNodeOp;
 import com.hazelcast.cp.internal.raftop.metadata.DestroyRaftNodesOp;
 import com.hazelcast.cp.internal.raftop.metadata.InitMetadataRaftGroupOp;
 import com.hazelcast.cp.internal.raftop.metadata.PublishActiveCPMembersOp;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -664,7 +664,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     }
 
     public MembershipChangeSchedule completeRaftGroupMembershipChanges(long commitIndex,
-                                                                       Map<CPGroupId, Tuple2<Long, Long>> changedGroups) {
+                                                                       Map<CPGroupId, BiTuple<Long, Long>> changedGroups) {
         checkNotNull(changedGroups);
         if (membershipChangeSchedule == null) {
             String msg = "Cannot apply CP membership changes: " + changedGroups + " since there is no membership change context!";
@@ -677,7 +677,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
             CPGroupInfo group = groups.get(groupId);
             checkState(group != null, groupId + "not found in CP groups: " + groups.keySet()
                     + "to apply " + change);
-            Tuple2<Long, Long> t = changedGroups.get(groupId);
+            BiTuple<Long, Long> t = changedGroups.get(groupId);
 
             if (t != null) {
                 if (!applyMembershipChange(change, group, t.element1, t.element2)) {
@@ -687,7 +687,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
                 if (logger.isFineEnabled()) {
                     logger.warning(groupId + " is already destroyed so will skip: " + change);
                 }
-                changedGroups.put(groupId, Tuple2.of(0L, 0L));
+                changedGroups.put(groupId, BiTuple.of(0L, 0L));
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatch.java
@@ -18,7 +18,7 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch;
 
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.BlockingResource;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -58,27 +58,27 @@ public class RaftCountDownLatch extends BlockingResource<AwaitInvocationKey> imp
      * a retry or a countDown() request sent before re-initialization
      * of the latch. In this case, this count down request is ignored.
      */
-    Tuple2<Integer, Collection<AwaitInvocationKey>> countDown(UUID invocationUuid, int expectedRound) {
+    BiTuple<Integer, Collection<AwaitInvocationKey>> countDown(UUID invocationUuid, int expectedRound) {
         if (expectedRound > round) {
             throw new IllegalArgumentException("expected round: " + expectedRound + ", actual round: " + round);
         }
 
         if (expectedRound < round) {
             Collection<AwaitInvocationKey> c = Collections.emptyList();
-            return Tuple2.of(0, c);
+            return BiTuple.of(0, c);
         }
 
         countDownUids.add(invocationUuid);
         int remaining = getRemainingCount();
         if (remaining > 0) {
             Collection<AwaitInvocationKey> c = Collections.emptyList();
-            return Tuple2.of(remaining, c);
+            return BiTuple.of(remaining, c);
         }
 
         Collection<AwaitInvocationKey> w = getAllWaitKeys();
         clearWaitKeys();
 
-        return Tuple2.of(0, w);
+        return BiTuple.of(0, w);
     }
 
     boolean trySetCount(int count) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchRegistry.java
@@ -18,7 +18,7 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch;
 
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.ResourceRegistry;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.util.Collection;
@@ -60,9 +60,9 @@ public class RaftCountDownLatchRegistry extends ResourceRegistry<AwaitInvocation
         return getOrInitResource(name).trySetCount(count);
     }
 
-    Tuple2<Integer, Collection<AwaitInvocationKey>> countDown(String name, UUID invocationUuid, int expectedRound) {
+    BiTuple<Integer, Collection<AwaitInvocationKey>> countDown(String name, UUID invocationUuid, int expectedRound) {
         RaftCountDownLatch latch = getOrInitResource(name);
-        Tuple2<Integer, Collection<AwaitInvocationKey>> t = latch.countDown(invocationUuid, expectedRound);
+        BiTuple<Integer, Collection<AwaitInvocationKey>> t = latch.countDown(invocationUuid, expectedRound);
         for (AwaitInvocationKey key : t.element2) {
             removeWaitKey(name, key);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchService.java
@@ -22,7 +22,7 @@ import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.proxy.RaftCountDownLatchProxy;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.AbstractBlockingService;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.spi.impl.NodeEngine;
 
 import java.util.Collection;
@@ -53,7 +53,7 @@ public class RaftCountDownLatchService
 
     public int countDown(CPGroupId groupId, String name, UUID invocationUuid, int expectedRound) {
         RaftCountDownLatchRegistry registry = getOrInitRegistry(groupId);
-        Tuple2<Integer, Collection<AwaitInvocationKey>> t = registry.countDown(name, invocationUuid, expectedRound);
+        BiTuple<Integer, Collection<AwaitInvocationKey>> t = registry.countDown(name, invocationUuid, expectedRound);
         notifyWaitKeys(groupId, name, t.element2, true);
 
         return t.element1;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/RaftLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/RaftLock.java
@@ -20,7 +20,7 @@ import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.datastructures.lock.AcquireResult.AcquireStatus;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.BlockingResource;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.WaitKeyContainer;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -66,7 +66,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
      * and uid of the previous owner's last unlock() invocation.
      * Used for preventing duplicate execution of lock() / unlock() invocations
      */
-    private Map<Tuple2<LockEndpoint, UUID>, RaftLockOwnershipState> ownerInvocationRefUids = new HashMap<>();
+    private Map<BiTuple<LockEndpoint, UUID>, RaftLockOwnershipState> ownerInvocationRefUids = new HashMap<>();
 
     RaftLock() {
     }
@@ -94,7 +94,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
     AcquireResult acquire(LockInvocationKey key, boolean wait) {
         LockEndpoint endpoint = key.endpoint();
         UUID invocationUid = key.invocationUid();
-        RaftLockOwnershipState memorized = ownerInvocationRefUids.get(Tuple2.of(endpoint, invocationUid));
+        RaftLockOwnershipState memorized = ownerInvocationRefUids.get(BiTuple.of(endpoint, invocationUid));
         if (memorized != null) {
             AcquireStatus status = memorized.isLocked() ? SUCCESSFUL : FAILED;
             return new AcquireResult(status, memorized.getFence(), Collections.emptyList());
@@ -106,12 +106,12 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
 
         if (endpoint.equals(owner.endpoint())) {
             if (lockCount == lockCountLimit) {
-                ownerInvocationRefUids.put(Tuple2.of(endpoint, invocationUid), NOT_LOCKED);
+                ownerInvocationRefUids.put(BiTuple.of(endpoint, invocationUid), NOT_LOCKED);
                 return AcquireResult.failed(Collections.emptyList());
             }
 
             lockCount++;
-            ownerInvocationRefUids.put(Tuple2.of(endpoint, invocationUid), lockOwnershipState());
+            ownerInvocationRefUids.put(BiTuple.of(endpoint, invocationUid), lockOwnershipState());
             return AcquireResult.acquired(owner.commitIndex());
         }
 
@@ -154,7 +154,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
     }
 
     private ReleaseResult doRelease(LockEndpoint endpoint, UUID invocationUid, int releaseCount) {
-        RaftLockOwnershipState memorized = ownerInvocationRefUids.get(Tuple2.of(endpoint, invocationUid));
+        RaftLockOwnershipState memorized = ownerInvocationRefUids.get(BiTuple.of(endpoint, invocationUid));
         if (memorized != null) {
             return ReleaseResult.successful(memorized);
         }
@@ -166,7 +166,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
         lockCount = lockCount - min(lockCount, releaseCount);
         if (lockCount > 0) {
             RaftLockOwnershipState ownership = lockOwnershipState();
-            ownerInvocationRefUids.put(Tuple2.of(endpoint, invocationUid), ownership);
+            ownerInvocationRefUids.put(BiTuple.of(endpoint, invocationUid), ownership);
             return ReleaseResult.successful(ownership);
         }
 
@@ -174,13 +174,13 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
 
         Collection<LockInvocationKey> newOwnerWaitKeys = setNewLockOwner();
 
-        ownerInvocationRefUids.put(Tuple2.of(endpoint, invocationUid), lockOwnershipState());
+        ownerInvocationRefUids.put(BiTuple.of(endpoint, invocationUid), lockOwnershipState());
 
         return ReleaseResult.successful(lockOwnershipState(), newOwnerWaitKeys);
     }
 
     private void removeInvocationRefUids(LockEndpoint endpoint) {
-        ownerInvocationRefUids.keySet().removeIf(lockEndpointUUIDTuple2 -> lockEndpointUUIDTuple2.element1.equals(endpoint));
+        ownerInvocationRefUids.keySet().removeIf(lockEndpointUUIDBiTuple -> lockEndpointUUIDBiTuple.element1.equals(endpoint));
     }
 
     private Collection<LockInvocationKey> setNewLockOwner() {
@@ -194,7 +194,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
             iter.remove();
             owner = newOwner;
             lockCount = 1;
-            ownerInvocationRefUids.put(Tuple2.of(owner.endpoint(), owner.invocationUid()), lockOwnershipState());
+            ownerInvocationRefUids.put(BiTuple.of(owner.endpoint(), owner.invocationUid()), lockOwnershipState());
         } else {
             owner = null;
             newOwnerWaitKeys = Collections.emptyList();
@@ -239,7 +239,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
 
     private void removeInvocationRefUids(long sessionId) {
         ownerInvocationRefUids.keySet()
-                              .removeIf(lockEndpointUUIDTuple2 -> lockEndpointUUIDTuple2.element1.sessionId() == sessionId);
+                              .removeIf(lockEndpointUUIDBiTuple -> lockEndpointUUIDBiTuple.element1.sessionId() == sessionId);
     }
 
     /**
@@ -272,7 +272,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
         }
         out.writeInt(lockCount);
         out.writeInt(ownerInvocationRefUids.size());
-        for (Map.Entry<Tuple2<LockEndpoint, UUID>, RaftLockOwnershipState> e : ownerInvocationRefUids.entrySet()) {
+        for (Map.Entry<BiTuple<LockEndpoint, UUID>, RaftLockOwnershipState> e : ownerInvocationRefUids.entrySet()) {
             out.writeObject(e.getKey().element1);
             writeUUID(out, e.getKey().element2);
             out.writeObject(e.getValue());
@@ -293,7 +293,7 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
             LockEndpoint endpoint = in.readObject();
             UUID invocationUid = readUUID(in);
             RaftLockOwnershipState ownership = in.readObject();
-            ownerInvocationRefUids.put(Tuple2.of(endpoint, invocationUid), ownership);
+            ownerInvocationRefUids.put(BiTuple.of(endpoint, invocationUid), ownership);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
@@ -29,7 +29,7 @@ import com.hazelcast.cp.internal.raft.impl.RaftNode;
 import com.hazelcast.cp.internal.session.SessionAccessor;
 import com.hazelcast.cp.internal.session.SessionAwareService;
 import com.hazelcast.cp.internal.session.SessionExpiredException;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
@@ -171,10 +171,10 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
     public final void restoreSnapshot(CPGroupId groupId, long commitIndex, RR registry) {
         RR prev = registries.put(registry.getGroupId(), registry);
         // do not shift the already existing wait timeouts...
-        Map<Tuple2<String, UUID>, Tuple2<Long, Long>> existingWaitTimeouts =
+        Map<BiTuple<String, UUID>, BiTuple<Long, Long>> existingWaitTimeouts =
                 prev != null ? prev.getWaitTimeouts() : Collections.emptyMap();
-        Map<Tuple2<String, UUID>, Long> newWaitKeys = registry.overwriteWaitTimeouts(existingWaitTimeouts);
-        for (Entry<Tuple2<String, UUID>, Long> e : newWaitKeys.entrySet()) {
+        Map<BiTuple<String, UUID>, Long> newWaitKeys = registry.overwriteWaitTimeouts(existingWaitTimeouts);
+        for (Entry<BiTuple<String, UUID>, Long> e : newWaitKeys.entrySet()) {
             scheduleTimeout(groupId, e.getKey().element1, e.getKey().element2, e.getValue());
         }
         registry.onSnapshotRestore();
@@ -235,7 +235,7 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
         }
     }
 
-    public final void expireWaitKeys(CPGroupId groupId, Collection<Tuple2<String, UUID>> keys) {
+    public final void expireWaitKeys(CPGroupId groupId, Collection<BiTuple<String, UUID>> keys) {
         // no need to validate the session. if the session is expired, the corresponding wait key is gone already
         ResourceRegistry<W, R> registry = registries.get(groupId);
         if (registry == null) {
@@ -244,7 +244,7 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
         }
 
         List<W> expired = new ArrayList<>();
-        for (Tuple2<String, UUID> key : keys) {
+        for (BiTuple<String, UUID> key : keys) {
             registry.expireWaitKey(key.element1, key.element2, expired);
         }
 
@@ -261,7 +261,7 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
         return registries.get(groupId);
     }
 
-    public Collection<Tuple2<Address, Long>> getLiveOperations(CPGroupId groupId) {
+    public Collection<BiTuple<Address, Long>> getLiveOperations(CPGroupId groupId) {
         RR registry = registries.get(groupId);
         if (registry == null) {
             return Collections.emptySet();
@@ -282,7 +282,7 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
     protected final void scheduleTimeout(CPGroupId groupId, String name, UUID invocationUid, long timeoutMs) {
         if (timeoutMs > 0 && timeoutMs <= WAIT_TIMEOUT_TASK_UPPER_BOUND_MILLIS) {
             ExecutionService executionService = nodeEngine.getExecutionService();
-            executionService.schedule(new ExpireWaitKeysTask(groupId, Tuple2.of(name, invocationUid)), timeoutMs, MILLISECONDS);
+            executionService.schedule(new ExpireWaitKeysTask(groupId, BiTuple.of(name, invocationUid)), timeoutMs, MILLISECONDS);
         }
     }
 
@@ -324,7 +324,7 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
         }
     }
 
-    private void locallyInvokeExpireWaitKeysOp(CPGroupId groupId, Collection<Tuple2<String, UUID>> keys) {
+    private void locallyInvokeExpireWaitKeysOp(CPGroupId groupId, Collection<BiTuple<String, UUID>> keys) {
         try {
             ExpireWaitKeysOp op = new ExpireWaitKeysOp(serviceName(), keys);
             if (raftService.isCpSubsystemEnabled()) {
@@ -348,9 +348,9 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
 
     private class ExpireWaitKeysTask implements Runnable {
         final CPGroupId groupId;
-        final Collection<Tuple2<String, UUID>> keys;
+        final Collection<BiTuple<String, UUID>> keys;
 
-        ExpireWaitKeysTask(CPGroupId groupId, Tuple2<String, UUID> key) {
+        ExpireWaitKeysTask(CPGroupId groupId, BiTuple<String, UUID> key) {
             this.groupId = groupId;
             this.keys = Collections.singleton(key);
         }
@@ -364,17 +364,17 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
     private class ExpireWaitKeysPeriodicTask implements Runnable {
         @Override
         public void run() {
-            for (Entry<CPGroupId, Collection<Tuple2<String, UUID>>> e : getWaitKeysToExpire().entrySet()) {
+            for (Entry<CPGroupId, Collection<BiTuple<String, UUID>>> e : getWaitKeysToExpire().entrySet()) {
                 locallyInvokeExpireWaitKeysOp(e.getKey(), e.getValue());
             }
         }
 
         // queried locally
-        private Map<CPGroupId, Collection<Tuple2<String, UUID>>> getWaitKeysToExpire() {
-            Map<CPGroupId, Collection<Tuple2<String, UUID>>> timeouts = new HashMap<>();
+        private Map<CPGroupId, Collection<BiTuple<String, UUID>>> getWaitKeysToExpire() {
+            Map<CPGroupId, Collection<BiTuple<String, UUID>>> timeouts = new HashMap<>();
             long now = Clock.currentTimeMillis();
             for (ResourceRegistry<W, R> registry : registries.values()) {
-                Collection<Tuple2<String, UUID>> t = registry.getWaitKeysToExpire(now);
+                Collection<BiTuple<String, UUID>> t = registry.getWaitKeysToExpire(now);
                 if (t.size() > 0) {
                     timeouts.put(registry.getGroupId(), t);
                 }
@@ -394,7 +394,7 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
         assert !raftService.isCpSubsystemEnabled();
         return getGroupIdSet().stream()
                 .filter(groupId -> raftService.getCPGroupPartitionId(groupId) == partitionId)
-                .map(groupId -> Tuple2.of(groupId, takeSnapshot(groupId, 0L)))
+                .map(groupId -> BiTuple.of(groupId, takeSnapshot(groupId, 0L)))
                 .collect(Collectors.toMap(tuple -> tuple.element1, tuple -> tuple.element2));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/operation/ExpireWaitKeysOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/operation/ExpireWaitKeysOp.java
@@ -20,7 +20,7 @@ import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.RaftOp;
 import com.hazelcast.cp.internal.datastructures.RaftDataServiceDataSerializerHook;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.AbstractBlockingService;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -42,12 +42,12 @@ import static com.hazelcast.cp.internal.util.UUIDSerializationUtil.writeUUID;
 public class ExpireWaitKeysOp extends RaftOp implements IdentifiedDataSerializable {
 
     private String serviceName;
-    private Collection<Tuple2<String, UUID>> keys;
+    private Collection<BiTuple<String, UUID>> keys;
 
     public ExpireWaitKeysOp() {
     }
 
-    public ExpireWaitKeysOp(String serviceName, Collection<Tuple2<String, UUID>> keys) {
+    public ExpireWaitKeysOp(String serviceName, Collection<BiTuple<String, UUID>> keys) {
         this.serviceName = serviceName;
         this.keys = keys;
     }
@@ -78,7 +78,7 @@ public class ExpireWaitKeysOp extends RaftOp implements IdentifiedDataSerializab
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(serviceName);
         out.writeInt(keys.size());
-        for (Tuple2<String, UUID> key : keys) {
+        for (BiTuple<String, UUID> key : keys) {
             out.writeUTF(key.element1);
             writeUUID(out, key.element2);
         }
@@ -92,7 +92,7 @@ public class ExpireWaitKeysOp extends RaftOp implements IdentifiedDataSerializab
         for (int i = 0; i < size; i++) {
             String name = in.readUTF();
             UUID invocationUid = readUUID(in);
-            keys.add(Tuple2.of(name, invocationUid));
+            keys.add(BiTuple.of(name, invocationUid));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
@@ -58,7 +58,7 @@ import com.hazelcast.cp.internal.raft.impl.task.QueryTask;
 import com.hazelcast.cp.internal.raft.impl.task.RaftNodeStatusAwareTask;
 import com.hazelcast.cp.internal.raft.impl.task.ReplicateTask;
 import com.hazelcast.cp.internal.raft.impl.util.PostponedResponse;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.internal.util.SimpleCompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Clock;
@@ -931,7 +931,7 @@ public class RaftNodeImpl implements RaftNode {
     public void toFollower(int term) {
         LeaderState leaderState = state.leaderState();
         if (leaderState != null) {
-            for (Tuple2<Object, SimpleCompletableFuture> t : leaderState.queryState().operations()) {
+            for (BiTuple<Object, SimpleCompletableFuture> t : leaderState.queryState().operations()) {
                 t.element2.complete(new NotLeaderException(groupId, localMember, null));
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendSuccessResponseHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendSuccessResponseHandlerTask.java
@@ -25,7 +25,7 @@ import com.hazelcast.cp.internal.raft.impl.state.FollowerState;
 import com.hazelcast.cp.internal.raft.impl.state.LeaderState;
 import com.hazelcast.cp.internal.raft.impl.state.QueryState;
 import com.hazelcast.cp.internal.raft.impl.state.RaftState;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.internal.util.SimpleCompletableFuture;
 
 import java.util.Arrays;
@@ -191,14 +191,14 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
             return;
         }
 
-        Collection<Tuple2<Object, SimpleCompletableFuture>> operations = queryState.operations();
+        Collection<BiTuple<Object, SimpleCompletableFuture>> operations = queryState.operations();
 
         if (logger.isFineEnabled()) {
             logger.fine("Running " + operations.size() + " queries at commit index: " + commitIndex
                     + ", query round: " + queryState.queryRound());
         }
 
-        for (Tuple2<Object, SimpleCompletableFuture> t : operations) {
+        for (BiTuple<Object, SimpleCompletableFuture> t : operations) {
             raftNode.runQuery(t.element1, t.element2);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/QueryState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/QueryState.java
@@ -17,7 +17,7 @@
 package com.hazelcast.cp.internal.raft.impl.state;
 
 import com.hazelcast.cluster.Endpoint;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.internal.util.SimpleCompletableFuture;
 
 import java.util.ArrayList;
@@ -64,7 +64,7 @@ public class QueryState {
     /**
      * Queries waiting to be executed.
      */
-    private final List<Tuple2<Object, SimpleCompletableFuture>> operations = new ArrayList<>();
+    private final List<BiTuple<Object, SimpleCompletableFuture>> operations = new ArrayList<>();
 
     /**
      * The set of followers acknowledged the leader in the current heartbeat
@@ -87,7 +87,7 @@ public class QueryState {
             queryCommitIndex = commitIndex;
         }
 
-        operations.add(Tuple2.of(operation, resultFuture));
+        operations.add(BiTuple.of(operation, resultFuture));
         int size = operations.size();
         if (size == 1) {
             queryRound++;
@@ -161,7 +161,7 @@ public class QueryState {
     /**
      * Returns the queries waiting to be executed.
      */
-    public Collection<Tuple2<Object, SimpleCompletableFuture>> operations() {
+    public Collection<BiTuple<Object, SimpleCompletableFuture>> operations() {
         return operations;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CompleteRaftGroupMembershipChangesOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CompleteRaftGroupMembershipChangesOp.java
@@ -20,7 +20,7 @@ import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.IndeterminateOperationStateAware;
 import com.hazelcast.cp.internal.MetadataRaftGroupManager;
 import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -38,12 +38,12 @@ import java.util.Map.Entry;
 public class CompleteRaftGroupMembershipChangesOp extends MetadataRaftGroupOp implements IndeterminateOperationStateAware,
                                                                                          IdentifiedDataSerializable {
 
-    private Map<CPGroupId, Tuple2<Long, Long>> changedGroups;
+    private Map<CPGroupId, BiTuple<Long, Long>> changedGroups;
 
     public CompleteRaftGroupMembershipChangesOp() {
     }
 
-    public CompleteRaftGroupMembershipChangesOp(Map<CPGroupId, Tuple2<Long, Long>> changedGroups) {
+    public CompleteRaftGroupMembershipChangesOp(Map<CPGroupId, BiTuple<Long, Long>> changedGroups) {
         this.changedGroups = changedGroups;
     }
 
@@ -70,9 +70,9 @@ public class CompleteRaftGroupMembershipChangesOp extends MetadataRaftGroupOp im
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(changedGroups.size());
-        for (Entry<CPGroupId, Tuple2<Long, Long>> e : changedGroups.entrySet()) {
+        for (Entry<CPGroupId, BiTuple<Long, Long>> e : changedGroups.entrySet()) {
             out.writeObject(e.getKey());
-            Tuple2<Long, Long> value = e.getValue();
+            BiTuple<Long, Long> value = e.getValue();
             out.writeLong(value.element1);
             out.writeLong(value.element2);
         }
@@ -81,12 +81,12 @@ public class CompleteRaftGroupMembershipChangesOp extends MetadataRaftGroupOp im
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int count = in.readInt();
-        changedGroups = new HashMap<CPGroupId, Tuple2<Long, Long>>(count);
+        changedGroups = new HashMap<CPGroupId, BiTuple<Long, Long>>(count);
         for (int i = 0; i < count; i++) {
             CPGroupId groupId = in.readObject();
             long currMembersCommitIndex = in.readLong();
             long newMembersCommitIndex = in.readLong();
-            changedGroups.put(groupId, Tuple2.of(currMembersCommitIndex, newMembersCommitIndex));
+            changedGroups.put(groupId, BiTuple.of(currMembersCommitIndex, newMembersCommitIndex));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/AbstractProxySessionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/AbstractProxySessionManager.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
 import com.hazelcast.cp.internal.RaftGroupId;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.util.Clock;
 
 import java.util.ArrayList;
@@ -53,7 +53,7 @@ public abstract class AbstractProxySessionManager {
 
     private final ConcurrentMap<RaftGroupId, Object> mutexes = new ConcurrentHashMap<>();
     private final ConcurrentMap<RaftGroupId, SessionState> sessions = new ConcurrentHashMap<>();
-    private final ConcurrentMap<Tuple2<RaftGroupId, Long>, Long> threadIds = new ConcurrentHashMap<>();
+    private final ConcurrentMap<BiTuple<RaftGroupId, Long>, Long> threadIds = new ConcurrentHashMap<>();
     private final AtomicBoolean scheduleHeartbeat = new AtomicBoolean(false);
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private boolean running = true;
@@ -98,7 +98,7 @@ public abstract class AbstractProxySessionManager {
     public final Long getOrCreateUniqueThreadId(RaftGroupId groupId) {
         lock.readLock().lock();
         try {
-            Tuple2<RaftGroupId, Long> key = Tuple2.of(groupId, getThreadId());
+            BiTuple<RaftGroupId, Long> key = BiTuple.of(groupId, getThreadId());
             Long globalThreadId = threadIds.get(key);
             if (globalThreadId != null) {
                 return globalThreadId;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionRegistry.java
@@ -19,7 +19,7 @@ package com.hazelcast.cp.internal.session;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.session.CPSession;
 import com.hazelcast.cp.session.CPSession.CPSessionOwnerType;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -99,12 +99,12 @@ class RaftSessionRegistry implements IdentifiedDataSerializable {
     }
 
     // queried locally
-    Collection<Tuple2<Long, Long>> getSessionsToExpire() {
-        List<Tuple2<Long, Long>> expired = new ArrayList<>();
+    Collection<BiTuple<Long, Long>> getSessionsToExpire() {
+        List<BiTuple<Long, Long>> expired = new ArrayList<>();
         long now = Clock.currentTimeMillis();
         for (CPSessionInfo session : sessions.values()) {
             if (session.isExpired(now)) {
-                expired.add(Tuple2.of(session.id(), session.version()));
+                expired.add(BiTuple.of(session.id(), session.version()));
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
@@ -32,7 +32,7 @@ import com.hazelcast.cp.internal.session.operation.CloseSessionOp;
 import com.hazelcast.cp.internal.session.operation.ExpireSessionsOp;
 import com.hazelcast.cp.internal.session.operation.GetSessionsOp;
 import com.hazelcast.cp.internal.util.PartitionSpecificRunnableAdaptor;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.cp.session.CPSession;
 import com.hazelcast.cp.session.CPSession.CPSessionOwnerType;
 import com.hazelcast.cp.session.CPSessionManagementService;
@@ -288,14 +288,14 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
         return false;
     }
 
-    public void expireSessions(CPGroupId groupId, Collection<Tuple2<Long, Long>> sessionsToExpire) {
+    public void expireSessions(CPGroupId groupId, Collection<BiTuple<Long, Long>> sessionsToExpire) {
         RaftSessionRegistry registry = registries.get(groupId);
         if (registry == null) {
             return;
         }
 
         List<Long> expired = new ArrayList<>();
-        for (Tuple2<Long, Long> s : sessionsToExpire) {
+        for (BiTuple<Long, Long> s : sessionsToExpire) {
             long sessionId = s.element1;
             long version = s.element2;
             if (registry.expireSession(sessionId, version)) {
@@ -381,10 +381,10 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
     }
 
     // queried locally
-    private Map<CPGroupId, Collection<Tuple2<Long, Long>>> getSessionsToExpire() {
-        Map<CPGroupId, Collection<Tuple2<Long, Long>>> expired = new HashMap<>();
+    private Map<CPGroupId, Collection<BiTuple<Long, Long>>> getSessionsToExpire() {
+        Map<CPGroupId, Collection<BiTuple<Long, Long>>> expired = new HashMap<>();
         for (RaftSessionRegistry registry : registries.values()) {
-            Collection<Tuple2<Long, Long>> e = registry.getSessionsToExpire();
+            Collection<BiTuple<Long, Long>> e = registry.getSessionsToExpire();
             if (!e.isEmpty()) {
                 expired.put(registry.groupId(), e);
             }
@@ -436,10 +436,10 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
     private class CheckSessionsToExpire implements Runnable {
         @Override
         public void run() {
-            Map<CPGroupId, Collection<Tuple2<Long, Long>>> sessionsToExpire = getSessionsToExpire();
-            for (Entry<CPGroupId, Collection<Tuple2<Long, Long>>> entry : sessionsToExpire.entrySet()) {
+            Map<CPGroupId, Collection<BiTuple<Long, Long>>> sessionsToExpire = getSessionsToExpire();
+            for (Entry<CPGroupId, Collection<BiTuple<Long, Long>>> entry : sessionsToExpire.entrySet()) {
                 CPGroupId groupId = entry.getKey();
-                Collection<Tuple2<Long, Long>> sessions = entry.getValue();
+                Collection<BiTuple<Long, Long>> sessions = entry.getValue();
                 if (raftService.isCpSubsystemEnabled()) {
                     expireOnRaftNode(groupId, sessions);
                 } else {
@@ -448,7 +448,7 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
             }
         }
 
-        private void expireOnRaftNode(CPGroupId groupId, Collection<Tuple2<Long, Long>> sessions) {
+        private void expireOnRaftNode(CPGroupId groupId, Collection<BiTuple<Long, Long>> sessions) {
             RaftNode raftNode = raftService.getRaftNode(groupId);
             if (raftNode != null) {
                 try {
@@ -462,7 +462,7 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
             }
         }
 
-        private void expireOnPartitionOwner(CPGroupId groupId, Collection<Tuple2<Long, Long>> sessions) {
+        private void expireOnPartitionOwner(CPGroupId groupId, Collection<BiTuple<Long, Long>> sessions) {
             InternalCompletableFuture<Object> future = raftService.getInvocationManager()
                     .invokeOnPartition(new UnsafeRaftReplicateOp(groupId, new ExpireSessionsOp(sessions)));
             try {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/operation/ExpireSessionsOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/operation/ExpireSessionsOp.java
@@ -25,7 +25,7 @@ import com.hazelcast.cp.internal.RaftOp;
 import com.hazelcast.cp.internal.IndeterminateOperationStateAware;
 import com.hazelcast.cp.internal.session.RaftSessionService;
 import com.hazelcast.cp.internal.session.RaftSessionServiceDataSerializerHook;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,12 +38,12 @@ import java.util.List;
  */
 public class ExpireSessionsOp extends RaftOp implements IndeterminateOperationStateAware, IdentifiedDataSerializable {
 
-    private Collection<Tuple2<Long, Long>> sessions;
+    private Collection<BiTuple<Long, Long>> sessions;
 
     public ExpireSessionsOp() {
     }
 
-    public ExpireSessionsOp(Collection<Tuple2<Long, Long>> sessionIds) {
+    public ExpireSessionsOp(Collection<BiTuple<Long, Long>> sessionIds) {
         this.sessions = sessionIds;
     }
 
@@ -77,7 +77,7 @@ public class ExpireSessionsOp extends RaftOp implements IndeterminateOperationSt
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(sessions.size());
-        for (Tuple2<Long, Long> s : sessions) {
+        for (BiTuple<Long, Long> s : sessions) {
             out.writeLong(s.element1);
             out.writeLong(s.element2);
         }
@@ -86,11 +86,11 @@ public class ExpireSessionsOp extends RaftOp implements IndeterminateOperationSt
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        List<Tuple2<Long, Long>> sessionIds = new ArrayList<>();
+        List<BiTuple<Long, Long>> sessionIds = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             long sessionId = in.readLong();
             long version = in.readLong();
-            sessionIds.add(Tuple2.of(sessionId, version));
+            sessionIds.add(BiTuple.of(sessionId, version));
         }
         this.sessions = sessionIds;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/BiTuple.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/BiTuple.java
@@ -14,36 +14,40 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cp.internal.util;
+package com.hazelcast.internal.util;
 
 import java.util.Objects;
 
 /**
- * An immutable container of 3 statically typed fields
+ * An immutable container of 2 statically typed fields
  *
  * @param <X> type of the first element
  * @param <Y> type of the second element
- * @param <Z> type of the third element
  */
 @SuppressWarnings("checkstyle:visibilitymodifier")
-public final class Tuple3<X, Y, Z> {
+public final class BiTuple<X, Y> {
 
     public final X element1;
     public final Y element2;
-    public final Z element3;
 
-    private Tuple3(X element1, Y element2, Z element3) {
+    private BiTuple(X element1, Y element2) {
         this.element1 = element1;
         this.element2 = element2;
-        this.element3 = element3;
     }
 
-    public static <X, Y, Z> Tuple3<X, Y, Z> of(X element1, Y element2, Z element3) {
-        return new Tuple3<>(element1, element2, element3);
+    public static <X, Y> BiTuple<X, Y> of(X element1, Y element2) {
+        return new BiTuple<>(element1, element2);
+    }
+
+    public X element1() {
+        return element1;
+    }
+
+    public Y element2() {
+        return element2;
     }
 
     @Override
-    @SuppressWarnings("checkstyle:npathcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -52,27 +56,23 @@ public final class Tuple3<X, Y, Z> {
             return false;
         }
 
-        Tuple3<?, ?, ?> tuple3 = (Tuple3<?, ?, ?>) o;
+        BiTuple<?, ?> biTuple = (BiTuple<?, ?>) o;
 
-        if (!Objects.equals(element1, tuple3.element1)) {
+        if (!Objects.equals(element1, biTuple.element1)) {
             return false;
         }
-        if (!Objects.equals(element2, tuple3.element2)) {
-            return false;
-        }
-        return Objects.equals(element3, tuple3.element3);
+        return Objects.equals(element2, biTuple.element2);
     }
 
     @Override
     public int hashCode() {
         int result = element1 != null ? element1.hashCode() : 0;
         result = 31 * result + (element2 != null ? element2.hashCode() : 0);
-        result = 31 * result + (element3 != null ? element3.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
-        return "Tuple3{" + "element1=" + element1 + ", element2=" + element2 + ", element3=" + element3 + '}';
+        return "BiTuple{" + "element1=" + element1 + ", element2=" + element2 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/TriTuple.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/TriTuple.java
@@ -14,39 +14,36 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cp.internal.util;
+package com.hazelcast.internal.util;
 
 import java.util.Objects;
 
 /**
- * An immutable container of 2 statically typed fields
+ * An immutable container of 3 statically typed fields
+ *
  * @param <X> type of the first element
  * @param <Y> type of the second element
+ * @param <Z> type of the third element
  */
 @SuppressWarnings("checkstyle:visibilitymodifier")
-public final class Tuple2<X, Y> {
+public final class TriTuple<X, Y, Z> {
 
     public final X element1;
     public final Y element2;
+    public final Z element3;
 
-    private Tuple2(X element1, Y element2) {
+    private TriTuple(X element1, Y element2, Z element3) {
         this.element1 = element1;
         this.element2 = element2;
+        this.element3 = element3;
     }
 
-    public static <X, Y> Tuple2<X, Y> of(X element1, Y element2) {
-        return new Tuple2<>(element1, element2);
-    }
-
-    public X element1() {
-        return element1;
-    }
-
-    public Y element2() {
-        return element2;
+    public static <X, Y, Z> TriTuple<X, Y, Z> of(X element1, Y element2, Z element3) {
+        return new TriTuple<>(element1, element2, element3);
     }
 
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -55,23 +52,27 @@ public final class Tuple2<X, Y> {
             return false;
         }
 
-        Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
+        TriTuple<?, ?, ?> triTuple = (TriTuple<?, ?, ?>) o;
 
-        if (!Objects.equals(element1, tuple2.element1)) {
+        if (!Objects.equals(element1, triTuple.element1)) {
             return false;
         }
-        return Objects.equals(element2, tuple2.element2);
+        if (!Objects.equals(element2, triTuple.element2)) {
+            return false;
+        }
+        return Objects.equals(element3, triTuple.element3);
     }
 
     @Override
     public int hashCode() {
         int result = element1 != null ? element1.hashCode() : 0;
         result = 31 * result + (element2 != null ? element2.hashCode() : 0);
+        result = 31 * result + (element3 != null ? element3.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
-        return "Tuple2{" + "element1=" + element1 + ", element2=" + element2 + '}';
+        return "TriTuple{" + "element1=" + element1 + ", element2=" + element2 + ", element3=" + element3 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/AbstractFencedLockFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/AbstractFencedLockFailureTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.cp.internal.datastructures.spi.blocking.WaitKeyContainer;
 import com.hazelcast.cp.internal.datastructures.spi.blocking.operation.ExpireWaitKeysOp;
 import com.hazelcast.cp.internal.session.AbstractProxySessionManager;
 import com.hazelcast.cp.internal.session.ProxySessionManagerService;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
@@ -527,7 +527,7 @@ public abstract class AbstractFencedLockFailureTest extends HazelcastRaftTestSup
 
         RaftInvocationManager invocationManager = getRaftInvocationManager();
         UUID invUid = newUnsecureUUID();
-        Tuple2[] lockWaitTimeoutKeyRef = new Tuple2[1];
+        BiTuple[] lockWaitTimeoutKeyRef = new BiTuple[1];
 
         InternalCompletableFuture<Long> f1 = invocationManager
                 .invoke(groupId, new TryLockOp(objectName, sessionId, getThreadId(), invUid, SECONDS.toMillis(300)));
@@ -537,7 +537,7 @@ public abstract class AbstractFencedLockFailureTest extends HazelcastRaftTestSup
 
         assertTrueEventually(() -> {
             RaftLockRegistry registry = service.getRegistryOrNull(groupId);
-            Map<Tuple2<String, UUID>, Tuple2<Long, Long>> waitTimeouts = registry.getWaitTimeouts();
+            Map<BiTuple<String, UUID>, BiTuple<Long, Long>> waitTimeouts = registry.getWaitTimeouts();
             assertEquals(1, waitTimeouts.size());
             lockWaitTimeoutKeyRef[0] = waitTimeouts.keySet().iterator().next();
         });

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSemaphoreAdvancedTest.java
@@ -33,7 +33,7 @@ import com.hazelcast.cp.internal.session.AbstractProxySessionManager;
 import com.hazelcast.cp.internal.session.ProxySessionManagerService;
 import com.hazelcast.cp.internal.session.RaftSessionService;
 import com.hazelcast.cp.internal.session.SessionAwareProxy;
-import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
@@ -405,7 +405,7 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
         assertNotEquals(NO_SESSION_ID, sessionId);
 
         UUID invUid = newUnsecureUUID();
-        Tuple2[] acquireWaitTimeoutKeyRef = new Tuple2[1];
+        BiTuple[] acquireWaitTimeoutKeyRef = new BiTuple[1];
 
         InternalCompletableFuture<Boolean> f1 =
                 invokeRaftOp(groupId, new AcquirePermitsOp(objectName, sessionId, getThreadId(), invUid, 1, SECONDS.toMillis(300)));
@@ -414,7 +414,7 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
             NodeEngineImpl nodeEngine = getNodeEngineImpl(primaryInstance);
             RaftSemaphoreService service = nodeEngine.getService(RaftSemaphoreService.SERVICE_NAME);
             RaftSemaphoreRegistry registry = service.getRegistryOrNull(groupId);
-            Map<Tuple2<String, UUID>, Tuple2<Long, Long>> waitTimeouts = registry.getWaitTimeouts();
+            Map<BiTuple<String, UUID>, BiTuple<Long, Long>> waitTimeouts = registry.getWaitTimeouts();
             assertEquals(1, waitTimeouts.size());
             acquireWaitTimeoutKeyRef[0] = waitTimeouts.keySet().iterator().next();
         });


### PR DESCRIPTION
Moving out `Tuple2` and `Tuple3` classes from CP package to
`com.hazelcast.internal.util` to let non-CP features to use them, like
Metrics. Besides moving the classes they got renamed to `BiTuple` and
`TriTuple` to get rid of name clashing with the similar classes in Jet.

Needed for https://github.com/hazelcast/hazelcast/pull/15560