### PR TITLE
Fix isMaster() guards in migration system

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionListener.java
@@ -29,13 +29,11 @@ import com.hazelcast.logging.ILogger;
  * Also this listener delegates the partition change events to its child listeners.
  */
 final class InternalPartitionListener implements PartitionListener {
-    private final Node node;
     private final InternalPartitionServiceImpl partitionService;
     private final ILogger logger;
     private volatile PartitionListenerNode listenerHead;
 
     InternalPartitionListener(Node node, InternalPartitionServiceImpl partitionService) {
-        this.node = node;
         this.partitionService = partitionService;
         logger = node.getLogger(InternalPartitionService.class);
     }
@@ -49,7 +47,7 @@ final class InternalPartitionListener implements PartitionListener {
             partitionService.getReplicaManager().cancelReplicaSync(partitionId);
         }
 
-        if (node.isMaster()) {
+        if (partitionService.isLocalMemberMaster()) {
             partitionService.getPartitionStateManager().incrementVersion();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -530,7 +530,7 @@ public class MigrationManager {
             logger.fine("Node is not joined, will not trigger ControlTask");
             return;
         }
-        if (!node.isMaster()) {
+        if (!partitionService.isLocalMemberMaster()) {
             logger.fine("Node is not master, will not trigger ControlTask");
             return;
         }
@@ -665,7 +665,7 @@ public class MigrationManager {
     }
 
     private void publishCompletedMigrations() {
-        assert node.isMaster();
+        assert partitionService.isLocalMemberMaster();
         assert partitionStateManager.isInitialized();
 
         final List<MigrationInfo> migrations = getCompletedMigrationsCopy();
@@ -738,7 +738,7 @@ public class MigrationManager {
     private class RepartitioningTask implements MigrationRunnable {
         @Override
         public void run() {
-            if (!node.isMaster()) {
+            if (!partitionService.isLocalMemberMaster()) {
                 return;
             }
             partitionServiceLock.lock();
@@ -982,7 +982,7 @@ public class MigrationManager {
 
         @Override
         public void run() {
-            if (!node.isMaster()) {
+            if (!partitionService.isLocalMemberMaster()) {
                 return;
             }
             if (migrationInfo.getSource() == null
@@ -1561,7 +1561,7 @@ public class MigrationManager {
     private class ProcessShutdownRequestsTask implements MigrationRunnable {
         @Override
         public void run() {
-            if (!node.isMaster()) {
+            if (!partitionService.isLocalMemberMaster()) {
                 return;
             }
             partitionServiceLock.lock();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -90,7 +90,7 @@ public class PartitionReplicaStateChecker {
             return MIGRATION_LOCAL;
         }
 
-        if (!node.isMaster() && hasOnGoingMigrationMaster(Level.OFF)) {
+        if (!partitionService.isLocalMemberMaster() && hasOnGoingMigrationMaster(Level.OFF)) {
             return MIGRATION_ON_MASTER;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -38,7 +38,7 @@ class PublishPartitionRuntimeStateTask implements Runnable {
 
     @Override
     public void run() {
-        if (node.isMaster()) {
+        if (partitionService.isLocalMemberMaster()) {
             MigrationManager migrationManager = partitionService.getMigrationManager();
             boolean migrationAllowed = migrationManager.areMigrationTasksAllowed()
                     && !partitionService.isFetchMostRecentPartitionTableTaskRequired();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 
 /** Sent from non-master nodes to the master to initialize the partition assignment. */
 public class AssignPartitions extends AbstractPartitionOperation implements MigrationCycleOperation {
@@ -40,5 +43,14 @@ public class AssignPartitions extends AbstractPartitionOperation implements Migr
     @Override
     public int getId() {
         return PartitionDataSerializerHook.ASSIGN_PARTITIONS;
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException
+                || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
     }
 }


### PR DESCRIPTION
`node.isMaster()` was being used in migration mechanism
to detect whether or not a node is master. Depending on this
check, a process executes or rejects to execute.

But while a migration method is executing under partition service
lock, the node may become master (when former master leaves the cluster).
This may cause inconsistenct behaviours during execution of the specific method.

For example, master node increments partition version when a replica ownership
changes. If a node becomes master while appyling partition table updates,
the race mentioned above can cause multiple increments of partition version.

Fixes #hazelcast/hazelcast-enterprise#2837
Backport of https://github.com/hazelcast/hazelcast/pull/15617