### PR TITLE
Fix NPE in MemberHazelcastInstanceInfoPlugin

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
@@ -22,6 +22,8 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
+import java.util.UUID;
+
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -71,7 +73,8 @@ public class MemberHazelcastInstanceInfoPlugin extends DiagnosticsPlugin {
         NodeState state = nodeEngine.getNode().getState();
         writer.writeKeyValueEntry("nodeState", state == null ? "null" : state.toString());
 
-        writer.writeKeyValueEntry("clusterId", nodeEngine.getClusterService().getClusterId().toString());
+        UUID clusterId = nodeEngine.getClusterService().getClusterId();
+        writer.writeKeyValueEntry("clusterId", clusterId != null ? clusterId.toString() : "null");
         writer.writeKeyValueEntry("clusterSize", nodeEngine.getClusterService().getSize());
         writer.writeKeyValueEntry("isMaster", nodeEngine.getClusterService().isMaster());
         Address masterAddress = nodeEngine.getClusterService().getMasterAddress();


### PR DESCRIPTION
ClusterId is null until it is explicitly set when the member forms or
joins a cluster. The clusterId can also be reset to null when the
ClusterService is reset. This leads to NPE in
MemberHazelcastInstanceInfoPlugin.

Fixes #15629