### PR TITLE
Minor fixes and improvements for WAN protocol

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInput.java
@@ -21,8 +21,6 @@ import com.hazelcast.version.Version;
 
 import java.io.InputStream;
 
-import static com.hazelcast.version.Version.UNKNOWN;
-
 /**
  * Base class for ObjectDataInput that is VersionAware and allows mutating
  * the version.
@@ -44,7 +42,6 @@ abstract class VersionedObjectDataInput extends InputStream implements ObjectDat
     @Override
     public void setWanProtocolVersion(Version version) {
         this.wanProtocolVersion = version;
-        this.version = UNKNOWN;
     }
 
     /**
@@ -69,6 +66,5 @@ abstract class VersionedObjectDataInput extends InputStream implements ObjectDat
     @Override
     public void setVersion(Version version) {
         this.version = version;
-        this.wanProtocolVersion = UNKNOWN;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataOutput.java
@@ -22,8 +22,6 @@ import com.hazelcast.version.Version;
 
 import java.io.OutputStream;
 
-import static com.hazelcast.version.Version.UNKNOWN;
-
 /**
  * Base class for ObjectDataInput that is {@link VersionAware} and allows
  * mutating the version.
@@ -57,13 +55,11 @@ abstract class VersionedObjectDataOutput extends OutputStream implements ObjectD
     @Override
     public void setVersion(Version version) {
         this.version = version;
-        this.wanProtocolVersion = UNKNOWN;
     }
 
     @Override
     public void setWanProtocolVersion(Version version) {
         this.wanProtocolVersion = version;
-        this.version = UNKNOWN;
     }
 
     @Override


### PR DESCRIPTION
Fixes issue where by setting the WAN protocol to a value other than
UNKNOWN after which the cluster version was set to UNKOWN would
overwrite the previously set WAN protocol version. Now, setting either
WAN protocol version or cluster version will not invalidate the other
and users of the input/output stream must set both separately.

Also, moved the wanProtocolVersion from the BatchWanReplicationEvent to
the parent WanOperation. Now, WanOperation can make conditional
serialization as well was the BatchWanReplicationEvent.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/3184
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3189