### PR TITLE
Add support for excluding targets for Probes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.diagnostics;
 
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
@@ -24,6 +25,9 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
+import java.util.Set;
+
+import static com.hazelcast.internal.metrics.MetricTarget.DIAGNOSTICS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -88,23 +92,31 @@ public class MetricsPlugin extends DiagnosticsPlugin {
         private long timeMillis;
 
         @Override
-        public void collectLong(String name, long value) {
-            writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, value);
+        public void collectLong(String name, long value, Set<MetricTarget> excludedMetricTargets) {
+            if (!excludedMetricTargets.contains(DIAGNOSTICS)) {
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, value);
+            }
         }
 
         @Override
-        public void collectDouble(String name, double value) {
-            writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, value);
+        public void collectDouble(String name, double value, Set<MetricTarget> excludedMetricTargets) {
+            if (!excludedMetricTargets.contains(DIAGNOSTICS)) {
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, value);
+            }
         }
 
         @Override
-        public void collectException(String name, Exception e) {
-            writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, e.getClass().getName() + ':' + e.getMessage());
+        public void collectException(String name, Exception e, Set<MetricTarget> excludedMetricTargets) {
+            if (!excludedMetricTargets.contains(DIAGNOSTICS)) {
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, e.getClass().getName() + ':' + e.getMessage());
+            }
         }
 
         @Override
-        public void collectNoValue(String name) {
-            writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, "NA");
+        public void collectNoValue(String name, Set<MetricTarget> excludedMetricTargets) {
+            if (!excludedMetricTargets.contains(DIAGNOSTICS)) {
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, name, "NA");
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Enum representing the target platforms of the metrics collection.
+ */
+public enum MetricTarget {
+    MANAGEMENT_CENTER,
+    JMX,
+    DIAGNOSTICS
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsPublisher.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.metrics;
 
+import java.util.Set;
+
 /**
  * Represents an object which publishes a set of metrics to some destination.
  */
@@ -24,12 +26,12 @@ public interface MetricsPublisher {
     /**
      * Publish the given metric with a long value.
      */
-    void publishLong(String name, long value);
+    void publishLong(String name, long value, Set<MetricTarget> excludedTargets);
 
     /**
      * Publish the given metric with a double value.
      */
-    void publishDouble(String name, double value);
+    void publishDouble(String name, double value, Set<MetricTarget> excludedTargets);
 
     /**
      * Callback is called after all metrics are published for a given

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -90,4 +90,12 @@ public @interface Probe {
      * Measurement unit of a Probe. Not used on member, becomes a part of the key.
      */
     ProbeUnit unit() default COUNT;
+
+    /**
+     * Returns the targets excluded for this Probe. Used for filtering in
+     * {@link MetricsPublisher}s.
+     *
+     * @return the targets excluded for this Probe
+     */
+    MetricTarget[] excludedTargets() default {};
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeAware.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Interface that can return a Probe instance.
+ */
+public interface ProbeAware {
+    /**
+     * Returns the probe.
+     *
+     * @return the probe
+     */
+    Probe getProbe();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/collectors/MetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/collectors/MetricsCollector.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.internal.metrics.collectors;
 
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+
+import java.util.Set;
 
 /**
  * With the {@link MetricsCollector} the metrics registered in the
@@ -24,12 +27,12 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
  */
 public interface MetricsCollector {
 
-    void collectLong(String name, long value);
+    void collectLong(String name, long value, Set<MetricTarget> excludedTargets);
 
-    void collectDouble(String name, double value);
+    void collectDouble(String name, double value, Set<MetricTarget> excludedTargets);
 
-    void collectException(String name, Exception e);
+    void collectException(String name, Exception e, Set<MetricTarget> excludedTargets);
 
-    void collectNoValue(String name);
+    void collectNoValue(String name, Set<MetricTarget> excludedTargets);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricTagger;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
+import com.hazelcast.internal.metrics.ProbeAware;
 import com.hazelcast.internal.util.counters.Counter;
 
 import java.lang.reflect.Field;
@@ -43,7 +44,7 @@ import static java.lang.String.format;
 /**
  * A FieldProbe is a {@link ProbeFunction} that reads out a field that is annotated with {@link Probe}.
  */
-abstract class FieldProbe implements ProbeFunction {
+abstract class FieldProbe implements ProbeFunction, ProbeAware {
 
     final Probe probe;
     final Field field;
@@ -54,6 +55,11 @@ abstract class FieldProbe implements ProbeFunction {
         this.probe = probe;
         this.type = type;
         field.setAccessible(true);
+    }
+
+    @Override
+    public Probe getProbe() {
+        return probe;
     }
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricTagger;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
+import com.hazelcast.internal.metrics.ProbeAware;
 import com.hazelcast.internal.util.counters.Counter;
 
 import java.lang.reflect.Method;
@@ -44,7 +45,7 @@ import static java.lang.String.format;
 /**
  * A MethodProbe is a {@link ProbeFunction} that invokes a method that is annotated with {@link Probe}.
  */
-abstract class MethodProbe implements ProbeFunction {
+abstract class MethodProbe implements ProbeFunction, ProbeAware {
 
     private static final Object[] EMPTY_ARGS = new Object[0];
 
@@ -57,6 +58,11 @@ abstract class MethodProbe implements ProbeFunction {
         this.probe = probe;
         this.type = type;
         method.setAccessible(true);
+    }
+
+    @Override
+    public Probe getProbe() {
+        return probe;
     }
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -17,13 +17,14 @@
 package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.config.MetricsConfig;
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsPublisher;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.internal.metrics.jmx.JmxPublisher;
 import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer;
 import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
 import com.hazelcast.internal.metrics.managementcenter.ManagementCenterPublisher;
-import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.internal.services.ManagedService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -35,6 +36,7 @@ import com.hazelcast.spi.impl.operationservice.LiveOperationsTracker;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -242,10 +244,10 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
      */
     private class PublisherMetricsCollector implements MetricsCollector {
         @Override
-        public void collectLong(String name, long value) {
+        public void collectLong(String name, long value, Set<MetricTarget> excludedTargets) {
             for (MetricsPublisher publisher : publishers) {
                 try {
-                    publisher.publishLong(name, value);
+                    publisher.publishLong(name, value, excludedTargets);
                 } catch (Exception e) {
                     logError(name, value, publisher, e);
                 }
@@ -253,10 +255,10 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
         }
 
         @Override
-        public void collectDouble(String name, double value) {
+        public void collectDouble(String name, double value, Set<MetricTarget> excludedTargets) {
             for (MetricsPublisher publisher : publishers) {
                 try {
-                    publisher.publishDouble(name, value);
+                    publisher.publishDouble(name, value, excludedTargets);
                 } catch (Exception e) {
                     logError(name, value, publisher, e);
                 }
@@ -264,12 +266,12 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
         }
 
         @Override
-        public void collectException(String name, Exception e) {
+        public void collectException(String name, Exception e, Set<MetricTarget> excludedTargets) {
             logger.warning("Error when rendering '" + name + '\'', e);
         }
 
         @Override
-        public void collectNoValue(String name) {
+        public void collectNoValue(String name, Set<MetricTarget> excludedTargets) {
             // noop
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.metrics.jmx;
 
 import com.hazelcast.config.MetricsConfig;
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsPublisher;
 import com.hazelcast.internal.metrics.MetricsUtil;
 
@@ -32,8 +33,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
 
+import static com.hazelcast.internal.metrics.MetricTarget.JMX;
 import static com.hazelcast.internal.util.MapUtil.entry;
 
 /**
@@ -79,16 +82,20 @@ public class JmxPublisher implements MetricsPublisher {
     }
 
     @Override
-    public void publishLong(String metricName, long value) {
-        publishNumber(metricName, value);
+    public void publishLong(String metricName, long value, Set<MetricTarget> excludedTargets) {
+        publishNumber(metricName, value, excludedTargets);
     }
 
     @Override
-    public void publishDouble(String metricName, double value) {
-        publishNumber(metricName, value);
+    public void publishDouble(String metricName, double value, Set<MetricTarget> excludedTargets) {
+        publishNumber(metricName, value, excludedTargets);
     }
 
-    private void publishNumber(String metricName, Number value) {
+    private void publishNumber(String metricName, Number value, Set<MetricTarget> excludedTargets) {
+        if (excludedTargets.contains(JMX)) {
+            return;
+        }
+
         MetricData metricData = metricNameToMetricData.computeIfAbsent(metricName, createMetricDataFunction);
         assert !metricData.wasPresent : "metric '" + metricName + "' was rendered twice";
         metricData.wasPresent = true;

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ManagementCenterPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ManagementCenterPublisher.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.internal.metrics.managementcenter;
 
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsPublisher;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 
 import javax.annotation.Nonnull;
+import java.util.Set;
 import java.util.function.ObjLongConsumer;
 
 /**
@@ -45,13 +47,17 @@ public class ManagementCenterPublisher implements MetricsPublisher {
     }
 
     @Override
-    public void publishLong(String name, long value) {
-        compressor.addLong(name, value);
+    public void publishLong(String name, long value, Set<MetricTarget> excludedTargets) {
+        if (!excludedTargets.contains(MetricTarget.MANAGEMENT_CENTER)) {
+            compressor.addLong(name, value);
+        }
     }
 
     @Override
-    public void publishDouble(String name, double value) {
-        compressor.addDouble(name, value);
+    public void publishDouble(String name, double value, Set<MetricTarget> excludedTargets) {
+        if (!excludedTargets.contains(MetricTarget.MANAGEMENT_CENTER)) {
+            compressor.addDouble(name, value);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
@@ -42,10 +42,10 @@ public final class FileMetricSet {
         checkNotNull(metricsRegistry, "metricsRegistry");
 
         File file = new File(System.getProperty("user.home"));
-        MetricTagger builder = metricsRegistry.newMetricTagger("file.partition")
-                                              .withIdTag("dir", "user.home");
-        builder.registerStaticProbe(file, "freeSpace", MANDATORY, BYTES, File::getFreeSpace);
-        builder.registerStaticProbe(file, "totalSpace", MANDATORY, BYTES, File::getTotalSpace);
-        builder.registerStaticProbe(file, "usableSpace", MANDATORY, BYTES, File::getUsableSpace);
+        MetricTagger tagger = metricsRegistry.newMetricTagger("file.partition")
+                                             .withIdTag("dir", "user.home");
+        tagger.registerStaticProbe(file, "freeSpace", MANDATORY, BYTES, File::getFreeSpace);
+        tagger.registerStaticProbe(file, "totalSpace", MANDATORY, BYTES, File::getTotalSpace);
+        tagger.registerStaticProbe(file, "usableSpace", MANDATORY, BYTES, File::getUsableSpace);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
@@ -42,6 +43,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.regex.Pattern;
 
@@ -189,28 +191,28 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
         }
 
         @Override
-        public void collectLong(String name, long value) {
+        public void collectLong(String name, long value, Set<MetricTarget> excludedMetricTargets) {
             if (pattern.matcher(name).matches()) {
                 probes.put(name, value);
             }
         }
 
         @Override
-        public void collectDouble(String name, double value) {
+        public void collectDouble(String name, double value, Set<MetricTarget> excludedMetricTargets) {
             if (pattern.matcher(name).matches()) {
                 probes.put(name, value);
             }
         }
 
         @Override
-        public void collectException(String name, Exception e) {
+        public void collectException(String name, Exception e, Set<MetricTarget> excludedMetricTargets) {
             if (pattern.matcher(name).matches()) {
                 probes.put(name, e);
             }
         }
 
         @Override
-        public void collectNoValue(String name) {
+        public void collectNoValue(String name, Set<MetricTarget> excludedMetricTargets) {
             if (pattern.matcher(name).matches()) {
                 probes.put(name, null);
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricTaggerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricTaggerImplTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricTagger;
+import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.ProbeUnit;
@@ -31,6 +32,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -175,7 +177,7 @@ public class MetricTaggerImplTest {
 
         registry.collect(new MetricsCollector() {
             @Override
-            public void collectLong(String name, long value) {
+            public void collectLong(String name, long value, Set<MetricTarget> excludedTargets) {
                 if (p1Name.equals(name)) {
                     assertEquals(probe1, value);
                 } else if (p2Name.equals(name)) {
@@ -186,17 +188,17 @@ public class MetricTaggerImplTest {
             }
 
             @Override
-            public void collectDouble(String name, double value) {
+            public void collectDouble(String name, double value, Set<MetricTarget> excludedTargets) {
                 fail("Unknown metric: " + name);
             }
 
             @Override
-            public void collectException(String name, Exception e) {
+            public void collectException(String name, Exception e, Set<MetricTarget> excludedTargets) {
                 throw new RuntimeException(e);
             }
 
             @Override
-            public void collectNoValue(String name) {
+            public void collectNoValue(String name, Set<MetricTarget> excludedTargets) {
                 fail("Unknown metric: " + name);
             }
         });

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static java.util.Collections.EMPTY_SET;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -69,8 +70,8 @@ public class RenderTest {
 
         metricsRegistry.collect(renderer);
 
-        verify(renderer).collectLong("[metric=foo]", 10);
-        verify(renderer).collectLong("[metric=bar]", 20);
+        verify(renderer).collectLong("[metric=foo]", 10, EMPTY_SET);
+        verify(renderer).collectLong("[metric=bar]", 20, EMPTY_SET);
         verifyNoMoreInteractions(renderer);
     }
 
@@ -83,8 +84,8 @@ public class RenderTest {
 
         metricsRegistry.collect(renderer);
 
-        verify(renderer).collectDouble("[metric=foo]", 10);
-        verify(renderer).collectDouble("[metric=bar]", 20);
+        verify(renderer).collectDouble("[metric=foo]", 10, EMPTY_SET);
+        verify(renderer).collectDouble("[metric=bar]", 20, EMPTY_SET);
         verifyNoMoreInteractions(renderer);
     }
 
@@ -101,7 +102,7 @@ public class RenderTest {
 
         metricsRegistry.collect(renderer);
 
-        verify(renderer).collectException("[metric=foo]", ex);
+        verify(renderer).collectException("[metric=foo]", ex, EMPTY_SET);
         verifyNoMoreInteractions(renderer);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -19,9 +19,11 @@ package com.hazelcast.internal.metrics.jmx;
 import com.hazelcast.internal.metrics.MetricsUtil;
 import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.management.InstanceNotFoundException;
@@ -29,6 +31,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,15 +41,18 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.internal.metrics.MetricTarget.JMX;
 import static com.hazelcast.internal.util.BiTuple.of;
 import static com.hazelcast.internal.util.MapUtil.entry;
 import static java.util.Arrays.asList;
+import static java.util.Collections.EMPTY_SET;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class JmxPublisherTest {
 
     private static final String MODULE_NAME = "moduleA";
@@ -85,35 +91,35 @@ public class JmxPublisherTest {
 
     @Test
     public void when_singleMetricOldFormat() throws Exception {
-        jmxPublisher.publishLong("a.b.c", 1L);
+        jmxPublisher.publishLong("a.b.c", 1L, EMPTY_SET);
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("c", 1L)))));
     }
 
     @Test
     public void when_trailingPeriodOldFormat_doNotFail() throws Exception {
-        jmxPublisher.publishLong("a.b.", 1L);
+        jmxPublisher.publishLong("a.b.", 1L, EMPTY_SET);
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("metric", 1L)))));
     }
 
     @Test
     public void when_twoDotsOldFormat_doNotFail() throws Exception {
-        jmxPublisher.publishLong("a.b..c", 1L);
+        jmxPublisher.publishLong("a.b..c", 1L, EMPTY_SET);
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("c", 1L)))));
     }
 
     @Test
     public void when_metricTagMissingNewFormat_then_useDefault() throws Exception {
-        jmxPublisher.publishLong("a.b.", 1L);
+        jmxPublisher.publishLong("a.b.", 1L, EMPTY_SET);
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b", singletonList(entry("metric", 1L)))));
     }
 
     @Test
     public void when_singleMetricNewFormat() throws Exception {
-        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=c]", 1L);
+        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=c]", 1L, EMPTY_SET);
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
                         singletonList(entry("c", 1L)))));
@@ -121,7 +127,7 @@ public class JmxPublisherTest {
 
     @Test
     public void when_singleMetricNewFormatWithModule() throws Exception {
-        jmxPublisher.publishLong("[tag1=a,module=" + MODULE_NAME + ",metric=c]", 1L);
+        jmxPublisher.publishLong("[tag1=a,module=" + MODULE_NAME + ",metric=c]", 1L, EMPTY_SET);
         assertMBeans(singletonList(
                 of(domainPrefix + "." + MODULE_NAME + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
                         singletonList(entry("c", 1L)))));
@@ -129,10 +135,10 @@ public class JmxPublisherTest {
 
     @Test
     public void when_moreMetricsOldFormat() throws Exception {
-        jmxPublisher.publishLong("a.b.c", 1L);
-        jmxPublisher.publishLong("a.b.d", 2L);
-        jmxPublisher.publishLong("a.c.a", 3L);
-        jmxPublisher.publishLong("a", 4L);
+        jmxPublisher.publishLong("a.b.c", 1L, EMPTY_SET);
+        jmxPublisher.publishLong("a.b.d", 2L, EMPTY_SET);
+        jmxPublisher.publishLong("a.c.a", 3L, EMPTY_SET);
+        jmxPublisher.publishLong("a", 4L, EMPTY_SET);
         assertMBeans(asList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=a,tag1=b",
                         asList(entry("c", 1L), entry("d", 2L))),
@@ -145,11 +151,11 @@ public class JmxPublisherTest {
 
     @Test
     public void when_moreMetricsNewFormat() throws Exception {
-        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=c]", 1L);
-        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=d]", 2L);
-        jmxPublisher.publishLong("[module=" + MODULE_NAME + ",tag1=a,tag2=b,metric=d]", 5L);
-        jmxPublisher.publishLong("[tag1=a,tag2=c,metric=a]", 3L);
-        jmxPublisher.publishLong("[metric=a]", 4L);
+        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=c]", 1L, EMPTY_SET);
+        jmxPublisher.publishLong("[tag1=a,tag2=b,metric=d]", 2L, EMPTY_SET);
+        jmxPublisher.publishLong("[module=" + MODULE_NAME + ",tag1=a,tag2=b,metric=d]", 5L, EMPTY_SET);
+        jmxPublisher.publishLong("[tag1=a,tag2=c,metric=a]", 3L, EMPTY_SET);
+        jmxPublisher.publishLong("[metric=a]", 4L, EMPTY_SET);
         assertMBeans(asList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
                         asList(entry("c", 1L), entry("d", 2L))),
@@ -164,15 +170,15 @@ public class JmxPublisherTest {
 
     @Test
     public void when_metricNotRendered_then_mBeanRemoved() throws Exception {
-        jmxPublisher.publishLong("[tag1=a,metric=b]", 1L);
-        jmxPublisher.publishLong("[tag1=a,metric=c]", 2L);
+        jmxPublisher.publishLong("[tag1=a,metric=b]", 1L, EMPTY_SET);
+        jmxPublisher.publishLong("[tag1=a,metric=c]", 2L, EMPTY_SET);
         jmxPublisher.whenComplete();
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
                         asList(entry("b", 1L), entry("c", 2L)))
         ));
 
-        jmxPublisher.publishLong("[tag1=a,metric=b]", 1L);
+        jmxPublisher.publishLong("[tag1=a,metric=b]", 1L, EMPTY_SET);
         jmxPublisher.whenComplete();
         assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
@@ -217,8 +223,8 @@ public class JmxPublisherTest {
     private void when_badCharacters_then_escaped(String badText) throws Exception {
         // we must be able to work with any crazy user input
         System.out.println("badText: " + badText);
-        jmxPublisher.publishLong(badText + ".metric", 1L);
-        jmxPublisher.publishLong("[tag1=a,metric=" + MetricsUtil.escapeMetricNamePart(badText) + "]", 2L);
+        jmxPublisher.publishLong(badText + ".metric", 1L, EMPTY_SET);
+        jmxPublisher.publishLong("[tag1=a,metric=" + MetricsUtil.escapeMetricNamePart(badText) + "]", 2L, EMPTY_SET);
         jmxPublisher.whenComplete();
 
         assertMBeans(asList(
@@ -226,6 +232,22 @@ public class JmxPublisherTest {
                         singletonList(entry("metric", 1L))),
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
                         singletonList(entry(badText, 2L)))
+        ));
+    }
+
+    @Test
+    public void when_jmxExcluded_notPublished() throws Exception {
+        jmxPublisher.publishLong("excluded.long", 1L, EnumSet.of(JMX));
+        jmxPublisher.publishLong("notExcluded.long", 2L, EMPTY_SET);
+        jmxPublisher.publishDouble("excluded.double", 1.5D, EnumSet.of(JMX));
+        jmxPublisher.publishDouble("notExcluded.double", 2.5D, EMPTY_SET);
+        jmxPublisher.whenComplete();
+
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=notExcluded", asList(
+                        entry("long", 2L),
+                        entry("double", 2.5D)
+                ))
         ));
     }
 


### PR DESCRIPTION
The change introduces `excludedTargets` to the `@Probe` annotation for
excluding probes on a certain metrics target platform. These platforms
are defined in the `MetricsTarget` enum, listing `MANAGEMENT_CENTER`, `JMX`,
`DIAGNOSTICS`.

Only probes are supported for exclusion. Metrics inserted directly via
probe functions are not. These are typically JVM/OS level metrics that
we want to publish to all platforms.

The main motivation for this change is to prevent metrics sent to
Management Center. Examples are: `operation.thread*`, `tcp.connection[*]`,
`tcp.inputThread*`, `tcp.outputThread*` and `internal-executor*`.

This change doesn't extend any production probe with the new tag. That
change needs to be done separately after reviewing the exclusion list.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3204