### PR TITLE
CPSubsystem restart should cancel & wait running/scheduled discovery task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.cp.internal;
 
-import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.cp.CPGroup.CPGroupStatus;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPMember;
@@ -34,12 +34,12 @@ import com.hazelcast.cp.internal.raftop.metadata.InitMetadataRaftGroupOp;
 import com.hazelcast.cp.internal.raftop.metadata.PublishActiveCPMembersOp;
 import com.hazelcast.cp.internal.util.Tuple2;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.RaftInvocationContext;
 import com.hazelcast.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -104,6 +104,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     private final AtomicReference<RaftGroupId> metadataGroupIdRef = new AtomicReference<>(INITIAL_METADATA_GROUP_ID);
     private final AtomicBoolean discoveryCompleted = new AtomicBoolean();
     private final boolean cpSubsystemEnabled;
+    private volatile DiscoverInitialCPMembersTask currentDiscoveryTask;
 
     // all fields below are state of the Metadata CP group and put into Metadata snapshot and reset while restarting...
     // these fields are accessed outside of Raft while restarting or local querying, etc.
@@ -169,6 +170,11 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
         metadataGroupIdRef.set(new RaftGroupId(METADATA_CP_GROUP_NAME, seed, 0));
         localCPMember.set(null);
+
+        DiscoverInitialCPMembersTask discoveryTask = currentDiscoveryTask;
+        if (discoveryTask != null) {
+            discoveryTask.cancelAndAwaitCompletion();
+        }
         discoveryCompleted.set(false);
 
         scheduleDiscoverInitialCPMembersTask(false);
@@ -969,7 +975,8 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     }
 
     private void scheduleDiscoverInitialCPMembersTask(boolean terminateOnDiscoveryFailure) {
-        Runnable task = new DiscoverInitialCPMembersTask(terminateOnDiscoveryFailure);
+        DiscoverInitialCPMembersTask task = new DiscoverInitialCPMembersTask(terminateOnDiscoveryFailure);
+        currentDiscoveryTask = task;
         ExecutionService executionService = nodeEngine.getExecutionService();
         executionService.schedule(task, DISCOVER_INITIAL_CP_MEMBERS_TASK_DELAY_MILLIS, MILLISECONDS);
     }
@@ -981,18 +988,36 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
         }
     }
 
+    private enum DiscoveryTaskState {
+        RUNNING, SCHEDULED, COMPLETED
+    }
+
     private class DiscoverInitialCPMembersTask implements Runnable {
 
         private Collection<Member> latestMembers = Collections.emptySet();
         private final boolean terminateOnDiscoveryFailure;
         private long lastLoggingTime;
+        private volatile boolean cancelled;
+        private volatile DiscoveryTaskState state;
 
         DiscoverInitialCPMembersTask(boolean terminateOnDiscoveryFailure) {
             this.terminateOnDiscoveryFailure = terminateOnDiscoveryFailure;
+            state = DiscoveryTaskState.SCHEDULED;
         }
 
         @Override
         public void run() {
+            state = DiscoveryTaskState.RUNNING;
+            try {
+                doRun();
+            } finally {
+                if (state == DiscoveryTaskState.RUNNING) {
+                    state = DiscoveryTaskState.COMPLETED;
+                }
+            }
+        }
+
+        private void doRun() {
             if (shouldRescheduleOrSkip()) {
                 return;
             }
@@ -1033,7 +1058,15 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
             scheduleRaftGroupMembershipManagementTasks();
         }
 
+        /**
+         * Returns {@code true} if task is skipped or rescheduled
+         * or {@code false} if task should execute now.
+         */
         private boolean shouldRescheduleOrSkip() {
+            if (cancelled) {
+                return true;
+            }
+
             // When a node joins to the cluster, first, discoveryCompleted flag is set, then the join flag is set.
             // Hence, we need to check these flags in the reverse order here.
 
@@ -1061,6 +1094,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
         }
 
         private void scheduleSelf() {
+            state = DiscoveryTaskState.SCHEDULED;
             nodeEngine.getExecutionService()
                       .schedule(this, DISCOVER_INITIAL_CP_MEMBERS_TASK_DELAY_MILLIS, MILLISECONDS);
         }
@@ -1125,6 +1159,19 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
         private void terminateNode() {
             ((NodeEngineImpl) nodeEngine).getNode().shutdown(true);
+        }
+
+        @SuppressWarnings("checkstyle:magicnumber")
+        void cancelAndAwaitCompletion() {
+            cancelled = true;
+            while (state != DiscoveryTaskState.COMPLETED) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Otherwise, two different discovery tasks can overlap and run concurrently.
Or one of the discovery tasks can run with a corrupted state.

Fixes #14554