### PR TITLE
represent enums with integers in the protocol

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -147,6 +147,10 @@
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]MemberImpl"/>
     <suppress checks="ClassFanOutComplexity|AnonInnerLength"
               files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]connection[\\/]nio[\\/]ClientConnectionManagerImpl"/>
+    <suppress checks="MagicNumber"
+              files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]protocol[\\/]codec[\\/]builtin[\\/]FixedSizeTypesCodec"/>
+    <suppress checks="MagicNumber"
+              files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]protocol[\\/]codec[\\/]builtin[\\/]CustomTypeFactory" />
 
     <!-- Client Protocol (auto-generated) -->
     <suppress checks="Header|MethodCount|Length|ClassDataAbstractionCoupling|ClassFanOutComplexity|Whitespace|MethodParamPad"

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CustomTypeFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CustomTypeFactory.java
@@ -41,8 +41,6 @@ import static com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.D
 
 public final class CustomTypeFactory {
 
-    private static final TimeUnit[] CACHED_TIME_UNIT_VALUES = TimeUnit.values();
-
     private CustomTypeFactory() {
     }
 
@@ -62,7 +60,7 @@ public final class CustomTypeFactory {
 
     public static TimedExpiryPolicyFactoryConfig createTimedExpiryPolicyFactoryConfig(int expiryPolicyType,
                                                                                         DurationConfig durationConfig) {
-        return new TimedExpiryPolicyFactoryConfig(ExpiryPolicyType.getByType(expiryPolicyType), durationConfig);
+        return new TimedExpiryPolicyFactoryConfig(ExpiryPolicyType.getById(expiryPolicyType), durationConfig);
     }
 
     public static CacheSimpleEntryListenerConfig createCacheSimpleEntryListenerConfig(boolean oldValueRequired,
@@ -141,8 +139,26 @@ public final class CustomTypeFactory {
         return eventData;
     }
 
-    public static DurationConfig createDurationConfig(long durationAmount, int timeUnit) {
-        return new DurationConfig(durationAmount, CACHED_TIME_UNIT_VALUES[timeUnit]);
+    public static DurationConfig createDurationConfig(long durationAmount, int timeUnitId) {
+        TimeUnit timeUnit;
+        if (timeUnitId == 0) {
+            timeUnit = TimeUnit.NANOSECONDS;
+        } else if (timeUnitId == 1) {
+            timeUnit = TimeUnit.MICROSECONDS;
+        } else if (timeUnitId == 2) {
+            timeUnit = TimeUnit.MILLISECONDS;
+        } else if (timeUnitId == 3) {
+            timeUnit = TimeUnit.SECONDS;
+        } else if (timeUnitId == 4) {
+            timeUnit = TimeUnit.MINUTES;
+        } else if (timeUnitId == 5) {
+            timeUnit = TimeUnit.HOURS;
+        } else if (timeUnitId == 6) {
+            timeUnit = TimeUnit.DAYS;
+        } else {
+            timeUnit = null;
+        }
+        return new DurationConfig(durationAmount, timeUnit);
     }
 
     public static IndexConfig createIndexConfig(String name, int type, List<String> attributes) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CustomTypeFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CustomTypeFactory.java
@@ -41,6 +41,8 @@ import static com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.D
 
 public final class CustomTypeFactory {
 
+    private static final TimeUnit[] CACHED_TIME_UNIT_VALUES = TimeUnit.values();
+
     private CustomTypeFactory() {
     }
 
@@ -58,9 +60,9 @@ public final class CustomTypeFactory {
                 dataOldValue, oldValueAvailable);
     }
 
-    public static TimedExpiryPolicyFactoryConfig createTimedExpiryPolicyFactoryConfig(String expiryPolicyType,
+    public static TimedExpiryPolicyFactoryConfig createTimedExpiryPolicyFactoryConfig(int expiryPolicyType,
                                                                                         DurationConfig durationConfig) {
-        return new TimedExpiryPolicyFactoryConfig(ExpiryPolicyType.valueOf(expiryPolicyType), durationConfig);
+        return new TimedExpiryPolicyFactoryConfig(ExpiryPolicyType.getByType(expiryPolicyType), durationConfig);
     }
 
     public static CacheSimpleEntryListenerConfig createCacheSimpleEntryListenerConfig(boolean oldValueRequired,
@@ -139,8 +141,8 @@ public final class CustomTypeFactory {
         return eventData;
     }
 
-    public static DurationConfig createDurationConfig(long durationAmount, String timeUnit) {
-        return new DurationConfig(durationAmount, TimeUnit.valueOf(timeUnit));
+    public static DurationConfig createDurationConfig(long durationAmount, int timeUnit) {
+        return new DurationConfig(durationAmount, CACHED_TIME_UNIT_VALUES[timeUnit]);
     }
 
     public static IndexConfig createIndexConfig(String name, int type, List<String> attributes) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
@@ -17,16 +17,19 @@
 package com.hazelcast.client.impl.protocol.codec.builtin;
 
 import com.hazelcast.cache.CacheEventType;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.internal.nio.Bits;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 public final class FixedSizeTypesCodec {
 
     public static final int BYTE_SIZE_IN_BYTES = Bits.BYTE_SIZE_IN_BYTES;
     public static final int LONG_SIZE_IN_BYTES = Bits.LONG_SIZE_IN_BYTES;
     public static final int INT_SIZE_IN_BYTES = Bits.INT_SIZE_IN_BYTES;
+    public static final int ENUM_SIZE_IN_BYTES = Bits.INT_SIZE_IN_BYTES;
     public static final int BOOLEAN_SIZE_IN_BYTES = Bits.BOOLEAN_SIZE_IN_BYTES;
     public static final int UUID_SIZE_IN_BYTES = Bits.BOOLEAN_SIZE_IN_BYTES + Bits.LONG_SIZE_IN_BYTES * 2;
 
@@ -37,16 +40,28 @@ public final class FixedSizeTypesCodec {
         Bits.writeIntL(buffer, pos, value);
     }
 
-    public static void encodeInt(byte[] buffer, int pos, CacheEventType cacheEventType) {
+    public static int decodeInt(byte[] buffer, int pos) {
+        return Bits.readIntL(buffer, pos);
+    }
+
+    public static void encodeEnum(byte[] buffer, int pos, CacheEventType cacheEventType) {
         encodeInt(buffer, pos, cacheEventType.getType());
     }
 
-    public static void encodeInt(byte[] buffer, int pos, IndexType indexType) {
+    public static void encodeEnum(byte[] buffer, int pos, IndexType indexType) {
         encodeInt(buffer, pos, indexType.getId());
     }
 
-    public static int decodeInt(byte[] buffer, int pos) {
-        return Bits.readIntL(buffer, pos);
+    public static void encodeEnum(byte[] buffer, int pos, ExpiryPolicyType expiryPolicyType) {
+        encodeInt(buffer, pos, expiryPolicyType.getType());
+    }
+
+    public static void encodeEnum(byte[] buffer, int pos, TimeUnit timeUnit) {
+        encodeInt(buffer, pos, timeUnit.ordinal());
+    }
+
+    public static int decodeEnum(byte[] buffer, int pos) {
+        return decodeInt(buffer, pos);
     }
 
     public static void encodeInteger(byte[] buffer, int pos, Integer value) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
@@ -53,11 +53,29 @@ public final class FixedSizeTypesCodec {
     }
 
     public static void encodeEnum(byte[] buffer, int pos, ExpiryPolicyType expiryPolicyType) {
-        encodeInt(buffer, pos, expiryPolicyType.getType());
+        encodeInt(buffer, pos, expiryPolicyType.getId());
     }
 
     public static void encodeEnum(byte[] buffer, int pos, TimeUnit timeUnit) {
-        encodeInt(buffer, pos, timeUnit.ordinal());
+        int timeUnitId;
+        if (TimeUnit.NANOSECONDS.equals(timeUnit)) {
+            timeUnitId = 0;
+        } else if (TimeUnit.MICROSECONDS.equals(timeUnit)) {
+            timeUnitId = 1;
+        } else if (TimeUnit.MILLISECONDS.equals(timeUnit)) {
+            timeUnitId = 2;
+        } else if (TimeUnit.SECONDS.equals(timeUnit)) {
+            timeUnitId = 3;
+        } else if (TimeUnit.MINUTES.equals(timeUnit)) {
+            timeUnitId = 4;
+        } else if (TimeUnit.HOURS.equals(timeUnit)) {
+            timeUnitId = 5;
+        } else if (TimeUnit.DAYS.equals(timeUnit)) {
+            timeUnitId = 6;
+        } else {
+            timeUnitId = -1;
+        }
+        encodeInt(buffer, pos, timeUnitId);
     }
 
     public static int decodeEnum(byte[] buffer, int pos) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/CacheEventDataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/CacheEventDataCodec.java
@@ -24,10 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("282e93f22afcfa00409312ef12e2b2e3")
+@Generated("247cc4f0b57e1badfaea4c096c5ecb4d")
 public final class CacheEventDataCodec {
     private static final int CACHE_EVENT_TYPE_FIELD_OFFSET = 0;
-    private static final int OLD_VALUE_AVAILABLE_FIELD_OFFSET = CACHE_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
+    private static final int OLD_VALUE_AVAILABLE_FIELD_OFFSET = CACHE_EVENT_TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
     private static final int INITIAL_FRAME_SIZE = OLD_VALUE_AVAILABLE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
 
     private CacheEventDataCodec() {
@@ -37,7 +37,7 @@ public final class CacheEventDataCodec {
         clientMessage.add(BEGIN_FRAME.copy());
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
-        encodeInt(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET, cacheEventData.getCacheEventType());
+        encodeEnum(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET, cacheEventData.getCacheEventType());
         encodeBoolean(initialFrame.content, OLD_VALUE_AVAILABLE_FIELD_OFFSET, cacheEventData.isOldValueAvailable());
         clientMessage.add(initialFrame);
 
@@ -54,7 +54,7 @@ public final class CacheEventDataCodec {
         iterator.next();
 
         ClientMessage.Frame initialFrame = iterator.next();
-        int cacheEventType = decodeInt(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET);
+        int cacheEventType = decodeEnum(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET);
         boolean oldValueAvailable = decodeBoolean(initialFrame.content, OLD_VALUE_AVAILABLE_FIELD_OFFSET);
 
         java.lang.String name = StringCodec.decode(iterator);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/DurationConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/DurationConfigCodec.java
@@ -24,10 +24,11 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("90fef85f84a90dd33b5fef9f784bc227")
+@Generated("8d20297504932d681de4e796a0a9739d")
 public final class DurationConfigCodec {
     private static final int DURATION_AMOUNT_FIELD_OFFSET = 0;
-    private static final int INITIAL_FRAME_SIZE = DURATION_AMOUNT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
+    private static final int TIME_UNIT_FIELD_OFFSET = DURATION_AMOUNT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = TIME_UNIT_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
 
     private DurationConfigCodec() {
     }
@@ -37,9 +38,8 @@ public final class DurationConfigCodec {
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
         encodeLong(initialFrame.content, DURATION_AMOUNT_FIELD_OFFSET, durationConfig.getDurationAmount());
+        encodeEnum(initialFrame.content, TIME_UNIT_FIELD_OFFSET, durationConfig.getTimeUnit());
         clientMessage.add(initialFrame);
-
-        StringCodec.encode(clientMessage, durationConfig.getTimeUnit());
 
         clientMessage.add(END_FRAME.copy());
     }
@@ -50,8 +50,7 @@ public final class DurationConfigCodec {
 
         ClientMessage.Frame initialFrame = iterator.next();
         long durationAmount = decodeLong(initialFrame.content, DURATION_AMOUNT_FIELD_OFFSET);
-
-        String timeUnit = StringCodec.decode(iterator);
+        int timeUnit = decodeEnum(initialFrame.content, TIME_UNIT_FIELD_OFFSET);
 
         fastForwardToEndFrame(iterator);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/IndexConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/IndexConfigCodec.java
@@ -24,10 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("507ef913a17bfc1fb14319a9e7e8a540")
+@Generated("e999d835cca0d67db67c1b3997c32742")
 public final class IndexConfigCodec {
     private static final int TYPE_FIELD_OFFSET = 0;
-    private static final int INITIAL_FRAME_SIZE = TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
 
     private IndexConfigCodec() {
     }
@@ -36,7 +36,7 @@ public final class IndexConfigCodec {
         clientMessage.add(BEGIN_FRAME.copy());
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
-        encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, indexConfig.getType());
+        encodeEnum(initialFrame.content, TYPE_FIELD_OFFSET, indexConfig.getType());
         clientMessage.add(initialFrame);
 
         CodecUtil.encodeNullable(clientMessage, indexConfig.getName(), StringCodec::encode);
@@ -50,7 +50,7 @@ public final class IndexConfigCodec {
         iterator.next();
 
         ClientMessage.Frame initialFrame = iterator.next();
-        int type = decodeInt(initialFrame.content, TYPE_FIELD_OFFSET);
+        int type = decodeEnum(initialFrame.content, TYPE_FIELD_OFFSET);
 
         java.lang.String name = CodecUtil.decodeNullable(iterator, StringCodec::decode);
         java.util.List<java.lang.String> attributes = ListMultiFrameCodec.decode(iterator, StringCodec::decode);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/TimedExpiryPolicyFactoryConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/TimedExpiryPolicyFactoryConfigCodec.java
@@ -24,8 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("f9514b1565705c20a5341f4c9e6182d6")
+@Generated("1987b802fbe9214f4364946f0ad19ec7")
 public final class TimedExpiryPolicyFactoryConfigCodec {
+    private static final int EXPIRY_POLICY_TYPE_FIELD_OFFSET = 0;
+    private static final int INITIAL_FRAME_SIZE = EXPIRY_POLICY_TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
 
     private TimedExpiryPolicyFactoryConfigCodec() {
     }
@@ -33,7 +35,10 @@ public final class TimedExpiryPolicyFactoryConfigCodec {
     public static void encode(ClientMessage clientMessage, com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig) {
         clientMessage.add(BEGIN_FRAME.copy());
 
-        StringCodec.encode(clientMessage, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
+        encodeEnum(initialFrame.content, EXPIRY_POLICY_TYPE_FIELD_OFFSET, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        clientMessage.add(initialFrame);
+
         DurationConfigCodec.encode(clientMessage, timedExpiryPolicyFactoryConfig.getDurationConfig());
 
         clientMessage.add(END_FRAME.copy());
@@ -43,7 +48,9 @@ public final class TimedExpiryPolicyFactoryConfigCodec {
         // begin frame
         iterator.next();
 
-        String expiryPolicyType = StringCodec.decode(iterator);
+        ClientMessage.Frame initialFrame = iterator.next();
+        int expiryPolicyType = decodeEnum(initialFrame.content, EXPIRY_POLICY_TYPE_FIELD_OFFSET);
+
         com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig durationConfig = DurationConfigCodec.decode(iterator);
 
         fastForwardToEndFrame(iterator);

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -1042,23 +1042,47 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
                 /**
                  * Expiry policy type for the {@link javax.cache.expiry.CreatedExpiryPolicy}.
                  */
-                CREATED,
+                CREATED(0),
                 /**
                  * Expiry policy type for the {@link javax.cache.expiry.ModifiedExpiryPolicy}.
                  */
-                MODIFIED,
+                MODIFIED(1),
                 /**
                  * Expiry policy type for the {@link javax.cache.expiry.AccessedExpiryPolicy}.
                  */
-                ACCESSED,
+                ACCESSED(2),
                 /**
                  * Expiry policy type for the {@link javax.cache.expiry.TouchedExpiryPolicy}.
                  */
-                TOUCHED,
+                TOUCHED(3),
                 /**
                  * Expiry policy type for the {@link javax.cache.expiry.EternalExpiryPolicy}.
                  */
-                ETERNAL
+                ETERNAL(4);
+
+                private static final int MIN_TYPE_ID = CREATED.type;
+                private static final int MAX_TYPE_ID = ETERNAL.type;
+                private static final ExpiryPolicyType[] CACHED_VALUES = values();
+
+                private int type;
+
+                ExpiryPolicyType(int type) {
+                    this.type = type;
+                }
+
+                /**
+                 * @return unique ID for the expiry policy type
+                 */
+                public int getType() {
+                    return type;
+                }
+
+                public static ExpiryPolicyType getByType(int type) {
+                    if (MIN_TYPE_ID <= type && type <= MAX_TYPE_ID) {
+                        return CACHED_VALUES[type];
+                    }
+                    return null;
+                }
             }
 
             @Override
@@ -1074,7 +1098,7 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
                 if (expiryPolicyType != that.expiryPolicyType) {
                     return false;
                 }
-                return durationConfig != null ? durationConfig.equals(that.durationConfig) : that.durationConfig == null;
+                return Objects.equals(durationConfig, that.durationConfig);
             }
 
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -1060,26 +1060,26 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
                  */
                 ETERNAL(4);
 
-                private static final int MIN_TYPE_ID = CREATED.type;
-                private static final int MAX_TYPE_ID = ETERNAL.type;
+                private static final int MIN_ID = CREATED.id;
+                private static final int MAX_ID = ETERNAL.id;
                 private static final ExpiryPolicyType[] CACHED_VALUES = values();
 
-                private int type;
+                private int id;
 
-                ExpiryPolicyType(int type) {
-                    this.type = type;
+                ExpiryPolicyType(int id) {
+                    this.id = id;
                 }
 
                 /**
                  * @return unique ID for the expiry policy type
                  */
-                public int getType() {
-                    return type;
+                public int getId() {
+                    return id;
                 }
 
-                public static ExpiryPolicyType getByType(int type) {
-                    if (MIN_TYPE_ID <= type && type <= MAX_TYPE_ID) {
-                        return CACHED_VALUES[type];
+                public static ExpiryPolicyType getById(int id) {
+                    if (MIN_ID <= id && id <= MAX_ID) {
+                        return CACHED_VALUES[id];
                     }
                     return null;
                 }


### PR DESCRIPTION
For custom type codecs, some enums were represented with strings (`TimeUnit` and `ExpiryPolicyType`). After the discussion within the team, we decided to use integers for all enum types in the protocol level. This PR adds a integer type to the `ExpiryPolicyType`, uses ordinal values for the `TimeUnit` and adds the necessary codec changes.

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/241