### PR TITLE
Temporarily disable client ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo . @hazelcast/clients team will be requested for
 # review when someone opens a pull request.
 
-**/client/**       @hazelcast/clients
+# **/client/**       @hazelcast/clients


### PR DESCRIPTION
Temporarily disable client team's ownership to fix the broken build.