### PR TITLE
Rename cluster name in AbstractWanEventBase

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEventBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEventBase.java
@@ -45,7 +45,7 @@ abstract class AbstractWanEventBase extends AbstractEventBase {
     public JsonObject toJson() {
         JsonObject json = new JsonObject();
         json.add("wanReplicationName", wanReplicationName);
-        json.add("targetClusterName", wanPublisherId);
+        json.add("wanPublisherId", wanPublisherId);
         json.add("mapName", mapName);
         return json;
     }


### PR DESCRIPTION
We send WAN target information to MC as `targetClusterName` in
WAN events. The name may be misleading, since we put the `publisherId`
to this field that can either be the group name or a publisher id
set in the config. We change the name of the field to `wanPublisherId`
to be consistent.

This is noticed since recent refactoring changed `targetGroupName` to
`targetClusterName` that led to rendering `undefined` targets in MC.