### PR TITLE
4.0/mc metrics/consistent metric names

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -204,4 +204,14 @@ public interface MetricsRegistry {
      * Creates a new {@link ProbeBuilder}.
      */
     ProbeBuilder newProbeBuilder();
+
+    /**
+     * Creates a new {@link ProbeBuilder} with the given metric name prefix.
+     * This prefix will be appended to "metric" tag names for all Probes
+     * created with the ProbeBuilder.
+     *
+     * @param namePrefix the name prefix.
+     * @return the created builder.
+     */
+    ProbeBuilder newProbeBuilder(String namePrefix);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -359,6 +359,11 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     @Override
     public ProbeBuilder newProbeBuilder() {
-        return new ProbeBuilderImpl(this);
+        return new ProbeBuilderImpl(this, null);
+    }
+
+    @Override
+    public ProbeBuilder newProbeBuilder(String namePrefix) {
+        return new ProbeBuilderImpl(this, namePrefix);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
@@ -55,6 +55,10 @@ public class ProbeBuilderImpl implements ProbeBuilder {
                 metricNamePrefix);
     }
 
+    private ProbeBuilderImpl withMetricTag(String metricName) {
+        return withTag("metric", metricNamePrefix != null ? metricNamePrefix + '.' + metricName : metricName);
+    }
+
     @Override
     public String metricName() {
         return keyPrefix + ']';
@@ -70,7 +74,7 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     ) {
         String name = this
                 .withTag("unit", unit.name().toLowerCase())
-                .withTag("metric", prefixedMetricName(metricName))
+                .withMetricTag(metricName)
                 .metricName();
         metricsRegistry.register(source, name, level, probe);
     }
@@ -85,13 +89,13 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     ) {
         String name = this
                 .withTag("unit", unit.name().toLowerCase())
-                .withTag("metric", prefixedMetricName(metricName))
+                .withMetricTag(metricName)
                 .metricName();
         metricsRegistry.register(source, name, level, probe);
     }
 
     <S> void register(S source, String metricName, ProbeLevel level, ProbeFunction probe) {
-        metricsRegistry.registerInternal(source, withTag("metric", prefixedMetricName(metricName)).metricName(), level, probe);
+        metricsRegistry.registerInternal(source, withMetricTag(metricName).metricName(), level, probe);
     }
 
     @Override
@@ -104,12 +108,5 @@ public class ProbeBuilderImpl implements ProbeBuilder {
         for (MethodProbe method : metadata.methods()) {
             method.register(this, source);
         }
-    }
-
-    private String prefixedMetricName(String metricName) {
-        if (metricNamePrefix != null) {
-            return metricNamePrefix + '.' + metricName;
-        }
-        return metricName;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
@@ -33,15 +33,16 @@ public class ProbeBuilderImpl implements ProbeBuilder {
 
     private final MetricsRegistryImpl metricsRegistry;
     private final String keyPrefix;
+    private final String metricNamePrefix;
 
-    ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry) {
-        this.metricsRegistry = metricsRegistry;
-        this.keyPrefix = "[";
+    ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry, String metricNamePrefix) {
+        this(metricsRegistry, "[", metricNamePrefix);
     }
 
-    private ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry, String keyPrefix) {
+    private ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry, String keyPrefix, String metricNamePrefix) {
         this.metricsRegistry = metricsRegistry;
         this.keyPrefix = keyPrefix;
+        this.metricNamePrefix = metricNamePrefix;
     }
 
     @Override
@@ -49,9 +50,9 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     public ProbeBuilderImpl withTag(String tag, String value) {
         assert containsSpecialCharacters(tag) : "tag contains special characters";
         return new ProbeBuilderImpl(
-                metricsRegistry, keyPrefix
-                        + (keyPrefix.length() == 1 ? "" : ",")
-                        + tag + '=' + escapeMetricNamePart(value));
+                metricsRegistry,
+                keyPrefix + (keyPrefix.length() == 1 ? "" : ",") + tag + '=' + escapeMetricNamePart(value),
+                metricNamePrefix);
     }
 
     @Override
@@ -69,7 +70,7 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     ) {
         String name = this
                 .withTag("unit", unit.name().toLowerCase())
-                .withTag("metric", metricName)
+                .withTag("metric", prefixedMetricName(metricName))
                 .metricName();
         metricsRegistry.register(source, name, level, probe);
     }
@@ -84,13 +85,13 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     ) {
         String name = this
                 .withTag("unit", unit.name().toLowerCase())
-                .withTag("metric", metricName)
+                .withTag("metric", prefixedMetricName(metricName))
                 .metricName();
         metricsRegistry.register(source, name, level, probe);
     }
 
     <S> void register(S source, String metricName, ProbeLevel level, ProbeFunction probe) {
-        metricsRegistry.registerInternal(source, withTag("metric", metricName).metricName(), level, probe);
+        metricsRegistry.registerInternal(source, withTag("metric", prefixedMetricName(metricName)).metricName(), level, probe);
     }
 
     @Override
@@ -103,5 +104,12 @@ public class ProbeBuilderImpl implements ProbeBuilder {
         for (MethodProbe method : metadata.methods()) {
             method.register(this, source);
         }
+    }
+
+    private String prefixedMetricName(String metricName) {
+        if (metricNamePrefix != null) {
+            return metricNamePrefix + '.' + metricName;
+        }
+        return metricName;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
@@ -17,10 +17,12 @@
 package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeBuilder;
 
 import java.io.File;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -40,8 +42,10 @@ public final class FileMetricSet {
         checkNotNull(metricsRegistry, "metricsRegistry");
 
         File file = new File(System.getProperty("user.home"));
-        metricsRegistry.register(file, "file.partition[user.home].freeSpace", MANDATORY, File::getFreeSpace);
-        metricsRegistry.register(file, "file.partition[user.home].totalSpace", MANDATORY, File::getTotalSpace);
-        metricsRegistry.register(file, "file.partition[user.home].usableSpace", MANDATORY, File::getUsableSpace);
+        ProbeBuilder builder = metricsRegistry.newProbeBuilder("file.partition")
+                                              .withTag("dir", "user.home");
+        builder.register(file, "freeSpace", MANDATORY, BYTES, File::getFreeSpace);
+        builder.register(file, "totalSpace", MANDATORY, BYTES, File::getTotalSpace);
+        builder.register(file, "usableSpace", MANDATORY, BYTES, File::getUsableSpace);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -116,20 +116,24 @@ public class StatisticsAwareMetricsSet {
                             .replace("Impl", "");
                     baseName = lowerCaseFirstChar(baseName);
                     if (nearCacheStats != null) {
-                        metricsRegistry.scanAndRegister(nearCacheStats,
-                                baseName + "[" + name + "].nearcache");
+                        metricsRegistry.newProbeBuilder(baseName + ".nearcache")
+                                       .withTag("name", name)
+                                       .scanAndRegister(nearCacheStats);
                     }
 
                     if (localInstanceStats instanceof LocalMapStatsImpl) {
                         Map<String, LocalIndexStats> indexStats = ((LocalMapStatsImpl) localInstanceStats).getIndexStats();
                         for (Map.Entry<String, LocalIndexStats> indexEntry : indexStats.entrySet()) {
-                            metricsRegistry.scanAndRegister(indexEntry.getValue(),
-                                    baseName + "[" + name + "].index[" + indexEntry.getKey() + "]");
+                            metricsRegistry.newProbeBuilder(baseName + ".index")
+                                           .withTag("name", name)
+                                           .withTag("index", indexEntry.getKey())
+                                           .scanAndRegister(indexEntry.getValue());
                         }
                     }
 
-                    metricsRegistry.scanAndRegister(localInstanceStats,
-                            baseName + "[" + name + "]");
+                    metricsRegistry.newProbeBuilder(baseName)
+                                   .withTag("name", name)
+                                   .scanAndRegister(localInstanceStats);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -96,9 +96,13 @@ public final class NioChannel extends AbstractChannel {
 
     @Override
     public void start() {
-        String metricsId = localSocketAddress() + "->" + remoteSocketAddress();
-        metricsRegistry.scanAndRegister(outboundPipeline, "tcp.connection[" + metricsId + "].out");
-        metricsRegistry.scanAndRegister(inboundPipeline, "tcp.connection[" + metricsId + "].in");
+        String pipelineId = localSocketAddress() + "->" + remoteSocketAddress();
+        metricsRegistry.newProbeBuilder("tcp.connection.out")
+                       .withTag("pipelineId", pipelineId)
+                       .scanAndRegister(outboundPipeline);
+        metricsRegistry.newProbeBuilder("tcp.connection.in")
+                       .withTag("pipelineId", pipelineId)
+                       .scanAndRegister(inboundPipeline);
 
         try {
             // before starting the channel, the socketChannel need to be put in

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -191,7 +191,9 @@ public final class NioNetworking implements Networking {
             thread.id = i;
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
             inThreads[i] = thread;
-            metricsRegistry.scanAndRegister(thread, "tcp.inputThread[" + thread.getName() + "]");
+            metricsRegistry.newProbeBuilder("tcp.inputThread")
+                           .withTag("threadName", thread.getName())
+                           .scanAndRegister(thread);
             thread.start();
         }
         this.inputThreads = inThreads;
@@ -207,7 +209,9 @@ public final class NioNetworking implements Networking {
             thread.id = i;
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
             outThreads[i] = thread;
-            metricsRegistry.scanAndRegister(thread, "tcp.outputThread[" + thread.getName() + "]");
+            metricsRegistry.newProbeBuilder("tcp.outputThread")
+                           .withTag("threadName", thread.getName())
+                           .scanAndRegister(thread);
             thread.start();
         }
         this.outputThreads = outThreads;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -192,7 +192,7 @@ public final class NioNetworking implements Networking {
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
             inThreads[i] = thread;
             metricsRegistry.newProbeBuilder("tcp.inputThread")
-                           .withTag("threadName", thread.getName())
+                           .withTag("thread", thread.getName())
                            .scanAndRegister(thread);
             thread.start();
         }
@@ -210,7 +210,7 @@ public final class NioNetworking implements Networking {
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
             outThreads[i] = thread;
             metricsRegistry.newProbeBuilder("tcp.outputThread")
-                           .withTag("threadName", thread.getName())
+                           .withTag("thread", thread.getName())
                            .scanAndRegister(thread);
             thread.start();
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpAcceptor.java
@@ -107,7 +107,9 @@ public class TcpIpAcceptor implements MetricsProvider {
 
     @Override
     public void provideMetrics(MetricsRegistry registry) {
-        registry.scanAndRegister(this, "tcp." + acceptorThread.getName());
+        registry.newProbeBuilder("tcp.acceptor")
+                .withTag("thread", acceptorThread.getName())
+                .scanAndRegister(this);
     }
 
     public TcpIpAcceptor start() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManager.java
@@ -128,7 +128,9 @@ public class TcpIpEndpointManager
         if (endpointQualifier == null) {
             metricsRegistry.scanAndRegister(this, "tcp.connection");
         } else {
-            metricsRegistry.scanAndRegister(this, endpointQualifier.toMetricsPrefixString() + ".tcp.connection");
+            metricsRegistry.newProbeBuilder("tcp.connection")
+                           .withTag("endpoint", endpointQualifier.toMetricsPrefixString())
+                           .scanAndRegister(this);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -565,7 +565,10 @@ public class EventServiceImpl implements EventService, MetricsProvider {
             EventServiceSegment existingSegment = segments.putIfAbsent(service, newSegment);
             if (existingSegment == null) {
                 segment = newSegment;
-                nodeEngine.getMetricsRegistry().scanAndRegister(newSegment, "event.[" + service + "]");
+                nodeEngine.getMetricsRegistry()
+                          .newProbeBuilder("event")
+                          .withTag("service", service)
+                          .scanAndRegister(newSegment);
             } else {
                 segment = existingSegment;
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -183,7 +183,9 @@ public final class ExecutionServiceImpl implements ExecutionService {
             throw new IllegalArgumentException("ExecutorService['" + name + "'] already exists!");
         }
 
-        metricsRegistry.scanAndRegister(executor, "internal-executor[" + name + "]");
+        metricsRegistry.newProbeBuilder("internal-executor")
+                       .withTag("executor", name)
+                       .scanAndRegister(executor);
 
         return executor;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -20,13 +20,13 @@ import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
-import com.hazelcast.internal.util.counters.SwCounter;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.internal.nio.Packet;
-import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.internal.util.counters.SwCounter;
+import com.hazelcast.internal.util.executor.HazelcastManagedThread;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
-import com.hazelcast.internal.util.executor.HazelcastManagedThread;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.concurrent.TimeUnit;
 
@@ -187,7 +187,9 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
 
     @Override
     public void provideMetrics(MetricsRegistry registry) {
-        registry.scanAndRegister(this, "operation.thread[" + getName() + "]");
+        registry.newProbeBuilder("operation.thread")
+                .withTag("threadName", getName())
+                .scanAndRegister(this);
     }
 
     public final void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -188,7 +188,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     @Override
     public void provideMetrics(MetricsRegistry registry) {
         registry.newProbeBuilder("operation.thread")
-                .withTag("threadName", getName())
+                .withTag("thread", getName())
                 .scanAndRegister(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandlerSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandlerSupplier.java
@@ -141,7 +141,7 @@ public class InboundResponseHandlerSupplier implements MetricsProvider, Supplier
         return result;
     }
 
-    @Probe(name = "responses[normal]", level = MANDATORY)
+    @Probe(name = "responses.normalCount", level = MANDATORY)
     long responsesNormal() {
         long result = 0;
         for (InboundResponseHandler handler : inboundResponseHandlers) {
@@ -150,7 +150,7 @@ public class InboundResponseHandlerSupplier implements MetricsProvider, Supplier
         return result;
     }
 
-    @Probe(name = "responses[timeout]", level = MANDATORY)
+    @Probe(name = "responses.timeoutCount", level = MANDATORY)
     long responsesTimeout() {
         long result = 0;
         for (InboundResponseHandler handler : inboundResponseHandlers) {
@@ -159,7 +159,7 @@ public class InboundResponseHandlerSupplier implements MetricsProvider, Supplier
         return result;
     }
 
-    @Probe(name = "responses[backup]", level = MANDATORY)
+    @Probe(name = "responses.backupCount", level = MANDATORY)
     long responsesBackup() {
         long result = 0;
         for (InboundResponseHandler handler : inboundResponseHandlers) {
@@ -168,7 +168,7 @@ public class InboundResponseHandlerSupplier implements MetricsProvider, Supplier
         return result;
     }
 
-    @Probe(name = "responses[error]", level = MANDATORY)
+    @Probe(name = "responses.errorCount", level = MANDATORY)
     long responsesError() {
         long result = 0;
         for (InboundResponseHandler handler : inboundResponseHandlers) {
@@ -177,7 +177,7 @@ public class InboundResponseHandlerSupplier implements MetricsProvider, Supplier
         return result;
     }
 
-    @Probe(name = "responses[missing]", level = MANDATORY)
+    @Probe(name = "responses.missingCount", level = MANDATORY)
     long responsesMissing() {
         long result = 0;
         for (InboundResponseHandler handler : inboundResponseHandlers) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -143,9 +143,13 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
     @Override
     public void provideMetrics(MetricsRegistry registry) {
         if (partitionId >= 0) {
-            registry.scanAndRegister(this, "operation.partition[" + partitionId + "]");
+            registry.newProbeBuilder("operation.partition")
+                    .withTag("partitionId", String.valueOf(partitionId))
+                    .scanAndRegister(this);
         } else if (partitionId == -1) {
-            registry.scanAndRegister(this, "operation.generic[" + genericId + "]");
+            registry.newProbeBuilder("operation.generic")
+                    .withTag("genericId", String.valueOf(genericId))
+                    .scanAndRegister(this);
         } else {
             registry.scanAndRegister(this, "operation.adhoc");
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationTest.java
@@ -78,7 +78,7 @@ public class ReadMetricsOperationTest extends HazelcastTestSupport {
                 Iterator<Metric> metricIterator = decompressingIterator(entry.getValue());
                 while (metricIterator.hasNext()) {
                     Metric metric = metricIterator.next();
-                    mapMetric |= metric.key().contains("map[");
+                    mapMetric |= metric.key().contains("name=map") & metric.key().contains("map.");
                 }
             }
             assertTrue(mapMetric);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
@@ -52,7 +52,8 @@ public class FileMetricSetTest extends HazelcastTestSupport {
     public void freeSpace() {
         File file = new File(System.getProperty("user.home"));
 
-        LongGauge freeSpaceGauge = metricsRegistry.newLongGauge("file.partition[user.home].freeSpace");
+        LongGauge freeSpaceGauge =
+                metricsRegistry.newLongGauge("[dir=user.home,unit=bytes,metric=file.partition.freeSpace]");
 
         assertAlmostEquals(file.getFreeSpace(), freeSpaceGauge.read());
     }
@@ -61,7 +62,8 @@ public class FileMetricSetTest extends HazelcastTestSupport {
     public void totalSpace() {
         File file = new File(System.getProperty("user.home"));
 
-        LongGauge totalSpaceGauge = metricsRegistry.newLongGauge("file.partition[user.home].totalSpace");
+        LongGauge totalSpaceGauge =
+                metricsRegistry.newLongGauge("[dir=user.home,unit=bytes,metric=file.partition.totalSpace]");
 
         assertAlmostEquals(file.getTotalSpace(), totalSpaceGauge.read());
     }
@@ -70,7 +72,8 @@ public class FileMetricSetTest extends HazelcastTestSupport {
     public void usableSpace() {
         File file = new File(System.getProperty("user.home"));
 
-        LongGauge usableSpaceGauge = metricsRegistry.newLongGauge("file.partition[user.home].usableSpace");
+        LongGauge usableSpaceGauge =
+                metricsRegistry.newLongGauge("[dir=user.home,unit=bytes,metric=file.partition.usableSpace]");
 
         assertAlmostEquals(file.getUsableSpace(), usableSpaceGauge.read());
     }


### PR DESCRIPTION
* Extracts tags from metric names for legacy probes. Example: `map[my-test-map].removeCount` becomes something like `[name=my-test-map,unit=count,metric=map.removeCount]`

EE counterpart of this PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3190