### PR TITLE
Handle exception while getting CP member UUID in TimedMemberStateFactory when RU is in progress

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1322,7 +1322,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         File hotBackupDir = new File("/mnt/hot-backup/");
         HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
 
-        assertTrue(hotRestartPersistenceConfig.isEnabled());
+        assertFalse(hotRestartPersistenceConfig.isEnabled());
         assertEquals(dir.getAbsolutePath(), hotRestartPersistenceConfig.getBaseDir().getAbsolutePath());
         assertEquals(hotBackupDir.getAbsolutePath(), hotRestartPersistenceConfig.getBackupDir().getAbsolutePath());
         assertEquals(1111, hotRestartPersistenceConfig.getValidationTimeoutSeconds());
@@ -1460,7 +1460,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(120, cpSubsystemConfig.getMissingCPMemberAutoRemovalSeconds());
         assertEquals(30, cpSubsystemConfig.getDataLoadTimeoutSeconds());
         assertTrue(cpSubsystemConfig.isFailOnIndeterminateOperationState());
-        assertTrue(cpSubsystemConfig.isPersistenceEnabled());
+        assertFalse(cpSubsystemConfig.isPersistenceEnabled());
         assertEquals(new File("/custom-dir"), cpSubsystemConfig.getBaseDir().getAbsoluteFile());
         RaftAlgorithmConfig raftAlgorithmConfig = cpSubsystemConfig.getRaftAlgorithmConfig();
         assertEquals(500, raftAlgorithmConfig.getLeaderElectionTimeoutInMillis());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -811,7 +811,7 @@
                 <hz:recently-active-quorum heartbeat-tolerance-millis="5123"/>
             </hz:quorum>
 
-            <hz:hot-restart-persistence enabled="true"
+            <hz:hot-restart-persistence enabled="false"
                                         validation-timeout-seconds="1111"
                                         data-load-timeout-seconds="2222"
                                         auto-remove-stale-data="false"
@@ -837,7 +837,7 @@
                 <hz:session-heartbeat-interval-seconds>3</hz:session-heartbeat-interval-seconds>
                 <hz:missing-cp-member-auto-removal-seconds>120</hz:missing-cp-member-auto-removal-seconds>
                 <hz:fail-on-indeterminate-operation-state>true</hz:fail-on-indeterminate-operation-state>
-                <hz:persistence-enabled>true</hz:persistence-enabled>
+                <hz:persistence-enabled>false</hz:persistence-enabled>
                 <hz:base-dir>/custom-dir</hz:base-dir>
                 <hz:data-load-timeout-seconds>30</hz:data-load-timeout-seconds>
                 <hz:raft-algorithm>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3185,7 +3185,7 @@ hazelcast:
     missing-cp-member-auto-removal-seconds: 120
     fail-on-indeterminate-operation-state: false
     persistence-enabled: true
-    base-dir: custom-cp-data
+    base-dir: custom-cp-dir
     data-load-timeout-seconds: 30
     raft-algorithm:
       leader-election-timeout-in-millis: 2000

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -18,6 +18,7 @@ package com.hazelcast.instance;
 
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cluster.Joiner;
+import com.hazelcast.cp.internal.persistence.CPPersistenceService;
 import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.impl.MapService;
@@ -70,6 +71,7 @@ public class TestNodeContext implements NodeContext {
         when(nodeExtension.isStartCompleted()).thenReturn(true);
         when(nodeExtension.isNodeVersionCompatibleWith(any(Version.class))).thenReturn(true);
         when(nodeExtension.getMemoryStats()).thenReturn(new DefaultMemoryStats());
+        when(nodeExtension.getCPPersistenceService()).thenReturn(mock(CPPersistenceService.class));
         return nodeExtension;
     }
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -871,6 +871,8 @@ hazelcast:
     session-heartbeat-interval-seconds: 5
     missing-cp-member-auto-removal-seconds: 120
     fail-on-indeterminate-operation-state: false
+    persistence-enabled: false
+    base-dir: data
     raft-algorithm:
       leader-election-timeout-in-millis: 2000
       leader-heartbeat-period-in-millis: 5000


### PR DESCRIPTION
* `instance.getCPSubsystem().getLocalCPMember()` call in `TimedMemberStateFactory` was throwing `UnsupportedOperationException` when RU is in progress as `HazelcastInstanceImpl#getCPSubsystem` checks cluster version and throws in case of `3.11`.
* Also fixes tests broken by previous changes
* One of tests was failing due to differences in `hazelcast-full-example.xml` and `hazelcast-full-example.yaml`

Corresponding ZenDesk ticket: https://hazelcast.zendesk.com/agent/tickets/5552