### PR TITLE
Update codecs for the id reorderings

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAddAndGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAddAndGetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically adds the given value to the current value.
  */
-@Generated("e678e0a9a99e7c9187a6c60557c63230")
+@Generated("35b295ffbf7e4b8a8046b86fb6294d5a")
 public final class AtomicLongAddAndGetCodec {
-    //hex: 0x0A0300
-    public static final int REQUEST_MESSAGE_TYPE = 656128;
-    //hex: 0x0A0301
-    public static final int RESPONSE_MESSAGE_TYPE = 656129;
+    //hex: 0x090300
+    public static final int REQUEST_MESSAGE_TYPE = 590592;
+    //hex: 0x090301
+    public static final int RESPONSE_MESSAGE_TYPE = 590593;
     private static final int REQUEST_DELTA_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_DELTA_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAlterCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAlterCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Alters the currently stored value by applying a function on it.
  */
-@Generated("52b9114879f09140afab5bbb55c23219")
+@Generated("bb55b7849e6ac9440275cbb16c24250c")
 public final class AtomicLongAlterCodec {
-    //hex: 0x0A0200
-    public static final int REQUEST_MESSAGE_TYPE = 655872;
-    //hex: 0x0A0201
-    public static final int RESPONSE_MESSAGE_TYPE = 655873;
+    //hex: 0x090200
+    public static final int REQUEST_MESSAGE_TYPE = 590336;
+    //hex: 0x090201
+    public static final int RESPONSE_MESSAGE_TYPE = 590337;
     private static final int REQUEST_RETURN_VALUE_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_RETURN_VALUE_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongApplyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongApplyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies a function on the value, the actual stored value will not change
  */
-@Generated("c4c84c284033a1ad74193e7b9df2c382")
+@Generated("9f4d6689c4cde5c2b98a041bbaed03ac")
 public final class AtomicLongApplyCodec {
-    //hex: 0x0A0100
-    public static final int REQUEST_MESSAGE_TYPE = 655616;
-    //hex: 0x0A0101
-    public static final int RESPONSE_MESSAGE_TYPE = 655617;
+    //hex: 0x090100
+    public static final int REQUEST_MESSAGE_TYPE = 590080;
+    //hex: 0x090101
+    public static final int RESPONSE_MESSAGE_TYPE = 590081;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongCompareAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongCompareAndSetCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Atomically sets the value to the given updated value only if the current
  * value the expected value.
  */
-@Generated("6c32572db4d31486401acee85dffbf3b")
+@Generated("c3576f22ec8c9d498256c52e6aec073c")
 public final class AtomicLongCompareAndSetCodec {
-    //hex: 0x0A0400
-    public static final int REQUEST_MESSAGE_TYPE = 656384;
-    //hex: 0x0A0401
-    public static final int RESPONSE_MESSAGE_TYPE = 656385;
+    //hex: 0x090400
+    public static final int REQUEST_MESSAGE_TYPE = 590848;
+    //hex: 0x090401
+    public static final int RESPONSE_MESSAGE_TYPE = 590849;
     private static final int REQUEST_EXPECTED_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_UPDATED_FIELD_OFFSET = REQUEST_EXPECTED_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_UPDATED_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndAddCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically adds the given value to the current value.
  */
-@Generated("c517d5677f98995dd5372cddffea74d1")
+@Generated("fa20f8e2137c3493943890170efc59c5")
 public final class AtomicLongGetAndAddCodec {
-    //hex: 0x0A0600
-    public static final int REQUEST_MESSAGE_TYPE = 656896;
-    //hex: 0x0A0601
-    public static final int RESPONSE_MESSAGE_TYPE = 656897;
+    //hex: 0x090600
+    public static final int REQUEST_MESSAGE_TYPE = 591360;
+    //hex: 0x090601
+    public static final int RESPONSE_MESSAGE_TYPE = 591361;
     private static final int REQUEST_DELTA_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_DELTA_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndSetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value and returns the old value.
  */
-@Generated("21a731a7851edbd81d03717e6cb1b021")
+@Generated("db94d613a0b9985edce31880eb3f3cd2")
 public final class AtomicLongGetAndSetCodec {
-    //hex: 0x0A0700
-    public static final int REQUEST_MESSAGE_TYPE = 657152;
-    //hex: 0x0A0701
-    public static final int RESPONSE_MESSAGE_TYPE = 657153;
+    //hex: 0x090700
+    public static final int REQUEST_MESSAGE_TYPE = 591616;
+    //hex: 0x090701
+    public static final int RESPONSE_MESSAGE_TYPE = 591617;
     private static final int REQUEST_NEW_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_NEW_VALUE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the current value.
  */
-@Generated("273bc579e7ad4aa282a4dbc137fe5cfc")
+@Generated("725455f650ae780dfec20fe9f14586d0")
 public final class AtomicLongGetCodec {
-    //hex: 0x0A0500
-    public static final int REQUEST_MESSAGE_TYPE = 656640;
-    //hex: 0x0A0501
-    public static final int RESPONSE_MESSAGE_TYPE = 656641;
+    //hex: 0x090500
+    public static final int REQUEST_MESSAGE_TYPE = 591104;
+    //hex: 0x090501
+    public static final int RESPONSE_MESSAGE_TYPE = 591105;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefApplyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefApplyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies a function on the value
  */
-@Generated("75cf07187203e9fa8d6bf7e8a1459cba")
+@Generated("2715baa01382b7afcb671a22618a8037")
 public final class AtomicRefApplyCodec {
-    //hex: 0x0B0100
-    public static final int REQUEST_MESSAGE_TYPE = 721152;
-    //hex: 0x0B0101
-    public static final int RESPONSE_MESSAGE_TYPE = 721153;
+    //hex: 0x0A0100
+    public static final int REQUEST_MESSAGE_TYPE = 655616;
+    //hex: 0x0A0101
+    public static final int RESPONSE_MESSAGE_TYPE = 655617;
     private static final int REQUEST_RETURN_VALUE_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ALTER_FIELD_OFFSET = REQUEST_RETURN_VALUE_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_ALTER_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefCompareAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefCompareAndSetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Alters the currently stored value by applying a function on it.
  */
-@Generated("7583b7ff7ba427eba0f4ee329e5d5546")
+@Generated("ab37a6ff4405747fb4fbb3f2bfc70bb8")
 public final class AtomicRefCompareAndSetCodec {
-    //hex: 0x0B0200
-    public static final int REQUEST_MESSAGE_TYPE = 721408;
-    //hex: 0x0B0201
-    public static final int RESPONSE_MESSAGE_TYPE = 721409;
+    //hex: 0x0A0200
+    public static final int REQUEST_MESSAGE_TYPE = 655872;
+    //hex: 0x0A0201
+    public static final int RESPONSE_MESSAGE_TYPE = 655873;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefContainsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks if the reference contains the value.
  */
-@Generated("dc4e8eaab18edc886c96204b86d379e4")
+@Generated("4587d508362d9721c6001d9df939a820")
 public final class AtomicRefContainsCodec {
-    //hex: 0x0B0300
-    public static final int REQUEST_MESSAGE_TYPE = 721664;
-    //hex: 0x0B0301
-    public static final int RESPONSE_MESSAGE_TYPE = 721665;
+    //hex: 0x0A0300
+    public static final int REQUEST_MESSAGE_TYPE = 656128;
+    //hex: 0x0A0301
+    public static final int RESPONSE_MESSAGE_TYPE = 656129;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefGetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the current value.
  */
-@Generated("f4c6d653a0de22dcd0944065c9f21b13")
+@Generated("69b9275235227db7867500db05c1aaee")
 public final class AtomicRefGetCodec {
-    //hex: 0x0B0500
-    public static final int REQUEST_MESSAGE_TYPE = 722176;
-    //hex: 0x0B0501
-    public static final int RESPONSE_MESSAGE_TYPE = 722177;
+    //hex: 0x0A0400
+    public static final int REQUEST_MESSAGE_TYPE = 656384;
+    //hex: 0x0A0401
+    public static final int RESPONSE_MESSAGE_TYPE = 656385;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefSetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value
  */
-@Generated("5c7fd7c1b5971ca09d94aa22982aaa8f")
+@Generated("155a18e3df3a53db1aeb8687914404b7")
 public final class AtomicRefSetCodec {
-    //hex: 0x0B0600
-    public static final int REQUEST_MESSAGE_TYPE = 722432;
-    //hex: 0x0B0601
-    public static final int RESPONSE_MESSAGE_TYPE = 722433;
+    //hex: 0x0A0500
+    public static final int REQUEST_MESSAGE_TYPE = 656640;
+    //hex: 0x0A0501
+    public static final int RESPONSE_MESSAGE_TYPE = 656641;
     private static final int REQUEST_RETURN_OLD_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_RETURN_OLD_VALUE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPGroupCreateCPGroupCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPGroupCreateCPGroupCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a new CP group with the given name
  */
-@Generated("e78c2a6fbd7f51e71f78e1106388d386")
+@Generated("743cc736104e71257064c1f98fb47c94")
 public final class CPGroupCreateCPGroupCodec {
-    //hex: 0x210100
-    public static final int REQUEST_MESSAGE_TYPE = 2162944;
-    //hex: 0x210101
-    public static final int RESPONSE_MESSAGE_TYPE = 2162945;
+    //hex: 0x1E0100
+    public static final int REQUEST_MESSAGE_TYPE = 1966336;
+    //hex: 0x1E0101
+    public static final int RESPONSE_MESSAGE_TYPE = 1966337;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPGroupDestroyCPObjectCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPGroupDestroyCPObjectCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Destroys the distributed object with the given name on the requested
  * CP group
  */
-@Generated("83489d24a45a3d6ca9b6c0551990ce96")
+@Generated("09ae8204d8fc34d21cd70e74a0bc87aa")
 public final class CPGroupDestroyCPObjectCodec {
-    //hex: 0x210200
-    public static final int REQUEST_MESSAGE_TYPE = 2163200;
-    //hex: 0x210201
-    public static final int RESPONSE_MESSAGE_TYPE = 2163201;
+    //hex: 0x1E0200
+    public static final int REQUEST_MESSAGE_TYPE = 1966592;
+    //hex: 0x1E0201
+    public static final int RESPONSE_MESSAGE_TYPE = 1966593;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCloseSessionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCloseSessionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Closes the given session on the given CP group
  */
-@Generated("b040e6333d163b67e204649da305b307")
+@Generated("956f2fe9f87d4f3bdc8a5abffbe17adf")
 public final class CPSessionCloseSessionCodec {
-    //hex: 0x220200
-    public static final int REQUEST_MESSAGE_TYPE = 2228736;
-    //hex: 0x220201
-    public static final int RESPONSE_MESSAGE_TYPE = 2228737;
+    //hex: 0x1F0200
+    public static final int REQUEST_MESSAGE_TYPE = 2032128;
+    //hex: 0x1F0201
+    public static final int RESPONSE_MESSAGE_TYPE = 2032129;
     private static final int REQUEST_SESSION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCreateSessionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCreateSessionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a session for the caller on the given CP group.
  */
-@Generated("4063b8efe4e8af5606e4acf9b9f546f8")
+@Generated("81d6a7c68ae557c07eb5bd1ca1c83fe5")
 public final class CPSessionCreateSessionCodec {
-    //hex: 0x220100
-    public static final int REQUEST_MESSAGE_TYPE = 2228480;
-    //hex: 0x220101
-    public static final int RESPONSE_MESSAGE_TYPE = 2228481;
+    //hex: 0x1F0100
+    public static final int REQUEST_MESSAGE_TYPE = 2031872;
+    //hex: 0x1F0101
+    public static final int RESPONSE_MESSAGE_TYPE = 2031873;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_SESSION_ID_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_TTL_MILLIS_FIELD_OFFSET = RESPONSE_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionGenerateThreadIdCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionGenerateThreadIdCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Generates a new ID for the caller thread. The ID is unique in the given
  * CP group.
  */
-@Generated("ddbf28fb32e5ee5a04bb1b328f93713b")
+@Generated("1a1f9434c9bcb8759a59a6e32968cf25")
 public final class CPSessionGenerateThreadIdCodec {
-    //hex: 0x220400
-    public static final int REQUEST_MESSAGE_TYPE = 2229248;
-    //hex: 0x220401
-    public static final int RESPONSE_MESSAGE_TYPE = 2229249;
+    //hex: 0x1F0400
+    public static final int REQUEST_MESSAGE_TYPE = 2032640;
+    //hex: 0x1F0401
+    public static final int RESPONSE_MESSAGE_TYPE = 2032641;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionHeartbeatSessionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionHeartbeatSessionCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Commits a heartbeat for the given session on the given cP group and
  * extends its session expiration time.
  */
-@Generated("4138f0b65953874b626fea70280a51ad")
+@Generated("f74ae1c2b9b30a41c56a241265f3d66d")
 public final class CPSessionHeartbeatSessionCodec {
-    //hex: 0x220300
-    public static final int REQUEST_MESSAGE_TYPE = 2228992;
-    //hex: 0x220301
-    public static final int RESPONSE_MESSAGE_TYPE = 2228993;
+    //hex: 0x1F0300
+    public static final int REQUEST_MESSAGE_TYPE = 2032384;
+    //hex: 0x1F0301
+    public static final int RESPONSE_MESSAGE_TYPE = 2032385;
     private static final int REQUEST_SESSION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddEntryListenerCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("3ff09fcc69fa367298d48577da2fa68f")
+@Generated("84bb405c9774904ef9adb8c582795af9")
 public final class CacheAddEntryListenerCodec {
-    //hex: 0x150100
-    public static final int REQUEST_MESSAGE_TYPE = 1376512;
-    //hex: 0x150101
-    public static final int RESPONSE_MESSAGE_TYPE = 1376513;
+    //hex: 0x130100
+    public static final int REQUEST_MESSAGE_TYPE = 1245440;
+    //hex: 0x130101
+    public static final int RESPONSE_MESSAGE_TYPE = 1245441;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -50,8 +50,8 @@ public final class CacheAddEntryListenerCodec {
     private static final int EVENT_CACHE_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_COMPLETION_ID_FIELD_OFFSET = EVENT_CACHE_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_INITIAL_FRAME_SIZE = EVENT_CACHE_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x150102
-    private static final int EVENT_CACHE_MESSAGE_TYPE = 1376514;
+    //hex: 0x130102
+    private static final int EVENT_CACHE_MESSAGE_TYPE = 1245442;
 
     private CacheAddEntryListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddInvalidationListenerCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("094dd59a8fad11dc377d5371db22524a")
+@Generated("9869071d5cd81dd0224c4345b47b7e56")
 public final class CacheAddInvalidationListenerCodec {
-    //hex: 0x150200
-    public static final int REQUEST_MESSAGE_TYPE = 1376768;
-    //hex: 0x150201
-    public static final int RESPONSE_MESSAGE_TYPE = 1376769;
+    //hex: 0x130200
+    public static final int REQUEST_MESSAGE_TYPE = 1245696;
+    //hex: 0x130201
+    public static final int RESPONSE_MESSAGE_TYPE = 1245697;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -51,11 +51,11 @@ public final class CacheAddInvalidationListenerCodec {
     private static final int EVENT_CACHE_INVALIDATION_PARTITION_UUID_FIELD_OFFSET = EVENT_CACHE_INVALIDATION_SOURCE_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_INVALIDATION_SEQUENCE_FIELD_OFFSET = EVENT_CACHE_INVALIDATION_PARTITION_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_INVALIDATION_INITIAL_FRAME_SIZE = EVENT_CACHE_INVALIDATION_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
-    //hex: 0x150202
-    private static final int EVENT_CACHE_INVALIDATION_MESSAGE_TYPE = 1376770;
+    //hex: 0x130202
+    private static final int EVENT_CACHE_INVALIDATION_MESSAGE_TYPE = 1245698;
     private static final int EVENT_CACHE_BATCH_INVALIDATION_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x150203
-    private static final int EVENT_CACHE_BATCH_INVALIDATION_MESSAGE_TYPE = 1376771;
+    //hex: 0x130203
+    private static final int EVENT_CACHE_BATCH_INVALIDATION_MESSAGE_TYPE = 1245699;
 
     private CacheAddInvalidationListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddNearCacheInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddNearCacheInvalidationListenerCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Eventually consistent client near caches should use this method to add invalidation listeners
  * instead of {@link #addInvalidationListener(String, boolean)}
  */
-@Generated("6cccf6f776ea16ca45f8cb28541853a2")
+@Generated("d5b033498c827fc9a680c4078b3d73e3")
 public final class CacheAddNearCacheInvalidationListenerCodec {
-    //hex: 0x151E00
-    public static final int REQUEST_MESSAGE_TYPE = 1383936;
-    //hex: 0x151E01
-    public static final int RESPONSE_MESSAGE_TYPE = 1383937;
+    //hex: 0x131E00
+    public static final int REQUEST_MESSAGE_TYPE = 1252864;
+    //hex: 0x131E01
+    public static final int RESPONSE_MESSAGE_TYPE = 1252865;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -53,11 +53,11 @@ public final class CacheAddNearCacheInvalidationListenerCodec {
     private static final int EVENT_CACHE_INVALIDATION_PARTITION_UUID_FIELD_OFFSET = EVENT_CACHE_INVALIDATION_SOURCE_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_INVALIDATION_SEQUENCE_FIELD_OFFSET = EVENT_CACHE_INVALIDATION_PARTITION_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_INVALIDATION_INITIAL_FRAME_SIZE = EVENT_CACHE_INVALIDATION_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
-    //hex: 0x151E02
-    private static final int EVENT_CACHE_INVALIDATION_MESSAGE_TYPE = 1383938;
+    //hex: 0x131E02
+    private static final int EVENT_CACHE_INVALIDATION_MESSAGE_TYPE = 1252866;
     private static final int EVENT_CACHE_BATCH_INVALIDATION_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x151E03
-    private static final int EVENT_CACHE_BATCH_INVALIDATION_MESSAGE_TYPE = 1383939;
+    //hex: 0x131E03
+    private static final int EVENT_CACHE_BATCH_INVALIDATION_MESSAGE_TYPE = 1252867;
 
     private CacheAddNearCacheInvalidationListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddPartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddPartitionLostListenerCodec.java
@@ -40,12 +40,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * registrations, so if you register the listener twice, it will get events twice.Listeners registered from
  * HazelcastClient may miss some of the cache partition lost events due to design limitations.
  */
-@Generated("c296dff32ba219baa518d404c831ffeb")
+@Generated("e18d90f725c558746995f19b1287aaf7")
 public final class CacheAddPartitionLostListenerCodec {
-    //hex: 0x151A00
-    public static final int REQUEST_MESSAGE_TYPE = 1382912;
-    //hex: 0x151A01
-    public static final int RESPONSE_MESSAGE_TYPE = 1382913;
+    //hex: 0x131A00
+    public static final int REQUEST_MESSAGE_TYPE = 1251840;
+    //hex: 0x131A01
+    public static final int RESPONSE_MESSAGE_TYPE = 1251841;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -53,8 +53,8 @@ public final class CacheAddPartitionLostListenerCodec {
     private static final int EVENT_CACHE_PARTITION_LOST_PARTITION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_PARTITION_LOST_UUID_FIELD_OFFSET = EVENT_CACHE_PARTITION_LOST_PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_CACHE_PARTITION_LOST_INITIAL_FRAME_SIZE = EVENT_CACHE_PARTITION_LOST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
-    //hex: 0x151A02
-    private static final int EVENT_CACHE_PARTITION_LOST_MESSAGE_TYPE = 1382914;
+    //hex: 0x131A02
+    private static final int EVENT_CACHE_PARTITION_LOST_MESSAGE_TYPE = 1251842;
 
     private CacheAddPartitionLostListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAssignAndGetUuidsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAssignAndGetUuidsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("67f3ee457fb83bba0cc0cb1c20b6b381")
+@Generated("84eb6a5f7a348c1c30625d1c4b8091d2")
 public final class CacheAssignAndGetUuidsCodec {
-    //hex: 0x152000
-    public static final int REQUEST_MESSAGE_TYPE = 1384448;
-    //hex: 0x152001
-    public static final int RESPONSE_MESSAGE_TYPE = 1384449;
+    //hex: 0x132000
+    public static final int REQUEST_MESSAGE_TYPE = 1253376;
+    //hex: 0x132001
+    public static final int RESPONSE_MESSAGE_TYPE = 1253377;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheClearCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Clears the contents of the cache, without notifying listeners or CacheWriters.
  */
-@Generated("da283393aa463e830272e2c0646696a1")
+@Generated("7ce831f51f0f01269de2b1c6718b7ec8")
 public final class CacheClearCodec {
-    //hex: 0x150300
-    public static final int REQUEST_MESSAGE_TYPE = 1377024;
-    //hex: 0x150301
-    public static final int RESPONSE_MESSAGE_TYPE = 1377025;
+    //hex: 0x130300
+    public static final int REQUEST_MESSAGE_TYPE = 1245952;
+    //hex: 0x130301
+    public static final int RESPONSE_MESSAGE_TYPE = 1245953;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheContainsKeyCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Determines if the Cache contains an entry for the specified key. More formally, returns true if and only if this
  * cache contains a mapping for a key k such that key.equals(k). (There can be at most one such mapping.)
  */
-@Generated("2680bea52def7f6b64dcc21ae2e89673")
+@Generated("00187836ca59def3dfc0f22e8a386783")
 public final class CacheContainsKeyCodec {
-    //hex: 0x150600
-    public static final int REQUEST_MESSAGE_TYPE = 1377792;
-    //hex: 0x150601
-    public static final int RESPONSE_MESSAGE_TYPE = 1377793;
+    //hex: 0x130600
+    public static final int REQUEST_MESSAGE_TYPE = 1246720;
+    //hex: 0x130601
+    public static final int RESPONSE_MESSAGE_TYPE = 1246721;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheCreateConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheCreateConfigCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("e698dfdb7ae68ea9dcd61543fe537166")
+@Generated("63d0fd8569e1854604874664e8240598")
 public final class CacheCreateConfigCodec {
-    //hex: 0x150700
-    public static final int REQUEST_MESSAGE_TYPE = 1378048;
-    //hex: 0x150701
-    public static final int RESPONSE_MESSAGE_TYPE = 1378049;
+    //hex: 0x130700
+    public static final int REQUEST_MESSAGE_TYPE = 1246976;
+    //hex: 0x130701
+    public static final int RESPONSE_MESSAGE_TYPE = 1246977;
     private static final int REQUEST_CREATE_ALSO_ON_OTHERS_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_CREATE_ALSO_ON_OTHERS_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheDestroyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheDestroyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Closes the cache. Clears the internal content and releases any resource.
  */
-@Generated("41d0bd0429749bb1a67bd6d7c8f17896")
+@Generated("7855046fa822960752615bae500650d5")
 public final class CacheDestroyCodec {
-    //hex: 0x150800
-    public static final int REQUEST_MESSAGE_TYPE = 1378304;
-    //hex: 0x150801
-    public static final int RESPONSE_MESSAGE_TYPE = 1378305;
+    //hex: 0x130800
+    public static final int REQUEST_MESSAGE_TYPE = 1247232;
+    //hex: 0x130801
+    public static final int RESPONSE_MESSAGE_TYPE = 1247233;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEntryProcessorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEntryProcessorCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("9c97dfa8c894d7b4d839f629a1d6bc83")
+@Generated("16aa6d5499cc565a76907189864b4b64")
 public final class CacheEntryProcessorCodec {
-    //hex: 0x150900
-    public static final int REQUEST_MESSAGE_TYPE = 1378560;
-    //hex: 0x150901
-    public static final int RESPONSE_MESSAGE_TYPE = 1378561;
+    //hex: 0x130900
+    public static final int REQUEST_MESSAGE_TYPE = 1247488;
+    //hex: 0x130901
+    public static final int RESPONSE_MESSAGE_TYPE = 1247489;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
@@ -43,12 +43,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("5f63659e19c81019c8c42ff50a76ec6b")
+@Generated("8fe47d9b7fa144da9cf42aa4c06d2fd9")
 public final class CacheEventJournalReadCodec {
-    //hex: 0x152200
-    public static final int REQUEST_MESSAGE_TYPE = 1384960;
-    //hex: 0x152201
-    public static final int RESPONSE_MESSAGE_TYPE = 1384961;
+    //hex: 0x132200
+    public static final int REQUEST_MESSAGE_TYPE = 1253888;
+    //hex: 0x132201
+    public static final int RESPONSE_MESSAGE_TYPE = 1253889;
     private static final int REQUEST_START_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MIN_SIZE_FIELD_OFFSET = REQUEST_START_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_SIZE_FIELD_OFFSET = REQUEST_MIN_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalSubscribeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalSubscribeCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This includes retrieving the event journal sequences of the
  * oldest and newest event in the journal.
  */
-@Generated("71c591708bf79c4284a597db9b49ff5e")
+@Generated("c083745f0581108698a57e34e9225af5")
 public final class CacheEventJournalSubscribeCodec {
-    //hex: 0x152100
-    public static final int REQUEST_MESSAGE_TYPE = 1384704;
-    //hex: 0x152101
-    public static final int RESPONSE_MESSAGE_TYPE = 1384705;
+    //hex: 0x132100
+    public static final int REQUEST_MESSAGE_TYPE = 1253632;
+    //hex: 0x132101
+    public static final int RESPONSE_MESSAGE_TYPE = 1253633;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_OLDEST_SEQUENCE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_NEWEST_SEQUENCE_FIELD_OFFSET = RESPONSE_OLDEST_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheFetchNearCacheInvalidationMetadataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheFetchNearCacheInvalidationMetadataCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches invalidation metadata from partitions of map.
  */
-@Generated("eb48267f633426a42f547d8421c63a4b")
+@Generated("477013fd0d1bc9d472cc99214cddca44")
 public final class CacheFetchNearCacheInvalidationMetadataCodec {
-    //hex: 0x151F00
-    public static final int REQUEST_MESSAGE_TYPE = 1384192;
-    //hex: 0x151F01
-    public static final int RESPONSE_MESSAGE_TYPE = 1384193;
+    //hex: 0x131F00
+    public static final int REQUEST_MESSAGE_TYPE = 1253120;
+    //hex: 0x131F01
+    public static final int RESPONSE_MESSAGE_TYPE = 1253121;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * configured javax.cache.integration.CacheLoader might be called to retrieve the values of the keys from any kind
  * of external resource.
  */
-@Generated("178e10c63c8c168d6b65eb770a278dcb")
+@Generated("0e3ce696068267c44574ce3bfcb60597")
 public final class CacheGetAllCodec {
-    //hex: 0x150A00
-    public static final int REQUEST_MESSAGE_TYPE = 1378816;
-    //hex: 0x150A01
-    public static final int RESPONSE_MESSAGE_TYPE = 1378817;
+    //hex: 0x130A00
+    public static final int REQUEST_MESSAGE_TYPE = 1247744;
+    //hex: 0x130A01
+    public static final int RESPONSE_MESSAGE_TYPE = 1247745;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndRemoveCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically removes the entry for a key only if currently mapped to some value.
  */
-@Generated("9d20f97de94bac7228779f7da8645a15")
+@Generated("168a9fad8429184f09984713ab5ab2ae")
 public final class CacheGetAndRemoveCodec {
-    //hex: 0x150B00
-    public static final int REQUEST_MESSAGE_TYPE = 1379072;
-    //hex: 0x150B01
-    public static final int RESPONSE_MESSAGE_TYPE = 1379073;
+    //hex: 0x130B00
+    public static final int REQUEST_MESSAGE_TYPE = 1248000;
+    //hex: 0x130B01
+    public static final int RESPONSE_MESSAGE_TYPE = 1248001;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndReplaceCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * write-through operation mode, the underlying configured javax.cache.integration.CacheWriter might be called to
  * store the value of the key to any kind of external resource.
  */
-@Generated("58a3711c095c970cd71ccf482267d97b")
+@Generated("94eae4a621e55194bf52ae9725101791")
 public final class CacheGetAndReplaceCodec {
-    //hex: 0x150C00
-    public static final int REQUEST_MESSAGE_TYPE = 1379328;
-    //hex: 0x150C01
-    public static final int RESPONSE_MESSAGE_TYPE = 1379329;
+    //hex: 0x130C00
+    public static final int REQUEST_MESSAGE_TYPE = 1248256;
+    //hex: 0x130C01
+    public static final int RESPONSE_MESSAGE_TYPE = 1248257;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * null is returned. If the cache is configured for read-through operation mode, the underlying configured
  * javax.cache.integration.CacheLoader might be called to retrieve the value of the key from any kind of external resource.
  */
-@Generated("f3a40ba3b50bac8756bd1a017e91bd86")
+@Generated("e77abded1f23625adbd3c5dd51b5afec")
 public final class CacheGetCodec {
-    //hex: 0x150E00
-    public static final int REQUEST_MESSAGE_TYPE = 1379840;
-    //hex: 0x150E01
-    public static final int RESPONSE_MESSAGE_TYPE = 1379841;
+    //hex: 0x130E00
+    public static final int REQUEST_MESSAGE_TYPE = 1248768;
+    //hex: 0x130E01
+    public static final int RESPONSE_MESSAGE_TYPE = 1248769;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetConfigCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("611580f8b7b6ba67acc4b483899a1189")
+@Generated("af0c952f1b6a5d42ea72f7a974870c6e")
 public final class CacheGetConfigCodec {
-    //hex: 0x150D00
-    public static final int REQUEST_MESSAGE_TYPE = 1379584;
-    //hex: 0x150D01
-    public static final int RESPONSE_MESSAGE_TYPE = 1379585;
+    //hex: 0x130D00
+    public static final int REQUEST_MESSAGE_TYPE = 1248512;
+    //hex: 0x130D01
+    public static final int RESPONSE_MESSAGE_TYPE = 1248513;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * CacheEntryRemoveListeners notified. java.util.Iterator#next() may return null if the entry is no longer present,
  * has expired or has been evicted.
  */
-@Generated("1d49a57e149a5fa63c068a8526dc8b29")
+@Generated("9eb7048c2387adc6e38bb7ea2bf1a1af")
 public final class CacheIterateCodec {
-    //hex: 0x150F00
-    public static final int REQUEST_MESSAGE_TYPE = 1380096;
-    //hex: 0x150F01
-    public static final int RESPONSE_MESSAGE_TYPE = 1380097;
+    //hex: 0x130F00
+    public static final int REQUEST_MESSAGE_TYPE = 1249024;
+    //hex: 0x130F01
+    public static final int RESPONSE_MESSAGE_TYPE = 1249025;
     private static final int REQUEST_TABLE_INDEX_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BATCH_FIELD_OFFSET = REQUEST_TABLE_INDEX_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_BATCH_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateEntriesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateEntriesCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of entries from the specified partition starting from specified table index.
  */
-@Generated("7fe4f4fc4c3331aed3468c91b5dca07f")
+@Generated("858ce7643857f1533662d9b42d93b498")
 public final class CacheIterateEntriesCodec {
-    //hex: 0x151D00
-    public static final int REQUEST_MESSAGE_TYPE = 1383680;
-    //hex: 0x151D01
-    public static final int RESPONSE_MESSAGE_TYPE = 1383681;
+    //hex: 0x131D00
+    public static final int REQUEST_MESSAGE_TYPE = 1252608;
+    //hex: 0x131D01
+    public static final int RESPONSE_MESSAGE_TYPE = 1252609;
     private static final int REQUEST_TABLE_INDEX_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BATCH_FIELD_OFFSET = REQUEST_TABLE_INDEX_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_BATCH_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheListenerRegistrationCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheListenerRegistrationCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("39140de13b3321521a49b952f6ab0053")
+@Generated("24e996e182abf95ab15200a92ff75b10")
 public final class CacheListenerRegistrationCodec {
-    //hex: 0x151000
-    public static final int REQUEST_MESSAGE_TYPE = 1380352;
-    //hex: 0x151001
-    public static final int RESPONSE_MESSAGE_TYPE = 1380353;
+    //hex: 0x131000
+    public static final int REQUEST_MESSAGE_TYPE = 1249280;
+    //hex: 0x131001
+    public static final int RESPONSE_MESSAGE_TYPE = 1249281;
     private static final int REQUEST_SHOULD_REGISTER_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SHOULD_REGISTER_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheLoadAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheLoadAllCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("6626604b5e111f3c0be04ba04b85bd16")
+@Generated("8296812a52381e0b2cb8f89006d938c5")
 public final class CacheLoadAllCodec {
-    //hex: 0x151100
-    public static final int REQUEST_MESSAGE_TYPE = 1380608;
-    //hex: 0x151101
-    public static final int RESPONSE_MESSAGE_TYPE = 1380609;
+    //hex: 0x131100
+    public static final int REQUEST_MESSAGE_TYPE = 1249536;
+    //hex: 0x131101
+    public static final int RESPONSE_MESSAGE_TYPE = 1249537;
     private static final int REQUEST_REPLACE_EXISTING_VALUES_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REPLACE_EXISTING_VALUES_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheManagementConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheManagementConfigCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("62c6d217d83d7bd2fe26a4f4b272b5c2")
+@Generated("f03334363ced4c6f7057501c78196e19")
 public final class CacheManagementConfigCodec {
-    //hex: 0x151200
-    public static final int REQUEST_MESSAGE_TYPE = 1380864;
-    //hex: 0x151201
-    public static final int RESPONSE_MESSAGE_TYPE = 1380865;
+    //hex: 0x131200
+    public static final int REQUEST_MESSAGE_TYPE = 1249792;
+    //hex: 0x131201
+    public static final int RESPONSE_MESSAGE_TYPE = 1249793;
     private static final int REQUEST_IS_STAT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ENABLED_FIELD_OFFSET = REQUEST_IS_STAT_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutAllCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("3a305ff0d74d8fcfbc9e6e84774594d1")
+@Generated("30528c6990913e992c7c54d4ef12fedc")
 public final class CachePutAllCodec {
-    //hex: 0x151C00
-    public static final int REQUEST_MESSAGE_TYPE = 1383424;
-    //hex: 0x151C01
-    public static final int RESPONSE_MESSAGE_TYPE = 1383425;
+    //hex: 0x131C00
+    public static final int REQUEST_MESSAGE_TYPE = 1252352;
+    //hex: 0x131C01
+    public static final int RESPONSE_MESSAGE_TYPE = 1252353;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("6923b92e67e7ddfb454e6492c879134c")
+@Generated("9f8ec75cca9f009f21eee4b406cd7fa5")
 public final class CachePutCodec {
-    //hex: 0x151400
-    public static final int REQUEST_MESSAGE_TYPE = 1381376;
-    //hex: 0x151401
-    public static final int RESPONSE_MESSAGE_TYPE = 1381377;
+    //hex: 0x131400
+    public static final int REQUEST_MESSAGE_TYPE = 1250304;
+    //hex: 0x131401
+    public static final int RESPONSE_MESSAGE_TYPE = 1250305;
     private static final int REQUEST_GET_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = REQUEST_GET_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutIfAbsentCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * specified key. If the cache is configured for write-through operation mode, the underlying configured
  * javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
  */
-@Generated("8eef474a5c63b85932b46a566db9bcf0")
+@Generated("c8f9bb939efc92a84c51e1b2307aae1a")
 public final class CachePutIfAbsentCodec {
-    //hex: 0x151300
-    public static final int REQUEST_MESSAGE_TYPE = 1381120;
-    //hex: 0x151301
-    public static final int RESPONSE_MESSAGE_TYPE = 1381121;
+    //hex: 0x131300
+    public static final int REQUEST_MESSAGE_TYPE = 1250048;
+    //hex: 0x131301
+    public static final int RESPONSE_MESSAGE_TYPE = 1250049;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveAllCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * a write-through cache, the CacheWriter.If the cache is empty, the CacheWriter is not called.
  * This is potentially an expensive operation as listeners are invoked. Use  #clear() to avoid this.
  */
-@Generated("fdf898c2838cdb19502c6dec82100f97")
+@Generated("00bd090c8e1951f1612c2310ad2abf35")
 public final class CacheRemoveAllCodec {
-    //hex: 0x150500
-    public static final int REQUEST_MESSAGE_TYPE = 1377536;
-    //hex: 0x150501
-    public static final int RESPONSE_MESSAGE_TYPE = 1377537;
+    //hex: 0x130500
+    public static final int REQUEST_MESSAGE_TYPE = 1246464;
+    //hex: 0x130501
+    public static final int RESPONSE_MESSAGE_TYPE = 1246465;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveAllKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveAllKeysCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * For every entry in the key set, the following are called: any registered CacheEntryRemovedListeners if the cache
  * is a write-through cache, the CacheWriter. If the key set is empty, the CacheWriter is not called.
  */
-@Generated("41ca5e443b658b500ece01ea955f6e59")
+@Generated("9e2c0f7b6d52f7167add4eaabd250c90")
 public final class CacheRemoveAllKeysCodec {
-    //hex: 0x150400
-    public static final int REQUEST_MESSAGE_TYPE = 1377280;
-    //hex: 0x150401
-    public static final int RESPONSE_MESSAGE_TYPE = 1377281;
+    //hex: 0x130400
+    public static final int REQUEST_MESSAGE_TYPE = 1246208;
+    //hex: 0x130401
+    public static final int RESPONSE_MESSAGE_TYPE = 1246209;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically removes the mapping for a key only if currently mapped to the given value.
  */
-@Generated("20f63a3a76b47f44cc3add7467442491")
+@Generated("bce5094b746e814f159011939283b134")
 public final class CacheRemoveCodec {
-    //hex: 0x151700
-    public static final int REQUEST_MESSAGE_TYPE = 1382144;
-    //hex: 0x151701
-    public static final int RESPONSE_MESSAGE_TYPE = 1382145;
+    //hex: 0x131700
+    public static final int REQUEST_MESSAGE_TYPE = 1251072;
+    //hex: 0x131701
+    public static final int RESPONSE_MESSAGE_TYPE = 1251073;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveEntryListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("7e404bafc64c138036d8f9f9fd70102a")
+@Generated("f9ba8a13b0e393529e406925d6ec415a")
 public final class CacheRemoveEntryListenerCodec {
-    //hex: 0x151500
-    public static final int REQUEST_MESSAGE_TYPE = 1381632;
-    //hex: 0x151501
-    public static final int RESPONSE_MESSAGE_TYPE = 1381633;
+    //hex: 0x131500
+    public static final int REQUEST_MESSAGE_TYPE = 1250560;
+    //hex: 0x131501
+    public static final int RESPONSE_MESSAGE_TYPE = 1250561;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveInvalidationListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("8cc433ea3ca17ae7e4f21f9a704f78bc")
+@Generated("a5a4dd6e3e8b400b986d91a6934147ba")
 public final class CacheRemoveInvalidationListenerCodec {
-    //hex: 0x151600
-    public static final int REQUEST_MESSAGE_TYPE = 1381888;
-    //hex: 0x151601
-    public static final int RESPONSE_MESSAGE_TYPE = 1381889;
+    //hex: 0x131600
+    public static final int REQUEST_MESSAGE_TYPE = 1250816;
+    //hex: 0x131601
+    public static final int RESPONSE_MESSAGE_TYPE = 1250817;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemovePartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemovePartitionLostListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the specified cache partition lost listener. Returns silently if there is no such listener added before
  */
-@Generated("d314c86573fafe7ba74f942c291cb79b")
+@Generated("8488da6ffed4d30c61eb93d9f0a8d127")
 public final class CacheRemovePartitionLostListenerCodec {
-    //hex: 0x151B00
-    public static final int REQUEST_MESSAGE_TYPE = 1383168;
-    //hex: 0x151B01
-    public static final int RESPONSE_MESSAGE_TYPE = 1383169;
+    //hex: 0x131B00
+    public static final int REQUEST_MESSAGE_TYPE = 1252096;
+    //hex: 0x131B01
+    public static final int RESPONSE_MESSAGE_TYPE = 1252097;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheReplaceCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the cache is configured for write-through operation mode, the underlying configured
  * javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
  */
-@Generated("72073abed5b3806582219da082cd2bce")
+@Generated("9deb1f39c7db55bd78fd510a9913fced")
 public final class CacheReplaceCodec {
-    //hex: 0x151800
-    public static final int REQUEST_MESSAGE_TYPE = 1382400;
-    //hex: 0x151801
-    public static final int RESPONSE_MESSAGE_TYPE = 1382401;
+    //hex: 0x131800
+    public static final int REQUEST_MESSAGE_TYPE = 1251328;
+    //hex: 0x131801
+    public static final int RESPONSE_MESSAGE_TYPE = 1251329;
     private static final int REQUEST_COMPLETION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COMPLETION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSetExpiryPolicyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSetExpiryPolicyCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
  * If some keys in {@code keys} do not exist or are already expired, this call has no effect for those.
  */
-@Generated("4ec75ca5b013d69c3e1f2f691951ee8f")
+@Generated("c30d556f8a8a01732d0cb9c846aa5bea")
 public final class CacheSetExpiryPolicyCodec {
-    //hex: 0x152300
-    public static final int REQUEST_MESSAGE_TYPE = 1385216;
-    //hex: 0x152301
-    public static final int RESPONSE_MESSAGE_TYPE = 1385217;
+    //hex: 0x132300
+    public static final int REQUEST_MESSAGE_TYPE = 1254144;
+    //hex: 0x132301
+    public static final int RESPONSE_MESSAGE_TYPE = 1254145;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSizeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Total entry count
  */
-@Generated("b0e8673de170e90fad0ba2b36da61120")
+@Generated("cb953a529b4d1feabccb45709491255e")
 public final class CacheSizeCodec {
-    //hex: 0x151900
-    public static final int REQUEST_MESSAGE_TYPE = 1382656;
-    //hex: 0x151901
-    public static final int RESPONSE_MESSAGE_TYPE = 1382657;
+    //hex: 0x131900
+    public static final int REQUEST_MESSAGE_TYPE = 1251584;
+    //hex: 0x131901
+    public static final int RESPONSE_MESSAGE_TYPE = 1251585;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CardinalityEstimatorAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CardinalityEstimatorAddCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Add a new hash in the estimation set. This is the method you want to
  * use to feed hash values into the estimator.
  */
-@Generated("fd9183ccef36787d57b08343fba96963")
+@Generated("31a4e56b1462936490c726a5f8a65888")
 public final class CardinalityEstimatorAddCodec {
-    //hex: 0x1C0100
-    public static final int REQUEST_MESSAGE_TYPE = 1835264;
-    //hex: 0x1C0101
-    public static final int RESPONSE_MESSAGE_TYPE = 1835265;
+    //hex: 0x190100
+    public static final int REQUEST_MESSAGE_TYPE = 1638656;
+    //hex: 0x190101
+    public static final int RESPONSE_MESSAGE_TYPE = 1638657;
     private static final int REQUEST_HASH_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_HASH_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CardinalityEstimatorEstimateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CardinalityEstimatorEstimateCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Estimates the cardinality of the aggregation so far.
  * If it was previously estimated and never invalidated, then the cached version is used.
  */
-@Generated("62b0c33b3b216ae4d5ec37987ffe1833")
+@Generated("9eaf043b7d63b5e0b44bf9bfd8304f04")
 public final class CardinalityEstimatorEstimateCodec {
-    //hex: 0x1C0200
-    public static final int REQUEST_MESSAGE_TYPE = 1835520;
-    //hex: 0x1C0201
-    public static final int RESPONSE_MESSAGE_TYPE = 1835521;
+    //hex: 0x190200
+    public static final int REQUEST_MESSAGE_TYPE = 1638912;
+    //hex: 0x190201
+    public static final int RESPONSE_MESSAGE_TYPE = 1638913;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddDistributedObjectListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddDistributedObjectListenerCodec.java
@@ -37,19 +37,19 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("b0beb098db6cd9fe5323dfa8c2b2b83c")
+@Generated("bdf682d9f24932f49064771e4421b0a7")
 public final class ClientAddDistributedObjectListenerCodec {
-    //hex: 0x000D00
-    public static final int REQUEST_MESSAGE_TYPE = 3328;
-    //hex: 0x000D01
-    public static final int RESPONSE_MESSAGE_TYPE = 3329;
+    //hex: 0x000B00
+    public static final int REQUEST_MESSAGE_TYPE = 2816;
+    //hex: 0x000B01
+    public static final int RESPONSE_MESSAGE_TYPE = 2817;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_DISTRIBUTED_OBJECT_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x000D02
-    private static final int EVENT_DISTRIBUTED_OBJECT_MESSAGE_TYPE = 3330;
+    //hex: 0x000B02
+    private static final int EVENT_DISTRIBUTED_OBJECT_MESSAGE_TYPE = 2818;
 
     private ClientAddDistributedObjectListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddMembershipListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddMembershipListenerCodec.java
@@ -37,27 +37,27 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("04c48da899108f6aa8add902c6e22823")
+@Generated("3bfd1411203a2d903bafa9ed3cc6886a")
 public final class ClientAddMembershipListenerCodec {
-    //hex: 0x000400
-    public static final int REQUEST_MESSAGE_TYPE = 1024;
-    //hex: 0x000401
-    public static final int RESPONSE_MESSAGE_TYPE = 1025;
+    //hex: 0x000300
+    public static final int REQUEST_MESSAGE_TYPE = 768;
+    //hex: 0x000301
+    public static final int RESPONSE_MESSAGE_TYPE = 769;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_MEMBER_EVENT_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_MEMBER_INITIAL_FRAME_SIZE = EVENT_MEMBER_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x000402
-    private static final int EVENT_MEMBER_MESSAGE_TYPE = 1026;
+    //hex: 0x000302
+    private static final int EVENT_MEMBER_MESSAGE_TYPE = 770;
     private static final int EVENT_MEMBER_LIST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x000403
-    private static final int EVENT_MEMBER_LIST_MESSAGE_TYPE = 1027;
+    //hex: 0x000303
+    private static final int EVENT_MEMBER_LIST_MESSAGE_TYPE = 771;
     private static final int EVENT_MEMBER_ATTRIBUTE_CHANGE_OPERATION_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_MEMBER_ATTRIBUTE_CHANGE_INITIAL_FRAME_SIZE = EVENT_MEMBER_ATTRIBUTE_CHANGE_OPERATION_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x000404
-    private static final int EVENT_MEMBER_ATTRIBUTE_CHANGE_MESSAGE_TYPE = 1028;
+    //hex: 0x000304
+    private static final int EVENT_MEMBER_ATTRIBUTE_CHANGE_MESSAGE_TYPE = 772;
 
     private ClientAddMembershipListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddPartitionListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddPartitionListenerCodec.java
@@ -37,18 +37,18 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("08199e0b80eb993bedd1c30ccf27d96e")
+@Generated("ddfa92f26796424c93b577943f351729")
 public final class ClientAddPartitionListenerCodec {
-    //hex: 0x001200
-    public static final int REQUEST_MESSAGE_TYPE = 4608;
-    //hex: 0x001201
-    public static final int RESPONSE_MESSAGE_TYPE = 4609;
+    //hex: 0x001000
+    public static final int REQUEST_MESSAGE_TYPE = 4096;
+    //hex: 0x001001
+    public static final int RESPONSE_MESSAGE_TYPE = 4097;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_PARTITIONS_PARTITION_STATE_VERSION_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_PARTITIONS_INITIAL_FRAME_SIZE = EVENT_PARTITIONS_PARTITION_STATE_VERSION_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x001202
-    private static final int EVENT_PARTITIONS_MESSAGE_TYPE = 4610;
+    //hex: 0x001002
+    private static final int EVENT_PARTITIONS_MESSAGE_TYPE = 4098;
 
     private ClientAddPartitionListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddPartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddPartitionLostListenerCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("8211192f2563b1c3bb225d2a9c1667eb")
+@Generated("7092b5c8df27de9bdcd8993a2b47ecda")
 public final class ClientAddPartitionLostListenerCodec {
-    //hex: 0x000A00
-    public static final int REQUEST_MESSAGE_TYPE = 2560;
-    //hex: 0x000A01
-    public static final int RESPONSE_MESSAGE_TYPE = 2561;
+    //hex: 0x000800
+    public static final int REQUEST_MESSAGE_TYPE = 2048;
+    //hex: 0x000801
+    public static final int RESPONSE_MESSAGE_TYPE = 2049;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -50,8 +50,8 @@ public final class ClientAddPartitionLostListenerCodec {
     private static final int EVENT_PARTITION_LOST_PARTITION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_PARTITION_LOST_LOST_BACKUP_COUNT_FIELD_OFFSET = EVENT_PARTITION_LOST_PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_PARTITION_LOST_INITIAL_FRAME_SIZE = EVENT_PARTITION_LOST_LOST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x000A02
-    private static final int EVENT_PARTITION_LOST_MESSAGE_TYPE = 2562;
+    //hex: 0x000802
+    private static final int EVENT_PARTITION_LOST_MESSAGE_TYPE = 2050;
 
     private ClientAddPartitionLostListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("15fa7bbbc1c0257e01b97438dcf15ba7")
+@Generated("d1b722e59a280bcb04d603c09a0585ba")
 public final class ClientAuthenticationCodec {
-    //hex: 0x000200
-    public static final int REQUEST_MESSAGE_TYPE = 512;
-    //hex: 0x000201
-    public static final int RESPONSE_MESSAGE_TYPE = 513;
+    //hex: 0x000100
+    public static final int REQUEST_MESSAGE_TYPE = 256;
+    //hex: 0x000101
+    public static final int RESPONSE_MESSAGE_TYPE = 257;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_PARTITION_COUNT_FIELD_OFFSET = REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
@@ -61,7 +61,7 @@ public final class ClientAuthenticationCodec {
     public static class RequestParameters {
 
         /**
-         * Cluster name that will client connect to.
+         * Cluster name that client will connect to.
          */
         public java.lang.String clusterName;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("8b039de7195bcd0e4871ba040d3626d5")
+@Generated("a746ebedcf4e508045b27b5ab354e556")
 public final class ClientAuthenticationCustomCodec {
-    //hex: 0x000300
-    public static final int REQUEST_MESSAGE_TYPE = 768;
-    //hex: 0x000301
-    public static final int RESPONSE_MESSAGE_TYPE = 769;
+    //hex: 0x000200
+    public static final int REQUEST_MESSAGE_TYPE = 512;
+    //hex: 0x000201
+    public static final int RESPONSE_MESSAGE_TYPE = 513;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_PARTITION_COUNT_FIELD_OFFSET = REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
@@ -61,7 +61,7 @@ public final class ClientAuthenticationCustomCodec {
     public static class RequestParameters {
 
         /**
-         * Cluster name that will client connect to.
+         * Cluster name that client will connect to.
          */
         public java.lang.String clusterName;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientCreateProxiesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientCreateProxiesCodec.java
@@ -40,12 +40,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Exceptions related to a proxy creation failure is not send to the client.
  * A proxy creation failure does not cancel this operation, all proxies will be attempted to be created.
  */
-@Generated("bb890f5226222178e9af4b88cc21c0e6")
+@Generated("18c92420c7b9a3b32001827af09c5b6d")
 public final class ClientCreateProxiesCodec {
-    //hex: 0x001300
-    public static final int REQUEST_MESSAGE_TYPE = 4864;
-    //hex: 0x001301
-    public static final int RESPONSE_MESSAGE_TYPE = 4865;
+    //hex: 0x001100
+    public static final int REQUEST_MESSAGE_TYPE = 4352;
+    //hex: 0x001101
+    public static final int RESPONSE_MESSAGE_TYPE = 4353;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientCreateProxyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientCreateProxyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("63d85e4b5343d80573e886a7418c4ce8")
+@Generated("21e81359c7f9c21e050ec3386fa2dee1")
 public final class ClientCreateProxyCodec {
-    //hex: 0x000500
-    public static final int REQUEST_MESSAGE_TYPE = 1280;
-    //hex: 0x000501
-    public static final int RESPONSE_MESSAGE_TYPE = 1281;
+    //hex: 0x000400
+    public static final int REQUEST_MESSAGE_TYPE = 1024;
+    //hex: 0x000401
+    public static final int RESPONSE_MESSAGE_TYPE = 1025;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientDeployClassesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientDeployClassesCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Each item is a Map.Entry<String, byte[]> in the list.
  * key of entry is full class name, and byte[] is the class definition.
  */
-@Generated("768a6a0f842c2ff4e8f3826725f122ba")
+@Generated("e531e1548f92f856c665ff373cff57e4")
 public final class ClientDeployClassesCodec {
-    //hex: 0x001100
-    public static final int REQUEST_MESSAGE_TYPE = 4352;
-    //hex: 0x001101
-    public static final int RESPONSE_MESSAGE_TYPE = 4353;
+    //hex: 0x000F00
+    public static final int REQUEST_MESSAGE_TYPE = 3840;
+    //hex: 0x000F01
+    public static final int RESPONSE_MESSAGE_TYPE = 3841;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientDestroyProxyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientDestroyProxyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("10bb57932ce0ce117ebfdb9f034d8998")
+@Generated("989c7f1cc8230f3b2ed869898ccef4a6")
 public final class ClientDestroyProxyCodec {
-    //hex: 0x000600
-    public static final int REQUEST_MESSAGE_TYPE = 1536;
-    //hex: 0x000601
-    public static final int RESPONSE_MESSAGE_TYPE = 1537;
+    //hex: 0x000500
+    public static final int REQUEST_MESSAGE_TYPE = 1280;
+    //hex: 0x000501
+    public static final int RESPONSE_MESSAGE_TYPE = 1281;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientGetDistributedObjectsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientGetDistributedObjectsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("64cb33af745e07d6a1decd765a54c551")
+@Generated("330dcace5742f0d9ede4a69c05f99bad")
 public final class ClientGetDistributedObjectsCodec {
-    //hex: 0x000C00
-    public static final int REQUEST_MESSAGE_TYPE = 3072;
-    //hex: 0x000C01
-    public static final int RESPONSE_MESSAGE_TYPE = 3073;
+    //hex: 0x000A00
+    public static final int REQUEST_MESSAGE_TYPE = 2560;
+    //hex: 0x000A01
+    public static final int RESPONSE_MESSAGE_TYPE = 2561;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientGetPartitionsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientGetPartitionsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("d0b8d921628a0cbdf8a08338f737f77b")
+@Generated("da5cf2d17502b84ad90e856abe94204f")
 public final class ClientGetPartitionsCodec {
-    //hex: 0x000800
-    public static final int REQUEST_MESSAGE_TYPE = 2048;
-    //hex: 0x000801
-    public static final int RESPONSE_MESSAGE_TYPE = 2049;
+    //hex: 0x000600
+    public static final int REQUEST_MESSAGE_TYPE = 1536;
+    //hex: 0x000601
+    public static final int RESPONSE_MESSAGE_TYPE = 1537;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_PARTITION_STATE_VERSION_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_PARTITION_STATE_VERSION_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientIsFailoverSupportedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientIsFailoverSupportedCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("52c11d99bb74f8ddc51961280d3adc3f")
+@Generated("805b76608bc1e243b96d649cdcf19614")
 public final class ClientIsFailoverSupportedCodec {
-    //hex: 0x001400
-    public static final int REQUEST_MESSAGE_TYPE = 5120;
-    //hex: 0x001401
-    public static final int RESPONSE_MESSAGE_TYPE = 5121;
+    //hex: 0x001200
+    public static final int REQUEST_MESSAGE_TYPE = 4608;
+    //hex: 0x001201
+    public static final int RESPONSE_MESSAGE_TYPE = 4609;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientLocalBackupListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientLocalBackupListenerCodec.java
@@ -37,19 +37,19 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds listener for backup acks
  */
-@Generated("55fddca1fa2e6c917b798ed39fc1bf87")
+@Generated("dddfdad59201bb7a0b04f313d2d98a16")
 public final class ClientLocalBackupListenerCodec {
-    //hex: 0x001500
-    public static final int REQUEST_MESSAGE_TYPE = 5376;
-    //hex: 0x001501
-    public static final int RESPONSE_MESSAGE_TYPE = 5377;
+    //hex: 0x001300
+    public static final int REQUEST_MESSAGE_TYPE = 4864;
+    //hex: 0x001301
+    public static final int RESPONSE_MESSAGE_TYPE = 4865;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_BACKUP_SOURCE_INVOCATION_CORRELATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_BACKUP_INITIAL_FRAME_SIZE = EVENT_BACKUP_SOURCE_INVOCATION_CORRELATION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
-    //hex: 0x001502
-    private static final int EVENT_BACKUP_MESSAGE_TYPE = 5378;
+    //hex: 0x001302
+    private static final int EVENT_BACKUP_MESSAGE_TYPE = 4866;
 
     private ClientLocalBackupListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientPingCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientPingCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("7b6a5d3236cd4dab1b64f39be1acd645")
+@Generated("a3bfeddba05cdc3533f9903a15d615ad")
 public final class ClientPingCodec {
-    //hex: 0x000F00
-    public static final int REQUEST_MESSAGE_TYPE = 3840;
-    //hex: 0x000F01
-    public static final int RESPONSE_MESSAGE_TYPE = 3841;
+    //hex: 0x000D00
+    public static final int REQUEST_MESSAGE_TYPE = 3328;
+    //hex: 0x000D01
+    public static final int RESPONSE_MESSAGE_TYPE = 3329;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemoveAllListenersCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemoveAllListenersCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("155064ce6772ecbbff667dcbd8c22f31")
+@Generated("b469765dee7bc92b0e0f048378777d42")
 public final class ClientRemoveAllListenersCodec {
-    //hex: 0x000900
-    public static final int REQUEST_MESSAGE_TYPE = 2304;
-    //hex: 0x000901
-    public static final int RESPONSE_MESSAGE_TYPE = 2305;
+    //hex: 0x000700
+    public static final int REQUEST_MESSAGE_TYPE = 1792;
+    //hex: 0x000701
+    public static final int RESPONSE_MESSAGE_TYPE = 1793;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemoveDistributedObjectListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemoveDistributedObjectListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("eb38541d7054120db6e7eab5cfde6814")
+@Generated("fe3a85afc631ab729dc355dd486398d2")
 public final class ClientRemoveDistributedObjectListenerCodec {
-    //hex: 0x000E00
-    public static final int REQUEST_MESSAGE_TYPE = 3584;
-    //hex: 0x000E01
-    public static final int RESPONSE_MESSAGE_TYPE = 3585;
+    //hex: 0x000C00
+    public static final int REQUEST_MESSAGE_TYPE = 3072;
+    //hex: 0x000C01
+    public static final int RESPONSE_MESSAGE_TYPE = 3073;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemovePartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemovePartitionLostListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("8def7186f67ff024a32830398d591d31")
+@Generated("6531b96830ce39c89dbb9c477eb96be3")
 public final class ClientRemovePartitionLostListenerCodec {
-    //hex: 0x000B00
-    public static final int REQUEST_MESSAGE_TYPE = 2816;
-    //hex: 0x000B01
-    public static final int RESPONSE_MESSAGE_TYPE = 2817;
+    //hex: 0x000900
+    public static final int REQUEST_MESSAGE_TYPE = 2304;
+    //hex: 0x000901
+    public static final int RESPONSE_MESSAGE_TYPE = 2305;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientStatisticsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientStatisticsCodec.java
@@ -184,12 +184,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * nc.hz/StatICacheName.lastPersistenceWrittenBytes=0,nc.hz/StatICacheName.misses=1,nc.hz/StatICacheName.ownedEntryCount=1,
  * nc.hz/StatICacheName.expirations=0,nc.hz/StatICacheName.ownedEntryMemoryCost=140
  */
-@Generated("5c86996712a7721bc0ffe9e63749b287")
+@Generated("1968cd0517bd12ee7b31c0e6a66e1a7b")
 public final class ClientStatisticsCodec {
-    //hex: 0x001000
-    public static final int REQUEST_MESSAGE_TYPE = 4096;
-    //hex: 0x001001
-    public static final int RESPONSE_MESSAGE_TYPE = 4097;
+    //hex: 0x000E00
+    public static final int REQUEST_MESSAGE_TYPE = 3584;
+    //hex: 0x000E01
+    public static final int RESPONSE_MESSAGE_TYPE = 3585;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryAddListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryAddListenerCodec.java
@@ -37,23 +37,23 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("5b8e1f59b3230fbace8f6b8fe8c82544")
+@Generated("89efd940fe8c1f4ca7a8f25b23ebe555")
 public final class ContinuousQueryAddListenerCodec {
-    //hex: 0x180400
-    public static final int REQUEST_MESSAGE_TYPE = 1573888;
-    //hex: 0x180401
-    public static final int RESPONSE_MESSAGE_TYPE = 1573889;
+    //hex: 0x160400
+    public static final int REQUEST_MESSAGE_TYPE = 1442816;
+    //hex: 0x160401
+    public static final int RESPONSE_MESSAGE_TYPE = 1442817;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_QUERY_CACHE_SINGLE_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x180402
-    private static final int EVENT_QUERY_CACHE_SINGLE_MESSAGE_TYPE = 1573890;
+    //hex: 0x160402
+    private static final int EVENT_QUERY_CACHE_SINGLE_MESSAGE_TYPE = 1442818;
     private static final int EVENT_QUERY_CACHE_BATCH_PARTITION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_QUERY_CACHE_BATCH_INITIAL_FRAME_SIZE = EVENT_QUERY_CACHE_BATCH_PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x180403
-    private static final int EVENT_QUERY_CACHE_BATCH_MESSAGE_TYPE = 1573891;
+    //hex: 0x160403
+    private static final int EVENT_QUERY_CACHE_BATCH_MESSAGE_TYPE = 1442819;
 
     private ContinuousQueryAddListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryDestroyCacheCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryDestroyCacheCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("be4e475ee27a3a36403a5db10c81bf54")
+@Generated("dc4978c539a848122854d456ca498e39")
 public final class ContinuousQueryDestroyCacheCodec {
-    //hex: 0x180600
-    public static final int REQUEST_MESSAGE_TYPE = 1574400;
-    //hex: 0x180601
-    public static final int RESPONSE_MESSAGE_TYPE = 1574401;
+    //hex: 0x160600
+    public static final int REQUEST_MESSAGE_TYPE = 1443328;
+    //hex: 0x160601
+    public static final int RESPONSE_MESSAGE_TYPE = 1443329;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryMadePublishableCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryMadePublishableCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("b88e27a300eb6dc0c0916d550dce851b")
+@Generated("625e6e2953e0fa866c53fb731c60f7f1")
 public final class ContinuousQueryMadePublishableCodec {
-    //hex: 0x180300
-    public static final int REQUEST_MESSAGE_TYPE = 1573632;
-    //hex: 0x180301
-    public static final int RESPONSE_MESSAGE_TYPE = 1573633;
+    //hex: 0x160300
+    public static final int REQUEST_MESSAGE_TYPE = 1442560;
+    //hex: 0x160301
+    public static final int RESPONSE_MESSAGE_TYPE = 1442561;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("fbbe07c5207514b97bf80199d420802b")
+@Generated("acf1b8bd0bacb1bc6455cd5d10ee6da1")
 public final class ContinuousQueryPublisherCreateCodec {
-    //hex: 0x180200
-    public static final int REQUEST_MESSAGE_TYPE = 1573376;
-    //hex: 0x180201
-    public static final int RESPONSE_MESSAGE_TYPE = 1573377;
+    //hex: 0x160200
+    public static final int REQUEST_MESSAGE_TYPE = 1442304;
+    //hex: 0x160201
+    public static final int RESPONSE_MESSAGE_TYPE = 1442305;
     private static final int REQUEST_BATCH_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BUFFER_SIZE_FIELD_OFFSET = REQUEST_BATCH_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_DELAY_SECONDS_FIELD_OFFSET = REQUEST_BUFFER_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("c72f25e58fc2e644f60edd085679926c")
+@Generated("c081e905ccd0c1f72a5f69f697ed0a1c")
 public final class ContinuousQueryPublisherCreateWithValueCodec {
-    //hex: 0x180100
-    public static final int REQUEST_MESSAGE_TYPE = 1573120;
-    //hex: 0x180101
-    public static final int RESPONSE_MESSAGE_TYPE = 1573121;
+    //hex: 0x160100
+    public static final int REQUEST_MESSAGE_TYPE = 1442048;
+    //hex: 0x160101
+    public static final int RESPONSE_MESSAGE_TYPE = 1442049;
     private static final int REQUEST_BATCH_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BUFFER_SIZE_FIELD_OFFSET = REQUEST_BATCH_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_DELAY_SECONDS_FIELD_OFFSET = REQUEST_BUFFER_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQuerySetReadCursorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQuerySetReadCursorCodec.java
@@ -41,12 +41,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns `false` if the event is not in the buffer of event publisher side. That means recovery is not
  * possible.
  */
-@Generated("9b5480d9718f431c81c6685653844f14")
+@Generated("a3d28e57ba2eb7dfc1108556da1ea0c5")
 public final class ContinuousQuerySetReadCursorCodec {
-    //hex: 0x180500
-    public static final int REQUEST_MESSAGE_TYPE = 1574144;
-    //hex: 0x180501
-    public static final int RESPONSE_MESSAGE_TYPE = 1574145;
+    //hex: 0x160500
+    public static final int REQUEST_MESSAGE_TYPE = 1443072;
+    //hex: 0x160501
+    public static final int RESPONSE_MESSAGE_TYPE = 1443073;
     private static final int REQUEST_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchAwaitCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchAwaitCodec.java
@@ -51,12 +51,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * waiting time elapses then the value false is returned.  If the time is
  * less than or equal to zero, the method will not wait at all.
  */
-@Generated("67847f9fd05e9bd66e90c987d3dfec4a")
+@Generated("9a39ed94c73a344c2faf7d92d626c878")
 public final class CountDownLatchAwaitCodec {
-    //hex: 0x0C0200
-    public static final int REQUEST_MESSAGE_TYPE = 786944;
-    //hex: 0x0C0201
-    public static final int RESPONSE_MESSAGE_TYPE = 786945;
+    //hex: 0x0B0200
+    public static final int REQUEST_MESSAGE_TYPE = 721408;
+    //hex: 0x0B0201
+    public static final int RESPONSE_MESSAGE_TYPE = 721409;
     private static final int REQUEST_INVOCATION_UID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_MS_FIELD_OFFSET = REQUEST_INVOCATION_UID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TIMEOUT_MS_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchCountDownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchCountDownCodec.java
@@ -40,12 +40,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * re-enabled for thread scheduling purposes, and Countdown owner is set to
  * null. If the current count equals zero, then nothing happens.
  */
-@Generated("fc46d6b0c5bb4f7ba26781598bfdced6")
+@Generated("0a95f7b9d6ff71e7ac20a742914c8ce5")
 public final class CountDownLatchCountDownCodec {
-    //hex: 0x0C0300
-    public static final int REQUEST_MESSAGE_TYPE = 787200;
-    //hex: 0x0C0301
-    public static final int RESPONSE_MESSAGE_TYPE = 787201;
+    //hex: 0x0B0300
+    public static final int REQUEST_MESSAGE_TYPE = 721664;
+    //hex: 0x0B0301
+    public static final int RESPONSE_MESSAGE_TYPE = 721665;
     private static final int REQUEST_INVOCATION_UID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_EXPECTED_ROUND_FIELD_OFFSET = REQUEST_INVOCATION_UID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_EXPECTED_ROUND_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetCountCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the current count.
  */
-@Generated("d85c405eb098af9d2377d782123d1935")
+@Generated("d9af84f8b8ec9362a6a0f7413a2e0dfa")
 public final class CountDownLatchGetCountCodec {
-    //hex: 0x0C0400
-    public static final int REQUEST_MESSAGE_TYPE = 787456;
-    //hex: 0x0C0401
-    public static final int RESPONSE_MESSAGE_TYPE = 787457;
+    //hex: 0x0B0400
+    public static final int REQUEST_MESSAGE_TYPE = 721920;
+    //hex: 0x0B0401
+    public static final int RESPONSE_MESSAGE_TYPE = 721921;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetRoundCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetRoundCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the current round. A round completes when the count value
  * reaches to 0 and a new round starts afterwards.
  */
-@Generated("613df1d0787f17100d327e8cd1c9f3cd")
+@Generated("2d2248511b76d5a7041fe18f254ba093")
 public final class CountDownLatchGetRoundCodec {
-    //hex: 0x0C0500
-    public static final int REQUEST_MESSAGE_TYPE = 787712;
-    //hex: 0x0C0501
-    public static final int RESPONSE_MESSAGE_TYPE = 787713;
+    //hex: 0x0B0500
+    public static final int REQUEST_MESSAGE_TYPE = 722176;
+    //hex: 0x0B0501
+    public static final int RESPONSE_MESSAGE_TYPE = 722177;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchTrySetCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchTrySetCountCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the count is not zero, then this method does nothing
  * and returns false
  */
-@Generated("27e0f0ebc2a42caaea164695cf64e1a0")
+@Generated("3dd362687baa33d8c2962ae2bb4d28ae")
 public final class CountDownLatchTrySetCountCodec {
-    //hex: 0x0C0100
-    public static final int REQUEST_MESSAGE_TYPE = 786688;
-    //hex: 0x0C0101
-    public static final int RESPONSE_MESSAGE_TYPE = 786689;
+    //hex: 0x0B0100
+    public static final int REQUEST_MESSAGE_TYPE = 721152;
+    //hex: 0x0B0101
+    public static final int RESPONSE_MESSAGE_TYPE = 721153;
     private static final int REQUEST_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorDisposeResultCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorDisposeResultCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Disposes the result of the execution with the given sequence
  */
-@Generated("567fe39c6bd89ff8acb18f84780a7be1")
+@Generated("c4de860ccf8488e98393c2176474bb3d")
 public final class DurableExecutorDisposeResultCodec {
-    //hex: 0x1B0500
-    public static final int REQUEST_MESSAGE_TYPE = 1770752;
-    //hex: 0x1B0501
-    public static final int RESPONSE_MESSAGE_TYPE = 1770753;
+    //hex: 0x180500
+    public static final int REQUEST_MESSAGE_TYPE = 1574144;
+    //hex: 0x180501
+    public static final int RESPONSE_MESSAGE_TYPE = 1574145;
     private static final int REQUEST_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SEQUENCE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorIsShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorIsShutdownCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this executor has been shut down.
  */
-@Generated("2fe33fd1f7dc4a5bfcc092f21f3def3f")
+@Generated("44acd1d46598bf7b8f0ef1b3669096b8")
 public final class DurableExecutorIsShutdownCodec {
-    //hex: 0x1B0200
-    public static final int REQUEST_MESSAGE_TYPE = 1769984;
-    //hex: 0x1B0201
-    public static final int RESPONSE_MESSAGE_TYPE = 1769985;
+    //hex: 0x180200
+    public static final int REQUEST_MESSAGE_TYPE = 1573376;
+    //hex: 0x180201
+    public static final int RESPONSE_MESSAGE_TYPE = 1573377;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveAndDisposeResultCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveAndDisposeResultCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves and disposes the result of the execution with the given sequence
  */
-@Generated("259a00833dadd1502706be830623a5e7")
+@Generated("4a0c132d25611c5af3628d6ce1ee3a6e")
 public final class DurableExecutorRetrieveAndDisposeResultCodec {
-    //hex: 0x1B0600
-    public static final int REQUEST_MESSAGE_TYPE = 1771008;
-    //hex: 0x1B0601
-    public static final int RESPONSE_MESSAGE_TYPE = 1771009;
+    //hex: 0x180600
+    public static final int REQUEST_MESSAGE_TYPE = 1574400;
+    //hex: 0x180601
+    public static final int RESPONSE_MESSAGE_TYPE = 1574401;
     private static final int REQUEST_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SEQUENCE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveResultCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveResultCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves the result of the execution with the given sequence
  */
-@Generated("9e8927b682c687cce797c2c8fa82dd15")
+@Generated("f2bb143cd746646a711ab37572bc6279")
 public final class DurableExecutorRetrieveResultCodec {
-    //hex: 0x1B0400
-    public static final int REQUEST_MESSAGE_TYPE = 1770496;
-    //hex: 0x1B0401
-    public static final int RESPONSE_MESSAGE_TYPE = 1770497;
+    //hex: 0x180400
+    public static final int REQUEST_MESSAGE_TYPE = 1573888;
+    //hex: 0x180401
+    public static final int RESPONSE_MESSAGE_TYPE = 1573889;
     private static final int REQUEST_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SEQUENCE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorShutdownCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
  * Invocation has no additional effect if already shut down.
  */
-@Generated("f252ff914b4dc8e9cdb6e03b28ac10bf")
+@Generated("61d5f17c16b62081830874d54eac29d9")
 public final class DurableExecutorShutdownCodec {
-    //hex: 0x1B0100
-    public static final int REQUEST_MESSAGE_TYPE = 1769728;
-    //hex: 0x1B0101
-    public static final int RESPONSE_MESSAGE_TYPE = 1769729;
+    //hex: 0x180100
+    public static final int REQUEST_MESSAGE_TYPE = 1573120;
+    //hex: 0x180101
+    public static final int RESPONSE_MESSAGE_TYPE = 1573121;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorSubmitToPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to partition for execution
  */
-@Generated("c1d7ace6c3ba6b041d96766b620caa31")
+@Generated("4ee41216b2ff79c91a6e624b15dbc4d8")
 public final class DurableExecutorSubmitToPartitionCodec {
-    //hex: 0x1B0300
-    public static final int REQUEST_MESSAGE_TYPE = 1770240;
-    //hex: 0x1B0301
-    public static final int RESPONSE_MESSAGE_TYPE = 1770241;
+    //hex: 0x180300
+    public static final int REQUEST_MESSAGE_TYPE = 1573632;
+    //hex: 0x180301
+    public static final int RESPONSE_MESSAGE_TYPE = 1573633;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddCacheConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddCacheConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a cache configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("1cfac6194512265ad5875af0236a8b5c")
+@Generated("058f3d7d9104da02d8d37da3a0cd22b3")
 public final class DynamicConfigAddCacheConfigCodec {
-    //hex: 0x1E1000
-    public static final int REQUEST_MESSAGE_TYPE = 1970176;
-    //hex: 0x1E1001
-    public static final int RESPONSE_MESSAGE_TYPE = 1970177;
+    //hex: 0x1B0E00
+    public static final int REQUEST_MESSAGE_TYPE = 1773056;
+    //hex: 0x1B0E01
+    public static final int RESPONSE_MESSAGE_TYPE = 1773057;
     private static final int REQUEST_STATISTICS_ENABLED_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MANAGEMENT_ENABLED_FIELD_OFFSET = REQUEST_STATISTICS_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_READ_THROUGH_FIELD_OFFSET = REQUEST_MANAGEMENT_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddCardinalityEstimatorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddCardinalityEstimatorConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a cardinality estimator configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("af1580adf59a30b9926dd08c5f861608")
+@Generated("0650461d63996f859c6c41d0a2426a7e")
 public final class DynamicConfigAddCardinalityEstimatorConfigCodec {
-    //hex: 0x1E0300
-    public static final int REQUEST_MESSAGE_TYPE = 1966848;
-    //hex: 0x1E0301
-    public static final int RESPONSE_MESSAGE_TYPE = 1966849;
+    //hex: 0x1B0300
+    public static final int REQUEST_MESSAGE_TYPE = 1770240;
+    //hex: 0x1B0301
+    public static final int RESPONSE_MESSAGE_TYPE = 1770241;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MERGE_BATCH_SIZE_FIELD_OFFSET = REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddDurableExecutorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddDurableExecutorConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a durable executor configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("5257bae8f034cec2506da3cee706d43e")
+@Generated("7368528dfe3b40bb1640a229741549f1")
 public final class DynamicConfigAddDurableExecutorConfigCodec {
-    //hex: 0x1E0A00
-    public static final int REQUEST_MESSAGE_TYPE = 1968640;
-    //hex: 0x1E0A01
-    public static final int RESPONSE_MESSAGE_TYPE = 1968641;
+    //hex: 0x1B0900
+    public static final int REQUEST_MESSAGE_TYPE = 1771776;
+    //hex: 0x1B0901
+    public static final int RESPONSE_MESSAGE_TYPE = 1771777;
     private static final int REQUEST_POOL_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_DURABILITY_FIELD_OFFSET = REQUEST_POOL_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_CAPACITY_FIELD_OFFSET = REQUEST_DURABILITY_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddExecutorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddExecutorConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If an executor configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("4bd6bb4b74389fe1ccb5d4c48c4563ed")
+@Generated("5cbcf30399b9de71c89ca3ceac4f8bca")
 public final class DynamicConfigAddExecutorConfigCodec {
-    //hex: 0x1E0900
-    public static final int REQUEST_MESSAGE_TYPE = 1968384;
-    //hex: 0x1E0901
-    public static final int RESPONSE_MESSAGE_TYPE = 1968385;
+    //hex: 0x1B0800
+    public static final int REQUEST_MESSAGE_TYPE = 1771520;
+    //hex: 0x1B0801
+    public static final int RESPONSE_MESSAGE_TYPE = 1771521;
     private static final int REQUEST_POOL_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_QUEUE_CAPACITY_FIELD_OFFSET = REQUEST_POOL_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_STATISTICS_ENABLED_FIELD_OFFSET = REQUEST_QUEUE_CAPACITY_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddFlakeIdGeneratorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddFlakeIdGeneratorConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a flake ID generator configuration for the same name already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("4e4bab15e4af5213f2dcdb8c874ee3cc")
+@Generated("53f25876800cbfe93fc6e130e10a18ca")
 public final class DynamicConfigAddFlakeIdGeneratorConfigCodec {
-    //hex: 0x1E1200
-    public static final int REQUEST_MESSAGE_TYPE = 1970688;
-    //hex: 0x1E1201
-    public static final int RESPONSE_MESSAGE_TYPE = 1970689;
+    //hex: 0x1B0F00
+    public static final int REQUEST_MESSAGE_TYPE = 1773312;
+    //hex: 0x1B0F01
+    public static final int RESPONSE_MESSAGE_TYPE = 1773313;
     private static final int REQUEST_PREFETCH_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_PREFETCH_VALIDITY_FIELD_OFFSET = REQUEST_PREFETCH_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ID_OFFSET_FIELD_OFFSET = REQUEST_PREFETCH_VALIDITY_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddListConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddListConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a list configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("00434cbd4969b1ffe8777386f930448e")
+@Generated("8f8977167b001deaf72fadbd11351481")
 public final class DynamicConfigAddListConfigCodec {
-    //hex: 0x1E0500
-    public static final int REQUEST_MESSAGE_TYPE = 1967360;
-    //hex: 0x1E0501
-    public static final int RESPONSE_MESSAGE_TYPE = 1967361;
+    //hex: 0x1B0400
+    public static final int REQUEST_MESSAGE_TYPE = 1770496;
+    //hex: 0x1B0401
+    public static final int RESPONSE_MESSAGE_TYPE = 1770497;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_SIZE_FIELD_OFFSET = REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMapConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a map configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("f036b6767cbd6d2580d8792f3afdcfa2")
+@Generated("04b98067353f6d45830300d38084a4c9")
 public final class DynamicConfigAddMapConfigCodec {
-    //hex: 0x1E0E00
-    public static final int REQUEST_MESSAGE_TYPE = 1969664;
-    //hex: 0x1E0E01
-    public static final int RESPONSE_MESSAGE_TYPE = 1969665;
+    //hex: 0x1B0C00
+    public static final int REQUEST_MESSAGE_TYPE = 1772544;
+    //hex: 0x1B0C01
+    public static final int RESPONSE_MESSAGE_TYPE = 1772545;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TIME_TO_LIVE_SECONDS_FIELD_OFFSET = REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMultiMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMultiMapConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a multimap configuration with the given {@code name} already exists, then
  * the new multimap config is ignored and the existing one is preserved.
  */
-@Generated("f85e60deb1deb694904cf88995c3d585")
+@Generated("4f2665cac378805c873374ea0db589c4")
 public final class DynamicConfigAddMultiMapConfigCodec {
-    //hex: 0x1E0100
-    public static final int REQUEST_MESSAGE_TYPE = 1966336;
-    //hex: 0x1E0101
-    public static final int RESPONSE_MESSAGE_TYPE = 1966337;
+    //hex: 0x1B0100
+    public static final int REQUEST_MESSAGE_TYPE = 1769728;
+    //hex: 0x1B0101
+    public static final int RESPONSE_MESSAGE_TYPE = 1769729;
     private static final int REQUEST_BINARY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BINARY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddPNCounterConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddPNCounterConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a PN counter configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("7a241b5b8516eb16c1f766b6a33be792")
+@Generated("7581bb72089a3897d502cf17e99138f2")
 public final class DynamicConfigAddPNCounterConfigCodec {
-    //hex: 0x1E1600
-    public static final int REQUEST_MESSAGE_TYPE = 1971712;
-    //hex: 0x1E1601
-    public static final int RESPONSE_MESSAGE_TYPE = 1971713;
+    //hex: 0x1B1000
+    public static final int REQUEST_MESSAGE_TYPE = 1773568;
+    //hex: 0x1B1001
+    public static final int RESPONSE_MESSAGE_TYPE = 1773569;
     private static final int REQUEST_REPLICA_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_STATISTICS_ENABLED_FIELD_OFFSET = REQUEST_REPLICA_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_STATISTICS_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddQueueConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddQueueConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a queue configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("4ab3c9005033b3012996fcb035a8bff0")
+@Generated("cde179e856ce4d9cc873a339c3b9d61f")
 public final class DynamicConfigAddQueueConfigCodec {
-    //hex: 0x1E0D00
-    public static final int REQUEST_MESSAGE_TYPE = 1969408;
-    //hex: 0x1E0D01
-    public static final int RESPONSE_MESSAGE_TYPE = 1969409;
+    //hex: 0x1B0B00
+    public static final int REQUEST_MESSAGE_TYPE = 1772288;
+    //hex: 0x1B0B01
+    public static final int RESPONSE_MESSAGE_TYPE = 1772289;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_SIZE_FIELD_OFFSET = REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReliableTopicConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReliableTopicConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a reliable topic configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("1461d6d2d34b6c5ee92681e4905d26a3")
+@Generated("10f0567119cbd206f754883b23e4dc44")
 public final class DynamicConfigAddReliableTopicConfigCodec {
-    //hex: 0x1E0F00
-    public static final int REQUEST_MESSAGE_TYPE = 1969920;
-    //hex: 0x1E0F01
-    public static final int RESPONSE_MESSAGE_TYPE = 1969921;
+    //hex: 0x1B0D00
+    public static final int REQUEST_MESSAGE_TYPE = 1772800;
+    //hex: 0x1B0D01
+    public static final int RESPONSE_MESSAGE_TYPE = 1772801;
     private static final int REQUEST_READ_BATCH_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_STATISTICS_ENABLED_FIELD_OFFSET = REQUEST_READ_BATCH_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_STATISTICS_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReplicatedMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReplicatedMapConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a replicated map configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("9d033954424d16a9fa992fc03cd80dfb")
+@Generated("5b3f7d61cedaffe4685e9f38b2ada1f0")
 public final class DynamicConfigAddReplicatedMapConfigCodec {
-    //hex: 0x1E0700
-    public static final int REQUEST_MESSAGE_TYPE = 1967872;
-    //hex: 0x1E0701
-    public static final int RESPONSE_MESSAGE_TYPE = 1967873;
+    //hex: 0x1B0600
+    public static final int REQUEST_MESSAGE_TYPE = 1771008;
+    //hex: 0x1B0601
+    public static final int RESPONSE_MESSAGE_TYPE = 1771009;
     private static final int REQUEST_ASYNC_FILLUP_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_STATISTICS_ENABLED_FIELD_OFFSET = REQUEST_ASYNC_FILLUP_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_MERGE_BATCH_SIZE_FIELD_OFFSET = REQUEST_STATISTICS_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddRingbufferConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddRingbufferConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a ringbuffer configuration with the given {@code name} already exists, then
  * the new ringbuffer config is ignored and the existing one is preserved.
  */
-@Generated("fdffb9416e2d15147bedcc2b55fda662")
+@Generated("fcc3c558cf0b61f26ee83415a8c0ecfc")
 public final class DynamicConfigAddRingbufferConfigCodec {
-    //hex: 0x1E0200
-    public static final int REQUEST_MESSAGE_TYPE = 1966592;
-    //hex: 0x1E0201
-    public static final int RESPONSE_MESSAGE_TYPE = 1966593;
+    //hex: 0x1B0200
+    public static final int REQUEST_MESSAGE_TYPE = 1769984;
+    //hex: 0x1B0201
+    public static final int RESPONSE_MESSAGE_TYPE = 1769985;
     private static final int REQUEST_CAPACITY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = REQUEST_CAPACITY_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddScheduledExecutorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddScheduledExecutorConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a scheduled executor configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("e801cae804b8fec74ccb137e6e7909de")
+@Generated("a78016fe55397d3254b572ad2c1edc55")
 public final class DynamicConfigAddScheduledExecutorConfigCodec {
-    //hex: 0x1E0B00
-    public static final int REQUEST_MESSAGE_TYPE = 1968896;
-    //hex: 0x1E0B01
-    public static final int RESPONSE_MESSAGE_TYPE = 1968897;
+    //hex: 0x1B0A00
+    public static final int REQUEST_MESSAGE_TYPE = 1772032;
+    //hex: 0x1B0A01
+    public static final int RESPONSE_MESSAGE_TYPE = 1772033;
     private static final int REQUEST_POOL_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_DURABILITY_FIELD_OFFSET = REQUEST_POOL_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_CAPACITY_FIELD_OFFSET = REQUEST_DURABILITY_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddSetConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddSetConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a set configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("ed24da24a5df4507fc68676df8285d5e")
+@Generated("5564c5cbb52bab298ecef67496671694")
 public final class DynamicConfigAddSetConfigCodec {
-    //hex: 0x1E0600
-    public static final int REQUEST_MESSAGE_TYPE = 1967616;
-    //hex: 0x1E0601
-    public static final int RESPONSE_MESSAGE_TYPE = 1967617;
+    //hex: 0x1B0500
+    public static final int REQUEST_MESSAGE_TYPE = 1770752;
+    //hex: 0x1B0501
+    public static final int RESPONSE_MESSAGE_TYPE = 1770753;
     private static final int REQUEST_BACKUP_COUNT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET = REQUEST_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_SIZE_FIELD_OFFSET = REQUEST_ASYNC_BACKUP_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddTopicConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddTopicConfigCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a topic configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("f85e44d8c645b52af66ff9e0cd1186d8")
+@Generated("99dd88e39f3856cc5c0ac4bbdd9ae580")
 public final class DynamicConfigAddTopicConfigCodec {
-    //hex: 0x1E0800
-    public static final int REQUEST_MESSAGE_TYPE = 1968128;
-    //hex: 0x1E0801
-    public static final int RESPONSE_MESSAGE_TYPE = 1968129;
+    //hex: 0x1B0700
+    public static final int REQUEST_MESSAGE_TYPE = 1771264;
+    //hex: 0x1B0701
+    public static final int RESPONSE_MESSAGE_TYPE = 1771265;
     private static final int REQUEST_GLOBAL_ORDERING_ENABLED_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_STATISTICS_ENABLED_FIELD_OFFSET = REQUEST_GLOBAL_ORDERING_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_MULTI_THREADING_ENABLED_FIELD_OFFSET = REQUEST_STATISTICS_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("58564f059fb2530d8502a725ee5fe954")
+@Generated("982a6943b5263e9137c120be7a9ec2c5")
 public final class ExecutorServiceCancelOnAddressCodec {
-    //hex: 0x090400
-    public static final int REQUEST_MESSAGE_TYPE = 590848;
-    //hex: 0x090401
-    public static final int RESPONSE_MESSAGE_TYPE = 590849;
+    //hex: 0x080400
+    public static final int REQUEST_MESSAGE_TYPE = 525312;
+    //hex: 0x080401
+    public static final int RESPONSE_MESSAGE_TYPE = 525313;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INTERRUPT_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_INTERRUPT_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("3dcb81d248c7723ff63e2ca7d5a2125d")
+@Generated("6ab8e13eb034c854577386150984be20")
 public final class ExecutorServiceCancelOnPartitionCodec {
-    //hex: 0x090300
-    public static final int REQUEST_MESSAGE_TYPE = 590592;
-    //hex: 0x090301
-    public static final int RESPONSE_MESSAGE_TYPE = 590593;
+    //hex: 0x080300
+    public static final int REQUEST_MESSAGE_TYPE = 525056;
+    //hex: 0x080301
+    public static final int RESPONSE_MESSAGE_TYPE = 525057;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INTERRUPT_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_INTERRUPT_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceIsShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceIsShutdownCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this executor has been shut down.
  */
-@Generated("d853eba42961b881fc50272c9a577c1e")
+@Generated("898a9a866b158345d969cd1105028d7f")
 public final class ExecutorServiceIsShutdownCodec {
-    //hex: 0x090200
-    public static final int REQUEST_MESSAGE_TYPE = 590336;
-    //hex: 0x090201
-    public static final int RESPONSE_MESSAGE_TYPE = 590337;
+    //hex: 0x080200
+    public static final int REQUEST_MESSAGE_TYPE = 524800;
+    //hex: 0x080201
+    public static final int RESPONSE_MESSAGE_TYPE = 524801;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceShutdownCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
  * Invocation has no additional effect if already shut down.
  */
-@Generated("2c020302d812c63e1d2ed6c262049289")
+@Generated("ad7a91fdad3fe279bcd945a3e6784450")
 public final class ExecutorServiceShutdownCodec {
-    //hex: 0x090100
-    public static final int REQUEST_MESSAGE_TYPE = 590080;
-    //hex: 0x090101
-    public static final int RESPONSE_MESSAGE_TYPE = 590081;
+    //hex: 0x080100
+    public static final int REQUEST_MESSAGE_TYPE = 524544;
+    //hex: 0x080101
+    public static final int RESPONSE_MESSAGE_TYPE = 524545;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("e07b8b7ee21fe54041ace00a7606b313")
+@Generated("7f5e3083bf1ad269da72c0b061168b57")
 public final class ExecutorServiceSubmitToAddressCodec {
-    //hex: 0x090600
-    public static final int REQUEST_MESSAGE_TYPE = 591360;
-    //hex: 0x090601
-    public static final int RESPONSE_MESSAGE_TYPE = 591361;
+    //hex: 0x080600
+    public static final int REQUEST_MESSAGE_TYPE = 525824;
+    //hex: 0x080601
+    public static final int RESPONSE_MESSAGE_TYPE = 525825;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("4541538399d9b0a214a97d78ddaf2dda")
+@Generated("f7cba1644baab2f874d4e903d410e242")
 public final class ExecutorServiceSubmitToPartitionCodec {
-    //hex: 0x090500
-    public static final int REQUEST_MESSAGE_TYPE = 591104;
-    //hex: 0x090501
-    public static final int RESPONSE_MESSAGE_TYPE = 591105;
+    //hex: 0x080500
+    public static final int REQUEST_MESSAGE_TYPE = 525568;
+    //hex: 0x080501
+    public static final int RESPONSE_MESSAGE_TYPE = 525569;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FlakeIdGeneratorNewIdBatchCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FlakeIdGeneratorNewIdBatchCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("9f8132c2f43b93af23847a60cacf2832")
+@Generated("579ccf627a576abe309926eab8e3666d")
 public final class FlakeIdGeneratorNewIdBatchCodec {
-    //hex: 0x1F0100
-    public static final int REQUEST_MESSAGE_TYPE = 2031872;
-    //hex: 0x1F0101
-    public static final int RESPONSE_MESSAGE_TYPE = 2031873;
+    //hex: 0x1C0100
+    public static final int REQUEST_MESSAGE_TYPE = 1835264;
+    //hex: 0x1C0101
+    public static final int RESPONSE_MESSAGE_TYPE = 1835265;
     private static final int REQUEST_BATCH_SIZE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_BATCH_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_BASE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCChangeClusterStateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCChangeClusterStateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Changes the state of a cluster.
  */
-@Generated("78794bcdd1a58d51b27c534602500ded")
+@Generated("e664d75f262226619b5fe07a04821ba6")
 public final class MCChangeClusterStateCodec {
-    //hex: 0x270200
-    public static final int REQUEST_MESSAGE_TYPE = 2556416;
-    //hex: 0x270201
-    public static final int RESPONSE_MESSAGE_TYPE = 2556417;
+    //hex: 0x200200
+    public static final int REQUEST_MESSAGE_TYPE = 2097664;
+    //hex: 0x200201
+    public static final int RESPONSE_MESSAGE_TYPE = 2097665;
     private static final int REQUEST_NEW_STATE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_NEW_STATE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -53,7 +53,12 @@ public final class MCChangeClusterStateCodec {
     public static class RequestParameters {
 
         /**
-         * ID of the new state of the cluster.
+         * New state of the cluster:
+         * 0 - ACTIVE
+         * 1 - NO_MIGRATION
+         * 2 - FROZEN
+         * 3 - PASSIVE
+         * 4 - IN_TRANSITION (not allowed)
          */
         public int newState;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMapConfigCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the config of a map.
  */
-@Generated("5f25c65ac4e240ff44c58134c860c59d")
+@Generated("5cdc470a5f76c74bd3be97b8a255e4c3")
 public final class MCGetMapConfigCodec {
-    //hex: 0x270300
-    public static final int REQUEST_MESSAGE_TYPE = 2556672;
-    //hex: 0x270301
-    public static final int RESPONSE_MESSAGE_TYPE = 2556673;
+    //hex: 0x200300
+    public static final int REQUEST_MESSAGE_TYPE = 2097920;
+    //hex: 0x200301
+    public static final int RESPONSE_MESSAGE_TYPE = 2097921;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_IN_MEMORY_FORMAT_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_BACKUP_COUNT_FIELD_OFFSET = RESPONSE_IN_MEMORY_FORMAT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCReadMetricsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCReadMetricsCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Reads the recorded metrics starting with the smallest sequence number
  * greater or equals to the sequence number set in fromSequence.
  */
-@Generated("d789caaefcd74bc666ec8c009d276bb9")
+@Generated("a765b898c0b0515d16001c4aac25dfb4")
 public final class MCReadMetricsCodec {
-    //hex: 0x270100
-    public static final int REQUEST_MESSAGE_TYPE = 2556160;
-    //hex: 0x270101
-    public static final int RESPONSE_MESSAGE_TYPE = 2556161;
+    //hex: 0x200100
+    public static final int REQUEST_MESSAGE_TYPE = 2097408;
+    //hex: 0x200101
+    public static final int RESPONSE_MESSAGE_TYPE = 2097409;
     private static final int REQUEST_UUID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_FROM_SEQUENCE_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_FROM_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCUpdateMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCUpdateMapConfigCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Updates the config of a map.
  */
-@Generated("31c37f6d85a5d2dbb7f5a632753c3410")
+@Generated("43306c19c140e0c5628a4eb5dd8e9a88")
 public final class MCUpdateMapConfigCodec {
-    //hex: 0x270400
-    public static final int REQUEST_MESSAGE_TYPE = 2556928;
-    //hex: 0x270401
-    public static final int RESPONSE_MESSAGE_TYPE = 2556929;
+    //hex: 0x200400
+    public static final int REQUEST_MESSAGE_TYPE = 2098176;
+    //hex: 0x200401
+    public static final int RESPONSE_MESSAGE_TYPE = 2098177;
     private static final int REQUEST_TIME_TO_LIVE_SECONDS_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_IDLE_SECONDS_FIELD_OFFSET = REQUEST_TIME_TO_LIVE_SECONDS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_EVICTION_POLICY_FIELD_OFFSET = REQUEST_MAX_IDLE_SECONDS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("786c4f83d972499ce6d992054a0c0dd4")
+@Generated("e4910c025ee6a1151cd34dfc7aab1f00")
 public final class MapAddEntryListenerCodec {
-    //hex: 0x011C00
-    public static final int REQUEST_MESSAGE_TYPE = 72704;
-    //hex: 0x011C01
-    public static final int RESPONSE_MESSAGE_TYPE = 72705;
+    //hex: 0x011900
+    public static final int REQUEST_MESSAGE_TYPE = 71936;
+    //hex: 0x011901
+    public static final int RESPONSE_MESSAGE_TYPE = 71937;
     private static final int REQUEST_INCLUDE_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LISTENER_FLAGS_FIELD_OFFSET = REQUEST_INCLUDE_VALUE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_LISTENER_FLAGS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -54,8 +54,8 @@ public final class MapAddEntryListenerCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x011C02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 72706;
+    //hex: 0x011902
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 71938;
 
     private MapAddEntryListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("d2159fab8c768b35524c9620b73d857b")
+@Generated("96cd082af12c11ffbccae26ce6c6dd12")
 public final class MapAddEntryListenerToKeyCodec {
-    //hex: 0x011B00
-    public static final int REQUEST_MESSAGE_TYPE = 72448;
-    //hex: 0x011B01
-    public static final int RESPONSE_MESSAGE_TYPE = 72449;
+    //hex: 0x011800
+    public static final int REQUEST_MESSAGE_TYPE = 71680;
+    //hex: 0x011801
+    public static final int RESPONSE_MESSAGE_TYPE = 71681;
     private static final int REQUEST_INCLUDE_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LISTENER_FLAGS_FIELD_OFFSET = REQUEST_INCLUDE_VALUE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_LISTENER_FLAGS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -54,8 +54,8 @@ public final class MapAddEntryListenerToKeyCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x011B02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 72450;
+    //hex: 0x011802
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 71682;
 
     private MapAddEntryListenerToKeyCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyWithPredicateCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("5ca26f4a3673a942edf4aab978fa43ad")
+@Generated("58b91c666119a0c33704517d17e1dc4e")
 public final class MapAddEntryListenerToKeyWithPredicateCodec {
-    //hex: 0x011900
-    public static final int REQUEST_MESSAGE_TYPE = 71936;
-    //hex: 0x011901
-    public static final int RESPONSE_MESSAGE_TYPE = 71937;
+    //hex: 0x011600
+    public static final int REQUEST_MESSAGE_TYPE = 71168;
+    //hex: 0x011601
+    public static final int RESPONSE_MESSAGE_TYPE = 71169;
     private static final int REQUEST_INCLUDE_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LISTENER_FLAGS_FIELD_OFFSET = REQUEST_INCLUDE_VALUE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_LISTENER_FLAGS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -54,8 +54,8 @@ public final class MapAddEntryListenerToKeyWithPredicateCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x011902
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 71938;
+    //hex: 0x011602
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 71170;
 
     private MapAddEntryListenerToKeyWithPredicateCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerWithPredicateCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
  * filtered by the given predicate.
  */
-@Generated("f148d3150a1bd04a650dd48e27be006a")
+@Generated("6be209e49bb5ad0c515b59943051f465")
 public final class MapAddEntryListenerWithPredicateCodec {
-    //hex: 0x011A00
-    public static final int REQUEST_MESSAGE_TYPE = 72192;
-    //hex: 0x011A01
-    public static final int RESPONSE_MESSAGE_TYPE = 72193;
+    //hex: 0x011700
+    public static final int REQUEST_MESSAGE_TYPE = 71424;
+    //hex: 0x011701
+    public static final int RESPONSE_MESSAGE_TYPE = 71425;
     private static final int REQUEST_INCLUDE_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LISTENER_FLAGS_FIELD_OFFSET = REQUEST_INCLUDE_VALUE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_LISTENER_FLAGS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -54,8 +54,8 @@ public final class MapAddEntryListenerWithPredicateCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x011A02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 72194;
+    //hex: 0x011702
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 71426;
 
     private MapAddEntryListenerWithPredicateCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddIndexCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddIndexCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an index to this map with specified configuration.
  */
-@Generated("d4ccf748d2ba075ee5594efc1e4cc277")
+@Generated("74e5034bdefa98c0c0e480dd692fa3cc")
 public final class MapAddIndexCodec {
-    //hex: 0x012D00
-    public static final int REQUEST_MESSAGE_TYPE = 77056;
-    //hex: 0x012D01
-    public static final int RESPONSE_MESSAGE_TYPE = 77057;
+    //hex: 0x012A00
+    public static final int REQUEST_MESSAGE_TYPE = 76288;
+    //hex: 0x012A01
+    public static final int RESPONSE_MESSAGE_TYPE = 76289;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddInterceptorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddInterceptorCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an interceptor for this map. Added interceptor will intercept operations
  * and execute user defined methods and will cancel operations if user defined method throw exception.
  */
-@Generated("ff9386875905ab1adcd1d5bdfe34baa5")
+@Generated("a185543528ed18b1bcfa23ed41b47d52")
 public final class MapAddInterceptorCodec {
-    //hex: 0x011700
-    public static final int REQUEST_MESSAGE_TYPE = 71424;
-    //hex: 0x011701
-    public static final int RESPONSE_MESSAGE_TYPE = 71425;
+    //hex: 0x011400
+    public static final int REQUEST_MESSAGE_TYPE = 70656;
+    //hex: 0x011401
+    public static final int RESPONSE_MESSAGE_TYPE = 70657;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddNearCacheEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddNearCacheEntryListenerCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an entry listener for this map. Listener will get notified for all map add/remove/update/evict events.
  */
-@Generated("7037a5ba935804d5f2ef00249665bf01")
+@Generated("71cb5fb9d32b390e0dd13b201d817814")
 public final class MapAddNearCacheEntryListenerCodec {
-    //hex: 0x011D00
-    public static final int REQUEST_MESSAGE_TYPE = 72960;
-    //hex: 0x011D01
-    public static final int RESPONSE_MESSAGE_TYPE = 72961;
+    //hex: 0x011A00
+    public static final int REQUEST_MESSAGE_TYPE = 72192;
+    //hex: 0x011A01
+    public static final int RESPONSE_MESSAGE_TYPE = 72193;
     private static final int REQUEST_LISTENER_FLAGS_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_LISTENER_FLAGS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
@@ -52,11 +52,11 @@ public final class MapAddNearCacheEntryListenerCodec {
     private static final int EVENT_I_MAP_INVALIDATION_PARTITION_UUID_FIELD_OFFSET = EVENT_I_MAP_INVALIDATION_SOURCE_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_I_MAP_INVALIDATION_SEQUENCE_FIELD_OFFSET = EVENT_I_MAP_INVALIDATION_PARTITION_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_I_MAP_INVALIDATION_INITIAL_FRAME_SIZE = EVENT_I_MAP_INVALIDATION_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
-    //hex: 0x011D02
-    private static final int EVENT_I_MAP_INVALIDATION_MESSAGE_TYPE = 72962;
+    //hex: 0x011A02
+    private static final int EVENT_I_MAP_INVALIDATION_MESSAGE_TYPE = 72194;
     private static final int EVENT_I_MAP_BATCH_INVALIDATION_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x011D03
-    private static final int EVENT_I_MAP_BATCH_INVALIDATION_MESSAGE_TYPE = 72963;
+    //hex: 0x011A03
+    private static final int EVENT_I_MAP_BATCH_INVALIDATION_MESSAGE_TYPE = 72195;
 
     private MapAddNearCacheEntryListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddNearCacheInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddNearCacheInvalidationListenerCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Eventually consistent client near caches should use this method to add invalidation listeners
  * instead of {@link #addNearCacheEntryListener(String, int, boolean)}
  */
-@Generated("afa564bc2679b6452ad6409949307579")
+@Generated("ed24be7b6d4f5738996e25d079f67d24")
 public final class MapAddNearCacheInvalidationListenerCodec {
-    //hex: 0x014500
-    public static final int REQUEST_MESSAGE_TYPE = 83200;
-    //hex: 0x014501
-    public static final int RESPONSE_MESSAGE_TYPE = 83201;
+    //hex: 0x014200
+    public static final int REQUEST_MESSAGE_TYPE = 82432;
+    //hex: 0x014201
+    public static final int RESPONSE_MESSAGE_TYPE = 82433;
     private static final int REQUEST_LISTENER_FLAGS_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_LISTENER_FLAGS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
@@ -54,11 +54,11 @@ public final class MapAddNearCacheInvalidationListenerCodec {
     private static final int EVENT_I_MAP_INVALIDATION_PARTITION_UUID_FIELD_OFFSET = EVENT_I_MAP_INVALIDATION_SOURCE_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_I_MAP_INVALIDATION_SEQUENCE_FIELD_OFFSET = EVENT_I_MAP_INVALIDATION_PARTITION_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_I_MAP_INVALIDATION_INITIAL_FRAME_SIZE = EVENT_I_MAP_INVALIDATION_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
-    //hex: 0x014502
-    private static final int EVENT_I_MAP_INVALIDATION_MESSAGE_TYPE = 83202;
+    //hex: 0x014202
+    private static final int EVENT_I_MAP_INVALIDATION_MESSAGE_TYPE = 82434;
     private static final int EVENT_I_MAP_BATCH_INVALIDATION_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x014503
-    private static final int EVENT_I_MAP_BATCH_INVALIDATION_MESSAGE_TYPE = 83203;
+    //hex: 0x014203
+    private static final int EVENT_I_MAP_BATCH_INVALIDATION_MESSAGE_TYPE = 82435;
 
     private MapAddNearCacheInvalidationListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddPartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddPartitionLostListenerCodec.java
@@ -42,12 +42,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * IMPORTANT: Listeners registered from HazelcastClient may miss some of the map partition lost events due
  * to design limitations.
  */
-@Generated("f4fefb300e67875cb1a3f8efbaaf0844")
+@Generated("628bd92b01b2be4513bea0d82fbe057c")
 public final class MapAddPartitionLostListenerCodec {
-    //hex: 0x011F00
-    public static final int REQUEST_MESSAGE_TYPE = 73472;
-    //hex: 0x011F01
-    public static final int RESPONSE_MESSAGE_TYPE = 73473;
+    //hex: 0x011C00
+    public static final int REQUEST_MESSAGE_TYPE = 72704;
+    //hex: 0x011C01
+    public static final int RESPONSE_MESSAGE_TYPE = 72705;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -55,8 +55,8 @@ public final class MapAddPartitionLostListenerCodec {
     private static final int EVENT_MAP_PARTITION_LOST_PARTITION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_MAP_PARTITION_LOST_UUID_FIELD_OFFSET = EVENT_MAP_PARTITION_LOST_PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_MAP_PARTITION_LOST_INITIAL_FRAME_SIZE = EVENT_MAP_PARTITION_LOST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
-    //hex: 0x011F02
-    private static final int EVENT_MAP_PARTITION_LOST_MESSAGE_TYPE = 73474;
+    //hex: 0x011C02
+    private static final int EVENT_MAP_PARTITION_LOST_MESSAGE_TYPE = 72706;
 
     private MapAddPartitionLostListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the aggregation logic on all map entries and returns the result
  */
-@Generated("f2668edd53dfd25591b7f4058b4a8a6c")
+@Generated("2b17e00580d85da906f0461f34ba6d05")
 public final class MapAggregateCodec {
-    //hex: 0x013E00
-    public static final int REQUEST_MESSAGE_TYPE = 81408;
-    //hex: 0x013E01
-    public static final int RESPONSE_MESSAGE_TYPE = 81409;
+    //hex: 0x013B00
+    public static final int REQUEST_MESSAGE_TYPE = 80640;
+    //hex: 0x013B01
+    public static final int RESPONSE_MESSAGE_TYPE = 80641;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateWithPredicateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the aggregation logic on map entries filtered with the Predicate and returns the result
  */
-@Generated("498f655ab11d09323fadb7592c3bea5f")
+@Generated("3364548df078570243a38eacfcdaa3d7")
 public final class MapAggregateWithPredicateCodec {
-    //hex: 0x013F00
-    public static final int REQUEST_MESSAGE_TYPE = 81664;
-    //hex: 0x013F01
-    public static final int RESPONSE_MESSAGE_TYPE = 81665;
+    //hex: 0x013C00
+    public static final int REQUEST_MESSAGE_TYPE = 80896;
+    //hex: 0x013C01
+    public static final int RESPONSE_MESSAGE_TYPE = 80897;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAssignAndGetUuidsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAssignAndGetUuidsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("f54f40ee6eb14acf9dd30c68ebf754ec")
+@Generated("7fb27afcc1b5301c63b7a93b1ae09575")
 public final class MapAssignAndGetUuidsCodec {
-    //hex: 0x014300
-    public static final int REQUEST_MESSAGE_TYPE = 82688;
-    //hex: 0x014301
-    public static final int RESPONSE_MESSAGE_TYPE = 82689;
+    //hex: 0x014000
+    public static final int REQUEST_MESSAGE_TYPE = 81920;
+    //hex: 0x014001
+    public static final int RESPONSE_MESSAGE_TYPE = 81921;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapClearCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * will delete the records from that database. The MAP_CLEARED event is fired for any registered listeners.
  * To clear a map without calling MapStore#deleteAll, use #evictAll.
  */
-@Generated("0447951daefd316ec1e3a942ecd8cae1")
+@Generated("873c49d583da22c3575c4dc59ff851da")
 public final class MapClearCodec {
-    //hex: 0x013100
-    public static final int REQUEST_MESSAGE_TYPE = 78080;
-    //hex: 0x013101
-    public static final int RESPONSE_MESSAGE_TYPE = 78081;
+    //hex: 0x012E00
+    public static final int REQUEST_MESSAGE_TYPE = 77312;
+    //hex: 0x012E01
+    public static final int RESPONSE_MESSAGE_TYPE = 77313;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapClearNearCacheCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapClearNearCacheCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("fadb7bebe25d872e17d9b2cffdc9874a")
+@Generated("3dda2391ceb66647c196005113178c08")
 public final class MapClearNearCacheCodec {
-    //hex: 0x013B00
-    public static final int REQUEST_MESSAGE_TYPE = 80640;
-    //hex: 0x013B01
-    public static final int RESPONSE_MESSAGE_TYPE = 80641;
+    //hex: 0x013800
+    public static final int REQUEST_MESSAGE_TYPE = 79872;
+    //hex: 0x013801
+    public static final int RESPONSE_MESSAGE_TYPE = 79873;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsKeyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains a mapping for the specified key.
  */
-@Generated("fcb326059776d0af0e86df232dce9127")
+@Generated("d5b31f4b6b7d32479e7f91d78f760bc5")
 public final class MapContainsKeyCodec {
-    //hex: 0x010900
-    public static final int REQUEST_MESSAGE_TYPE = 67840;
-    //hex: 0x010901
-    public static final int RESPONSE_MESSAGE_TYPE = 67841;
+    //hex: 0x010600
+    public static final int REQUEST_MESSAGE_TYPE = 67072;
+    //hex: 0x010601
+    public static final int RESPONSE_MESSAGE_TYPE = 67073;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsValueCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this map maps one or more keys to the specified value.This operation will probably require time
  * linear in the map size for most implementations of the Map interface.
  */
-@Generated("607860e044f213682fb2d08cd0d38caf")
+@Generated("2eb138d9175d8942fb4fff832935fec5")
 public final class MapContainsValueCodec {
-    //hex: 0x010A00
-    public static final int REQUEST_MESSAGE_TYPE = 68096;
-    //hex: 0x010A01
-    public static final int RESPONSE_MESSAGE_TYPE = 68097;
+    //hex: 0x010700
+    public static final int REQUEST_MESSAGE_TYPE = 67328;
+    //hex: 0x010701
+    public static final int RESPONSE_MESSAGE_TYPE = 67329;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapDeleteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapDeleteCodec.java
@@ -41,12 +41,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method breaks the contract of EntryListener. When an entry is removed by delete(), it fires an EntryEvent
  * with a null oldValue. Also, a listener with predicates will have null values, so only keys can be queried via predicates
  */
-@Generated("509ea7c1efa160424cdcde217446aee5")
+@Generated("3664791e23d75bd374e2d1da6a7a2efa")
 public final class MapDeleteCodec {
-    //hex: 0x010C00
-    public static final int REQUEST_MESSAGE_TYPE = 68608;
-    //hex: 0x010C01
-    public static final int RESPONSE_MESSAGE_TYPE = 68609;
+    //hex: 0x010900
+    public static final int REQUEST_MESSAGE_TYPE = 67840;
+    //hex: 0x010901
+    public static final int RESPONSE_MESSAGE_TYPE = 67841;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("438f893711de9fcd44d99ba02085e32f")
+@Generated("2107e3cedd59831698c1f40c05a79b8b")
 public final class MapEntriesWithPagingPredicateCodec {
-    //hex: 0x013A00
-    public static final int REQUEST_MESSAGE_TYPE = 80384;
-    //hex: 0x013A01
-    public static final int RESPONSE_MESSAGE_TYPE = 80385;
+    //hex: 0x013700
+    public static final int REQUEST_MESSAGE_TYPE = 79616;
+    //hex: 0x013701
+    public static final int RESPONSE_MESSAGE_TYPE = 79617;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("08671b2a7b3da095f037a4a72170054e")
+@Generated("100ecba16a715492ee3beab34102c088")
 public final class MapEntriesWithPredicateCodec {
-    //hex: 0x012C00
-    public static final int REQUEST_MESSAGE_TYPE = 76800;
-    //hex: 0x012C01
-    public static final int RESPONSE_MESSAGE_TYPE = 76801;
+    //hex: 0x012900
+    public static final int REQUEST_MESSAGE_TYPE = 76032;
+    //hex: 0x012901
+    public static final int RESPONSE_MESSAGE_TYPE = 76033;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntrySetCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
  * if query result size limit is configured.
  */
-@Generated("1268995e527687e5fd3f86821490caba")
+@Generated("fb89aff6448a916072e8d1b6271957cf")
 public final class MapEntrySetCodec {
-    //hex: 0x012900
-    public static final int REQUEST_MESSAGE_TYPE = 76032;
-    //hex: 0x012901
-    public static final int RESPONSE_MESSAGE_TYPE = 76033;
+    //hex: 0x012600
+    public static final int REQUEST_MESSAGE_TYPE = 75264;
+    //hex: 0x012601
+    public static final int RESPONSE_MESSAGE_TYPE = 75265;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
@@ -43,12 +43,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("f79223662f103e04e7cbd3910f5e74a0")
+@Generated("2ee67463d8dbd557a7cacae5fec2574e")
 public final class MapEventJournalReadCodec {
-    //hex: 0x014800
-    public static final int REQUEST_MESSAGE_TYPE = 83968;
-    //hex: 0x014801
-    public static final int RESPONSE_MESSAGE_TYPE = 83969;
+    //hex: 0x014500
+    public static final int REQUEST_MESSAGE_TYPE = 83200;
+    //hex: 0x014501
+    public static final int RESPONSE_MESSAGE_TYPE = 83201;
     private static final int REQUEST_START_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MIN_SIZE_FIELD_OFFSET = REQUEST_START_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_SIZE_FIELD_OFFSET = REQUEST_MIN_SIZE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalSubscribeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalSubscribeCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This includes retrieving the event journal sequences of the
  * oldest and newest event in the journal.
  */
-@Generated("8a027f10ee2df9da76e26ad9fc1f131d")
+@Generated("de9f3b9ae03f56d09c9499564170aa26")
 public final class MapEventJournalSubscribeCodec {
-    //hex: 0x014700
-    public static final int REQUEST_MESSAGE_TYPE = 83712;
-    //hex: 0x014701
-    public static final int RESPONSE_MESSAGE_TYPE = 83713;
+    //hex: 0x014400
+    public static final int REQUEST_MESSAGE_TYPE = 82944;
+    //hex: 0x014401
+    public static final int RESPONSE_MESSAGE_TYPE = 82945;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_OLDEST_SEQUENCE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_NEWEST_SEQUENCE_FIELD_OFFSET = RESPONSE_OLDEST_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictAllCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * called by this method. If you do want to deleteAll to be called use the clear method. The EVICT_ALL event is
  * fired for any registered listeners.
  */
-@Generated("4a9c39b95eaf38438ac1505446876bcc")
+@Generated("418329797b639a33ad329ea078408f8c")
 public final class MapEvictAllCodec {
-    //hex: 0x012300
-    public static final int REQUEST_MESSAGE_TYPE = 74496;
-    //hex: 0x012301
-    public static final int RESPONSE_MESSAGE_TYPE = 74497;
+    //hex: 0x012000
+    public static final int REQUEST_MESSAGE_TYPE = 73728;
+    //hex: 0x012001
+    public static final int RESPONSE_MESSAGE_TYPE = 73729;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
  * from the underlying MapStore, evict only removes the entry from the memory.
  */
-@Generated("13a8d21c4e1f02a3a4a45cf310382873")
+@Generated("b0d6c62f9a5cce643cb615894d88229e")
 public final class MapEvictCodec {
-    //hex: 0x012200
-    public static final int REQUEST_MESSAGE_TYPE = 74240;
-    //hex: 0x012201
-    public static final int RESPONSE_MESSAGE_TYPE = 74241;
+    //hex: 0x011F00
+    public static final int REQUEST_MESSAGE_TYPE = 73472;
+    //hex: 0x011F01
+    public static final int RESPONSE_MESSAGE_TYPE = 73473;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
  */
-@Generated("8ff40f58bf622ef0bed0918c66d17a82")
+@Generated("09050c5b2dc63e983deb3db5f4ae466d")
 public final class MapExecuteOnAllKeysCodec {
-    //hex: 0x013400
-    public static final int REQUEST_MESSAGE_TYPE = 78848;
-    //hex: 0x013401
-    public static final int RESPONSE_MESSAGE_TYPE = 78849;
+    //hex: 0x013100
+    public static final int REQUEST_MESSAGE_TYPE = 78080;
+    //hex: 0x013101
+    public static final int RESPONSE_MESSAGE_TYPE = 78081;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeyCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
  * the process() method of EntryProcessor.
  */
-@Generated("182bf971dd4021a51c17b1c531640456")
+@Generated("88c06b7c7bad389044829859aa3dcb8d")
 public final class MapExecuteOnKeyCodec {
-    //hex: 0x013200
-    public static final int REQUEST_MESSAGE_TYPE = 78336;
-    //hex: 0x013201
-    public static final int RESPONSE_MESSAGE_TYPE = 78337;
+    //hex: 0x012F00
+    public static final int REQUEST_MESSAGE_TYPE = 77568;
+    //hex: 0x012F01
+    public static final int RESPONSE_MESSAGE_TYPE = 77569;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
  * each key in the collection.
  */
-@Generated("1683e5415f50ac8774830cd2f1e7cc1d")
+@Generated("8c17d002b2d50c2e510e1190d6cf09cc")
 public final class MapExecuteOnKeysCodec {
-    //hex: 0x013600
-    public static final int REQUEST_MESSAGE_TYPE = 79360;
-    //hex: 0x013601
-    public static final int RESPONSE_MESSAGE_TYPE = 79361;
+    //hex: 0x013300
+    public static final int REQUEST_MESSAGE_TYPE = 78592;
+    //hex: 0x013301
+    public static final int RESPONSE_MESSAGE_TYPE = 78593;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
  * Returns the results mapped by each key in the map.
  */
-@Generated("9d03d62d283806234e91aa308aab1fe4")
+@Generated("df2ecb1710f8310eb46d88a845ac8a49")
 public final class MapExecuteWithPredicateCodec {
-    //hex: 0x013500
-    public static final int REQUEST_MESSAGE_TYPE = 79104;
-    //hex: 0x013501
-    public static final int RESPONSE_MESSAGE_TYPE = 79105;
+    //hex: 0x013200
+    public static final int REQUEST_MESSAGE_TYPE = 78336;
+    //hex: 0x013201
+    public static final int RESPONSE_MESSAGE_TYPE = 78337;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchEntriesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchEntriesCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of entries from the specified partition starting from specified table index.
  */
-@Generated("00952cd07c50d3bb53fde9eccf7a4588")
+@Generated("857b75c855f5d756ea735912a660c305")
 public final class MapFetchEntriesCodec {
-    //hex: 0x013D00
-    public static final int REQUEST_MESSAGE_TYPE = 81152;
-    //hex: 0x013D01
-    public static final int RESPONSE_MESSAGE_TYPE = 81153;
+    //hex: 0x013A00
+    public static final int REQUEST_MESSAGE_TYPE = 80384;
+    //hex: 0x013A01
+    public static final int RESPONSE_MESSAGE_TYPE = 80385;
     private static final int REQUEST_TABLE_INDEX_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BATCH_FIELD_OFFSET = REQUEST_TABLE_INDEX_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_BATCH_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchKeysCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of keys from the specified partition starting from specified table index.
  */
-@Generated("de255123e75a328dd79a8ee9c95f450e")
+@Generated("a981c8a1314373326f592b1f0e705f2f")
 public final class MapFetchKeysCodec {
-    //hex: 0x013C00
-    public static final int REQUEST_MESSAGE_TYPE = 80896;
-    //hex: 0x013C01
-    public static final int RESPONSE_MESSAGE_TYPE = 80897;
+    //hex: 0x013900
+    public static final int REQUEST_MESSAGE_TYPE = 80128;
+    //hex: 0x013901
+    public static final int RESPONSE_MESSAGE_TYPE = 80129;
     private static final int REQUEST_TABLE_INDEX_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BATCH_FIELD_OFFSET = REQUEST_TABLE_INDEX_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_BATCH_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchNearCacheInvalidationMetadataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchNearCacheInvalidationMetadataCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches invalidation metadata from partitions of map.
  */
-@Generated("32ae1ad1024171eb05b30ee2116272c1")
+@Generated("004122c3400285dcce1a1d03e5fe4b41")
 public final class MapFetchNearCacheInvalidationMetadataCodec {
-    //hex: 0x014200
-    public static final int REQUEST_MESSAGE_TYPE = 82432;
-    //hex: 0x014201
-    public static final int RESPONSE_MESSAGE_TYPE = 82433;
+    //hex: 0x013F00
+    public static final int REQUEST_MESSAGE_TYPE = 81664;
+    //hex: 0x013F01
+    public static final int RESPONSE_MESSAGE_TYPE = 81665;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchWithQueryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchWithQueryCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the specified number of entries from the specified partition starting from specified table index
  * that match the predicate and applies the projection logic on them.
  */
-@Generated("688fa6868dc7bfc1acd8314667937a9c")
+@Generated("d042355b4157eac9b5a4bdf374e4c928")
 public final class MapFetchWithQueryCodec {
-    //hex: 0x014600
-    public static final int REQUEST_MESSAGE_TYPE = 83456;
-    //hex: 0x014601
-    public static final int RESPONSE_MESSAGE_TYPE = 83457;
+    //hex: 0x014300
+    public static final int REQUEST_MESSAGE_TYPE = 82688;
+    //hex: 0x014301
+    public static final int RESPONSE_MESSAGE_TYPE = 82689;
     private static final int REQUEST_TABLE_INDEX_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_BATCH_FIELD_OFFSET = REQUEST_TABLE_INDEX_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_BATCH_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFlushCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFlushCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If this map has a MapStore, this method flushes all the local dirty entries by calling MapStore.storeAll()
  * and/or MapStore.deleteAll().
  */
-@Generated("da27ab2d3a82680c68bba87d3a5a55ef")
+@Generated("0d6d23342b2f12a2218128396d5aa9a1")
 public final class MapFlushCodec {
-    //hex: 0x010D00
-    public static final int REQUEST_MESSAGE_TYPE = 68864;
-    //hex: 0x010D01
-    public static final int RESPONSE_MESSAGE_TYPE = 68865;
+    //hex: 0x010A00
+    public static final int REQUEST_MESSAGE_TYPE = 68096;
+    //hex: 0x010A01
+    public static final int RESPONSE_MESSAGE_TYPE = 68097;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapForceUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapForceUnlockCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,
  * never blocks,and returns immediately.
  */
-@Generated("f43036cab7e68806d410358655fba99a")
+@Generated("a2bb8cde6a3a9fd101ef034d9b01cffc")
 public final class MapForceUnlockCodec {
-    //hex: 0x013700
-    public static final int REQUEST_MESSAGE_TYPE = 79616;
-    //hex: 0x013701
-    public static final int RESPONSE_MESSAGE_TYPE = 79617;
+    //hex: 0x013400
+    public static final int REQUEST_MESSAGE_TYPE = 78848;
+    //hex: 0x013401
+    public static final int RESPONSE_MESSAGE_TYPE = 78849;
     private static final int REQUEST_REFERENCE_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REFERENCE_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
@@ -40,12 +40,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("c7271281303ff86937f5b804d7c58ed9")
+@Generated("d5dfd7f9aa4821b9a9628eb70f01d512")
 public final class MapGetAllCodec {
-    //hex: 0x012700
-    public static final int REQUEST_MESSAGE_TYPE = 75520;
-    //hex: 0x012701
-    public static final int RESPONSE_MESSAGE_TYPE = 75521;
+    //hex: 0x012400
+    public static final int REQUEST_MESSAGE_TYPE = 74752;
+    //hex: 0x012401
+    public static final int RESPONSE_MESSAGE_TYPE = 74753;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetEntryViewCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetEntryViewCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns a clone of original mapping, modifying the returned value does not change the actual value
  * in the map. One should put modified value back to make changes visible to all nodes.
  */
-@Generated("ad1473267ac2a33d8b3b71c6d63dcbab")
+@Generated("63e6508bd39ed803009f7be6154441c6")
 public final class MapGetEntryViewCodec {
-    //hex: 0x012100
-    public static final int REQUEST_MESSAGE_TYPE = 73984;
-    //hex: 0x012101
-    public static final int RESPONSE_MESSAGE_TYPE = 73985;
+    //hex: 0x011E00
+    public static final int REQUEST_MESSAGE_TYPE = 73216;
+    //hex: 0x011E01
+    public static final int RESPONSE_MESSAGE_TYPE = 73217;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_MAX_IDLE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsEmptyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains no key-value mappings.
  */
-@Generated("626a5a617f6566cfd714c130e1c406d6")
+@Generated("d70ccfe0d4b9a52f293443d6b0aab95b")
 public final class MapIsEmptyCodec {
-    //hex: 0x012F00
-    public static final int REQUEST_MESSAGE_TYPE = 77568;
-    //hex: 0x012F01
-    public static final int RESPONSE_MESSAGE_TYPE = 77569;
+    //hex: 0x012C00
+    public static final int REQUEST_MESSAGE_TYPE = 76800;
+    //hex: 0x012C01
+    public static final int RESPONSE_MESSAGE_TYPE = 76801;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsLockedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsLockedCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
  */
-@Generated("728cf4081fe47329f7264f37413cfe2f")
+@Generated("8b344809866b7234a4bed697c67690d8")
 public final class MapIsLockedCodec {
-    //hex: 0x011500
-    public static final int REQUEST_MESSAGE_TYPE = 70912;
-    //hex: 0x011501
-    public static final int RESPONSE_MESSAGE_TYPE = 70913;
+    //hex: 0x011200
+    public static final int REQUEST_MESSAGE_TYPE = 70144;
+    //hex: 0x011201
+    public static final int RESPONSE_MESSAGE_TYPE = 70145;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
  * throw a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("4a5a88e6f7fb35bec376ac451671eef3")
+@Generated("ced7902d8a75b4008ce293624917e2ca")
 public final class MapKeySetCodec {
-    //hex: 0x012600
-    public static final int REQUEST_MESSAGE_TYPE = 75264;
-    //hex: 0x012601
-    public static final int RESPONSE_MESSAGE_TYPE = 75265;
+    //hex: 0x012300
+    public static final int REQUEST_MESSAGE_TYPE = 74496;
+    //hex: 0x012301
+    public static final int RESPONSE_MESSAGE_TYPE = 74497;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("3e2c2cc8b67ee5b62a4f3827fbb643de")
+@Generated("c5a87fe3238dcdde7fff4fcb940974f3")
 public final class MapKeySetWithPagingPredicateCodec {
-    //hex: 0x013800
-    public static final int REQUEST_MESSAGE_TYPE = 79872;
-    //hex: 0x013801
-    public static final int RESPONSE_MESSAGE_TYPE = 79873;
+    //hex: 0x013500
+    public static final int REQUEST_MESSAGE_TYPE = 79104;
+    //hex: 0x013501
+    public static final int RESPONSE_MESSAGE_TYPE = 79105;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("a605158d3a8bd9d4778d8df1932de3d3")
+@Generated("f32b6227ccbe769a5d75202599842177")
 public final class MapKeySetWithPredicateCodec {
-    //hex: 0x012A00
-    public static final int REQUEST_MESSAGE_TYPE = 76288;
-    //hex: 0x012A01
-    public static final int RESPONSE_MESSAGE_TYPE = 76289;
+    //hex: 0x012700
+    public static final int REQUEST_MESSAGE_TYPE = 75520;
+    //hex: 0x012701
+    public static final int RESPONSE_MESSAGE_TYPE = 75521;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLoadAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLoadAllCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Loads all keys into the store. This is a batch load operation so that an implementation can optimize the multiple loads.
  */
-@Generated("03dcf0c03b5e01350d2058cb650cce33")
+@Generated("85c315543548949a1ba7a0ee4feaf849")
 public final class MapLoadAllCodec {
-    //hex: 0x012400
-    public static final int REQUEST_MESSAGE_TYPE = 74752;
-    //hex: 0x012401
-    public static final int RESPONSE_MESSAGE_TYPE = 74753;
+    //hex: 0x012100
+    public static final int REQUEST_MESSAGE_TYPE = 73984;
+    //hex: 0x012101
+    public static final int RESPONSE_MESSAGE_TYPE = 73985;
     private static final int REQUEST_REPLACE_EXISTING_VALUES_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REPLACE_EXISTING_VALUES_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLoadGivenKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLoadGivenKeysCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
  */
-@Generated("933cd150a0fdd6bae8dc2780ec05bfd7")
+@Generated("6bfaa4059a23a953017d10ab82eb7e68")
 public final class MapLoadGivenKeysCodec {
-    //hex: 0x012500
-    public static final int REQUEST_MESSAGE_TYPE = 75008;
-    //hex: 0x012501
-    public static final int RESPONSE_MESSAGE_TYPE = 75009;
+    //hex: 0x012200
+    public static final int REQUEST_MESSAGE_TYPE = 74240;
+    //hex: 0x012201
+    public static final int RESPONSE_MESSAGE_TYPE = 74241;
     private static final int REQUEST_REPLACE_EXISTING_VALUES_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REPLACE_EXISTING_VALUES_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLockCodec.java
@@ -40,12 +40,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Scope of the lock is this map only. Acquired lock is only for the key in this map. Locks are re-entrant,
  * so if the key is locked N times then it should be unlocked N times before another thread can acquire it.
  */
-@Generated("0347feade4a40c2ac9f2e057cec4eb3f")
+@Generated("74d10d3542c4c68b7fd0f549e7dbfdcd")
 public final class MapLockCodec {
-    //hex: 0x011300
-    public static final int REQUEST_MESSAGE_TYPE = 70400;
-    //hex: 0x011301
-    public static final int RESPONSE_MESSAGE_TYPE = 70401;
+    //hex: 0x011000
+    public static final int REQUEST_MESSAGE_TYPE = 69632;
+    //hex: 0x011001
+    public static final int RESPONSE_MESSAGE_TYPE = 69633;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_REFERENCE_ID_FIELD_OFFSET = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the projection logic on all map entries and returns the result
  */
-@Generated("cdd98a52d0df2ec70dd8e9e30f3f6937")
+@Generated("c9164143360a84fd72365ec6fdda922c")
 public final class MapProjectCodec {
-    //hex: 0x014000
-    public static final int REQUEST_MESSAGE_TYPE = 81920;
-    //hex: 0x014001
-    public static final int RESPONSE_MESSAGE_TYPE = 81921;
+    //hex: 0x013D00
+    public static final int REQUEST_MESSAGE_TYPE = 81152;
+    //hex: 0x013D01
+    public static final int RESPONSE_MESSAGE_TYPE = 81153;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectWithPredicateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the projection logic on map entries filtered with the Predicate and returns the result
  */
-@Generated("b16f64d000c522478485af8edbff96a4")
+@Generated("6858faf18bc6100cd6b1995de0d5ba7a")
 public final class MapProjectWithPredicateCodec {
-    //hex: 0x014100
-    public static final int REQUEST_MESSAGE_TYPE = 82176;
-    //hex: 0x014101
-    public static final int RESPONSE_MESSAGE_TYPE = 82177;
+    //hex: 0x013E00
+    public static final int REQUEST_MESSAGE_TYPE = 81408;
+    //hex: 0x013E01
+    public static final int RESPONSE_MESSAGE_TYPE = 81409;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutAllCodec.java
@@ -42,12 +42,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("26a9bb543124623f75365cd1a1c7ead1")
+@Generated("41d39207c126cb496bcc7bcda3b1d1bb")
 public final class MapPutAllCodec {
-    //hex: 0x013000
-    public static final int REQUEST_MESSAGE_TYPE = 77824;
-    //hex: 0x013001
-    public static final int RESPONSE_MESSAGE_TYPE = 77825;
+    //hex: 0x012D00
+    public static final int REQUEST_MESSAGE_TYPE = 77056;
+    //hex: 0x012D01
+    public static final int RESPONSE_MESSAGE_TYPE = 77057;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
  * with a value. Entry will expire and get evicted after the ttl.
  */
-@Generated("73ce9375567bf8ec98f624779fad9ffc")
+@Generated("4834f29744c9287995a085241290aab4")
 public final class MapPutIfAbsentCodec {
-    //hex: 0x011100
-    public static final int REQUEST_MESSAGE_TYPE = 69888;
-    //hex: 0x011101
-    public static final int RESPONSE_MESSAGE_TYPE = 69889;
+    //hex: 0x010E00
+    public static final int REQUEST_MESSAGE_TYPE = 69120;
+    //hex: 0x010E01
+    public static final int RESPONSE_MESSAGE_TYPE = 69121;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentWithMaxIdleCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
  * with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
  */
-@Generated("3f57f51a765f1db6b8291eb8304b8507")
+@Generated("4d12c330fc09665bd4457ef088d41a99")
 public final class MapPutIfAbsentWithMaxIdleCodec {
-    //hex: 0x014C00
-    public static final int REQUEST_MESSAGE_TYPE = 84992;
-    //hex: 0x014C01
-    public static final int RESPONSE_MESSAGE_TYPE = 84993;
+    //hex: 0x014900
+    public static final int REQUEST_MESSAGE_TYPE = 84224;
+    //hex: 0x014901
+    public static final int RESPONSE_MESSAGE_TYPE = 84225;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_IDLE_FIELD_OFFSET = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
  * If ttl is 0, then the entry lives forever.
  */
-@Generated("928df0fabe3881653c537040e389ef02")
+@Generated("2be85cf50dadcc379eca3485171e6209")
 public final class MapPutTransientCodec {
-    //hex: 0x011000
-    public static final int REQUEST_MESSAGE_TYPE = 69632;
-    //hex: 0x011001
-    public static final int RESPONSE_MESSAGE_TYPE = 69633;
+    //hex: 0x010D00
+    public static final int REQUEST_MESSAGE_TYPE = 68864;
+    //hex: 0x010D01
+    public static final int RESPONSE_MESSAGE_TYPE = 68865;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientWithMaxIdleCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
  * If ttl and maxIdle are 0, then the entry lives forever.
  */
-@Generated("3fc9f6a46e601e735517020cb5fc1c75")
+@Generated("8d8be95febeca743bd1677cac6f13b9e")
 public final class MapPutTransientWithMaxIdleCodec {
-    //hex: 0x014B00
-    public static final int REQUEST_MESSAGE_TYPE = 84736;
-    //hex: 0x014B01
-    public static final int RESPONSE_MESSAGE_TYPE = 84737;
+    //hex: 0x014800
+    public static final int REQUEST_MESSAGE_TYPE = 83968;
+    //hex: 0x014801
+    public static final int RESPONSE_MESSAGE_TYPE = 83969;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_IDLE_FIELD_OFFSET = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutWithMaxIdleCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
  * rounded to the next closest second value.
  */
-@Generated("1d0f7337ac2f3ee7e77db517891a98e8")
+@Generated("d03765a54c4e20f0726ae1bcecc911a8")
 public final class MapPutWithMaxIdleCodec {
-    //hex: 0x014A00
-    public static final int REQUEST_MESSAGE_TYPE = 84480;
-    //hex: 0x014A01
-    public static final int RESPONSE_MESSAGE_TYPE = 84481;
+    //hex: 0x014700
+    public static final int REQUEST_MESSAGE_TYPE = 83712;
+    //hex: 0x014701
+    public static final int RESPONSE_MESSAGE_TYPE = 83713;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_IDLE_FIELD_OFFSET = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveAllCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all entries which match with the supplied predicate
  */
-@Generated("edfa1885acc73cb356514688ec0778c2")
+@Generated("43c17c0d6115093e1a5cb692f49fa0b3")
 public final class MapRemoveAllCodec {
-    //hex: 0x014400
-    public static final int REQUEST_MESSAGE_TYPE = 82944;
-    //hex: 0x014401
-    public static final int RESPONSE_MESSAGE_TYPE = 82945;
+    //hex: 0x014100
+    public static final int REQUEST_MESSAGE_TYPE = 82176;
+    //hex: 0x014101
+    public static final int RESPONSE_MESSAGE_TYPE = 82177;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveEntryListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the specified entry listener. Returns silently if there is no such listener added before.
  */
-@Generated("db3e58128dc4fea2ad3896020bffb904")
+@Generated("a6a03622b3c6aea254951ddc7a89141e")
 public final class MapRemoveEntryListenerCodec {
-    //hex: 0x011E00
-    public static final int REQUEST_MESSAGE_TYPE = 73216;
-    //hex: 0x011E01
-    public static final int RESPONSE_MESSAGE_TYPE = 73217;
+    //hex: 0x011B00
+    public static final int REQUEST_MESSAGE_TYPE = 72448;
+    //hex: 0x011B01
+    public static final int RESPONSE_MESSAGE_TYPE = 72449;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveIfSameCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the mapping for a key from this map if existing value equal to the this value
  */
-@Generated("4545cbaa149bf37676f2931173b76e26")
+@Generated("862e7c965ba4512c0231c692607cc8d6")
 public final class MapRemoveIfSameCodec {
-    //hex: 0x010B00
-    public static final int REQUEST_MESSAGE_TYPE = 68352;
-    //hex: 0x010B01
-    public static final int RESPONSE_MESSAGE_TYPE = 68353;
+    //hex: 0x010800
+    public static final int REQUEST_MESSAGE_TYPE = 67584;
+    //hex: 0x010801
+    public static final int RESPONSE_MESSAGE_TYPE = 67585;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveInterceptorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveInterceptorCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given interceptor for this map so it will not intercept operations anymore.
  */
-@Generated("b13d56eb903ddc803d43c995c73f1c5a")
+@Generated("a7a9fea0e3eca646b75fed4512e3d150")
 public final class MapRemoveInterceptorCodec {
-    //hex: 0x011800
-    public static final int REQUEST_MESSAGE_TYPE = 71680;
-    //hex: 0x011801
-    public static final int RESPONSE_MESSAGE_TYPE = 71681;
+    //hex: 0x011500
+    public static final int REQUEST_MESSAGE_TYPE = 70912;
+    //hex: 0x011501
+    public static final int RESPONSE_MESSAGE_TYPE = 70913;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemovePartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemovePartitionLostListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the specified map partition lost listener. Returns silently if there is no such listener added before.
  */
-@Generated("351b5d007b0018ddaf247cdd0e765882")
+@Generated("a0ba0e47aefd1509f958a9393f7be5e5")
 public final class MapRemovePartitionLostListenerCodec {
-    //hex: 0x012000
-    public static final int REQUEST_MESSAGE_TYPE = 73728;
-    //hex: 0x012001
-    public static final int RESPONSE_MESSAGE_TYPE = 73729;
+    //hex: 0x011D00
+    public static final int REQUEST_MESSAGE_TYPE = 72960;
+    //hex: 0x011D01
+    public static final int RESPONSE_MESSAGE_TYPE = 72961;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
  * return the old value, which is more efficient.
  */
-@Generated("68243665e46de483da0d8f18a8fd4099")
+@Generated("17c1dbfe18a1cbb376a7a9e3098e5b50")
 public final class MapSetCodec {
-    //hex: 0x011200
-    public static final int REQUEST_MESSAGE_TYPE = 70144;
-    //hex: 0x011201
-    public static final int RESPONSE_MESSAGE_TYPE = 70145;
+    //hex: 0x010F00
+    public static final int REQUEST_MESSAGE_TYPE = 69376;
+    //hex: 0x010F01
+    public static final int RESPONSE_MESSAGE_TYPE = 69377;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetTtlCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetTtlCodec.java
@@ -48,12 +48,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * <p>
  * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
  */
-@Generated("1b5f6435d19bbd9e8ec6f563de3f7212")
+@Generated("4b4bd541d7b8a5c74dc81856a2df5bcc")
 public final class MapSetTtlCodec {
-    //hex: 0x014900
-    public static final int REQUEST_MESSAGE_TYPE = 84224;
-    //hex: 0x014901
-    public static final int RESPONSE_MESSAGE_TYPE = 84225;
+    //hex: 0x014600
+    public static final int REQUEST_MESSAGE_TYPE = 83456;
+    //hex: 0x014601
+    public static final int RESPONSE_MESSAGE_TYPE = 83457;
     private static final int REQUEST_TTL_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetWithMaxIdleCodec.java
@@ -40,12 +40,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * 
  * Similar to the put operation except that set doesn't return the old value, which is more efficient.
  */
-@Generated("8f79fea8a147694289167e0be6fc00c5")
+@Generated("24f6ba0b6d4f33cd54db3453f4efea0e")
 public final class MapSetWithMaxIdleCodec {
-    //hex: 0x014D00
-    public static final int REQUEST_MESSAGE_TYPE = 85248;
-    //hex: 0x014D01
-    public static final int RESPONSE_MESSAGE_TYPE = 85249;
+    //hex: 0x014A00
+    public static final int REQUEST_MESSAGE_TYPE = 84480;
+    //hex: 0x014A01
+    public static final int RESPONSE_MESSAGE_TYPE = 84481;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_IDLE_FIELD_OFFSET = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSizeCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
  * returns Integer.MAX_VALUE
  */
-@Generated("34bc262e4e6df02014200929ec9e05c1")
+@Generated("2f90556b20234ba7264a603cb44c8b94")
 public final class MapSizeCodec {
-    //hex: 0x012E00
-    public static final int REQUEST_MESSAGE_TYPE = 77312;
-    //hex: 0x012E01
-    public static final int RESPONSE_MESSAGE_TYPE = 77313;
+    //hex: 0x012B00
+    public static final int REQUEST_MESSAGE_TYPE = 76544;
+    //hex: 0x012B01
+    public static final int RESPONSE_MESSAGE_TYPE = 76545;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSubmitToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSubmitToKeyCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
  * operation of EntryProcessor.
  */
-@Generated("9f20b6c6f67fab3d344faf510efcf456")
+@Generated("6c7befb9fdf11f36b0a75eac90cd4317")
 public final class MapSubmitToKeyCodec {
-    //hex: 0x013300
-    public static final int REQUEST_MESSAGE_TYPE = 78592;
-    //hex: 0x013301
-    public static final int RESPONSE_MESSAGE_TYPE = 78593;
+    //hex: 0x013000
+    public static final int REQUEST_MESSAGE_TYPE = 77824;
+    //hex: 0x013001
+    public static final int RESPONSE_MESSAGE_TYPE = 77825;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryLockCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * purposes and lies dormant until one of two things happens the lock is acquired by the current thread, or
  * the specified waiting time elapses.
  */
-@Generated("881d1f8bfd52599e8695cf596a8e3f8c")
+@Generated("d15562fa7e6f8342b66bd7b797932aae")
 public final class MapTryLockCodec {
-    //hex: 0x011400
-    public static final int REQUEST_MESSAGE_TYPE = 70656;
-    //hex: 0x011401
-    public static final int RESPONSE_MESSAGE_TYPE = 70657;
+    //hex: 0x011100
+    public static final int REQUEST_MESSAGE_TYPE = 69888;
+    //hex: 0x011101
+    public static final int RESPONSE_MESSAGE_TYPE = 69889;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LEASE_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = REQUEST_LEASE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryPutCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * it means that the caller thread could not acquire the lock for the key within the timeout duration,
  * thus the put operation is not successful.
  */
-@Generated("61ac21cb145d91b920836a5aaa69aaad")
+@Generated("815bcd8c1702f3b5d4b1104288bb7264")
 public final class MapTryPutCodec {
-    //hex: 0x010F00
-    public static final int REQUEST_MESSAGE_TYPE = 69376;
-    //hex: 0x010F01
-    public static final int RESPONSE_MESSAGE_TYPE = 69377;
+    //hex: 0x010C00
+    public static final int REQUEST_MESSAGE_TYPE = 68608;
+    //hex: 0x010C01
+    public static final int RESPONSE_MESSAGE_TYPE = 68609;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TIMEOUT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryRemoveCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the key is already locked by another thread and/or member, then this operation will wait the timeout
  * amount for acquiring the lock.
  */
-@Generated("f29e14961791983d5c741b5b12096c77")
+@Generated("bcdb05444213a940d87381a22c6a2ce1")
 public final class MapTryRemoveCodec {
-    //hex: 0x010E00
-    public static final int REQUEST_MESSAGE_TYPE = 69120;
-    //hex: 0x010E01
-    public static final int RESPONSE_MESSAGE_TYPE = 69121;
+    //hex: 0x010B00
+    public static final int REQUEST_MESSAGE_TYPE = 68352;
+    //hex: 0x010B01
+    public static final int RESPONSE_MESSAGE_TYPE = 68353;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TIMEOUT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapUnlockCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * then the lock is released.  If the current thread is not the holder of this lock,
  * then ILLEGAL_MONITOR_STATE is thrown.
  */
-@Generated("6bbc7b5da329e1fb66db7b9d4c9c82c2")
+@Generated("322ad0741d7da86bfbb24012da45ae62")
 public final class MapUnlockCodec {
-    //hex: 0x011600
-    public static final int REQUEST_MESSAGE_TYPE = 71168;
-    //hex: 0x011601
-    public static final int RESPONSE_MESSAGE_TYPE = 71169;
+    //hex: 0x011300
+    public static final int REQUEST_MESSAGE_TYPE = 70400;
+    //hex: 0x011301
+    public static final int RESPONSE_MESSAGE_TYPE = 70401;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_REFERENCE_ID_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REFERENCE_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
  * if query result size limit is configured.
  */
-@Generated("bd124027102295102ffcb85430e572fc")
+@Generated("78072b1bed85221b44f9aa5ec6f857cb")
 public final class MapValuesCodec {
-    //hex: 0x012800
-    public static final int REQUEST_MESSAGE_TYPE = 75776;
-    //hex: 0x012801
-    public static final int RESPONSE_MESSAGE_TYPE = 75777;
+    //hex: 0x012500
+    public static final int REQUEST_MESSAGE_TYPE = 75008;
+    //hex: 0x012501
+    public static final int RESPONSE_MESSAGE_TYPE = 75009;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("e6ca22c62491f2b341bc0d29800931f1")
+@Generated("5417067d86b295cf72b0adcb816448b0")
 public final class MapValuesWithPagingPredicateCodec {
-    //hex: 0x013900
-    public static final int REQUEST_MESSAGE_TYPE = 80128;
-    //hex: 0x013901
-    public static final int RESPONSE_MESSAGE_TYPE = 80129;
+    //hex: 0x013600
+    public static final int REQUEST_MESSAGE_TYPE = 79360;
+    //hex: 0x013601
+    public static final int RESPONSE_MESSAGE_TYPE = 79361;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("3be90dc7d091ce47553e8d23d31b6cc5")
+@Generated("e7d5a90249abd2b11c4ebeafbc6e52d4")
 public final class MapValuesWithPredicateCodec {
-    //hex: 0x012B00
-    public static final int REQUEST_MESSAGE_TYPE = 76544;
-    //hex: 0x012B01
-    public static final int RESPONSE_MESSAGE_TYPE = 76545;
+    //hex: 0x012800
+    public static final int REQUEST_MESSAGE_TYPE = 75776;
+    //hex: 0x012801
+    public static final int RESPONSE_MESSAGE_TYPE = 75777;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterAddCodec.java
@@ -44,12 +44,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If smart routing is disabled, the actual member processing the client
  * message may act as a proxy.
  */
-@Generated("2920258d707e2c3f447c5ea486725174")
+@Generated("ed703b66ef8fc5ae9dd94f3493e6c4cd")
 public final class PNCounterAddCodec {
-    //hex: 0x200200
-    public static final int REQUEST_MESSAGE_TYPE = 2097664;
-    //hex: 0x200201
-    public static final int RESPONSE_MESSAGE_TYPE = 2097665;
+    //hex: 0x1D0200
+    public static final int REQUEST_MESSAGE_TYPE = 1901056;
+    //hex: 0x1D0201
+    public static final int RESPONSE_MESSAGE_TYPE = 1901057;
     private static final int REQUEST_DELTA_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_GET_BEFORE_UPDATE_FIELD_OFFSET = REQUEST_DELTA_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_GET_BEFORE_UPDATE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetCodec.java
@@ -43,12 +43,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If smart routing is disabled, the actual member processing the client
  * message may act as a proxy.
  */
-@Generated("56b05c7d10a61e45a1c702184a56348a")
+@Generated("dfed6f618fb432f40e937036b93c9ed6")
 public final class PNCounterGetCodec {
-    //hex: 0x200100
-    public static final int REQUEST_MESSAGE_TYPE = 2097408;
-    //hex: 0x200101
-    public static final int RESPONSE_MESSAGE_TYPE = 2097409;
+    //hex: 0x1D0100
+    public static final int REQUEST_MESSAGE_TYPE = 1900800;
+    //hex: 0x1D0101
+    public static final int RESPONSE_MESSAGE_TYPE = 1900801;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_VALUE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_REPLICA_COUNT_FIELD_OFFSET = RESPONSE_VALUE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetConfiguredReplicaCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetConfiguredReplicaCountCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The actual replica count may be less, depending on the number of data
  * members in the cluster (members that own data).
  */
-@Generated("2cc4b3e9c2a7f8cc61bf8d6138936353")
+@Generated("effa1b7b881d332ca894db5d5708e3ae")
 public final class PNCounterGetConfiguredReplicaCountCodec {
-    //hex: 0x200300
-    public static final int REQUEST_MESSAGE_TYPE = 2097920;
-    //hex: 0x200301
-    public static final int RESPONSE_MESSAGE_TYPE = 2097921;
+    //hex: 0x1D0300
+    public static final int REQUEST_MESSAGE_TYPE = 1901312;
+    //hex: 0x1D0301
+    public static final int RESPONSE_MESSAGE_TYPE = 1901313;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
  */
-@Generated("ff1ce87d62f1d620294b4a85dea4bd6c")
+@Generated("070c915a0c35942e64ba5d018e2a18c2")
 public final class ReplicatedMapAddEntryListenerCodec {
-    //hex: 0x0E0D00
-    public static final int REQUEST_MESSAGE_TYPE = 920832;
-    //hex: 0x0E0D01
-    public static final int RESPONSE_MESSAGE_TYPE = 920833;
+    //hex: 0x0D0D00
+    public static final int REQUEST_MESSAGE_TYPE = 855296;
+    //hex: 0x0D0D01
+    public static final int RESPONSE_MESSAGE_TYPE = 855297;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -51,8 +51,8 @@ public final class ReplicatedMapAddEntryListenerCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x0E0D02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 920834;
+    //hex: 0x0D0D02
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 855298;
 
     private ReplicatedMapAddEntryListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds the specified entry listener for the specified key. The listener will be notified for all
  * add/remove/update/evict events of the specified key only.
  */
-@Generated("881a2b58f1e5d632c83f34c01cc8b15b")
+@Generated("8597f720feec8770fdcf404232c3558c")
 public final class ReplicatedMapAddEntryListenerToKeyCodec {
-    //hex: 0x0E0C00
-    public static final int REQUEST_MESSAGE_TYPE = 920576;
-    //hex: 0x0E0C01
-    public static final int RESPONSE_MESSAGE_TYPE = 920577;
+    //hex: 0x0D0C00
+    public static final int REQUEST_MESSAGE_TYPE = 855040;
+    //hex: 0x0D0C01
+    public static final int RESPONSE_MESSAGE_TYPE = 855041;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -52,8 +52,8 @@ public final class ReplicatedMapAddEntryListenerToKeyCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x0E0C02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 920578;
+    //hex: 0x0D0C02
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 855042;
 
     private ReplicatedMapAddEntryListenerToKeyCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
  * events filtered by the given predicate.
  */
-@Generated("f3c48152fb7a44d4664f9cf4602d881c")
+@Generated("2fd369662d2966eab0f9079f4517dfed")
 public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
-    //hex: 0x0E0A00
-    public static final int REQUEST_MESSAGE_TYPE = 920064;
-    //hex: 0x0E0A01
-    public static final int RESPONSE_MESSAGE_TYPE = 920065;
+    //hex: 0x0D0A00
+    public static final int REQUEST_MESSAGE_TYPE = 854528;
+    //hex: 0x0D0A01
+    public static final int RESPONSE_MESSAGE_TYPE = 854529;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -52,8 +52,8 @@ public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x0E0A02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 920066;
+    //hex: 0x0D0A02
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 854530;
 
     private ReplicatedMapAddEntryListenerToKeyWithPredicateCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
  * events filtered by the given predicate.
  */
-@Generated("313559529a9686ba2435d768350a3c25")
+@Generated("c8589c7012ba010c7e73390267b92287")
 public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
-    //hex: 0x0E0B00
-    public static final int REQUEST_MESSAGE_TYPE = 920320;
-    //hex: 0x0E0B01
-    public static final int RESPONSE_MESSAGE_TYPE = 920321;
+    //hex: 0x0D0B00
+    public static final int REQUEST_MESSAGE_TYPE = 854784;
+    //hex: 0x0D0B01
+    public static final int RESPONSE_MESSAGE_TYPE = 854785;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -52,8 +52,8 @@ public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x0E0B02
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 920322;
+    //hex: 0x0D0B02
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 854786;
 
     private ReplicatedMapAddEntryListenerWithPredicateCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddNearCacheEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddNearCacheEntryListenerCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("03abb2a6e0e4a7d85a9523c8561dcb4d")
+@Generated("6828bef281b3707266a251254c07f499")
 public final class ReplicatedMapAddNearCacheEntryListenerCodec {
-    //hex: 0x0E1200
-    public static final int REQUEST_MESSAGE_TYPE = 922112;
-    //hex: 0x0E1201
-    public static final int RESPONSE_MESSAGE_TYPE = 922113;
+    //hex: 0x0D1200
+    public static final int REQUEST_MESSAGE_TYPE = 856576;
+    //hex: 0x0D1201
+    public static final int RESPONSE_MESSAGE_TYPE = 856577;
     private static final int REQUEST_INCLUDE_VALUE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_LOCAL_ONLY_FIELD_OFFSET = REQUEST_INCLUDE_VALUE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_LOCAL_ONLY_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
@@ -52,8 +52,8 @@ public final class ReplicatedMapAddNearCacheEntryListenerCodec {
     private static final int EVENT_ENTRY_UUID_FIELD_OFFSET = EVENT_ENTRY_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET = EVENT_ENTRY_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int EVENT_ENTRY_INITIAL_FRAME_SIZE = EVENT_ENTRY_NUMBER_OF_AFFECTED_ENTRIES_FIELD_OFFSET + INT_SIZE_IN_BYTES;
-    //hex: 0x0E1202
-    private static final int EVENT_ENTRY_MESSAGE_TYPE = 922114;
+    //hex: 0x0D1202
+    private static final int EVENT_ENTRY_MESSAGE_TYPE = 856578;
 
     private ReplicatedMapAddNearCacheEntryListenerCodec() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapClearCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * it is retried for at most 3 times (on the failing nodes only). If it does not work after the third time, this
  * method throws a OPERATION_TIMEOUT back to the caller.
  */
-@Generated("aeca221d75bc6b501d16a113da413fa5")
+@Generated("8dbec5a73a7d7d966b4f0bf36df500f1")
 public final class ReplicatedMapClearCodec {
-    //hex: 0x0E0900
-    public static final int REQUEST_MESSAGE_TYPE = 919808;
-    //hex: 0x0E0901
-    public static final int RESPONSE_MESSAGE_TYPE = 919809;
+    //hex: 0x0D0900
+    public static final int REQUEST_MESSAGE_TYPE = 854272;
+    //hex: 0x0D0901
+    public static final int RESPONSE_MESSAGE_TYPE = 854273;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsKeyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains a mapping for the specified key.
  */
-@Generated("3c86ae31aa85757821c092fbb28fe93d")
+@Generated("fd7559a3bb2c161dea71e0ed592df69e")
 public final class ReplicatedMapContainsKeyCodec {
-    //hex: 0x0E0400
-    public static final int REQUEST_MESSAGE_TYPE = 918528;
-    //hex: 0x0E0401
-    public static final int RESPONSE_MESSAGE_TYPE = 918529;
+    //hex: 0x0D0400
+    public static final int REQUEST_MESSAGE_TYPE = 852992;
+    //hex: 0x0D0401
+    public static final int RESPONSE_MESSAGE_TYPE = 852993;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsValueCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this map maps one or more keys to the specified value.
  * This operation will probably require time linear in the map size for most implementations of the Map interface.
  */
-@Generated("0a84d86fb3a2c370b7b035eb3a98f7ad")
+@Generated("449f4ff0b70de47bdfb143ad0f143d52")
 public final class ReplicatedMapContainsValueCodec {
-    //hex: 0x0E0500
-    public static final int REQUEST_MESSAGE_TYPE = 918784;
-    //hex: 0x0E0501
-    public static final int RESPONSE_MESSAGE_TYPE = 918785;
+    //hex: 0x0D0500
+    public static final int REQUEST_MESSAGE_TYPE = 853248;
+    //hex: 0x0D0501
+    public static final int RESPONSE_MESSAGE_TYPE = 853249;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapEntrySetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("36a9073416464c15816d060b3a367873")
+@Generated("a8ca88a14958e8606f423a4a8cb5e366")
 public final class ReplicatedMapEntrySetCodec {
-    //hex: 0x0E1100
-    public static final int REQUEST_MESSAGE_TYPE = 921856;
-    //hex: 0x0E1101
-    public static final int RESPONSE_MESSAGE_TYPE = 921857;
+    //hex: 0x0D1100
+    public static final int REQUEST_MESSAGE_TYPE = 856320;
+    //hex: 0x0D1101
+    public static final int RESPONSE_MESSAGE_TYPE = 856321;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapGetCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * necessarily indicate that the map contains no mapping for the key; it's also possible that the map
  * explicitly maps the key to null.  The #containsKey operation may be used to distinguish these two cases.
  */
-@Generated("a75e49fcce0b316a804420ff6cf986a0")
+@Generated("de80fffb16dfe3ffd08af0caa7756a72")
 public final class ReplicatedMapGetCodec {
-    //hex: 0x0E0600
-    public static final int REQUEST_MESSAGE_TYPE = 919040;
-    //hex: 0x0E0601
-    public static final int RESPONSE_MESSAGE_TYPE = 919041;
+    //hex: 0x0D0600
+    public static final int REQUEST_MESSAGE_TYPE = 853504;
+    //hex: 0x0D0601
+    public static final int RESPONSE_MESSAGE_TYPE = 853505;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapIsEmptyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return true if this map contains no key-value mappings
  */
-@Generated("c25b5ba13b3bca24fd2f08099ed5ef94")
+@Generated("14a9c5f31e4a49f9bb089db5cb60e787")
 public final class ReplicatedMapIsEmptyCodec {
-    //hex: 0x0E0300
-    public static final int REQUEST_MESSAGE_TYPE = 918272;
-    //hex: 0x0E0301
-    public static final int RESPONSE_MESSAGE_TYPE = 918273;
+    //hex: 0x0D0300
+    public static final int REQUEST_MESSAGE_TYPE = 852736;
+    //hex: 0x0D0301
+    public static final int RESPONSE_MESSAGE_TYPE = 852737;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapKeySetCodec.java
@@ -41,12 +41,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * very poor performance if called repeatedly (for example, in a loop). If the use case is different from querying
  * the data, please copy the resulting set into a new java.util.HashSet.
  */
-@Generated("48288991f6c9579eaab7038cacd39c74")
+@Generated("f8d1e0673564d6d69dcdfa96aebc4067")
 public final class ReplicatedMapKeySetCodec {
-    //hex: 0x0E0F00
-    public static final int REQUEST_MESSAGE_TYPE = 921344;
-    //hex: 0x0E0F01
-    public static final int RESPONSE_MESSAGE_TYPE = 921345;
+    //hex: 0x0D0F00
+    public static final int REQUEST_MESSAGE_TYPE = 855808;
+    //hex: 0x0D0F01
+    public static final int RESPONSE_MESSAGE_TYPE = 855809;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutAllCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * v in the specified map. The behavior of this operation is undefined if the specified map is modified while the
  * operation is in progress.
  */
-@Generated("26c941fda5fc81d5687f61a8b8581f11")
+@Generated("5f80e3bcc7334f8e7deef3d0b31b3a44")
 public final class ReplicatedMapPutAllCodec {
-    //hex: 0x0E0800
-    public static final int REQUEST_MESSAGE_TYPE = 919552;
-    //hex: 0x0E0801
-    public static final int RESPONSE_MESSAGE_TYPE = 919553;
+    //hex: 0x0D0800
+    public static final int REQUEST_MESSAGE_TYPE = 854016;
+    //hex: 0x0D0801
+    public static final int RESPONSE_MESSAGE_TYPE = 854017;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
  * to define when the value is outdated and thus should be removed from the replicated map.
  */
-@Generated("ef21d7bda7ad7bcdc8435aa7742d1f11")
+@Generated("75f1148adc709b2a5424539e9d26ec84")
 public final class ReplicatedMapPutCodec {
-    //hex: 0x0E0100
-    public static final int REQUEST_MESSAGE_TYPE = 917760;
-    //hex: 0x0E0101
-    public static final int RESPONSE_MESSAGE_TYPE = 917761;
+    //hex: 0x0D0100
+    public static final int REQUEST_MESSAGE_TYPE = 852224;
+    //hex: 0x0D0101
+    public static final int RESPONSE_MESSAGE_TYPE = 852225;
     private static final int REQUEST_TTL_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TTL_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * null does not necessarily indicate that the map contained no mapping for the key; it's also possible that the map
  * explicitly mapped the key to null. The map will not contain a mapping for the specified key once the call returns.
  */
-@Generated("b80c607809267884c9ee34b135ab8faa")
+@Generated("05902594290a2bf11f92dd2fde46087b")
 public final class ReplicatedMapRemoveCodec {
-    //hex: 0x0E0700
-    public static final int REQUEST_MESSAGE_TYPE = 919296;
-    //hex: 0x0E0701
-    public static final int RESPONSE_MESSAGE_TYPE = 919297;
+    //hex: 0x0D0700
+    public static final int REQUEST_MESSAGE_TYPE = 853760;
+    //hex: 0x0D0701
+    public static final int RESPONSE_MESSAGE_TYPE = 853761;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveEntryListenerCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the specified entry listener. Returns silently if there was no such listener added before.
  */
-@Generated("17d4bc024db86feb7ffe91107b146107")
+@Generated("7e97d4bc7c85790e0041aed233d7ce0e")
 public final class ReplicatedMapRemoveEntryListenerCodec {
-    //hex: 0x0E0E00
-    public static final int REQUEST_MESSAGE_TYPE = 921088;
-    //hex: 0x0E0E01
-    public static final int RESPONSE_MESSAGE_TYPE = 921089;
+    //hex: 0x0D0E00
+    public static final int REQUEST_MESSAGE_TYPE = 855552;
+    //hex: 0x0D0E01
+    public static final int RESPONSE_MESSAGE_TYPE = 855553;
     private static final int REQUEST_REGISTRATION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_REGISTRATION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapSizeCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of key-value mappings in this map. If the map contains more than Integer.MAX_VALUE elements,
  * returns Integer.MAX_VALUE.
  */
-@Generated("855050a9b6ef64060a24a6108dceaa73")
+@Generated("77dc644424e124611a2758655d05ac7e")
 public final class ReplicatedMapSizeCodec {
-    //hex: 0x0E0200
-    public static final int REQUEST_MESSAGE_TYPE = 918016;
-    //hex: 0x0E0201
-    public static final int RESPONSE_MESSAGE_TYPE = 918017;
+    //hex: 0x0D0200
+    public static final int REQUEST_MESSAGE_TYPE = 852480;
+    //hex: 0x0D0201
+    public static final int RESPONSE_MESSAGE_TYPE = 852481;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapValuesCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("d87b156aab7490bd047105d8aca87f97")
+@Generated("7e975724bf1358dd9720f4768a277d3b")
 public final class ReplicatedMapValuesCodec {
-    //hex: 0x0E1000
-    public static final int REQUEST_MESSAGE_TYPE = 921600;
-    //hex: 0x0E1001
-    public static final int RESPONSE_MESSAGE_TYPE = 921601;
+    //hex: 0x0D1000
+    public static final int REQUEST_MESSAGE_TYPE = 856064;
+    //hex: 0x0D1001
+    public static final int RESPONSE_MESSAGE_TYPE = 856065;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddAllCodec.java
@@ -43,12 +43,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
  * The result of the future contains the sequenceId of the last written item
  */
-@Generated("0909cc25867bd3587925b44510e2b4f8")
+@Generated("93c0fccb114d5861aeaba26d7983a05f")
 public final class RingbufferAddAllCodec {
-    //hex: 0x190900
-    public static final int REQUEST_MESSAGE_TYPE = 1640704;
-    //hex: 0x190901
-    public static final int RESPONSE_MESSAGE_TYPE = 1640705;
+    //hex: 0x170800
+    public static final int REQUEST_MESSAGE_TYPE = 1509376;
+    //hex: 0x170801
+    public static final int RESPONSE_MESSAGE_TYPE = 1509377;
     private static final int REQUEST_OVERFLOW_POLICY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_OVERFLOW_POLICY_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddCodec.java
@@ -46,12 +46,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
  * to find that item.
  */
-@Generated("0bc8a0bc4da0b2a5b68a1d8225d11cd3")
+@Generated("886ab4c7658aa4e408fb240607b89f24")
 public final class RingbufferAddCodec {
-    //hex: 0x190600
-    public static final int REQUEST_MESSAGE_TYPE = 1639936;
-    //hex: 0x190601
-    public static final int RESPONSE_MESSAGE_TYPE = 1639937;
+    //hex: 0x170600
+    public static final int REQUEST_MESSAGE_TYPE = 1508864;
+    //hex: 0x170601
+    public static final int RESPONSE_MESSAGE_TYPE = 1508865;
     private static final int REQUEST_OVERFLOW_POLICY_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_OVERFLOW_POLICY_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferCapacityCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferCapacityCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the capacity of this Ringbuffer.
  */
-@Generated("c76ce61cb969c1d3f8b135f167b5a5ab")
+@Generated("37afb0d10788644dca73631879ae44c0")
 public final class RingbufferCapacityCodec {
-    //hex: 0x190400
-    public static final int REQUEST_MESSAGE_TYPE = 1639424;
-    //hex: 0x190401
-    public static final int RESPONSE_MESSAGE_TYPE = 1639425;
+    //hex: 0x170400
+    public static final int REQUEST_MESSAGE_TYPE = 1508352;
+    //hex: 0x170401
+    public static final int RESPONSE_MESSAGE_TYPE = 1508353;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferHeadSequenceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferHeadSequenceCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are found. If the RingBuffer is empty, the head will be one more than the tail.
  * The initial value of the head is 0 (1 more than tail).
  */
-@Generated("50aa61dc2b3a2c90c12e2c37738bb00f")
+@Generated("899a174c8797c6cb6c76f39b006310ef")
 public final class RingbufferHeadSequenceCodec {
-    //hex: 0x190300
-    public static final int REQUEST_MESSAGE_TYPE = 1639168;
-    //hex: 0x190301
-    public static final int RESPONSE_MESSAGE_TYPE = 1639169;
+    //hex: 0x170300
+    public static final int REQUEST_MESSAGE_TYPE = 1508096;
+    //hex: 0x170301
+    public static final int RESPONSE_MESSAGE_TYPE = 1508097;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
@@ -42,12 +42,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
  * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
  */
-@Generated("7cad5253bcbb2f1751293e4b5e226b51")
+@Generated("aa4d44b7f013a1c77c4b04fa473fc72d")
 public final class RingbufferReadManyCodec {
-    //hex: 0x190A00
-    public static final int REQUEST_MESSAGE_TYPE = 1640960;
-    //hex: 0x190A01
-    public static final int RESPONSE_MESSAGE_TYPE = 1640961;
+    //hex: 0x170900
+    public static final int REQUEST_MESSAGE_TYPE = 1509632;
+    //hex: 0x170901
+    public static final int RESPONSE_MESSAGE_TYPE = 1509633;
     private static final int REQUEST_START_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_MIN_COUNT_FIELD_OFFSET = REQUEST_START_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_MAX_COUNT_FIELD_OFFSET = REQUEST_MIN_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadOneCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadOneCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * readers or it can be read multiple times by the same reader. Currently it isn't possible to control how long this
  * call is going to block. In the future we could add e.g. tryReadOne(long sequence, long timeout, TimeUnit unit).
  */
-@Generated("91d90e10ddd27f4fea03c5399b08c5e5")
+@Generated("a4211b695de30ac37124a87102af98d5")
 public final class RingbufferReadOneCodec {
-    //hex: 0x190800
-    public static final int REQUEST_MESSAGE_TYPE = 1640448;
-    //hex: 0x190801
-    public static final int RESPONSE_MESSAGE_TYPE = 1640449;
+    //hex: 0x170700
+    public static final int REQUEST_MESSAGE_TYPE = 1509120;
+    //hex: 0x170701
+    public static final int RESPONSE_MESSAGE_TYPE = 1509121;
     private static final int REQUEST_SEQUENCE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SEQUENCE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferRemainingCapacityCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferRemainingCapacityCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the remaining capacity of the ringbuffer. The returned value could be stale as soon as it is returned.
  * If ttl is not set, the remaining capacity will always be the capacity.
  */
-@Generated("551d9e94365ed4755f432a691d059f7a")
+@Generated("ae2a21ac2c45d7c1aed1ac808153d81a")
 public final class RingbufferRemainingCapacityCodec {
-    //hex: 0x190500
-    public static final int REQUEST_MESSAGE_TYPE = 1639680;
-    //hex: 0x190501
-    public static final int RESPONSE_MESSAGE_TYPE = 1639681;
+    //hex: 0x170500
+    public static final int REQUEST_MESSAGE_TYPE = 1508608;
+    //hex: 0x170501
+    public static final int RESPONSE_MESSAGE_TYPE = 1508609;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferSizeCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
  * head completed the first looparound the ring. This is because no items are getting retired.
  */
-@Generated("2891fd1ce08dd9aa7141845e3bf1ea2c")
+@Generated("3feb4f68e802c5a9763b320428ed8a5a")
 public final class RingbufferSizeCodec {
-    //hex: 0x190100
-    public static final int REQUEST_MESSAGE_TYPE = 1638656;
-    //hex: 0x190101
-    public static final int RESPONSE_MESSAGE_TYPE = 1638657;
+    //hex: 0x170100
+    public static final int REQUEST_MESSAGE_TYPE = 1507584;
+    //hex: 0x170101
+    public static final int RESPONSE_MESSAGE_TYPE = 1507585;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferTailSequenceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferTailSequenceCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
  * The initial value of the tail is -1.
  */
-@Generated("8c1f47d42f52c68fe0d899b26ca543ca")
+@Generated("47b799d0603908d223ae0eb5cdef1d7a")
 public final class RingbufferTailSequenceCodec {
-    //hex: 0x190200
-    public static final int REQUEST_MESSAGE_TYPE = 1638912;
-    //hex: 0x190201
-    public static final int RESPONSE_MESSAGE_TYPE = 1638913;
+    //hex: 0x170200
+    public static final int REQUEST_MESSAGE_TYPE = 1507840;
+    //hex: 0x170201
+    public static final int RESPONSE_MESSAGE_TYPE = 1507841;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Cancels further execution and scheduling of the task
  */
-@Generated("52a7547f0fc00bd615b237a2f188700e")
+@Generated("30afa4aa86af63a288b506c3d33d0cb9")
 public final class ScheduledExecutorCancelFromAddressCodec {
-    //hex: 0x1D0A00
-    public static final int REQUEST_MESSAGE_TYPE = 1903104;
-    //hex: 0x1D0A01
-    public static final int RESPONSE_MESSAGE_TYPE = 1903105;
+    //hex: 0x1A0A00
+    public static final int REQUEST_MESSAGE_TYPE = 1706496;
+    //hex: 0x1A0A01
+    public static final int RESPONSE_MESSAGE_TYPE = 1706497;
     private static final int REQUEST_MAY_INTERRUPT_IF_RUNNING_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_MAY_INTERRUPT_IF_RUNNING_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Cancels further execution and scheduling of the task
  */
-@Generated("c3b83ab0f73c2affa339197ce8c27e92")
+@Generated("57e428a212a27a0804ab89550758f04c")
 public final class ScheduledExecutorCancelFromPartitionCodec {
-    //hex: 0x1D0900
-    public static final int REQUEST_MESSAGE_TYPE = 1902848;
-    //hex: 0x1D0901
-    public static final int RESPONSE_MESSAGE_TYPE = 1902849;
+    //hex: 0x1A0900
+    public static final int REQUEST_MESSAGE_TYPE = 1706240;
+    //hex: 0x1A0901
+    public static final int RESPONSE_MESSAGE_TYPE = 1706241;
     private static final int REQUEST_MAY_INTERRUPT_IF_RUNNING_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_MAY_INTERRUPT_IF_RUNNING_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorDisposeFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorDisposeFromAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Dispose the task from the scheduler
  */
-@Generated("175873ccbec87087bf3af59d1d0f194f")
+@Generated("03f2a8a1189db02ea5fc4da84779a1b2")
 public final class ScheduledExecutorDisposeFromAddressCodec {
-    //hex: 0x1D1200
-    public static final int REQUEST_MESSAGE_TYPE = 1905152;
-    //hex: 0x1D1201
-    public static final int RESPONSE_MESSAGE_TYPE = 1905153;
+    //hex: 0x1A1200
+    public static final int REQUEST_MESSAGE_TYPE = 1708544;
+    //hex: 0x1A1201
+    public static final int RESPONSE_MESSAGE_TYPE = 1708545;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorDisposeFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorDisposeFromPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Dispose the task from the scheduler
  */
-@Generated("7d7630e578a88c6d61e490eb2421b246")
+@Generated("ff9e8430ff7a4853e8fb120c200cd28b")
 public final class ScheduledExecutorDisposeFromPartitionCodec {
-    //hex: 0x1D1100
-    public static final int REQUEST_MESSAGE_TYPE = 1904896;
-    //hex: 0x1D1101
-    public static final int RESPONSE_MESSAGE_TYPE = 1904897;
+    //hex: 0x1A1100
+    public static final int REQUEST_MESSAGE_TYPE = 1708288;
+    //hex: 0x1A1101
+    public static final int RESPONSE_MESSAGE_TYPE = 1708289;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetAllScheduledFuturesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetAllScheduledFuturesCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns all scheduled tasks in for a given scheduler in the given member.
  */
-@Generated("fcf9994ae5cf3f59776a2e9ef1fe83ee")
+@Generated("2422b478aad26d2da334aa6cc5162419")
 public final class ScheduledExecutorGetAllScheduledFuturesCodec {
-    //hex: 0x1D0400
-    public static final int REQUEST_MESSAGE_TYPE = 1901568;
-    //hex: 0x1D0401
-    public static final int RESPONSE_MESSAGE_TYPE = 1901569;
+    //hex: 0x1A0400
+    public static final int REQUEST_MESSAGE_TYPE = 1704960;
+    //hex: 0x1A0401
+    public static final int RESPONSE_MESSAGE_TYPE = 1704961;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
  */
-@Generated("f89307861addef55759ca3184562a261")
+@Generated("08bed216708fbbae73c920e7d6fddfd7")
 public final class ScheduledExecutorGetDelayFromAddressCodec {
-    //hex: 0x1D0800
-    public static final int REQUEST_MESSAGE_TYPE = 1902592;
-    //hex: 0x1D0801
-    public static final int RESPONSE_MESSAGE_TYPE = 1902593;
+    //hex: 0x1A0800
+    public static final int REQUEST_MESSAGE_TYPE = 1705984;
+    //hex: 0x1A0801
+    public static final int RESPONSE_MESSAGE_TYPE = 1705985;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
  */
-@Generated("bd8789188642f0f633ed3b06a9f69654")
+@Generated("c2393ea7d278df957954efded59674c3")
 public final class ScheduledExecutorGetDelayFromPartitionCodec {
-    //hex: 0x1D0700
-    public static final int REQUEST_MESSAGE_TYPE = 1902336;
-    //hex: 0x1D0701
-    public static final int RESPONSE_MESSAGE_TYPE = 1902337;
+    //hex: 0x1A0700
+    public static final int REQUEST_MESSAGE_TYPE = 1705728;
+    //hex: 0x1A0701
+    public static final int RESPONSE_MESSAGE_TYPE = 1705729;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromAddressCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the result of the task ({@link java.util.concurrent.Callable})
  * The call will blocking until the result is ready.
  */
-@Generated("2c80fd0299f05759bff23263537d3fec")
+@Generated("24ed9280d4f3264cce3e1bbec6333aed")
 public final class ScheduledExecutorGetResultFromAddressCodec {
-    //hex: 0x1D1000
-    public static final int REQUEST_MESSAGE_TYPE = 1904640;
-    //hex: 0x1D1001
-    public static final int RESPONSE_MESSAGE_TYPE = 1904641;
+    //hex: 0x1A1000
+    public static final int REQUEST_MESSAGE_TYPE = 1708032;
+    //hex: 0x1A1001
+    public static final int RESPONSE_MESSAGE_TYPE = 1708033;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromPartitionCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the result of the task ({@link java.util.concurrent.Callable})
  * The call will blocking until the result is ready.
  */
-@Generated("aa84957511ba3288767d89e03846badd")
+@Generated("c0a16ed973bb4b50d9a98f3c1d4c1be9")
 public final class ScheduledExecutorGetResultFromPartitionCodec {
-    //hex: 0x1D0F00
-    public static final int REQUEST_MESSAGE_TYPE = 1904384;
-    //hex: 0x1D0F01
-    public static final int RESPONSE_MESSAGE_TYPE = 1904385;
+    //hex: 0x1A0F00
+    public static final int REQUEST_MESSAGE_TYPE = 1707776;
+    //hex: 0x1A0F01
+    public static final int RESPONSE_MESSAGE_TYPE = 1707777;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns statistics of the task
  */
-@Generated("20fbabbdd21932266e92c0d27bbbe8b8")
+@Generated("49becd20767afc3a2deef8f84e65bc21")
 public final class ScheduledExecutorGetStatsFromAddressCodec {
-    //hex: 0x1D0600
-    public static final int REQUEST_MESSAGE_TYPE = 1902080;
-    //hex: 0x1D0601
-    public static final int RESPONSE_MESSAGE_TYPE = 1902081;
+    //hex: 0x1A0600
+    public static final int REQUEST_MESSAGE_TYPE = 1705472;
+    //hex: 0x1A0601
+    public static final int RESPONSE_MESSAGE_TYPE = 1705473;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_LAST_IDLE_TIME_NANOS_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_TOTAL_IDLE_TIME_NANOS_FIELD_OFFSET = RESPONSE_LAST_IDLE_TIME_NANOS_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns statistics of the task
  */
-@Generated("179d99a71e0f01bb94ac0d1c01370f07")
+@Generated("5c642e7022d4006cb5e7d4ff854b6575")
 public final class ScheduledExecutorGetStatsFromPartitionCodec {
-    //hex: 0x1D0500
-    public static final int REQUEST_MESSAGE_TYPE = 1901824;
-    //hex: 0x1D0501
-    public static final int RESPONSE_MESSAGE_TYPE = 1901825;
+    //hex: 0x1A0500
+    public static final int REQUEST_MESSAGE_TYPE = 1705216;
+    //hex: 0x1A0501
+    public static final int RESPONSE_MESSAGE_TYPE = 1705217;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_LAST_IDLE_TIME_NANOS_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_TOTAL_IDLE_TIME_NANOS_FIELD_OFFSET = RESPONSE_LAST_IDLE_TIME_NANOS_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks whether a task as identified from the given handler is already cancelled.
  */
-@Generated("11c05c02746fb55e9a785176a503853f")
+@Generated("8d85d0d018a5d1a998647b5678569648")
 public final class ScheduledExecutorIsCancelledFromAddressCodec {
-    //hex: 0x1D0C00
-    public static final int REQUEST_MESSAGE_TYPE = 1903616;
-    //hex: 0x1D0C01
-    public static final int RESPONSE_MESSAGE_TYPE = 1903617;
+    //hex: 0x1A0C00
+    public static final int REQUEST_MESSAGE_TYPE = 1707008;
+    //hex: 0x1A0C01
+    public static final int RESPONSE_MESSAGE_TYPE = 1707009;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks whether a task as identified from the given handler is already cancelled.
  */
-@Generated("2270419aef8acd246290020477c21cc1")
+@Generated("dad942134c2a29b48a15d342b0d0c53c")
 public final class ScheduledExecutorIsCancelledFromPartitionCodec {
-    //hex: 0x1D0B00
-    public static final int REQUEST_MESSAGE_TYPE = 1903360;
-    //hex: 0x1D0B01
-    public static final int RESPONSE_MESSAGE_TYPE = 1903361;
+    //hex: 0x1A0B00
+    public static final int REQUEST_MESSAGE_TYPE = 1706752;
+    //hex: 0x1A0B01
+    public static final int RESPONSE_MESSAGE_TYPE = 1706753;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromAddressCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Checks whether a task is done.
  * @see {@link java.util.concurrent.Future#cancel(boolean)}
  */
-@Generated("e5ec9e9cfc05d4872a86582ac656d435")
+@Generated("e34ed49cd6af1761fe941b7730a551e0")
 public final class ScheduledExecutorIsDoneFromAddressCodec {
-    //hex: 0x1D0E00
-    public static final int REQUEST_MESSAGE_TYPE = 1904128;
-    //hex: 0x1D0E01
-    public static final int RESPONSE_MESSAGE_TYPE = 1904129;
+    //hex: 0x1A0E00
+    public static final int REQUEST_MESSAGE_TYPE = 1707520;
+    //hex: 0x1A0E01
+    public static final int RESPONSE_MESSAGE_TYPE = 1707521;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromPartitionCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Checks whether a task is done.
  * @see {@link java.util.concurrent.Future#cancel(boolean)}
  */
-@Generated("6c26740d95b2a9a985adcb0f07a2131d")
+@Generated("ae6b70769025c237fa9a45bbe80b7051")
 public final class ScheduledExecutorIsDoneFromPartitionCodec {
-    //hex: 0x1D0D00
-    public static final int REQUEST_MESSAGE_TYPE = 1903872;
-    //hex: 0x1D0D01
-    public static final int RESPONSE_MESSAGE_TYPE = 1903873;
+    //hex: 0x1A0D00
+    public static final int REQUEST_MESSAGE_TYPE = 1707264;
+    //hex: 0x1A0D01
+    public static final int RESPONSE_MESSAGE_TYPE = 1707265;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorShutdownCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
  * Invocation has no additional effect if already shut down.
  */
-@Generated("69374030cf1bbd2ab5e15066c4041b7f")
+@Generated("901d2662b92b5b221f99ed2e96cf782f")
 public final class ScheduledExecutorShutdownCodec {
-    //hex: 0x1D0100
-    public static final int REQUEST_MESSAGE_TYPE = 1900800;
-    //hex: 0x1D0101
-    public static final int RESPONSE_MESSAGE_TYPE = 1900801;
+    //hex: 0x1A0100
+    public static final int REQUEST_MESSAGE_TYPE = 1704192;
+    //hex: 0x1A0101
+    public static final int RESPONSE_MESSAGE_TYPE = 1704193;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToAddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToAddressCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to a member for execution, member is provided in the form of an address.
  */
-@Generated("45865c6066e01fca6a1da1656a903f97")
+@Generated("2ade0398d24db8a0b52357f7e1730009")
 public final class ScheduledExecutorSubmitToAddressCodec {
-    //hex: 0x1D0300
-    public static final int REQUEST_MESSAGE_TYPE = 1901312;
-    //hex: 0x1D0301
-    public static final int RESPONSE_MESSAGE_TYPE = 1901313;
+    //hex: 0x1A0300
+    public static final int REQUEST_MESSAGE_TYPE = 1704704;
+    //hex: 0x1A0301
+    public static final int RESPONSE_MESSAGE_TYPE = 1704705;
     private static final int REQUEST_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_DELAY_IN_MILLIS_FIELD_OFFSET = REQUEST_TYPE_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
     private static final int REQUEST_PERIOD_IN_MILLIS_FIELD_OFFSET = REQUEST_INITIAL_DELAY_IN_MILLIS_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToPartitionCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
  */
-@Generated("a86289700efbecca0ebad3112036a70b")
+@Generated("cac0187a7ab723804cae2f176e1fdc3b")
 public final class ScheduledExecutorSubmitToPartitionCodec {
-    //hex: 0x1D0200
-    public static final int REQUEST_MESSAGE_TYPE = 1901056;
-    //hex: 0x1D0201
-    public static final int RESPONSE_MESSAGE_TYPE = 1901057;
+    //hex: 0x1A0200
+    public static final int REQUEST_MESSAGE_TYPE = 1704448;
+    //hex: 0x1A0201
+    public static final int RESPONSE_MESSAGE_TYPE = 1704449;
     private static final int REQUEST_TYPE_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_DELAY_IN_MILLIS_FIELD_OFFSET = REQUEST_TYPE_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
     private static final int REQUEST_PERIOD_IN_MILLIS_FIELD_OFFSET = REQUEST_INITIAL_DELAY_IN_MILLIS_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAcquireCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAcquireCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * then the current thread becomes disabled for thread scheduling purposes
  * and lies dormant until other threads release enough permits.
  */
-@Generated("da245f5a5a0888c7b111508533e162c6")
+@Generated("b69f89f71070953f5ab818c1dde3e061")
 public final class SemaphoreAcquireCodec {
-    //hex: 0x0D0200
-    public static final int REQUEST_MESSAGE_TYPE = 852480;
-    //hex: 0x0D0201
-    public static final int RESPONSE_MESSAGE_TYPE = 852481;
+    //hex: 0x0C0200
+    public static final int REQUEST_MESSAGE_TYPE = 786944;
+    //hex: 0x0C0201
+    public static final int RESPONSE_MESSAGE_TYPE = 786945;
     private static final int REQUEST_SESSION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INVOCATION_UID_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAvailablePermitsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAvailablePermitsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of available permits.
  */
-@Generated("c92bb49aa20068581818bd957de541a6")
+@Generated("f977ed1f7494a51171608b5875f3b8d6")
 public final class SemaphoreAvailablePermitsCodec {
-    //hex: 0x0D0600
-    public static final int REQUEST_MESSAGE_TYPE = 853504;
-    //hex: 0x0D0601
-    public static final int RESPONSE_MESSAGE_TYPE = 853505;
+    //hex: 0x0C0600
+    public static final int REQUEST_MESSAGE_TYPE = 787968;
+    //hex: 0x0C0601
+    public static final int RESPONSE_MESSAGE_TYPE = 787969;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreChangeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreChangeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Increases or decreases the number of permits by the given value.
  */
-@Generated("8eedc1f49139247560c45c6223bf9233")
+@Generated("59b44e5b1d37a6198d9184cd362cf777")
 public final class SemaphoreChangeCodec {
-    //hex: 0x0D0500
-    public static final int REQUEST_MESSAGE_TYPE = 853248;
-    //hex: 0x0D0501
-    public static final int RESPONSE_MESSAGE_TYPE = 853249;
+    //hex: 0x0C0500
+    public static final int REQUEST_MESSAGE_TYPE = 787712;
+    //hex: 0x0C0501
+    public static final int RESPONSE_MESSAGE_TYPE = 787713;
     private static final int REQUEST_SESSION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INVOCATION_UID_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreDrainCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreDrainCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Acquires all available permits at once and returns immediately.
  */
-@Generated("09a94b584e1f719f5050d0afe80f9011")
+@Generated("e81beaa8d4ebc5035783262c139177e6")
 public final class SemaphoreDrainCodec {
-    //hex: 0x0D0400
-    public static final int REQUEST_MESSAGE_TYPE = 852992;
-    //hex: 0x0D0401
-    public static final int RESPONSE_MESSAGE_TYPE = 852993;
+    //hex: 0x0C0400
+    public static final int REQUEST_MESSAGE_TYPE = 787456;
+    //hex: 0x0C0401
+    public static final int RESPONSE_MESSAGE_TYPE = 787457;
     private static final int REQUEST_SESSION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INVOCATION_UID_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreGetSemaphoreTypeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreGetSemaphoreTypeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if the semaphore is JDK compatible
  */
-@Generated("f2f808744238135174726b4fe63671d1")
+@Generated("60d8d47e45295bfa4ba8b69e8dcc06bf")
 public final class SemaphoreGetSemaphoreTypeCodec {
-    //hex: 0x0D0700
-    public static final int REQUEST_MESSAGE_TYPE = 853760;
-    //hex: 0x0D0701
-    public static final int RESPONSE_MESSAGE_TYPE = 853761;
+    //hex: 0x0C0700
+    public static final int REQUEST_MESSAGE_TYPE = 788224;
+    //hex: 0x0C0701
+    public static final int RESPONSE_MESSAGE_TYPE = 788225;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_RESPONSE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreInitCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreInitCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initializes the ISemaphore instance with the given permit number, if not
  * initialized before.
  */
-@Generated("99e2141047631e6c828301f156b4eae0")
+@Generated("7fe74580b6c906e6ad414ca4760a6731")
 public final class SemaphoreInitCodec {
-    //hex: 0x0D0100
-    public static final int REQUEST_MESSAGE_TYPE = 852224;
-    //hex: 0x0D0101
-    public static final int RESPONSE_MESSAGE_TYPE = 852225;
+    //hex: 0x0C0100
+    public static final int REQUEST_MESSAGE_TYPE = 786688;
+    //hex: 0x0C0101
+    public static final int RESPONSE_MESSAGE_TYPE = 786689;
     private static final int REQUEST_PERMITS_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_PERMITS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreReleaseCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreReleaseCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Releases the given number of permits and increases the number of
  * available permits by that amount.
  */
-@Generated("8fe58dcb7de54d167ae0867a48a1ff3d")
+@Generated("2ace13cccb7d379856cc51f83bde756d")
 public final class SemaphoreReleaseCodec {
-    //hex: 0x0D0300
-    public static final int REQUEST_MESSAGE_TYPE = 852736;
-    //hex: 0x0D0301
-    public static final int RESPONSE_MESSAGE_TYPE = 852737;
+    //hex: 0x0C0300
+    public static final int REQUEST_MESSAGE_TYPE = 787200;
+    //hex: 0x0C0301
+    public static final int RESPONSE_MESSAGE_TYPE = 787201;
     private static final int REQUEST_SESSION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_SESSION_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_INVOCATION_UID_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionCommitCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionCommitCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("1b2c66d05cd9865cbb107733c156c137")
+@Generated("1ecc680c5e8dc13e4270e0dd84cdcbc2")
 public final class TransactionCommitCodec {
-    //hex: 0x170100
-    public static final int REQUEST_MESSAGE_TYPE = 1507584;
-    //hex: 0x170101
-    public static final int RESPONSE_MESSAGE_TYPE = 1507585;
+    //hex: 0x150100
+    public static final int REQUEST_MESSAGE_TYPE = 1376512;
+    //hex: 0x150101
+    public static final int RESPONSE_MESSAGE_TYPE = 1376513;
     private static final int REQUEST_TRANSACTION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TRANSACTION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionCreateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("f93f257cba3cf40a7d46e09e6ebd21ce")
+@Generated("1b740b1e2ce72571a6ee1bd7f0945c0b")
 public final class TransactionCreateCodec {
-    //hex: 0x170200
-    public static final int REQUEST_MESSAGE_TYPE = 1507840;
-    //hex: 0x170201
-    public static final int RESPONSE_MESSAGE_TYPE = 1507841;
+    //hex: 0x150200
+    public static final int REQUEST_MESSAGE_TYPE = 1376768;
+    //hex: 0x150201
+    public static final int RESPONSE_MESSAGE_TYPE = 1376769;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_DURABILITY_FIELD_OFFSET = REQUEST_TIMEOUT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int REQUEST_TRANSACTION_TYPE_FIELD_OFFSET = REQUEST_DURABILITY_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionRollbackCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionRollbackCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("691a64de9d612290bf965dd1da71e156")
+@Generated("432060a61673d55e7442db1187a8ef6f")
 public final class TransactionRollbackCodec {
-    //hex: 0x170300
-    public static final int REQUEST_MESSAGE_TYPE = 1508096;
-    //hex: 0x170301
-    public static final int RESPONSE_MESSAGE_TYPE = 1508097;
+    //hex: 0x150300
+    public static final int REQUEST_MESSAGE_TYPE = 1377024;
+    //hex: 0x150301
+    public static final int RESPONSE_MESSAGE_TYPE = 1377025;
     private static final int REQUEST_TRANSACTION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TRANSACTION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListAddCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a new item to the transactional list.
  */
-@Generated("3ca7a5351bcde9d16793dc72b7ebebec")
+@Generated("b0aa437da39a6dcbe7c2d3ed236e9c8a")
 public final class TransactionalListAddCodec {
-    //hex: 0x130100
-    public static final int REQUEST_MESSAGE_TYPE = 1245440;
-    //hex: 0x130101
-    public static final int RESPONSE_MESSAGE_TYPE = 1245441;
+    //hex: 0x110100
+    public static final int REQUEST_MESSAGE_TYPE = 1114368;
+    //hex: 0x110101
+    public static final int RESPONSE_MESSAGE_TYPE = 1114369;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListRemoveCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Remove item from the transactional list
  */
-@Generated("3627dfd4bb464740b94c8d891ee809fc")
+@Generated("384dbec4d6913b5b949d6e94d2d80760")
 public final class TransactionalListRemoveCodec {
-    //hex: 0x130200
-    public static final int REQUEST_MESSAGE_TYPE = 1245696;
-    //hex: 0x130201
-    public static final int RESPONSE_MESSAGE_TYPE = 1245697;
+    //hex: 0x110200
+    public static final int REQUEST_MESSAGE_TYPE = 1114624;
+    //hex: 0x110201
+    public static final int RESPONSE_MESSAGE_TYPE = 1114625;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListSizeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the size of the list
  */
-@Generated("e450738731103e51ede7fc730a7c046f")
+@Generated("75edd57a70f2e2c9cec1bd607cdbc774")
 public final class TransactionalListSizeCodec {
-    //hex: 0x130300
-    public static final int REQUEST_MESSAGE_TYPE = 1245952;
-    //hex: 0x130301
-    public static final int RESPONSE_MESSAGE_TYPE = 1245953;
+    //hex: 0x110300
+    public static final int REQUEST_MESSAGE_TYPE = 1114880;
+    //hex: 0x110301
+    public static final int RESPONSE_MESSAGE_TYPE = 1114881;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsKeyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains an entry for the specified key.
  */
-@Generated("4cfb1a4c29818820e41e5e763a091f3d")
+@Generated("7e5a34f6ac8cf38eacf7202eec96fbeb")
 public final class TransactionalMapContainsKeyCodec {
-    //hex: 0x100100
-    public static final int REQUEST_MESSAGE_TYPE = 1048832;
-    //hex: 0x100101
-    public static final int RESPONSE_MESSAGE_TYPE = 1048833;
+    //hex: 0x0E0100
+    public static final int REQUEST_MESSAGE_TYPE = 917760;
+    //hex: 0x0E0101
+    public static final int RESPONSE_MESSAGE_TYPE = 917761;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsValueCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains an entry for the specified value.
  */
-@Generated("128b4a58b9ccc9919a93ad76dc33603f")
+@Generated("1698aa41098f5740da10ca5a61ce4837")
 public final class TransactionalMapContainsValueCodec {
-    //hex: 0x101200
-    public static final int REQUEST_MESSAGE_TYPE = 1053184;
-    //hex: 0x101201
-    public static final int RESPONSE_MESSAGE_TYPE = 1053185;
+    //hex: 0x0E1200
+    public static final int REQUEST_MESSAGE_TYPE = 922112;
+    //hex: 0x0E1201
+    public static final int RESPONSE_MESSAGE_TYPE = 922113;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapDeleteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapDeleteCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * key once the call returns. This method is preferred to #remove(Object) if the old value is not needed. The object
  * to be deleted will be removed from only the current transaction context until the transaction is committed.
  */
-@Generated("aaf9689025d84b99ed40c45ab6486c8a")
+@Generated("e50de9812cefd319acad422a001be6dc")
 public final class TransactionalMapDeleteCodec {
-    //hex: 0x100C00
-    public static final int REQUEST_MESSAGE_TYPE = 1051648;
-    //hex: 0x100C01
-    public static final int RESPONSE_MESSAGE_TYPE = 1051649;
+    //hex: 0x0E0C00
+    public static final int REQUEST_MESSAGE_TYPE = 920576;
+    //hex: 0x0E0C01
+    public static final int RESPONSE_MESSAGE_TYPE = 920577;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the value for the specified key, or null if this map does not contain this key.
  */
-@Generated("294fa37895b867a69dfbe90456bcc80b")
+@Generated("fe782106fbe0b379925fbca1705140e3")
 public final class TransactionalMapGetCodec {
-    //hex: 0x100200
-    public static final int REQUEST_MESSAGE_TYPE = 1049088;
-    //hex: 0x100201
-    public static final int RESPONSE_MESSAGE_TYPE = 1049089;
+    //hex: 0x0E0200
+    public static final int REQUEST_MESSAGE_TYPE = 918016;
+    //hex: 0x0E0201
+    public static final int RESPONSE_MESSAGE_TYPE = 918017;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetForUpdateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetForUpdateCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
  * the end of the transaction (either commit or rollback).
  */
-@Generated("575f9f3ebfbe563b6caf752ddc4f2603")
+@Generated("33d7db3955b836b6cc56f97932c06036")
 public final class TransactionalMapGetForUpdateCodec {
-    //hex: 0x100300
-    public static final int REQUEST_MESSAGE_TYPE = 1049344;
-    //hex: 0x100301
-    public static final int RESPONSE_MESSAGE_TYPE = 1049345;
+    //hex: 0x0E0300
+    public static final int REQUEST_MESSAGE_TYPE = 918272;
+    //hex: 0x0E0301
+    public static final int RESPONSE_MESSAGE_TYPE = 918273;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapIsEmptyCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains no entries.
  */
-@Generated("65c083a078335d1c6547bc7283b31fc0")
+@Generated("b208b7000323060acc23f40b7a54065b")
 public final class TransactionalMapIsEmptyCodec {
-    //hex: 0x100500
-    public static final int REQUEST_MESSAGE_TYPE = 1049856;
-    //hex: 0x100501
-    public static final int RESPONSE_MESSAGE_TYPE = 1049857;
+    //hex: 0x0E0500
+    public static final int REQUEST_MESSAGE_TYPE = 918784;
+    //hex: 0x0E0501
+    public static final int RESPONSE_MESSAGE_TYPE = 918785;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("a24d18a3f808b4f2b9dbbddbc321c58c")
+@Generated("670a8f3363fe12b10a268b724990013c")
 public final class TransactionalMapKeySetCodec {
-    //hex: 0x100E00
-    public static final int REQUEST_MESSAGE_TYPE = 1052160;
-    //hex: 0x100E01
-    public static final int RESPONSE_MESSAGE_TYPE = 1052161;
+    //hex: 0x0E0E00
+    public static final int REQUEST_MESSAGE_TYPE = 921088;
+    //hex: 0x0E0E01
+    public static final int RESPONSE_MESSAGE_TYPE = 921089;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("5bf6f06f5c33ba1204e422ce7938dbde")
+@Generated("db68d8dc3d0195c1b68ec92a1a063e0a")
 public final class TransactionalMapKeySetWithPredicateCodec {
-    //hex: 0x100F00
-    public static final int REQUEST_MESSAGE_TYPE = 1052416;
-    //hex: 0x100F01
-    public static final int RESPONSE_MESSAGE_TYPE = 1052417;
+    //hex: 0x0E0F00
+    public static final int REQUEST_MESSAGE_TYPE = 921344;
+    //hex: 0x0E0F01
+    public static final int RESPONSE_MESSAGE_TYPE = 921345;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
  * current transaction context till transaction is committed.
  */
-@Generated("67fefe7771e2bcc4b1ee0585307f3b65")
+@Generated("df1f34d699c2fa082fb8faf98a8274e9")
 public final class TransactionalMapPutCodec {
-    //hex: 0x100600
-    public static final int REQUEST_MESSAGE_TYPE = 1050112;
-    //hex: 0x100601
-    public static final int RESPONSE_MESSAGE_TYPE = 1050113;
+    //hex: 0x0E0600
+    public static final int REQUEST_MESSAGE_TYPE = 919040;
+    //hex: 0x0E0601
+    public static final int RESPONSE_MESSAGE_TYPE = 919041;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_TTL_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutIfAbsentCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified key is not already associated with a value, associate it with the given value.
  * The object to be put will be accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("e0e1d7476a6fd15e776729492856c299")
+@Generated("f9a0bf8ec1e9e20cf896fe4990298d5f")
 public final class TransactionalMapPutIfAbsentCodec {
-    //hex: 0x100800
-    public static final int REQUEST_MESSAGE_TYPE = 1050624;
-    //hex: 0x100801
-    public static final int RESPONSE_MESSAGE_TYPE = 1050625;
+    //hex: 0x0E0800
+    public static final int REQUEST_MESSAGE_TYPE = 919552;
+    //hex: 0x0E0801
+    public static final int RESPONSE_MESSAGE_TYPE = 919553;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * specified key once the call returns. The object to be removed will be accessible only in the current transaction
  * context until the transaction is committed.
  */
-@Generated("3033c28c4efcf51aa818cfa5e40b394d")
+@Generated("49f3ec78fc8e0cf685ca18034d6423ea")
 public final class TransactionalMapRemoveCodec {
-    //hex: 0x100B00
-    public static final int REQUEST_MESSAGE_TYPE = 1051392;
-    //hex: 0x100B01
-    public static final int RESPONSE_MESSAGE_TYPE = 1051393;
+    //hex: 0x0E0B00
+    public static final int REQUEST_MESSAGE_TYPE = 920320;
+    //hex: 0x0E0B01
+    public static final int RESPONSE_MESSAGE_TYPE = 920321;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveIfSameCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
  * from only the current transaction context until the transaction is committed.
  */
-@Generated("e28c735cebee4bdc87c1cdbf39164377")
+@Generated("97d3d7c9ce94ba6ae6aa1391dcb26b73")
 public final class TransactionalMapRemoveIfSameCodec {
-    //hex: 0x100D00
-    public static final int REQUEST_MESSAGE_TYPE = 1051904;
-    //hex: 0x100D01
-    public static final int RESPONSE_MESSAGE_TYPE = 1051905;
+    //hex: 0x0E0D00
+    public static final int REQUEST_MESSAGE_TYPE = 920832;
+    //hex: 0x0E0D01
+    public static final int RESPONSE_MESSAGE_TYPE = 920833;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
  * accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("3c9e27cad13c29bb5d8c9f1dcc04b32b")
+@Generated("6c91b2291b123cab3e3fabac2d47b8f6")
 public final class TransactionalMapReplaceCodec {
-    //hex: 0x100900
-    public static final int REQUEST_MESSAGE_TYPE = 1050880;
-    //hex: 0x100901
-    public static final int RESPONSE_MESSAGE_TYPE = 1050881;
+    //hex: 0x0E0900
+    public static final int REQUEST_MESSAGE_TYPE = 919808;
+    //hex: 0x0E0901
+    public static final int RESPONSE_MESSAGE_TYPE = 919809;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceIfSameCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
  * accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("5d7f08df015cd6376caae2132b99ad43")
+@Generated("8038f2c3d9d4209a4f3164f99e8f0136")
 public final class TransactionalMapReplaceIfSameCodec {
-    //hex: 0x100A00
-    public static final int REQUEST_MESSAGE_TYPE = 1051136;
-    //hex: 0x100A01
-    public static final int RESPONSE_MESSAGE_TYPE = 1051137;
+    //hex: 0x0E0A00
+    public static final int REQUEST_MESSAGE_TYPE = 920064;
+    //hex: 0x0E0A01
+    public static final int RESPONSE_MESSAGE_TYPE = 920065;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSetCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * if the old value is not needed.
  * The object to be set will be accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("4aa68ee4c4738e9796e4cf686efa6c2e")
+@Generated("a871063f32c67c85dbfdcd08d86e554a")
 public final class TransactionalMapSetCodec {
-    //hex: 0x100700
-    public static final int REQUEST_MESSAGE_TYPE = 1050368;
-    //hex: 0x100701
-    public static final int RESPONSE_MESSAGE_TYPE = 1050369;
+    //hex: 0x0E0700
+    public static final int REQUEST_MESSAGE_TYPE = 919296;
+    //hex: 0x0E0701
+    public static final int RESPONSE_MESSAGE_TYPE = 919297;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSizeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of entries in this map.
  */
-@Generated("97b0003943b2b7e52db156e2b6db7923")
+@Generated("ca632717b68a94ef2ebc2a7f3bd63ff6")
 public final class TransactionalMapSizeCodec {
-    //hex: 0x100400
-    public static final int REQUEST_MESSAGE_TYPE = 1049600;
-    //hex: 0x100401
-    public static final int RESPONSE_MESSAGE_TYPE = 1049601;
+    //hex: 0x0E0400
+    public static final int REQUEST_MESSAGE_TYPE = 918528;
+    //hex: 0x0E0401
+    public static final int RESPONSE_MESSAGE_TYPE = 918529;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesCodec.java
@@ -38,12 +38,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
  * distributed query, so it may throw a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("b1623045b8ceeb87298cd3bc48ac83d5")
+@Generated("699029c053f8feeac7be4f19b490d443")
 public final class TransactionalMapValuesCodec {
-    //hex: 0x101000
-    public static final int REQUEST_MESSAGE_TYPE = 1052672;
-    //hex: 0x101001
-    public static final int RESPONSE_MESSAGE_TYPE = 1052673;
+    //hex: 0x0E1000
+    public static final int REQUEST_MESSAGE_TYPE = 921600;
+    //hex: 0x0E1001
+    public static final int RESPONSE_MESSAGE_TYPE = 921601;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
@@ -39,12 +39,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("cfe4eee5f582f587e7def7b9c09a0970")
+@Generated("28a31fa661126bd5ba4d52183791d0c6")
 public final class TransactionalMapValuesWithPredicateCodec {
-    //hex: 0x101100
-    public static final int REQUEST_MESSAGE_TYPE = 1052928;
-    //hex: 0x101101
-    public static final int RESPONSE_MESSAGE_TYPE = 1052929;
+    //hex: 0x0E1100
+    public static final int REQUEST_MESSAGE_TYPE = 921856;
+    //hex: 0x0E1101
+    public static final int RESPONSE_MESSAGE_TYPE = 921857;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the collection of values associated with the key.
  */
-@Generated("617430996e27ed5701afbf20868bae8c")
+@Generated("dd4b617a5c72b9f1c535e95f0a66d845")
 public final class TransactionalMultiMapGetCodec {
-    //hex: 0x110200
-    public static final int REQUEST_MESSAGE_TYPE = 1114624;
-    //hex: 0x110201
-    public static final int RESPONSE_MESSAGE_TYPE = 1114625;
+    //hex: 0x0F0200
+    public static final int REQUEST_MESSAGE_TYPE = 983552;
+    //hex: 0x0F0201
+    public static final int RESPONSE_MESSAGE_TYPE = 983553;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapPutCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Stores a key-value pair in the multimap.
  */
-@Generated("4f1537ecb77836b3a14feecdd3d5b4e1")
+@Generated("43873d87b5b30448912f18260c8d5710")
 public final class TransactionalMultiMapPutCodec {
-    //hex: 0x110100
-    public static final int REQUEST_MESSAGE_TYPE = 1114368;
-    //hex: 0x110101
-    public static final int RESPONSE_MESSAGE_TYPE = 1114369;
+    //hex: 0x0F0100
+    public static final int REQUEST_MESSAGE_TYPE = 983296;
+    //hex: 0x0F0101
+    public static final int RESPONSE_MESSAGE_TYPE = 983297;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("4826b48774957cdb85cb45a9b17feba7")
+@Generated("80068bacea9f963c0f1886dba57e251a")
 public final class TransactionalMultiMapRemoveCodec {
-    //hex: 0x110300
-    public static final int REQUEST_MESSAGE_TYPE = 1114880;
-    //hex: 0x110301
-    public static final int RESPONSE_MESSAGE_TYPE = 1114881;
+    //hex: 0x0F0300
+    public static final int REQUEST_MESSAGE_TYPE = 983808;
+    //hex: 0x0F0301
+    public static final int RESPONSE_MESSAGE_TYPE = 983809;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveEntryCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all the entries associated with the given key.
  */
-@Generated("45cf33d0be7319e8921fa646366d6fe8")
+@Generated("5cde78e38f88b730cab6bc6abb4f544a")
 public final class TransactionalMultiMapRemoveEntryCodec {
-    //hex: 0x110400
-    public static final int REQUEST_MESSAGE_TYPE = 1115136;
-    //hex: 0x110401
-    public static final int RESPONSE_MESSAGE_TYPE = 1115137;
+    //hex: 0x0F0400
+    public static final int REQUEST_MESSAGE_TYPE = 984064;
+    //hex: 0x0F0401
+    public static final int RESPONSE_MESSAGE_TYPE = 984065;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapSizeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of key-value pairs in the multimap.
  */
-@Generated("04a794d9bfa49449bacf13054499a7e4")
+@Generated("d0d55b0a34c3a7216f9196b3058bfa58")
 public final class TransactionalMultiMapSizeCodec {
-    //hex: 0x110600
-    public static final int REQUEST_MESSAGE_TYPE = 1115648;
-    //hex: 0x110601
-    public static final int RESPONSE_MESSAGE_TYPE = 1115649;
+    //hex: 0x0F0600
+    public static final int REQUEST_MESSAGE_TYPE = 984576;
+    //hex: 0x0F0601
+    public static final int RESPONSE_MESSAGE_TYPE = 984577;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapValueCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapValueCountCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of values matching the given key in the multimap.
  */
-@Generated("deb3cb7099a3ffb61c1f4a96a6abf81a")
+@Generated("db9f3f160b5a81e5a2c661c82a42e90d")
 public final class TransactionalMultiMapValueCountCodec {
-    //hex: 0x110500
-    public static final int REQUEST_MESSAGE_TYPE = 1115392;
-    //hex: 0x110501
-    public static final int RESPONSE_MESSAGE_TYPE = 1115393;
+    //hex: 0x0F0500
+    public static final int REQUEST_MESSAGE_TYPE = 984320;
+    //hex: 0x0F0501
+    public static final int RESPONSE_MESSAGE_TYPE = 984321;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
  * become available.
  */
-@Generated("befa5ecca45823fb92e28a44c2bd50ad")
+@Generated("9686c69c0f6289c0f3ca5e5299627aac")
 public final class TransactionalQueueOfferCodec {
-    //hex: 0x140100
-    public static final int REQUEST_MESSAGE_TYPE = 1310976;
-    //hex: 0x140101
-    public static final int RESPONSE_MESSAGE_TYPE = 1310977;
+    //hex: 0x120100
+    public static final int REQUEST_MESSAGE_TYPE = 1179904;
+    //hex: 0x120101
+    public static final int RESPONSE_MESSAGE_TYPE = 1179905;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePeekCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePeekCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
  */
-@Generated("e5d0c00e4a5ad1d8c74054cc412e5b75")
+@Generated("b355dcad5ea7f3cef8aa077a49484d2e")
 public final class TransactionalQueuePeekCodec {
-    //hex: 0x140400
-    public static final int REQUEST_MESSAGE_TYPE = 1311744;
-    //hex: 0x140401
-    public static final int RESPONSE_MESSAGE_TYPE = 1311745;
+    //hex: 0x120400
+    public static final int REQUEST_MESSAGE_TYPE = 1180672;
+    //hex: 0x120401
+    public static final int RESPONSE_MESSAGE_TYPE = 1180673;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePollCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePollCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
  * to become available.
  */
-@Generated("565a1b40f90ead2b398b412eef46c11c")
+@Generated("3f7f507b5ee229d40eac07248fcce71a")
 public final class TransactionalQueuePollCodec {
-    //hex: 0x140300
-    public static final int REQUEST_MESSAGE_TYPE = 1311488;
-    //hex: 0x140301
-    public static final int RESPONSE_MESSAGE_TYPE = 1311489;
+    //hex: 0x120300
+    public static final int REQUEST_MESSAGE_TYPE = 1180416;
+    //hex: 0x120301
+    public static final int RESPONSE_MESSAGE_TYPE = 1180417;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueSizeCodec.java
@@ -37,12 +37,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
  * elements, returns Integer.MAX_VALUE.
  */
-@Generated("a4b3a7299f3e98005e34effc54a448d6")
+@Generated("9c24291be17026b800aacc31d7183729")
 public final class TransactionalQueueSizeCodec {
-    //hex: 0x140500
-    public static final int REQUEST_MESSAGE_TYPE = 1312000;
-    //hex: 0x140501
-    public static final int RESPONSE_MESSAGE_TYPE = 1312001;
+    //hex: 0x120500
+    public static final int REQUEST_MESSAGE_TYPE = 1180928;
+    //hex: 0x120501
+    public static final int RESPONSE_MESSAGE_TYPE = 1180929;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueTakeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueTakeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
  */
-@Generated("ae56a872e90347e7294ec5a1c016dd4e")
+@Generated("9306bb7af49ada82f10447dbb750e941")
 public final class TransactionalQueueTakeCodec {
-    //hex: 0x140200
-    public static final int REQUEST_MESSAGE_TYPE = 1311232;
-    //hex: 0x140201
-    public static final int RESPONSE_MESSAGE_TYPE = 1311233;
+    //hex: 0x120200
+    public static final int REQUEST_MESSAGE_TYPE = 1180160;
+    //hex: 0x120201
+    public static final int RESPONSE_MESSAGE_TYPE = 1180161;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetAddCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Add new item to transactional set.
  */
-@Generated("73a4e4ed77b44f39d6ca713f72d438ad")
+@Generated("d6eae63676b09c2f190dbf9c99fe3565")
 public final class TransactionalSetAddCodec {
-    //hex: 0x120100
-    public static final int REQUEST_MESSAGE_TYPE = 1179904;
-    //hex: 0x120101
-    public static final int RESPONSE_MESSAGE_TYPE = 1179905;
+    //hex: 0x100100
+    public static final int REQUEST_MESSAGE_TYPE = 1048832;
+    //hex: 0x100101
+    public static final int RESPONSE_MESSAGE_TYPE = 1048833;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetRemoveCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Remove item from transactional set.
  */
-@Generated("1b9ecd8775258364ca720316cb8b5f57")
+@Generated("683e8bd7abc3fa05eeaa9de0d32c0c31")
 public final class TransactionalSetRemoveCodec {
-    //hex: 0x120200
-    public static final int REQUEST_MESSAGE_TYPE = 1180160;
-    //hex: 0x120201
-    public static final int RESPONSE_MESSAGE_TYPE = 1180161;
+    //hex: 0x100200
+    public static final int REQUEST_MESSAGE_TYPE = 1049088;
+    //hex: 0x100201
+    public static final int RESPONSE_MESSAGE_TYPE = 1049089;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetSizeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the size of the set.
  */
-@Generated("f01cc595c95e5607403a5a42091af676")
+@Generated("da2db0cbe86049fd2e52c9361fa4078c")
 public final class TransactionalSetSizeCodec {
-    //hex: 0x120300
-    public static final int REQUEST_MESSAGE_TYPE = 1180416;
-    //hex: 0x120301
-    public static final int RESPONSE_MESSAGE_TYPE = 1180417;
+    //hex: 0x100300
+    public static final int REQUEST_MESSAGE_TYPE = 1049344;
+    //hex: 0x100301
+    public static final int RESPONSE_MESSAGE_TYPE = 1049345;
     private static final int REQUEST_TXN_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_THREAD_ID_FIELD_OFFSET = REQUEST_TXN_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_THREAD_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionClearRemoteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionClearRemoteCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("d13bfa911d65a090044c0d78719b1faf")
+@Generated("b2d72a3f4afb84c253f0183f665deef8")
 public final class XATransactionClearRemoteCodec {
-    //hex: 0x160100
-    public static final int REQUEST_MESSAGE_TYPE = 1442048;
-    //hex: 0x160101
-    public static final int RESPONSE_MESSAGE_TYPE = 1442049;
+    //hex: 0x140100
+    public static final int REQUEST_MESSAGE_TYPE = 1310976;
+    //hex: 0x140101
+    public static final int RESPONSE_MESSAGE_TYPE = 1310977;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCollectTransactionsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCollectTransactionsCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("4a41d163c531874c658735c35a2c87fe")
+@Generated("1faa08197abe5866d5f4cb22fdd6ad03")
 public final class XATransactionCollectTransactionsCodec {
-    //hex: 0x160200
-    public static final int REQUEST_MESSAGE_TYPE = 1442304;
-    //hex: 0x160201
-    public static final int RESPONSE_MESSAGE_TYPE = 1442305;
+    //hex: 0x140200
+    public static final int REQUEST_MESSAGE_TYPE = 1311232;
+    //hex: 0x140201
+    public static final int RESPONSE_MESSAGE_TYPE = 1311233;
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCommitCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCommitCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("4a07d2a4689107ae12ee29ad0486d906")
+@Generated("c97b8b1ebf3f55e76fea65abe45b3f90")
 public final class XATransactionCommitCodec {
-    //hex: 0x160400
-    public static final int REQUEST_MESSAGE_TYPE = 1442816;
-    //hex: 0x160401
-    public static final int RESPONSE_MESSAGE_TYPE = 1442817;
+    //hex: 0x140400
+    public static final int REQUEST_MESSAGE_TYPE = 1311744;
+    //hex: 0x140401
+    public static final int RESPONSE_MESSAGE_TYPE = 1311745;
     private static final int REQUEST_TRANSACTION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_ONE_PHASE_FIELD_OFFSET = REQUEST_TRANSACTION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_ONE_PHASE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCreateCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("f589155decfcb1e67b3d27fe6d220267")
+@Generated("90dee90f586b96a3eafc3e07ac68cb76")
 public final class XATransactionCreateCodec {
-    //hex: 0x160500
-    public static final int REQUEST_MESSAGE_TYPE = 1443072;
-    //hex: 0x160501
-    public static final int RESPONSE_MESSAGE_TYPE = 1443073;
+    //hex: 0x140500
+    public static final int REQUEST_MESSAGE_TYPE = 1312000;
+    //hex: 0x140501
+    public static final int RESPONSE_MESSAGE_TYPE = 1312001;
     private static final int REQUEST_TIMEOUT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TIMEOUT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_RESPONSE_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionFinalizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionFinalizeCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("c247687aa84ee3b990ea1a97d5dab952")
+@Generated("20e131c3ef7f37f13eb5447fcdc4c6cf")
 public final class XATransactionFinalizeCodec {
-    //hex: 0x160300
-    public static final int REQUEST_MESSAGE_TYPE = 1442560;
-    //hex: 0x160301
-    public static final int RESPONSE_MESSAGE_TYPE = 1442561;
+    //hex: 0x140300
+    public static final int REQUEST_MESSAGE_TYPE = 1311488;
+    //hex: 0x140301
+    public static final int RESPONSE_MESSAGE_TYPE = 1311489;
     private static final int REQUEST_IS_COMMIT_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_IS_COMMIT_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionPrepareCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionPrepareCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("cf18c97f381c76f8eb05f2f21e1d9f20")
+@Generated("49b5f901d0175fc19ca8cca939b34a6f")
 public final class XATransactionPrepareCodec {
-    //hex: 0x160600
-    public static final int REQUEST_MESSAGE_TYPE = 1443328;
-    //hex: 0x160601
-    public static final int RESPONSE_MESSAGE_TYPE = 1443329;
+    //hex: 0x140600
+    public static final int REQUEST_MESSAGE_TYPE = 1312256;
+    //hex: 0x140601
+    public static final int RESPONSE_MESSAGE_TYPE = 1312257;
     private static final int REQUEST_TRANSACTION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TRANSACTION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionRollbackCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionRollbackCodec.java
@@ -36,12 +36,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("0857a5b752eb91d6a41b86cfaeedf794")
+@Generated("4ecfe9786488e8ca5ce9ef995e7029ee")
 public final class XATransactionRollbackCodec {
-    //hex: 0x160700
-    public static final int REQUEST_MESSAGE_TYPE = 1443584;
-    //hex: 0x160701
-    public static final int RESPONSE_MESSAGE_TYPE = 1443585;
+    //hex: 0x140700
+    public static final int REQUEST_MESSAGE_TYPE = 1312512;
+    //hex: 0x140701
+    public static final int RESPONSE_MESSAGE_TYPE = 1312513;
     private static final int REQUEST_TRANSACTION_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_TRANSACTION_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;


### PR DESCRIPTION
IDs are reordered on the protocol side after the recent changes. This PR updates the codecs with the reordered IDs. 

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/239