### PR TITLE
Instance/ClientNotActiveEx for rejected callbacks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -58,9 +58,9 @@ public class ClientInvocation implements Runnable {
     private static final AtomicLongFieldUpdater<ClientInvocation> INVOKE_COUNT
             = AtomicLongFieldUpdater.newUpdater(ClientInvocation.class, "invokeCount");
 
+    final LifecycleService lifecycleService;
     private final ClientInvocationFuture clientInvocationFuture;
     private final ILogger logger;
-    private final LifecycleService lifecycleService;
     private final ClientClusterService clientClusterService;
     private final AbstractClientInvocationService invocationService;
     private final ClientExecutionService executionService;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFuture.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.spi.impl;
 
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.logging.ILogger;
@@ -25,6 +26,7 @@ import com.hazelcast.spi.impl.sequence.CallIdSequence;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -83,6 +85,14 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
     @Override
     public void andThen(ExecutionCallback<ClientMessage> callback, Executor executor) {
         super.andThen(new InternalDelegatingExecutionCallback(callback), executor);
+    }
+
+    @Override
+    protected Exception wrapToInstanceNotActiveException(RejectedExecutionException e) {
+        if (!invocation.lifecycleService.isRunning()) {
+            return new HazelcastClientNotActiveException("Client is shut down", e);
+        }
+        return e;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -17,8 +17,8 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.internal.util.executor.UnblockableThread;
+import com.hazelcast.logging.ILogger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.CancellationException;
@@ -262,9 +262,11 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
 
             });
         } catch (RejectedExecutionException e) {
-            callback.onFailure(e);
+            callback.onFailure(wrapToInstanceNotActiveException(e));
         }
     }
+
+    protected abstract Exception wrapToInstanceNotActiveException(RejectedExecutionException e);
 
     // this method should not be needed; but there is a difference between client and server how it handles async throwables
     protected Throwable unwrap(Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IndeterminateOperationState;
 import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.core.OperationTimeoutException;
@@ -27,6 +28,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -73,6 +75,14 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
     @Override
     protected void onInterruptDetected() {
         interrupted = true;
+    }
+
+    @Override
+    protected Exception wrapToInstanceNotActiveException(RejectedExecutionException e) {
+        if (!invocation.context.nodeEngine.isRunning()) {
+            return new HazelcastInstanceNotActiveException(e.getMessage());
+        }
+        return e;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -18,13 +18,15 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MembershipAdapter;
 import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.map.IMap;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -38,6 +40,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -138,6 +141,34 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         test.put("key", "value");
         server.shutdown();
         test.get("key");
+    }
+
+    @Test(expected = HazelcastClientNotActiveException.class)
+    public void testCallbackAfterClientShutdown() throws Throwable {
+        final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        IMap<Object, Object> test = client.getMap("test");
+        server.shutdown();
+        ICompletableFuture<Object> future = test.putAsync("key", "value");
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> reference = new AtomicReference<>();
+        future.andThen(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                reference.set(t);
+                latch.countDown();
+            }
+        });
+        assertOpenEventually(latch);
+        throw reference.get();
     }
 
     @Test(expected = HazelcastClientNotActiveException.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -143,8 +143,8 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         test.get("key");
     }
 
-    @Test(expected = HazelcastClientNotActiveException.class)
-    public void testCallbackAfterClientShutdown() throws Throwable {
+    @Test
+    public void testCallbackAfterClientShutdown() {
         final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
@@ -168,7 +168,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
             }
         });
         assertOpenEventually(latch);
-        throw reference.get();
+        assertInstanceOf(HazelcastClientNotActiveException.class, reference.get());
     }
 
     @Test(expected = HazelcastClientNotActiveException.class)

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -24,6 +25,7 @@ import org.junit.Before;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -57,6 +59,11 @@ public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTes
         protected void onInterruptDetected() {
             interruptDetected = true;
             complete(new InterruptedException());
+        }
+
+        @Override
+        protected IllegalStateException wrapToInstanceNotActiveException(RejectedExecutionException e) {
+            return new HazelcastInstanceNotActiveException(e.getMessage());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_ClosedExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_ClosedExecutorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -26,7 +27,6 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertTrue;
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class AbstractInvocationFuture_ClosedExecutorTest extends AbstractInvocationFuture_AbstractTest {
-
 
     @Test
     public void whenCompleteBeforeShutdown_thenCallback() {
@@ -51,7 +50,7 @@ public class AbstractInvocationFuture_ClosedExecutorTest extends AbstractInvocat
 
             @Override
             public void onFailure(Throwable t) {
-                if (t instanceof RejectedExecutionException) {
+                if (t instanceof HazelcastInstanceNotActiveException) {
                     onFailure.set(true);
                 }
             }
@@ -74,7 +73,7 @@ public class AbstractInvocationFuture_ClosedExecutorTest extends AbstractInvocat
 
             @Override
             public void onFailure(Throwable t) {
-                if (t instanceof RejectedExecutionException) {
+                if (t instanceof HazelcastInstanceNotActiveException) {
                     onFailure.set(true);
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
@@ -63,7 +63,7 @@ public class InvocationFuture_AndThenTest extends HazelcastTestSupport {
         future.andThen(null);
     }
 
-    @Test(expected = HazelcastInstanceNotActiveException.class)
+    @Test
     public void whenNodeIsShutdown() throws Throwable {
         Address address = getAddress(local);
         local.shutdown();
@@ -85,7 +85,7 @@ public class InvocationFuture_AndThenTest extends HazelcastTestSupport {
             }
         });
         assertOpenEventually(latch);
-        throw reference.get();
+        assertInstanceOf(HazelcastInstanceNotActiveException.class, reference.get());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -29,8 +31,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -57,6 +61,31 @@ public class InvocationFuture_AndThenTest extends HazelcastTestSupport {
         InternalCompletableFuture<Object> future = operationService.invokeOnTarget(null, op, getAddress(local));
 
         future.andThen(null);
+    }
+
+    @Test(expected = HazelcastInstanceNotActiveException.class)
+    public void whenNodeIsShutdown() throws Throwable {
+        Address address = getAddress(local);
+        local.shutdown();
+
+        DummyOperation op = new DummyOperation(null);
+        InternalCompletableFuture<Object> future = operationService.invokeOnTarget(null, op, address);
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> reference = new AtomicReference<>();
+        future.andThen(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                reference.set(t);
+                latch.countDown();
+            }
+        });
+        assertOpenEventually(latch);
+        throw reference.get();
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
We were returning RejectedExecutionException with
"instance is shutting down" message. We have clear exceptions to notify
the user in that case. This pr converts RejectedExecutionException
to Instance/ClientNotActiveException before throwing it to user.

fixes https://github.com/hazelcast/hazelcast/issues/15508