### PR TITLE
Fix isMaster() guards in migration system

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/DefaultPartitionReplicaInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/DefaultPartitionReplicaInterceptor.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.partition.impl;
 
-import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.partition.PartitionReplica;
 import com.hazelcast.internal.partition.PartitionReplicaInterceptor;
 
@@ -26,11 +25,9 @@ import com.hazelcast.internal.partition.PartitionReplicaInterceptor;
  * and cancel any ongoing replica synchronization on the changed partition.
  */
 final class DefaultPartitionReplicaInterceptor implements PartitionReplicaInterceptor {
-    private final Node node;
     private final InternalPartitionServiceImpl partitionService;
 
-    DefaultPartitionReplicaInterceptor(Node node, InternalPartitionServiceImpl partitionService) {
-        this.node = node;
+    DefaultPartitionReplicaInterceptor(InternalPartitionServiceImpl partitionService) {
         this.partitionService = partitionService;
     }
 
@@ -40,7 +37,7 @@ final class DefaultPartitionReplicaInterceptor implements PartitionReplicaInterc
             partitionService.getReplicaManager().cancelReplicaSync(partitionId);
         }
 
-        if (node.isMaster()) {
+        if (partitionService.isLocalMemberMaster()) {
             partitionService.getPartitionStateManager().incrementVersion();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -482,7 +482,7 @@ public class MigrationManager {
             logger.fine("Node is not joined, will not trigger ControlTask");
             return;
         }
-        if (!node.isMaster()) {
+        if (!partitionService.isLocalMemberMaster()) {
             logger.fine("Node is not master, will not trigger ControlTask");
             return;
         }
@@ -617,7 +617,7 @@ public class MigrationManager {
     }
 
     private void publishCompletedMigrations() {
-        assert node.isMaster();
+        assert partitionService.isLocalMemberMaster();
         assert partitionStateManager.isInitialized();
 
         final List<MigrationInfo> migrations = getCompletedMigrationsCopy();
@@ -674,7 +674,7 @@ public class MigrationManager {
     private class RepartitioningTask implements MigrationRunnable {
         @Override
         public void run() {
-            if (!node.isMaster()) {
+            if (!partitionService.isLocalMemberMaster()) {
                 return;
             }
             partitionServiceLock.lock();
@@ -919,7 +919,7 @@ public class MigrationManager {
 
         @Override
         public void run() {
-            if (!node.isMaster()) {
+            if (!partitionService.isLocalMemberMaster()) {
                 return;
             }
             if (migrationInfo.getSource() == null
@@ -1480,7 +1480,7 @@ public class MigrationManager {
     private class ProcessShutdownRequestsTask implements MigrationRunnable {
         @Override
         public void run() {
-            if (!node.isMaster()) {
+            if (!partitionService.isLocalMemberMaster()) {
                 return;
             }
             partitionServiceLock.lock();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -90,7 +90,7 @@ public class PartitionReplicaStateChecker {
             return MIGRATION_LOCAL;
         }
 
-        if (!node.isMaster() && hasOnGoingMigrationMaster(Level.OFF)) {
+        if (!partitionService.isLocalMemberMaster() && hasOnGoingMigrationMaster(Level.OFF)) {
             return MIGRATION_ON_MASTER;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -76,7 +76,7 @@ public class PartitionStateManager {
         this.partitionCount = partitionService.getPartitionCount();
         this.partitions = new InternalPartitionImpl[partitionCount];
 
-        PartitionReplicaInterceptor interceptor = new DefaultPartitionReplicaInterceptor(node, partitionService);
+        PartitionReplicaInterceptor interceptor = new DefaultPartitionReplicaInterceptor(partitionService);
         PartitionReplica localReplica = PartitionReplica.from(node.getLocalMember());
         for (int i = 0; i < partitionCount; i++) {
             this.partitions[i] = new InternalPartitionImpl(i, interceptor, localReplica);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -37,7 +37,7 @@ class PublishPartitionRuntimeStateTask implements Runnable {
 
     @Override
     public void run() {
-        if (node.isMaster()) {
+        if (partitionService.isLocalMemberMaster()) {
             MigrationManager migrationManager = partitionService.getMigrationManager();
             boolean migrationAllowed = migrationManager.areMigrationTasksAllowed()
                     && !partitionService.isFetchMostRecentPartitionTableTaskRequired();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 
 /** Sent from non-master nodes to the master to initialize the partition assignment. */
 public class AssignPartitions extends AbstractPartitionOperation implements MigrationCycleOperation {
@@ -40,5 +43,14 @@ public class AssignPartitions extends AbstractPartitionOperation implements Migr
     @Override
     public int getClassId() {
         return PartitionDataSerializerHook.ASSIGN_PARTITIONS;
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException
+                || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
     }
 }


### PR DESCRIPTION
`node.isMaster()` was being used in migration mechanism
to detect whether or not a node is master. Depending on this
check, a process executes or rejects to execute.

But while a migration method is executing under partition service
lock, the node may become master (when former master leaves the cluster).
This may cause inconsistenct behaviours during execution of the specific method.

For example, master node increments partition version when a replica ownership
changes. If a node becomes master while appyling partition table updates,
the race mentioned above can cause multiple increments of partition version.

To fix this issue, instead of checking `node.isMaster()`, we check “is master?” by using the latest observed master by the partition service under partition lock, so we order observation of master and partition update operations.

Fixes #https://github.com/hazelcast/hazelcast-enterprise/issues/2837