### PR TITLE
Made elements with a default value optional

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -4362,7 +4362,7 @@
 
     <xs:complexType name="cp-subsystem">
         <xs:all>
-            <xs:element name="cp-member-count" type="xs:unsignedInt" default="0">
+            <xs:element name="cp-member-count" type="xs:unsignedInt" default="0" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Number of CP Members to initialize the CP Subsystem.
@@ -4571,7 +4571,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="jdk-compatible" type="xs:boolean" default="false">
+            <xs:element name="jdk-compatible" type="xs:boolean" default="false" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Enables / disables JDK compatibility of the CP ISemaphore.
@@ -4605,7 +4605,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="lock-acquire-limit" type="xs:nonNegativeInteger" default="0">
+            <xs:element name="lock-acquire-limit" type="xs:nonNegativeInteger" default="0" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Maximum number of reentrant lock acquires. Once a caller acquires

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -1914,7 +1914,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="salt" type="xs:string" default="thesalt">
+            <xs:element name="salt" type="xs:string" default="thesalt" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Salt value to use when generating the secret key.
@@ -1928,7 +1928,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="iteration-count" type="xs:int" default="19">
+            <xs:element name="iteration-count" type="xs:int" default="19" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Iteration count to use when generating the secret key.
@@ -3566,7 +3566,7 @@
 
     <xs:complexType name="user-code-deployment">
         <xs:all>
-            <xs:element name="class-cache-mode" default="ETERNAL">
+            <xs:element name="class-cache-mode" default="ETERNAL" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Controls caching of user classes loaded from remote members.
@@ -3584,7 +3584,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="provider-mode" default="LOCAL_AND_CACHED_CLASSES">
+            <xs:element name="provider-mode" default="LOCAL_AND_CACHED_CLASSES" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Controls how to react on receiving a classloading request from a remote member
@@ -3764,7 +3764,7 @@
 
     <xs:complexType name="hot-restart">
         <xs:all>
-            <xs:element name="fsync" type="xs:boolean" default="false">
+            <xs:element name="fsync" type="xs:boolean" default="false" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         If set to true, when each update operation on this structure completes,
@@ -4348,7 +4348,7 @@
 
     <xs:complexType name="cp-subsystem">
         <xs:all>
-            <xs:element name="cp-member-count" type="xs:unsignedInt" default="0">
+            <xs:element name="cp-member-count" type="xs:unsignedInt" default="0" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Number of CP Members to initialize the CP Subsystem.
@@ -4556,7 +4556,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="jdk-compatible" type="xs:boolean" default="false">
+            <xs:element name="jdk-compatible" type="xs:boolean" default="false" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Enables / disables JDK compatibility of the CP ISemaphore.
@@ -4589,7 +4589,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="lock-acquire-limit" type="xs:nonNegativeInteger" default="0">
+            <xs:element name="lock-acquire-limit" type="xs:nonNegativeInteger" default="0" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Maximum number of reentrant lock acquires. Once a caller acquires


### PR DESCRIPTION
Some elements in the XSD had a default value but were effectively required (because of missing `minOccurs="0"`). Added `minOccurs="0"`, also checked that there is indeed a correct default value in the respective `*Config` classes.