### PR TITLE
Change WAN prefix with Wan

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -102,7 +102,7 @@ import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
-import com.hazelcast.config.WANQueueFullBehavior;
+import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
 import com.hazelcast.config.WanConsumerConfig;
@@ -986,7 +986,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("tokyo", pc.getGroupName());
         assertEquals("tokyoPublisherId", pc.getPublisherId());
         assertEquals("com.hazelcast.enterprise.wan.impl.replication.WanBatchReplication", pc.getClassName());
-        assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, pc.getQueueFullBehavior());
+        assertEquals(WanQueueFullBehavior.THROW_EXCEPTION, pc.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, pc.getInitialPublisherState());
         assertEquals(1000, pc.getQueueCapacity());
         assertEquals(50, pc.getBatchSize());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -73,7 +73,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.AddressUtil;
-import com.hazelcast.wan.WANReplicationQueueFullException;
+import com.hazelcast.wan.WanReplicationQueueFullException;
 
 import javax.cache.CacheException;
 import javax.cache.integration.CacheLoaderException;
@@ -539,10 +539,10 @@ public class ClientExceptionFactory {
                 return new MaxMessageSizeExceeded();
             }
         });
-        register(ClientProtocolErrorCodes.WAN_REPLICATION_QUEUE_FULL, WANReplicationQueueFullException.class, new ExceptionFactory() {
+        register(ClientProtocolErrorCodes.WAN_REPLICATION_QUEUE_FULL, WanReplicationQueueFullException.class, new ExceptionFactory() {
             @Override
             public Throwable createException(String message, Throwable cause) {
-                return new WANReplicationQueueFullException(message);
+                return new WanReplicationQueueFullException(message);
             }
         });
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
@@ -70,7 +70,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.AddressUtil;
-import com.hazelcast.wan.WANReplicationQueueFullException;
+import com.hazelcast.wan.WanReplicationQueueFullException;
 
 import javax.cache.CacheException;
 import javax.cache.integration.CacheLoaderException;
@@ -184,7 +184,7 @@ public class ClientExceptions {
         register(ClientProtocolErrorCodes.NO_DATA_MEMBER, NoDataMemberInClusterException.class);
         register(ClientProtocolErrorCodes.REPLICATED_MAP_CANT_BE_CREATED, ReplicatedMapCantBeCreatedOnLiteMemberException.class);
         register(ClientProtocolErrorCodes.MAX_MESSAGE_SIZE_EXCEEDED, MaxMessageSizeExceeded.class);
-        register(ClientProtocolErrorCodes.WAN_REPLICATION_QUEUE_FULL, WANReplicationQueueFullException.class);
+        register(ClientProtocolErrorCodes.WAN_REPLICATION_QUEUE_FULL, WanReplicationQueueFullException.class);
 
         register(ClientProtocolErrorCodes.ASSERTION_ERROR, AssertionError.class);
         register(ClientProtocolErrorCodes.OUT_OF_MEMORY_ERROR, OutOfMemoryError.class);

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -564,7 +564,7 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             } else if ("response-timeout-millis".equals(targetChildName)) {
                 config.setResponseTimeoutMillis(getIntegerValue("response-timeout-millis", getTextContent(targetChild)));
             } else if ("queue-full-behavior".equals(targetChildName)) {
-                config.setQueueFullBehavior(WANQueueFullBehavior.valueOf(upperCaseInternal(getTextContent(targetChild))));
+                config.setQueueFullBehavior(WanQueueFullBehavior.valueOf(upperCaseInternal(getTextContent(targetChild))));
             } else if ("acknowledge-type".equals(targetChildName)) {
                 config.setAcknowledgeType(WanAcknowledgeType.valueOf(upperCaseInternal(getTextContent(targetChild))));
             } else if ("discovery-period-seconds".equals(targetChildName)) {

--- a/hazelcast/src/main/java/com/hazelcast/config/WanBatchReplicationPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanBatchReplicationPublisherConfig.java
@@ -48,7 +48,7 @@ public class WanBatchReplicationPublisherConfig extends AbstractWanPublisherConf
     public static final int DEFAULT_BATCH_SIZE = 500;
     public static final int DEFAULT_BATCH_MAX_DELAY_MILLIS = 1000;
     public static final int DEFAULT_RESPONSE_TIMEOUT_MILLIS = 60000;
-    public static final WANQueueFullBehavior DEFAULT_QUEUE_FULL_BEHAVIOUR = WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
+    public static final WanQueueFullBehavior DEFAULT_QUEUE_FULL_BEHAVIOUR = WanQueueFullBehavior.DISCARD_AFTER_MUTATION;
     public static final WanAcknowledgeType DEFAULT_ACKNOWLEDGE_TYPE = WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE;
     public static final int DEFAULT_DISCOVERY_PERIOD_SECONDS = 10;
     public static final int DEFAULT_MAX_TARGET_ENDPOINTS = Integer.MAX_VALUE;
@@ -65,7 +65,7 @@ public class WanBatchReplicationPublisherConfig extends AbstractWanPublisherConf
     private int batchSize = DEFAULT_BATCH_SIZE;
     private int batchMaxDelayMillis = DEFAULT_BATCH_MAX_DELAY_MILLIS;
     private int responseTimeoutMillis = DEFAULT_RESPONSE_TIMEOUT_MILLIS;
-    private WANQueueFullBehavior queueFullBehavior = DEFAULT_QUEUE_FULL_BEHAVIOUR;
+    private WanQueueFullBehavior queueFullBehavior = DEFAULT_QUEUE_FULL_BEHAVIOUR;
     private WanAcknowledgeType acknowledgeType = DEFAULT_ACKNOWLEDGE_TYPE;
 
     private int discoveryPeriodSeconds = DEFAULT_DISCOVERY_PERIOD_SECONDS;
@@ -377,7 +377,7 @@ public class WanBatchReplicationPublisherConfig extends AbstractWanPublisherConf
      * is full.
      */
     public @Nonnull
-    WANQueueFullBehavior getQueueFullBehavior() {
+    WanQueueFullBehavior getQueueFullBehavior() {
         return queueFullBehavior;
     }
 
@@ -388,7 +388,7 @@ public class WanBatchReplicationPublisherConfig extends AbstractWanPublisherConf
      * @param queueFullBehavior the behaviour of this publisher when the WAN queue is full
      * @return this config
      */
-    public WanBatchReplicationPublisherConfig setQueueFullBehavior(@Nonnull WANQueueFullBehavior queueFullBehavior) {
+    public WanBatchReplicationPublisherConfig setQueueFullBehavior(@Nonnull WanQueueFullBehavior queueFullBehavior) {
         this.queueFullBehavior = checkNotNull(queueFullBehavior, "Queue full behaviour must not be null");
         return this;
     }
@@ -845,7 +845,7 @@ public class WanBatchReplicationPublisherConfig extends AbstractWanPublisherConf
         batchSize = in.readInt();
         batchMaxDelayMillis = in.readInt();
         responseTimeoutMillis = in.readInt();
-        queueFullBehavior = WANQueueFullBehavior.getByType(in.readInt());
+        queueFullBehavior = WanQueueFullBehavior.getByType(in.readInt());
         acknowledgeType = WanAcknowledgeType.getById(in.readInt());
         discoveryPeriodSeconds = in.readInt();
         maxTargetEndpoints = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/config/WanQueueFullBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanQueueFullBehavior.java
@@ -17,34 +17,38 @@
 package com.hazelcast.config;
 
 /**
- * Determines the behavior of WAN replication impl. In case of WAN event queues are full.
+ * Determines the behavior of WAN replication
+ * impl. In case of WAN event queues are full.
  */
-public enum WANQueueFullBehavior {
+public enum WanQueueFullBehavior {
 
     /**
-     * Instruct WAN replication implementation to drop new events when WAN event queues are full.
+     * Instruct WAN replication implementation to
+     * drop new events when WAN event queues are full.
      */
     DISCARD_AFTER_MUTATION(0),
 
     /**
-     * Instruct WAN replication implementation to throw an exception and doesn't allow further processing.
+     * Instruct WAN replication implementation to throw
+     * an exception and doesn't allow further processing.
      */
     THROW_EXCEPTION(1),
 
     /**
-     * Similar to {@link #THROW_EXCEPTION} but only throws exception when WAN replication is active.
-     * Discards the new events if WAN replication is stopped.
+     * Similar to {@link #THROW_EXCEPTION} but only throws
+     * exception when WAN replication is active. Discards
+     * the new events if WAN replication is stopped.
      */
     THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE(2);
 
     private final int id;
 
-    WANQueueFullBehavior(int id) {
+    WanQueueFullBehavior(int id) {
         this.id = id;
     }
 
     /**
-     * Gets the ID for the given {@link WANQueueFullBehavior}.
+     * Gets the ID for the given {@link WanQueueFullBehavior}.
      * <p>
      * The reason this ID is used instead of an the ordinal value is that the ordinal value is more prone to changes due to
      * reordering.
@@ -60,8 +64,8 @@ public enum WANQueueFullBehavior {
      *
      * @return the WANQueueFullBehavior as an enum
      */
-    public static WANQueueFullBehavior getByType(final int id) {
-        for (WANQueueFullBehavior behavior : values()) {
+    public static WanQueueFullBehavior getByType(final int id) {
+        for (WanQueueFullBehavior behavior : values()) {
             if (behavior.id == id) {
                 return behavior;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTO.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.EurekaConfig;
 import com.hazelcast.config.GcpConfig;
 import com.hazelcast.config.KubernetesConfig;
-import com.hazelcast.config.WANQueueFullBehavior;
+import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
 import com.hazelcast.config.WanPublisherState;
@@ -133,7 +133,7 @@ public class WanBatchReplicationPublisherConfigDTO implements JsonSerializable {
         consumeIfExists(json, "maxConcurrentInvocations", v -> config.setMaxConcurrentInvocations(v.asInt()));
         consumeIfExists(json, "discoveryPeriodSeconds", v -> config.setDiscoveryPeriodSeconds(v.asInt()));
         consumeIfExists(json, "useEndpointPrivateAddress", v -> config.setUseEndpointPrivateAddress(v.asBoolean()));
-        consumeIfExists(json, "queueFullBehavior", v -> config.setQueueFullBehavior(WANQueueFullBehavior.getByType(v.asInt())));
+        consumeIfExists(json, "queueFullBehavior", v -> config.setQueueFullBehavior(WanQueueFullBehavior.getByType(v.asInt())));
         consumeIfExists(json, "maxTargetEndpoints", v -> config.setMaxTargetEndpoints(v.asInt()));
         consumeIfExists(json, "queueCapacity", v -> config.setQueueCapacity(v.asInt()));
         consumeIfExists(json, "targetEndpoints", v -> config.setTargetEndpoints(v.asString()));

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationQueueFullException.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationQueueFullException.java
@@ -16,18 +16,19 @@
 
 package com.hazelcast.wan;
 
-import com.hazelcast.config.WANQueueFullBehavior;
+import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.core.HazelcastException;
 
 /**
- * A {@link com.hazelcast.core.HazelcastException} that is thrown when the wan replication queues are full
+ * A {@link com.hazelcast.core.HazelcastException} that
+ * is thrown when the wan replication queues are full
  *
  * This exception is only thrown when WAN is configured with
- * {@link WANQueueFullBehavior#THROW_EXCEPTION}
+ * {@link WanQueueFullBehavior#THROW_EXCEPTION}
  */
-public class WANReplicationQueueFullException extends HazelcastException {
+public class WanReplicationQueueFullException extends HazelcastException {
 
-    public WANReplicationQueueFullException(String message) {
+    public WanReplicationQueueFullException(String message) {
         super(message);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -61,7 +61,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.AddressUtil;
-import com.hazelcast.wan.WANReplicationQueueFullException;
+import com.hazelcast.wan.WanReplicationQueueFullException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -248,7 +248,7 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new NoDataMemberInClusterException(randomString())},
                 new Object[]{new ReplicatedMapCantBeCreatedOnLiteMemberException(randomString())},
                 new Object[]{new MaxMessageSizeExceeded()},
-                new Object[]{new WANReplicationQueueFullException(randomString())},
+                new Object[]{new WanReplicationQueueFullException(randomString())},
                 new Object[]{new AssertionError(randomString())},
                 new Object[]{new OutOfMemoryError(randomString())},
                 new Object[]{new StackOverflowError(randomString())},

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.MapUtil;
-import com.hazelcast.wan.WANReplicationQueueFullException;
+import com.hazelcast.wan.WanReplicationQueueFullException;
 import com.hazelcast.wan.impl.FullQueueWanReplication;
 import org.junit.After;
 import org.junit.Before;
@@ -59,13 +59,13 @@ public class ClientMapWANExceptionTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-    @Test(expected = WANReplicationQueueFullException.class)
+    @Test(expected = WanReplicationQueueFullException.class)
     public void testMapPut() {
         IMap<Object, Object> map = client.getMap("wan-exception-client-test-map");
         map.put(1, 1);
     }
 
-    @Test(expected = WANReplicationQueueFullException.class)
+    @Test(expected = WanReplicationQueueFullException.class)
     public void testMapPutAll() {
         IMap<Object, Object> map = client.getMap("wan-exception-client-test-map");
         Map<Object, Object> inputMap = MapUtil.createHashMap(1);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -92,7 +92,7 @@ import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import com.hazelcast.util.AddressUtil;
 import com.hazelcast.version.MemberVersion;
-import com.hazelcast.wan.WANReplicationQueueFullException;
+import com.hazelcast.wan.WanReplicationQueueFullException;
 
 import javax.cache.CacheException;
 import javax.cache.integration.CacheLoaderException;
@@ -818,7 +818,7 @@ public class ReferenceObjects {
             aString), new AccessControlException(aString), new LoginException(aString), new UnsupportedCallbackException(
             new Callback() {
             }), new NoDataMemberInClusterException(aString), new ReplicatedMapCantBeCreatedOnLiteMemberException(
-            aString), new MaxMessageSizeExceeded(), new WANReplicationQueueFullException(aString), new AssertionError(
+            aString), new MaxMessageSizeExceeded(), new WanReplicationQueueFullException(aString), new AssertionError(
             aString), new OutOfMemoryError(aString), new StackOverflowError(aString), new NativeOutOfMemoryError(aString)};
 
     public static Throwable[] throwables_1_1 = {new StaleTaskIdException(aString), new ServiceNotFoundException(aString)};

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1119,7 +1119,7 @@ public class ConfigXmlGeneratorTest {
                 .setBatchSize(500)
                 .setBatchMaxDelayMillis(1000)
                 .setResponseTimeoutMillis(60000)
-                .setQueueFullBehavior(WANQueueFullBehavior.DISCARD_AFTER_MUTATION)
+                .setQueueFullBehavior(WanQueueFullBehavior.DISCARD_AFTER_MUTATION)
                 .setAcknowledgeType(WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE)
                 .setDiscoveryPeriodSeconds(20)
                 .setMaxTargetEndpoints(100)

--- a/hazelcast/src/test/java/com/hazelcast/config/WanBatchReplicationPublisherConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanBatchReplicationPublisherConfigTest.java
@@ -55,7 +55,7 @@ public class WanBatchReplicationPublisherConfigTest {
                 .setBatchSize(500)
                 .setBatchMaxDelayMillis(1000)
                 .setResponseTimeoutMillis(60000)
-                .setQueueFullBehavior(WANQueueFullBehavior.THROW_EXCEPTION)
+                .setQueueFullBehavior(WanQueueFullBehavior.THROW_EXCEPTION)
                 .setAcknowledgeType(WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE)
                 .setDiscoveryPeriodSeconds(20)
                 .setMaxTargetEndpoints(100)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -60,7 +60,7 @@ import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
 import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
 import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
-import static com.hazelcast.config.WANQueueFullBehavior.THROW_EXCEPTION;
+import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.config.XmlYamlConfigBuilderEqualsTest.readResourceToString;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
@@ -1777,7 +1777,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         WanBatchReplicationPublisherConfig pc2 = publisherConfigs.get(1);
         assertEquals("ankara", pc2.getGroupName());
         assertEquals("", pc2.getPublisherId());
-        assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, pc2.getQueueFullBehavior());
+        assertEquals(WanQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, pc2.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, pc2.getInitialPublisherState());
 
         List<CustomWanPublisherConfig> customPublishers = wanConfig.getCustomPublisherConfigs();

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -56,8 +56,8 @@ import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
-import static com.hazelcast.config.WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
-import static com.hazelcast.config.WANQueueFullBehavior.THROW_EXCEPTION;
+import static com.hazelcast.config.WanQueueFullBehavior.DISCARD_AFTER_MUTATION;
+import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.config.XmlYamlConfigBuilderEqualsTest.readResourceToString;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
@@ -1775,7 +1775,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         WanBatchReplicationPublisherConfig pc2 = publisherConfigs.get(1);
         assertEquals("ankara", pc2.getGroupName());
         assertNull(pc2.getPublisherId());
-        assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, pc2.getQueueFullBehavior());
+        assertEquals(WanQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, pc2.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, pc2.getInitialPublisherState());
 
         WanConsumerConfig consumerConfig = wanConfig.getWanConsumerConfig();

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTOTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.EurekaConfig;
 import com.hazelcast.config.GcpConfig;
 import com.hazelcast.config.KubernetesConfig;
-import com.hazelcast.config.WANQueueFullBehavior;
+import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
 import com.hazelcast.config.WanPublisherState;
@@ -63,7 +63,7 @@ public class WanBatchReplicationPublisherConfigDTOTest {
                 .setBatchSize(500)
                 .setBatchMaxDelayMillis(1000)
                 .setResponseTimeoutMillis(60000)
-                .setQueueFullBehavior(WANQueueFullBehavior.THROW_EXCEPTION)
+                .setQueueFullBehavior(WanQueueFullBehavior.THROW_EXCEPTION)
                 .setAcknowledgeType(WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE)
                 .setDiscoveryPeriodSeconds(20)
                 .setMaxTargetEndpoints(100)

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/FullQueueWanReplication.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/FullQueueWanReplication.java
@@ -18,7 +18,7 @@ package com.hazelcast.wan.impl;
 
 import com.hazelcast.config.AbstractWanPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
-import com.hazelcast.wan.WANReplicationQueueFullException;
+import com.hazelcast.wan.WanReplicationQueueFullException;
 import com.hazelcast.wan.WanReplicationEvent;
 import com.hazelcast.wan.WanReplicationPublisher;
 
@@ -47,6 +47,6 @@ public class FullQueueWanReplication implements WanReplicationPublisher {
 
     @Override
     public void doPrepublicationChecks() {
-        throw new WANReplicationQueueFullException("WAN event queue is full");
+        throw new WanReplicationQueueFullException("WAN event queue is full");
     }
 }


### PR DESCRIPTION
Reason is to have consistent naming with other Wan classes.

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3164