### PR TITLE
Move private classes to internal package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -22,7 +22,7 @@ import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.cache.impl.event.InternalCachePartitionLostListenerAdapter;
 import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
 import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.internal.config.CacheConfigReadOnly;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastInstanceCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastInstanceCacheManager.java
@@ -18,7 +18,6 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.ICache;
-import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.ICacheManager;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastInstanceCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastInstanceCacheManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.instance;
+package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.ICache;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -23,7 +23,6 @@ import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceCacheManager;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
 import com.hazelcast.spi.impl.InternalCompletableFuture;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalFunctions.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.CacheEventType;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.internal.journal.DeserializingEntry;
 import com.hazelcast.internal.serialization.SerializableByConvention;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheService;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.internal.journal.EventJournal;
 import com.hazelcast.internal.journal.EventJournalReadOperation;
 import com.hazelcast.nio.ObjectDataInput;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.internal.serialization.SerializableByConvention;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
@@ -18,7 +18,6 @@ package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.CacheEventType;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.nio.ObjectDataOutput;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/EventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/EventJournalCacheEvent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cache.journal;
+package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.CacheEventType;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -21,7 +21,7 @@ import com.hazelcast.cache.impl.CacheEntryProcessorResult;
 import com.hazelcast.cache.impl.CacheEventListenerAdaptor;
 import com.hazelcast.cache.impl.CacheSyncListenerCompleter;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
 import com.hazelcast.client.impl.ClientDelegatingFuture;
 import com.hazelcast.client.impl.clientside.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
@@ -18,8 +18,8 @@ package com.hazelcast.client.config;
 
 import com.hazelcast.config.AbstractConfigLocator;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES;
 
 /**
  * A support class for the {@link XmlClientConfigBuilder} to locate the client

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigLocator.java
@@ -18,8 +18,8 @@ package com.hazelcast.client.config;
 
 import com.hazelcast.config.AbstractConfigLocator;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES;
 
 /**
  * A support class for the {@link XmlClientFailoverConfigBuilder} to

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
@@ -18,8 +18,8 @@ package com.hazelcast.client.config;
 
 import com.hazelcast.config.AbstractConfigLocator;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
 
 /**
  * A support class for the {@link YamlClientConfigBuilder} to locate the client

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigLocator.java
@@ -18,8 +18,8 @@ package com.hazelcast.client.config;
 
 import com.hazelcast.config.AbstractConfigLocator;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
 
 /**
  * A support class for the {@link YamlClientFailoverConfigBuilder} to

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -33,9 +33,9 @@ import com.hazelcast.core.HazelcastException;
 
 import java.util.List;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
 
 /**
  * Static methods to resolve and validate multiple client configs for blue green feature

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.cache;
 
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheEventJournalReadCodec;
 import com.hazelcast.instance.impl.Node;

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/MemberSelectors.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/MemberSelectors.java
@@ -18,6 +18,8 @@ package com.hazelcast.cluster.memberselector;
 
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberSelector;
+import com.hazelcast.cluster.memberselector.impl.AndMemberSelector;
+import com.hazelcast.cluster.memberselector.impl.OrMemberSelector;
 
 /**
  * A utility class to get {@link MemberSelector} instances.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/impl/AndMemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/impl/AndMemberSelector.java
@@ -14,30 +14,31 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cluster.memberselector;
+package com.hazelcast.cluster.memberselector.impl;
 
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberSelector;
 
 /**
- * Selects a member if one of the sub-selectors succeed
+ * Selects a member only if all of the sub-selectors succeed
  */
-class OrMemberSelector implements MemberSelector {
+public class AndMemberSelector
+        implements MemberSelector {
 
     private final MemberSelector[] selectors;
 
-    OrMemberSelector(MemberSelector... selectors) {
+    public AndMemberSelector(MemberSelector... selectors) {
         this.selectors = selectors;
     }
 
     @Override
     public boolean select(Member member) {
         for (MemberSelector selector : selectors) {
-            if (selector.select(member)) {
-                return true;
+            if (!selector.select(member)) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/impl/OrMemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/impl/OrMemberSelector.java
@@ -14,31 +14,30 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cluster.memberselector;
+package com.hazelcast.cluster.memberselector.impl;
 
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberSelector;
 
 /**
- * Selects a member only if all of the sub-selectors succeed
+ * Selects a member if one of the sub-selectors succeed
  */
-class AndMemberSelector
-        implements MemberSelector {
+public class OrMemberSelector implements MemberSelector {
 
     private final MemberSelector[] selectors;
 
-    AndMemberSelector(MemberSelector... selectors) {
+    public OrMemberSelector(MemberSelector... selectors) {
         this.selectors = selectors;
     }
 
     @Override
     public boolean select(Member member) {
         for (MemberSelector selector : selectors) {
-            if (!selector.select(member)) {
-                return false;
+            if (selector.select(member)) {
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
@@ -28,8 +28,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.isAcceptedSuffixConfigured;
-import static com.hazelcast.config.DeclarativeConfigUtil.throwUnacceptedSuffixInSystemProperty;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.isAcceptedSuffixConfigured;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.throwUnacceptedSuffixInSystemProperty;
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static java.util.Objects.requireNonNull;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.config;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES;
 
 /**
  * Support class for the {@link XmlConfigBuilder} that locates the XML configuration:

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.config;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
 
 /**
  * Support class for the {@link com.hazelcast.config.YamlConfigBuilder} that locates the YAML configuration:

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
@@ -27,7 +27,7 @@ import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.NioNetworking;
 import com.hazelcast.internal.util.InstantiationUtils;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.nio.NetworkingService;
 import com.hazelcast.internal.nio.NodeIOService;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
@@ -40,8 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.Preconditions.checkHasText;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.instance.impl;
 
+import com.hazelcast.cache.impl.HazelcastInstanceCacheManager;
 import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
 import com.hazelcast.client.ClientService;
@@ -45,7 +46,6 @@ import com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
-import com.hazelcast.instance.HazelcastInstanceCacheManager;
 import com.hazelcast.internal.crdt.pncounter.PNCounterService;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.memory.MemoryStats;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -69,7 +69,7 @@ import com.hazelcast.internal.services.GracefulShutdownAwareService;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentClassLoader;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.nio.Connection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DeclarativeConfigUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DeclarativeConfigUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.config;
+package com.hazelcast.internal.config;
 
 import com.hazelcast.core.HazelcastException;
 
@@ -122,7 +122,7 @@ public final class DeclarativeConfigUtil {
      *                            referring to the unaccepted suffix of
      *                            the file referenced by {@code propertyKey}
      */
-    static void throwUnacceptedSuffixInSystemProperty(String propertyKey, String configResource,
+    public static void throwUnacceptedSuffixInSystemProperty(String propertyKey, String configResource,
                                                       Collection<String> acceptedSuffixes) {
 
         String message = String.format("The suffix of the resource \'%s\' referenced in \'%s\' is not in the list of accepted "
@@ -139,7 +139,7 @@ public final class DeclarativeConfigUtil {
      * @return {@code true} if the suffix of the configuration file is in
      * the accepted list, {@code false} otherwise
      */
-    static boolean isAcceptedSuffixConfigured(String configFile, Collection<String> acceptedSuffixes) {
+    public static boolean isAcceptedSuffixConfigured(String configFile, Collection<String> acceptedSuffixes) {
         String configFileLower = configFile.toLowerCase();
         int lastDotIndex = configFileLower.lastIndexOf('.');
         if (lastDotIndex == -1) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -22,7 +22,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheEntryProcessorEntry;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.core.ReadOnly;
-import com.hazelcast.instance.HazelcastInstanceCacheManager;
+import com.hazelcast.cache.impl.HazelcastInstanceCacheManager;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.serialization.InternalSerializationService;

--- a/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-package com.hazelcast.logging;
+package com.hazelcast.logging.impl;
 
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.internal.util.ConstructorFunction;
+import com.hazelcast.logging.AbstractLogger;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LogEvent;
+import com.hazelcast.logging.LogListener;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggerFactory;
+import com.hazelcast.logging.LoggingService;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.getters.Extractors;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
@@ -32,7 +32,7 @@ import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStoreAdapter;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryableEntriesSegment;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.record;
 
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.record;
 
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 
 /**
  * @param <V> the type of value which is in the Record

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataRecordStoreMutationObserver.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.MetadataInitializer;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Metadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Metadata.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.query;
+package com.hazelcast.query.impl;
 
 /**
  * Keeps generic metadata for a key value pair. The type of kept metadata

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -24,7 +24,6 @@ import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.Portable;
-import com.hazelcast.query.Metadata;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.getters.MultiResult;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -48,7 +48,7 @@ import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentService;
 import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.nio.serialization.Data;

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/CacheEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/CacheEventJournalBasicTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig.MaxSizePolicy;

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheDataStructureAdapter.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl.journal;
 import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.CacheService;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.internal.journal.EventJournalReader;

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheEventAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheEventAdapter.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cache.impl.journal;
 
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.journal.EventJournalEventAdapter;
 
 public class EventJournalCacheEventAdapter<K, V> implements EventJournalEventAdapter<K, V, EventJournalCacheEvent<K, V>> {

--- a/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
@@ -30,7 +30,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICacheManager;
 import com.hazelcast.map.IMap;
-import com.hazelcast.instance.HazelcastInstanceCacheManager;
+import com.hazelcast.cache.impl.HazelcastInstanceCacheManager;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
@@ -34,8 +34,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.ALL_ACCEPTED_SUFFIXES_STRING;
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.ALL_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
@@ -33,8 +33,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.ALL_ACCEPTED_SUFFIXES_STRING;
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.ALL_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -31,8 +31,8 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES_STRING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES_STRING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigBuilderConfigResolutionTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
-import static com.hazelcast.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES_STRING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
@@ -37,7 +37,7 @@ import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.util.SimpleCompletableFuture;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.version.MemberVersion;
 
 import java.util.Collections;

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
@@ -33,8 +33,8 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
-import static com.hazelcast.config.DeclarativeConfigUtil.ALL_ACCEPTED_SUFFIXES_STRING;
-import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.ALL_ACCEPTED_SUFFIXES_STRING;
+import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
@@ -30,7 +30,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.internal.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.internal.networking.nio.Select_NioNetworkingFactory;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.test.AssertTask;

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationMigrationTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.Metadata;
+import com.hazelcast.query.impl.Metadata;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.instance.impl.DefaultNodeExtension;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/HazelcastInstanceImplAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/HazelcastInstanceImplAnswer.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.test.starter.answer;
 
-import com.hazelcast.instance.HazelcastInstanceCacheManager;
+import com.hazelcast.cache.impl.HazelcastInstanceCacheManager;
 import com.hazelcast.instance.impl.LifecycleServiceImpl;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import org.mockito.invocation.InvocationOnMock;


### PR DESCRIPTION
Finer-grained  change in moving private API from public to internal
package, this time for various packages. Other than moving the classes,
fixing checkstyle, adding visibility modifiers and formatting, there is
no code or behaviour change.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3178

Classes moved:
com.hazelcast.cache.journal.EventJournalCacheEvent

com.hazelcast.instance.HazelcastInstanceCacheManager

com.hazelcast.cluster.memberselector.AndMemberSelector
com.hazelcast.cluster.memberselector.OrMemberSelector

com.hazelcast.config.DeclarativeConfigUtil

com.hazelcast.logging.LoggingServiceImpl

com.hazelcast.query.Metadata

com.hazelcast.cache.hidensity.impl.nativememory.CacheHiDensityRecordProcessor
com.hazelcast.cache.hidensity.impl.nativememory.HiDensityNativeMemoryCacheEntryProcessorEntry
com.hazelcast.cache.hidensity.impl.nativememory.HiDensityNativeMemoryCacheRecord
com.hazelcast.cache.hidensity.impl.nativememory.HiDensityNativeMemoryCacheRecordAccessor
com.hazelcast.cache.hidensity.impl.nativememory.HiDensityNativeMemoryCacheRecordMap
com.hazelcast.cache.hidensity.impl.nativememory.HiDensityNativeMemoryCacheRecordStore
com.hazelcast.cache.hidensity.impl.nativememory.HotRestartHiDensityNativeMemoryCacheRecordMap
com.hazelcast.cache.hidensity.impl.nativememory.HotRestartHiDensityNativeMemoryCacheRecordStore

com.hazelcast.cache.hidensity.impl.HiDensityCacheRecord

com.hazelcast.cache.hidensity.maxsize.HiDensityEntryCountEvictionChecker
com.hazelcast.cache.hidensity.maxsize.HiDensityFreeNativeMemoryPercentageEvictionChecker
com.hazelcast.cache.hidensity.maxsize.HiDensityFreeNativeMemorySizeEvictionChecker
com.hazelcast.cache.hidensity.maxsize.HiDensityUsedNativeMemoryPercentageEvictionChecker
com.hazelcast.cache.hidensity.maxsize.HiDensityUsedNativeMemorySizeEvictionChecker

com.hazelcast.cache.hidensity.operation.BackupAwareHiDensityCacheOperation
com.hazelcast.cache.hidensity.operation.BackupAwareKeyBasedHiDensityCacheOperation
com.hazelcast.cache.hidensity.operation.CacheBackupRecordStore
com.hazelcast.cache.hidensity.operation.CacheContainsKeyOperation
com.hazelcast.cache.hidensity.operation.CacheEntryProcessorOperation
com.hazelcast.cache.hidensity.operation.CacheGetAllOperation
com.hazelcast.cache.hidensity.operation.CacheGetAllOperationFactory
com.hazelcast.cache.hidensity.operation.CacheGetAndRemoveOperation
com.hazelcast.cache.hidensity.operation.CacheGetAndReplaceOperation
com.hazelcast.cache.hidensity.operation.CacheGetOperation
com.hazelcast.cache.hidensity.operation.CacheLoadAllOperation
com.hazelcast.cache.hidensity.operation.CacheLoadAllOperationFactory
com.hazelcast.cache.hidensity.operation.CacheMergeBackupOperation
com.hazelcast.cache.hidensity.operation.CacheMergeOperation
com.hazelcast.cache.hidensity.operation.CacheMergeOperationFactory
com.hazelcast.cache.hidensity.operation.CachePutAllBackupOperation
com.hazelcast.cache.hidensity.operation.CachePutAllOperation
com.hazelcast.cache.hidensity.operation.CachePutBackupOperation
com.hazelcast.cache.hidensity.operation.CachePutIfAbsentOperation
com.hazelcast.cache.hidensity.operation.CachePutOperation
com.hazelcast.cache.hidensity.operation.CacheRemoveBackupOperation
com.hazelcast.cache.hidensity.operation.CacheRemoveOperation
com.hazelcast.cache.hidensity.operation.CacheReplaceOperation
com.hazelcast.cache.hidensity.operation.CacheSegmentShutdownOperation
com.hazelcast.cache.hidensity.operation.CacheSetExpiryPolicyBackupOperation
com.hazelcast.cache.hidensity.operation.CacheSetExpiryPolicyOperation
com.hazelcast.cache.hidensity.operation.CacheSizeOperation
com.hazelcast.cache.hidensity.operation.CacheSizeOperationFactory
com.hazelcast.cache.hidensity.operation.HiDensityCacheDataSerializerHook
com.hazelcast.cache.hidensity.operation.HiDensityCacheOperation
com.hazelcast.cache.hidensity.operation.HiDensityCacheOperationProvider
com.hazelcast.cache.hidensity.operation.HiDensityCacheReplicationOperation
com.hazelcast.cache.hidensity.operation.KeyBasedHiDensityCacheOperation
com.hazelcast.cache.hidensity.operation.WanCacheMergeOperation
com.hazelcast.cache.hidensity.operation.WanCacheRemoveOperation

com.hazelcast.cache.hidensity.HiDensityCacheRecordStore
com.hazelcast.cache.hidensity.HiDensityCacheStorageInfo
com.hazelcast.cache.hidensity.SampleableHiDensityCacheRecordMap

com.hazelcast.cache.hotrestart.HotRestartEnterpriseCacheRecordStore

com.hazelcast.enterprise.monitor.impl.jmx.EnterpriseManagementService
com.hazelcast.enterprise.monitor.impl.jmx.LicenseInfoMBean

com.hazelcast.enterprise.monitor.impl.management.EnterpriseManagementCenterConnectionFactory
com.hazelcast.enterprise.monitor.impl.management.EnterpriseNodeStateImpl
com.hazelcast.enterprise.monitor.impl.management.EnterpriseTimedMemberStateFactory

com.hazelcast.enterprise.monitor.impl.rest.EnterpriseHttpGetCommandProcessor
com.hazelcast.enterprise.monitor.impl.rest.EnterpriseTextCommandServiceImpl
com.hazelcast.enterprise.monitor.impl.rest.LicenseInfoImpl

com.hazelcast.enterprise.monitor.LicenseInfo

com.hazelcast.enterprise.EnterprisePhoneHome

com.hazelcast.nio.serialization.EnterpriseSerializationService

com.hazelcast.nio.ssl.AbstractMultiSocketTLSChannelInitializer
com.hazelcast.nio.ssl.AbstractTLSChannelInitializer
com.hazelcast.nio.ssl.ChannelHandlerPair
com.hazelcast.nio.ssl.ClientTLSChannelInitializer
com.hazelcast.nio.ssl.MemberTLSChannelInitializer
com.hazelcast.nio.ssl.SSLEngineFactoryAdaptor
com.hazelcast.nio.ssl.SSLEngineFactorySupport
com.hazelcast.nio.ssl.TextTLSChannelInitializer
com.hazelcast.nio.ssl.TLSDecoder
com.hazelcast.nio.ssl.TLSEncoder
com.hazelcast.nio.ssl.TLSExecutor
com.hazelcast.nio.ssl.TLSHandshakeDecoder
com.hazelcast.nio.ssl.TLSHandshakeEncoder
com.hazelcast.nio.ssl.TLSUtil
com.hazelcast.nio.ssl.UnifiedTLSChannelInitializer

com.hazelcast.nio.CipherByteArrayProcessor
com.hazelcast.nio.CipherHelper
com.hazelcast.nio.EnterpriseBufferObjectDataInput
com.hazelcast.nio.EnterpriseBufferObjectDataOutput
com.hazelcast.nio.EnterpriseChannelInitializerProvider
com.hazelcast.nio.EnterpriseObjectDataInput
com.hazelcast.nio.EnterpriseObjectDataOutput

com.hazelcast.security.ClusterCallbackHandler
com.hazelcast.security.EmptyParametersImpl
com.hazelcast.security.LoginConfigurationDelegate
com.hazelcast.security.ParametersImpl
com.hazelcast.security.SecureCallableImpl
com.hazelcast.security.SecurityConstants
com.hazelcast.security.SecurityContextImpl
com.hazelcast.security.SecurityUtil