### PR TITLE
Remove connection attempt limit and period configs

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -72,8 +72,7 @@ import static org.springframework.util.Assert.isTrue;
  * <pre>{@code
  *   <hz:client id="client">
  *      <hz:cluster name="${cluster.name}" password="${cluster.password}" />
- *      <hz:network connection-attempt-limit="3"
- *          connection-attempt-period="3000"
+ *      <hz:network
  *          connection-timeout="1000"
  *          redo-operation="true"
  *          smart-routing="true">

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2982,8 +2982,6 @@
         <xs:attribute name="smart-routing" use="optional" type="parameterized-boolean" default="true"/>
         <xs:attribute name="redo-operation" use="optional" type="parameterized-boolean" default="false"/>
         <xs:attribute name="connection-timeout" use="optional" type="parameterized-positive-integer" default="5000"/>
-        <xs:attribute name="connection-attempt-period" use="optional" type="parameterized-positive-integer" default="3000"/>
-        <xs:attribute name="connection-attempt-limit" use="optional" type="parameterized-non-negative-integer" default="2"/>
     </xs:complexType>
 
     <xs:complexType name="socket-options">
@@ -4093,7 +4091,6 @@
             <xs:element name="fail-on-max-backoff" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
             <xs:element name="jitter" type="xs:double" minOccurs="0" maxOccurs="1" default="0.2"/>
         </xs:all>
-        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="reconnect-mode">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -200,9 +200,7 @@ public class TestClientApplicationContext {
 
         ClientConfig config = client.getClientConfig();
         assertEquals("13", config.getProperty("hazelcast.client.retry.count"));
-        assertEquals(3, config.getNetworkConfig().getConnectionAttemptLimit());
         assertEquals(1000, config.getNetworkConfig().getConnectionTimeout());
-        assertEquals(3000, config.getNetworkConfig().getConnectionAttemptPeriod());
 
         ClientConfig config2 = client2.getClientConfig();
         assertEquals(credentials, config2.getSecurityConfig().getCredentials());
@@ -288,7 +286,7 @@ public class TestClientApplicationContext {
         assertNotNull(client5);
 
         ClientConfig config = client5.getClientConfig();
-        assertEquals(0, config.getNetworkConfig().getConnectionAttemptLimit());
+        assertFalse(config.getConnectionStrategyConfig().getConnectionRetryConfig().isFailOnMaxBackoff());
     }
 
     @Test
@@ -464,7 +462,6 @@ public class TestClientApplicationContext {
     public void testConnectionRetry() {
         ConnectionRetryConfig connectionRetryConfig = connectionRetryClient
                 .getClientConfig().getConnectionStrategyConfig().getConnectionRetryConfig();
-        assertTrue(connectionRetryConfig.isEnabled());
         assertTrue(connectionRetryConfig.isFailOnMaxBackoff());
         assertEquals(0.5, connectionRetryConfig.getJitter(), 0);
         assertEquals(2000, connectionRetryConfig.getInitialBackoffMillis());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -59,9 +59,7 @@
 
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
@@ -71,9 +71,7 @@
         <hz:properties>
             <hz:property name="hazelcast.client.retry.count">13</hz:property>
         </hz:properties>
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
             <hz:member>127.0.0.1:5700</hz:member>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -69,9 +69,7 @@
 
     <hz:client id="client"
                credentials-ref="credentials">
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
@@ -50,9 +50,7 @@
 
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="${client.connection.attemptLimit}"
-                    connection-attempt-period="${client.connection.attemptPeriod}"
-                    connection-timeout="1000">
+        <hz:network connection-timeout="1000">
         </hz:network>
     </hz:client>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -63,9 +63,7 @@
         <hz:properties>
             <hz:property name="hazelcast.client.retry.count">13</hz:property>
         </hz:properties>
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
             <hz:member>127.0.0.1:5700</hz:member>
@@ -81,9 +79,7 @@
     </hz:client>
 
     <hz:client id="client2" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
 
@@ -99,9 +95,7 @@
 
     <hz:client id="client3"
                credentials-ref="credentials">
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>
@@ -177,9 +171,7 @@
 
     <hz:client id="client4"
                credentials-ref="credentials">
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>
@@ -199,7 +191,12 @@
 
     <hz:client id="client5"
                credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:connection-strategy>
+            <hz:connection-retry>
+                <hz:fail-on-max-backoff>false</hz:fail-on-max-backoff>
+            </hz:connection-retry>
+        </hz:connection-strategy>
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -208,7 +205,7 @@
 
     <hz:client id="client6"
                credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -246,9 +243,7 @@
     </hz:client>
 
     <hz:client id="client7-empty-serialization-config" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
 
@@ -265,7 +260,7 @@
 
     <hz:client id="client8"
                credentials-ref="credentials">
-        <hz:network connection-attempt-limit="2">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -273,7 +268,7 @@
     </hz:client>
 
     <hz:client id="client9-user-code-deployment-test" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -290,7 +285,7 @@
     </hz:client>
 
     <hz:client id="client10-flakeIdGenerator" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -298,7 +293,7 @@
     </hz:client>
 
     <hz:client id="client11-icmp-ping" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
             <hz:icmp-ping enabled="false">
@@ -312,7 +307,7 @@
     </hz:client>
 
     <hz:client id="client12-hazelcast-cloud" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
             <hz:hazelcast-cloud enabled="false">
@@ -322,12 +317,12 @@
     </hz:client>
 
     <hz:client id="client13-exponential-connection-retry" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
         <hz:connection-strategy async-start="true" reconnect-mode="ASYNC">
-            <hz:connection-retry enabled="true">
+            <hz:connection-retry>
                 <hz:initial-backoff-millis>2000</hz:initial-backoff-millis>
                 <hz:max-backoff-millis>60000</hz:max-backoff-millis>
                 <hz:multiplier>3</hz:multiplier>
@@ -338,7 +333,7 @@
     </hz:client>
 
     <hz:client id="client14-reliable-topic" credentials-ref="credentials">
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -351,7 +346,7 @@
 
     <hz:client id="client15-credentials-factory">
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -367,7 +362,7 @@
 
     <hz:client id="client16-name-and-labels">
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
@@ -379,7 +374,7 @@
 
     <hz:client id="client17-backupAckToClient">
         <hz:cluster name="${cluster.name}"/>
-        <hz:network connection-attempt-limit="0">
+        <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -43,9 +43,7 @@
 
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -45,9 +45,7 @@
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:spring-aware/>
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -65,9 +65,7 @@
 
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:cluster name="${cluster.name}" password="${cluster.password}"/>
-        <hz:network connection-attempt-limit="3"
-                    connection-attempt-period="3000"
-                    connection-timeout="1000"
+        <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -207,12 +207,7 @@ public final class ClientConfigXmlGenerator {
         gen.open("network")
                 .node("smart-routing", network.isSmartRouting())
                 .node("redo-operation", network.isRedoOperation())
-                .node("connection-timeout", network.getConnectionTimeout())
-                .node("connection-attempt-period", network.getConnectionAttemptPeriod());
-
-        if (network.getConnectionAttemptLimit() >= 0) {
-            gen.node("connection-attempt-limit", network.getConnectionAttemptLimit());
-        }
+                .node("connection-timeout", network.getConnectionTimeout());
 
         clusterMembers(gen, network.getAddresses());
         socketOptions(gen, network.getSocketOptions());

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
@@ -176,13 +176,7 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     private void handleConnectionRetry(Node node, ClientConnectionStrategyConfig strategyConfig) {
-        Node enabledNode = node.getAttributes().getNamedItem("enabled");
-        boolean enabled = enabledNode != null && getBooleanValue(getTextContent(enabledNode).trim());
-        if (!enabled) {
-            LOGGER.warning("Exponential Connection Strategy is not enabled.");
-        }
         ConnectionRetryConfig connectionRetryConfig = new ConnectionRetryConfig();
-        connectionRetryConfig.setEnabled(enabled);
 
         String initialBackoffMillis = "initial-backoff-millis";
         String maxBackoffMillis = "max-backoff-millis";
@@ -386,10 +380,6 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
                 clientNetworkConfig.setRedoOperation(Boolean.parseBoolean(getTextContent(child)));
             } else if ("connection-timeout".equals(nodeName)) {
                 clientNetworkConfig.setConnectionTimeout(Integer.parseInt(getTextContent(child)));
-            } else if ("connection-attempt-period".equals(nodeName)) {
-                clientNetworkConfig.setConnectionAttemptPeriod(Integer.parseInt(getTextContent(child)));
-            } else if ("connection-attempt-limit".equals(nodeName)) {
-                clientNetworkConfig.setConnectionAttemptLimit(Integer.parseInt(getTextContent(child)));
             } else if ("socket-options".equals(nodeName)) {
                 handleSocketOptions(child, clientNetworkConfig);
             } else if ("socket-interceptor".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -41,13 +41,10 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
 public class ClientNetworkConfig {
 
     private static final int CONNECTION_TIMEOUT = 5000;
-    private static final int CONNECTION_ATTEMPT_PERIOD = 3000;
     private final List<String> addressList;
     private boolean smartRouting = true;
     private boolean redoOperation;
     private int connectionTimeout = CONNECTION_TIMEOUT;
-    private int connectionAttemptLimit = -1;
-    private int connectionAttemptPeriod = CONNECTION_ATTEMPT_PERIOD;
     private SocketInterceptorConfig socketInterceptorConfig = new SocketInterceptorConfig();
     private SocketOptions socketOptions = new SocketOptions();
     private SSLConfig sslConfig;
@@ -71,8 +68,6 @@ public class ClientNetworkConfig {
         smartRouting = networkConfig.smartRouting;
         redoOperation = networkConfig.redoOperation;
         connectionTimeout = networkConfig.connectionTimeout;
-        connectionAttemptLimit = networkConfig.connectionAttemptLimit;
-        connectionAttemptPeriod = networkConfig.connectionAttemptPeriod;
         socketInterceptorConfig = new SocketInterceptorConfig(networkConfig.socketInterceptorConfig);
         socketOptions = new SocketOptions(networkConfig.socketOptions);
         sslConfig = networkConfig.sslConfig == null ? null : new SSLConfig(networkConfig.sslConfig);
@@ -102,8 +97,8 @@ public class ClientNetworkConfig {
      * Defines the Discovery Provider SPI configuration
      *
      * @param discoveryConfig the Discovery Provider SPI configuration
-     * @throws java.lang.IllegalArgumentException if discoveryConfig is null
      * @return this configuration
+     * @throws java.lang.IllegalArgumentException if discoveryConfig is null
      */
     public ClientNetworkConfig setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
         this.discoveryConfig = isNotNull(discoveryConfig, "discoveryConfig");
@@ -153,58 +148,6 @@ public class ClientNetworkConfig {
      */
     public ClientNetworkConfig setSocketInterceptorConfig(SocketInterceptorConfig socketInterceptorConfig) {
         this.socketInterceptorConfig = isNotNull(socketInterceptorConfig, "socketInterceptorConfig");
-        return this;
-    }
-
-    /**
-     * Period for the next attempt to find a member to connect.
-     * <p>
-     * See {@link ClientNetworkConfig#connectionAttemptLimit}.
-     *
-     * @return connection attempt period in millis
-     */
-    public int getConnectionAttemptPeriod() {
-        return connectionAttemptPeriod;
-    }
-
-    /**
-     * Period for the next attempt to find a member to connect.
-     *
-     * @param connectionAttemptPeriod time to wait before another attempt in millis
-     * @return configured {@link com.hazelcast.client.config.ClientNetworkConfig} for chaining
-     */
-    public ClientNetworkConfig setConnectionAttemptPeriod(int connectionAttemptPeriod) {
-        if (connectionAttemptPeriod < 0) {
-            throw new IllegalArgumentException("connectionAttemptPeriod cannot be negative");
-        }
-        this.connectionAttemptPeriod = connectionAttemptPeriod;
-        return this;
-    }
-
-    /**
-     * See {@link com.hazelcast.client.config.ClientNetworkConfig#setConnectionAttemptLimit(int)} for details
-     *
-     * @return connection attempt Limit
-     */
-    public int getConnectionAttemptLimit() {
-        return connectionAttemptLimit;
-    }
-
-    /**
-     * While client is trying to connect initially to one of the members in the {@link ClientNetworkConfig#addressList},
-     * all might be not available. Instead of giving up, throwing Exception and stopping client, it will
-     * attempt to retry as much as {@link ClientNetworkConfig#connectionAttemptLimit} times.
-     *
-     * @param connectionAttemptLimit number of times to attempt to connect
-     *                               A zero value means try forever.
-     *                               A negative value means default value
-     * @return configured {@link com.hazelcast.client.config.ClientNetworkConfig} for chaining
-     */
-    public ClientNetworkConfig setConnectionAttemptLimit(int connectionAttemptLimit) {
-        if (connectionAttemptLimit < 0) {
-            throw new IllegalArgumentException("connectionAttemptLimit cannot be negative");
-        }
-        this.connectionAttemptLimit = connectionAttemptLimit;
         return this;
     }
 
@@ -563,12 +506,6 @@ public class ClientNetworkConfig {
         if (connectionTimeout != that.connectionTimeout) {
             return false;
         }
-        if (connectionAttemptLimit != that.connectionAttemptLimit) {
-            return false;
-        }
-        if (connectionAttemptPeriod != that.connectionAttemptPeriod) {
-            return false;
-        }
         if (!addressList.equals(that.addressList)) {
             return false;
         }
@@ -618,8 +555,6 @@ public class ClientNetworkConfig {
         result = 31 * result + (smartRouting ? 1 : 0);
         result = 31 * result + (redoOperation ? 1 : 0);
         result = 31 * result + connectionTimeout;
-        result = 31 * result + connectionAttemptLimit;
-        result = 31 * result + connectionAttemptPeriod;
         result = 31 * result + socketInterceptorConfig.hashCode();
         result = 31 * result + socketOptions.hashCode();
         result = 31 * result + (sslConfig != null ? sslConfig.hashCode() : 0);
@@ -643,8 +578,6 @@ public class ClientNetworkConfig {
                 + ", smartRouting=" + smartRouting
                 + ", redoOperation=" + redoOperation
                 + ", connectionTimeout=" + connectionTimeout
-                + ", connectionAttemptLimit=" + connectionAttemptLimit
-                + ", connectionAttemptPeriod=" + connectionAttemptPeriod
                 + ", socketInterceptorConfig=" + socketInterceptorConfig
                 + ", socketOptions=" + socketOptions
                 + ", sslConfig=" + sslConfig

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
@@ -28,7 +28,7 @@ public class ConnectionRetryConfig {
     private int initialBackoffMillis = INITIAL_BACKOFF_MILLIS;
     private int maxBackoffMillis = MAX_BACKOFF_MILLIS;
     private double multiplier = 2;
-    private boolean failOnMaxBackoff;
+    private boolean failOnMaxBackoff = true;
     private double jitter = JITTER;
     private boolean enabled;
 
@@ -146,31 +146,6 @@ public class ConnectionRetryConfig {
         return this;
     }
 
-    /**
-     * enables connection retry logic.
-     * When disabled, old configurations are used:
-     * {@link ClientNetworkConfig#getConnectionAttemptLimit()}
-     * {@link ClientNetworkConfig#getConnectionAttemptPeriod()} ()}
-     *
-     * @return true if enabled
-     */
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    /**
-     * enables connection retry logic.
-     * When disabled, old configurations are used:
-     * {@link ClientNetworkConfig#getConnectionAttemptLimit()}
-     * {@link ClientNetworkConfig#getConnectionAttemptPeriod()} ()}
-     *
-     * @param enabled
-     * @return updated ConnectionRetryConfig
-     */
-    public ConnectionRetryConfig setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        return this;
-    }
 
     @Override
     @SuppressWarnings("checkstyle:npathcomplexity")

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -289,12 +289,6 @@ public final class FailoverClientConfigSupport {
         if (mainNetworkConfig.getConnectionTimeout() != alternativeNetworkConfig.getConnectionTimeout()) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:connectionTimeout");
         }
-        if (mainNetworkConfig.getConnectionAttemptLimit() != alternativeNetworkConfig.getConnectionAttemptLimit()) {
-            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:connectionAttemptLimit");
-        }
-        if (mainNetworkConfig.getConnectionAttemptPeriod() != alternativeNetworkConfig.getConnectionAttemptPeriod()) {
-            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:connectionAttemptPeriod");
-        }
         if (notEqual(mainNetworkConfig.getSocketOptions(), alternativeNetworkConfig.getSocketOptions())) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:socketOptions");
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClusterConnectorServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClusterConnectorServiceImpl.java
@@ -19,25 +19,24 @@ package com.hazelcast.client.impl.connection.nio;
 import com.hazelcast.client.ClientNotAllowedInClusterException;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig;
-import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.ConnectionRetryConfig;
-import com.hazelcast.client.impl.connection.AddressProvider;
-import com.hazelcast.client.impl.connection.Addresses;
-import com.hazelcast.client.impl.connection.ClientConnectionStrategy;
 import com.hazelcast.client.impl.clientside.CandidateClusterContext;
 import com.hazelcast.client.impl.clientside.ClientDiscoveryService;
 import com.hazelcast.client.impl.clientside.ClientLoggingService;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.LifecycleServiceImpl;
+import com.hazelcast.client.impl.connection.AddressProvider;
+import com.hazelcast.client.impl.connection.Addresses;
+import com.hazelcast.client.impl.connection.ClientConnectionStrategy;
 import com.hazelcast.client.impl.spi.impl.ClientExecutionServiceImpl;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.Address;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.util.executor.SingleExecutorThreadFactory;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,9 +60,6 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
  * Changing cluster is also handled in this class(Blue/green feature)
  */
 public class ClusterConnectorServiceImpl implements ClusterConnectorService, ConnectionListener {
-
-    private static final int DEFAULT_CONNECTION_ATTEMPT_LIMIT_SYNC = 2;
-    private static final int DEFAULT_CONNECTION_ATTEMPT_LIMIT_ASYNC = 20;
 
     private final ILogger logger;
     private final HazelcastClientInstanceImpl client;
@@ -92,28 +88,11 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
     private WaitStrategy initializeWaitStrategy(ClientConfig clientConfig) {
         ClientConnectionStrategyConfig connectionStrategyConfig = clientConfig.getConnectionStrategyConfig();
         ConnectionRetryConfig expoRetryConfig = connectionStrategyConfig.getConnectionRetryConfig();
-        if (expoRetryConfig.isEnabled()) {
-            return new ExponentialWaitStrategy(expoRetryConfig.getInitialBackoffMillis(),
-                    expoRetryConfig.getMaxBackoffMillis(),
-                    expoRetryConfig.getMultiplier(),
-                    expoRetryConfig.isFailOnMaxBackoff(),
-                    expoRetryConfig.getJitter());
-        }
-        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
-
-        int connectionAttemptPeriod = networkConfig.getConnectionAttemptPeriod();
-
-        boolean isAsync = connectionStrategyConfig.isAsyncStart();
-
-        int connectionAttemptLimit = networkConfig.getConnectionAttemptLimit();
-        if (connectionAttemptLimit < 0) {
-            connectionAttemptLimit = isAsync ? DEFAULT_CONNECTION_ATTEMPT_LIMIT_ASYNC
-                    : DEFAULT_CONNECTION_ATTEMPT_LIMIT_SYNC;
-        } else {
-            connectionAttemptLimit = connectionAttemptLimit == 0 ? Integer.MAX_VALUE : connectionAttemptLimit;
-        }
-
-        return new DefaultWaitStrategy(connectionAttemptPeriod, connectionAttemptLimit);
+        return new WaitStrategy(expoRetryConfig.getInitialBackoffMillis(),
+                expoRetryConfig.getMaxBackoffMillis(),
+                expoRetryConfig.getMultiplier(),
+                expoRetryConfig.isFailOnMaxBackoff(),
+                expoRetryConfig.getJitter());
     }
 
     @Override
@@ -382,53 +361,8 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
 
     }
 
-    interface WaitStrategy {
 
-        void reset();
-
-        boolean sleep();
-
-    }
-
-    class DefaultWaitStrategy implements WaitStrategy {
-
-        private final int connectionAttemptPeriod;
-        private final int connectionAttemptLimit;
-        private int attempt;
-
-        DefaultWaitStrategy(int connectionAttemptPeriod, int connectionAttemptLimit) {
-            this.connectionAttemptPeriod = connectionAttemptPeriod;
-            this.connectionAttemptLimit = connectionAttemptLimit;
-        }
-
-        @Override
-        public void reset() {
-            attempt = 0;
-        }
-
-        @Override
-        public boolean sleep() {
-            attempt++;
-            if (attempt >= connectionAttemptLimit) {
-                logger.warning(String.format("Unable to get live cluster connection, attempt %d of %d.", attempt,
-                        connectionAttemptLimit));
-                return false;
-            }
-            logger.warning(String.format("Unable to get live cluster connection, retry in %d ms, attempt %d of %d.",
-                    connectionAttemptPeriod, attempt, connectionAttemptLimit));
-
-            try {
-                Thread.sleep(connectionAttemptPeriod);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return false;
-            }
-            return true;
-        }
-
-    }
-
-    class ExponentialWaitStrategy implements WaitStrategy {
+    class WaitStrategy {
 
         private final int initialBackoffMillis;
         private final int maxBackoffMillis;
@@ -439,8 +373,8 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
         private int attempt;
         private int currentBackoffMillis;
 
-        ExponentialWaitStrategy(int initialBackoffMillis, int maxBackoffMillis,
-                                double multiplier, boolean failOnMaxBackoff, double jitter) {
+        WaitStrategy(int initialBackoffMillis, int maxBackoffMillis,
+                     double multiplier, boolean failOnMaxBackoff, double jitter) {
             this.initialBackoffMillis = initialBackoffMillis;
             this.maxBackoffMillis = maxBackoffMillis;
             this.multiplier = multiplier;
@@ -448,13 +382,11 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
             this.jitter = jitter;
         }
 
-        @Override
         public void reset() {
             attempt = 0;
             currentBackoffMillis = Math.min(maxBackoffMillis, initialBackoffMillis);
         }
 
-        @Override
         public boolean sleep() {
             attempt++;
             if (failOnMaxBackoff && currentBackoffMillis >= maxBackoffMillis) {

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -111,8 +111,6 @@
             <xs:element ref="smart-routing" minOccurs="0" maxOccurs="1"/>
             <xs:element ref="redo-operation" minOccurs="0" maxOccurs="1"/>
             <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1"/>
-            <xs:element ref="connection-attempt-period" minOccurs="0" maxOccurs="1"/>
-            <xs:element ref="connection-attempt-limit" minOccurs="0" maxOccurs="1"/>
             <xs:element ref="socket-options" minOccurs="0" maxOccurs="1"/>
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
@@ -213,20 +211,6 @@
         <xs:simpleType>
             <xs:restriction base="xs:int">
                 <xs:minInclusive value="1"/>
-            </xs:restriction>
-        </xs:simpleType>
-    </xs:element>
-    <xs:element name="connection-attempt-period" default="3000">
-        <xs:simpleType>
-            <xs:restriction base="xs:int">
-                <xs:minInclusive value="1"/>
-            </xs:restriction>
-        </xs:simpleType>
-    </xs:element>
-    <xs:element name="connection-attempt-limit" default="2">
-        <xs:simpleType>
-            <xs:restriction base="xs:int">
-                <xs:minInclusive value="0"/>
             </xs:restriction>
         </xs:simpleType>
     </xs:element>
@@ -400,7 +384,6 @@
             <xs:element name="fail-on-max-backoff" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
             <xs:element name="jitter" type="xs:double" minOccurs="0" maxOccurs="1" default="0.2"/>
         </xs:all>
-        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="reconnect-mode">

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -176,14 +176,6 @@
         * <connection-timeout>:
             Connection timeout is the timeout value in milliseconds for members to accept client connection requests.
             The following are the example configurations. Its default value is 5000.
-        * <connection-attempt-limit>:
-            While the client is trying to connect initially to one of the members in the <cluster-members>, that
-            member might not  be available at that moment. Instead of giving up, throwing an exception and stopping
-            the client, the client retries as many the times configured by this setting. This is also the case
-            when the previously established connection between the client and that member goes down.
-        * <connection-attempt-period>:
-            Connection attempt period is the duration in milliseconds between the connection attempts defined by
-            <connection-attempt-limit>.
         * <socket-options>:
             You can configure the network socket options using this setting. It has the following sub-elements:
             - <tcp-no-delay>: Enables/disables the TCP_NODELAY socket option. Its default value is true.
@@ -299,8 +291,6 @@
         <smart-routing>true</smart-routing>
         <redo-operation>true</redo-operation>
         <connection-timeout>60000</connection-timeout>
-        <connection-attempt-period>3000</connection-attempt-period>
-        <connection-attempt-limit>2</connection-attempt-limit>
         <socket-options>
             <tcp-no-delay>false</tcp-no-delay>
             <keep-alive>true</keep-alive>
@@ -770,7 +760,7 @@
             * <jitter>: Specifies by how much to randomize backoffs. Its default value is 0.2.
     -->
     <connection-strategy async-start="true" reconnect-mode="ASYNC">
-        <connection-retry enabled="true">
+        <connection-retry>
             <initial-backoff-millis>2000</initial-backoff-millis>
             <max-backoff-millis>60000</max-backoff-millis>
             <multiplier>3</multiplier>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -148,14 +148,6 @@ hazelcast-client:
   # * "connection-timeout":
   #     Connection timeout is the timeout value in milliseconds for members to accept client connection requests.
   #     The following are the example configurations. Its default value is 5000.
-  # * "connection-attempt-limit":
-  #     While the client is trying to connect initially to one of the members in the "cluster-members", that
-  #     member might not  be available at that moment. Instead of giving up, throwing an exception and stopping
-  #     the client, the client retries as many the times configured by this setting. This is also the case
-  #     when the previously established connection between the client and that member goes down.
-  # * "connection-attempt-period":
-  #     Connection attempt period is the duration in milliseconds between the connection attempts defined by
-  #     "connection-attempt-limit".
   # * "socket-options":
   #     You can configure the network socket options using this setting. It has the following sub-elements:
   #       - "tcp-no-delay": Enables/disables the TCP_NODELAY socket option. Its default value is true.
@@ -262,8 +254,6 @@ hazelcast-client:
     smart-routing: true
     redo-operation: true
     connection-timeout: 60000
-    connection-attempt-period: 3000
-    connection-attempt-limit: 2
     socket-options:
       tcp-no-delay: false
       keep-alive: true
@@ -743,7 +733,6 @@ hazelcast-client:
     async-start: true
     reconnect-mode: ASYNC
     connection-retry:
-      enabled: true
       initial-backoff-millis: 2000
       max-backoff-millis: 60000
       multiplier: 3

--- a/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
@@ -65,7 +65,7 @@ public class ThreadLeakClientTest {
     public void testThreadLeak_withoutCluster() {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         Set<Thread> testStartThreads = getThreads();
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
@@ -53,7 +53,7 @@ public class ClientAuthenticationTest extends HazelcastTestSupport {
     @Test(expected = IllegalStateException.class)
     public void testNoClusterFound() throws Exception {
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptPeriod(1);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         hazelcastFactory.newHazelcastClient(clientConfig);
 
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -67,7 +67,7 @@ public class ClientClusterRestartEventTest {
 
     private ClientConfig newClientConfig() {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         return clientConfig;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -69,7 +69,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
         hazelcastFactory.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().setConnectionAttemptPeriod(1);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         config.getNetworkConfig().addAddress(illegalAddress);
         hazelcastFactory.newHazelcastClient(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -60,7 +60,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     public void testClientReconnectOnClusterDown() throws Exception {
         final HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final CountDownLatch connectedLatch = new CountDownLatch(2);
         client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
@@ -82,7 +82,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         Address localAddress = instance.getCluster().getLocalMember().getAddress();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final CountDownLatch memberRemovedLatch = new CountDownLatch(1);
@@ -113,7 +113,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     public void testClientShutdownIfReconnectionNotPossible() {
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -134,7 +134,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     public void testRequestShouldFailOnShutdown() {
         final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<Object, Object> test = client.getMap("test");
@@ -147,7 +147,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     public void testCallbackAfterClientShutdown() {
         final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<Object, Object> test = client.getMap("test");
@@ -201,8 +201,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     public void testShutdownClient_whenThereIsNoCluster() {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
-        clientConfig.getNetworkConfig()
-                .setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         client.shutdown();
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -252,7 +252,7 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         final ListenerConfig listenerConfig = new ListenerConfig(listener);
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.addListenerConfig(listenerConfig);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance hazelcastClient = hazelcastFactory.newHazelcastClient(clientConfig);
 
         hazelcastFactory.shutdownAllMembers();
@@ -456,7 +456,7 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
 
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         final String mapName = randomMapName();
 
         NearCacheConfig nearCacheConfig = new NearCacheConfig();
@@ -703,7 +703,7 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         //Retry all requests
         clientConfig.getNetworkConfig().setRedoOperation(true);
         //retry to connect to cluster forever(never shutdown the client)
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         //Retry all requests forever(until client is shutdown)
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -102,7 +102,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
             @Override
             public void run() {
                 ClientConfig config = new ClientConfig();
-                config.getNetworkConfig().setConnectionAttemptLimit(10);
+                config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
                 HazelcastClient.newHazelcastClient(config);
                 clientLatch.countDown();
             }
@@ -137,7 +137,8 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().addAddress(clientAddress).setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getNetworkConfig().addAddress(clientAddress);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
@@ -205,7 +206,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
         networkConfig.addAddress(clientAddress);
-        networkConfig.setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         final IMap<Integer, Integer> map = client.getMap("test");
 
@@ -277,7 +278,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
                 return address;
             }
         };
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
         HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(addressProvider, clientConfig);
 
@@ -307,7 +308,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         ClientConfig config = new ClientConfig();
         config.getConnectionStrategyConfig().setAsyncStart(true).
                 setReconnectMode(ClientConnectionStrategyConfig.ReconnectMode.ASYNC)
-                .getConnectionRetryConfig().setEnabled(true).setInitialBackoffMillis(1).setMaxBackoffMillis(1000);
+                .getConnectionRetryConfig().setInitialBackoffMillis(1).setMaxBackoffMillis(1000);
         HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
         final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         final ClientConnectionManagerImpl connectionManager = (ClientConnectionManagerImpl) clientInstanceImpl.getConnectionManager();

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -110,7 +110,7 @@ public class ClientServiceTest extends ClientTestSupport {
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.setClusterName("wrongName");
-
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         try {
             hazelcastFactory.newHazelcastClient(clientConfig);
         } catch (IllegalStateException ignored) {
@@ -126,7 +126,7 @@ public class ClientServiceTest extends ClientTestSupport {
         final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.setClusterName("wrongName");
-
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         try {
             hazelcastFactory.newHazelcastClient(clientConfig);
         } catch (IllegalStateException ignored) {
@@ -145,7 +145,7 @@ public class ClientServiceTest extends ClientTestSupport {
         final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.setClusterName("wrongName");
-
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         try {
             hazelcastFactory.newHazelcastClient(clientConfig);
         } catch (IllegalStateException ignored) {
@@ -234,8 +234,8 @@ public class ClientServiceTest extends ClientTestSupport {
     @Test(timeout = 120000)
     public void testConnectedClientsWithReAuth() throws InterruptedException {
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptPeriod(1000 * 5);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false)
+                .setMultiplier(1).setInitialBackoffMillis(5000);
 
         final CountDownLatch countDownLatch = new CountDownLatch(2);
 
@@ -245,8 +245,6 @@ public class ClientServiceTest extends ClientTestSupport {
                 if (event.getState() == LifecycleEvent.LifecycleState.CLIENT_CONNECTED) {
                     countDownLatch.countDown();
                 }
-
-
             }
         }));
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
@@ -394,7 +392,7 @@ public class ClientServiceTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().setConnectionAttemptPeriod(0).setConnectionAttemptLimit(1);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
         client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
@@ -57,7 +57,7 @@ public class ClientTimeoutTest {
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
         networkConfig.addAddress("8.8.8.8:5701");
         // Do only one connection-attempt
-        networkConfig.setConnectionAttemptLimit(1);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         // Timeout connection-attempt after 1000 millis
         networkConfig.setConnectionTimeout(1000);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/MembershipListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/MembershipListenerTest.java
@@ -277,7 +277,7 @@ public class MembershipListenerTest extends HazelcastTestSupport {
         HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         final InitialMemberShipEventLogger listener = new InitialMemberShipEventLogger();
         clientConfig.addListenerConfig(new ListenerConfig().setImplementation(listener));
         hazelcastFactory.newHazelcastClient(clientConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -61,7 +61,7 @@ public class ClientCacheCreationTest extends CacheCreationTest {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "2");
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         HazelcastClientCachingProvider cachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
@@ -77,7 +77,7 @@ public class ClientCacheCreationTest extends CacheCreationTest {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         HazelcastClientCachingProvider cachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
         final CacheManager cacheManager = cachingProvider.getCacheManager();

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheProxyTest.java
@@ -55,7 +55,7 @@ public class ClientCacheProxyTest extends ClientTestSupport {
     public void clusterRestart_proxyRemainsUsableOnClient() {
         HazelcastInstance instance = factory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = factory.newHazelcastClient(clientConfig);
 
         CachingProvider cachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);

--- a/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
@@ -96,6 +96,8 @@ public class ClientNodeExtensionTest
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress("127.0.0.1:5555");
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT.getName(), "1000");
         factory.newHazelcastClient(clientConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -71,7 +71,6 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     @Test
     public void testNetworkConfig() {
         final ClientNetworkConfig networkConfig = fullClientConfig.getNetworkConfig();
-        assertEquals(2, networkConfig.getConnectionAttemptLimit());
         assertEquals(2, networkConfig.getAddresses().size());
         assertContains(networkConfig.getAddresses(), "127.0.0.1");
         assertContains(networkConfig.getAddresses(), "127.0.0.2");
@@ -280,8 +279,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     public void testExponentialConnectionRetryConfig() {
         ClientConnectionStrategyConfig connectionStrategyConfig = fullClientConfig.getConnectionStrategyConfig();
         ConnectionRetryConfig exponentialRetryConfig = connectionStrategyConfig.getConnectionRetryConfig();
-        assertTrue(exponentialRetryConfig.isEnabled());
-        assertTrue(exponentialRetryConfig.isFailOnMaxBackoff());
+        assertFalse(exponentialRetryConfig.isFailOnMaxBackoff());
         assertEquals(0.5, exponentialRetryConfig.getJitter(), 0);
         assertEquals(2000, exponentialRetryConfig.getInitialBackoffMillis());
         assertEquals(60000, exponentialRetryConfig.getMaxBackoffMillis());
@@ -292,8 +290,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     public void testExponentialConnectionRetryConfig_defaults() {
         ClientConnectionStrategyConfig connectionStrategyConfig = defaultClientConfig.getConnectionStrategyConfig();
         ConnectionRetryConfig exponentialRetryConfig = connectionStrategyConfig.getConnectionRetryConfig();
-        assertFalse(exponentialRetryConfig.isEnabled());
-        assertFalse(exponentialRetryConfig.isFailOnMaxBackoff());
+        assertTrue(exponentialRetryConfig.isFailOnMaxBackoff());
         assertEquals(0.2, exponentialRetryConfig.getJitter(), 0);
         assertEquals(1000, exponentialRetryConfig.getInitialBackoffMillis());
         assertEquals(30000, exponentialRetryConfig.getMaxBackoffMillis());

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -141,8 +141,6 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         expected.setSmartRouting(false)
                 .setRedoOperation(true)
                 .setConnectionTimeout(randomInt())
-                .setConnectionAttemptPeriod(randomInt())
-                .setConnectionAttemptLimit(randomInt())
                 .addAddress(randomString())
                 .setOutboundPortDefinitions(Collections.singleton(randomString()));
 
@@ -153,8 +151,6 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         assertFalse(actual.isSmartRouting());
         assertTrue(actual.isRedoOperation());
         assertEquals(expected.getConnectionTimeout(), actual.getConnectionTimeout());
-        assertEquals(expected.getConnectionAttemptPeriod(), actual.getConnectionAttemptPeriod());
-        assertEquals(expected.getConnectionAttemptLimit(), actual.getConnectionAttemptLimit());
         assertCollection(expected.getAddresses(), actual.getAddresses());
         assertCollection(expected.getOutboundPortDefinitions(), actual.getOutboundPortDefinitions());
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -123,7 +123,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().setReconnectMode(OFF);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final CountDownLatch shutdownLatch = new CountDownLatch(1);
         client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
@@ -151,7 +151,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().setReconnectMode(OFF);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -181,7 +181,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final CountDownLatch disconnectedLatch = new CountDownLatch(1);
         client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
@@ -229,7 +229,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         HazelcastInstance member2 = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         IMap<Object, Object> map = client.getMap(randomMapName());
@@ -257,7 +257,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.addListenerConfig(new ListenerConfig(new LifecycleListener() {
             @Override
             public void stateChanged(LifecycleEvent event) {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/DistributedObjectListenerTest.java
@@ -121,7 +121,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         client.getMap("test");
@@ -148,7 +148,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         client.getMap("test");

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ProxyManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ProxyManagerTest.java
@@ -132,7 +132,7 @@ public class ProxyManagerTest extends HazelcastTestSupport {
         HazelcastInstance instance = factory.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "1");
-        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = factory.newHazelcastClient(config);
         instance.shutdown();
         client.getMap("test");

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -287,9 +287,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         ClientConfig config = new ClientConfig();
         config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
-        ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        networkConfig.setConnectionAttemptLimit(1);
-        networkConfig.setConnectionAttemptPeriod(1);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
 
         try {
             HazelcastClient.newHazelcastClient(config);
@@ -311,8 +309,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
             }
         };
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        networkConfig.setConnectionAttemptLimit(1);
-        networkConfig.setConnectionAttemptPeriod(1);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(new DiscoveryStrategyConfig());
         networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
 
@@ -338,8 +335,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
             }
         };
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        networkConfig.setConnectionAttemptLimit(1);
-        networkConfig.setConnectionAttemptPeriod(1);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(1000);
         networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(new DiscoveryStrategyConfig());
         networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
 
@@ -359,8 +355,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         clientConfig.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
-        networkConfig.setConnectionAttemptLimit(1);
-        networkConfig.setConnectionAttemptPeriod(1);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(
                 new DiscoveryStrategyConfig(new NoMemberDiscoveryStrategyFactory(), Collections.<String, Comparable>emptyMap()));
 

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -530,7 +530,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     private ClientConfig getSmartClientConfigWithHeartbeat() {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.getNetworkConfig().setRedoOperation(true);
         clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(20)));
         clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(1)));
@@ -539,7 +539,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     private ClientConfig getSmartClientConfig() {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.getNetworkConfig().setRedoOperation(true);
         return clientConfig;
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -240,7 +240,7 @@ public class ListenerLeakTest extends HazelcastTestSupport {
         //we are testing if any event handler of internal listeners are leaking
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().setSmartRouting(smartRouting);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance hazelcast = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         hazelcast.shutdown();

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -128,7 +128,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
 
         ClientConfig clientConfig = getClientConfig();
         clientConfig.setExecutorPoolSize(1);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "10");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
@@ -161,7 +161,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
 
         ClientConfig clientConfig = getClientConfig();
         clientConfig.setExecutorPoolSize(1);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "10");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/LocalMapStatsUnderOnGoingClientUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/LocalMapStatsUnderOnGoingClientUpdateTest.java
@@ -51,7 +51,7 @@ public class LocalMapStatsUnderOnGoingClientUpdateTest extends HazelcastTestSupp
     @Before
     public void setUp() throws Exception {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         client = factory.newHazelcastClient(clientConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheBasicTest.java
@@ -93,8 +93,7 @@ public class ClientQueryCacheBasicTest extends HazelcastTestSupport {
         clientConfig.addQueryCacheConfig(TEST_MAP_NAME, new QueryCacheConfig(QUERY_CACHE_NAME)
                 .setPredicateConfig(new PredicateConfig(predicate))
                 .setIncludeValue(includeValues));
-        clientConfig.getNetworkConfig()
-                    .setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         if (useNearCache) {
             clientConfig.addNearCacheConfig(new NearCacheConfig()
                     .setName(TEST_MAP_NAME)

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheCreateDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheCreateDestroyTest.java
@@ -106,7 +106,7 @@ public class ClientQueryCacheCreateDestroyTest extends HazelcastTestSupport {
 
     private static ClientConfig newClientConfigWithQueryCache(String mapName, String queryCacheName) {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(50);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         QueryCacheConfig queryCacheConfig = new QueryCacheConfig(queryCacheName);
         queryCacheConfig.getPredicateConfig().setImplementation(Predicates.alwaysTrue());

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheRecreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheRecreationTest.java
@@ -70,7 +70,7 @@ public class ClientQueryCacheRecreationTest extends HazelcastTestSupport {
 
         ClientConfig config = new ClientConfig();
         config.addQueryCacheConfig(mapName, queryCacheConfig);
-        config.getConnectionStrategyConfig().getConnectionRetryConfig().setEnabled(true)
+        config.getConnectionStrategyConfig().getConnectionRetryConfig()
                 .setMaxBackoffMillis((int) TimeUnit.SECONDS.toMillis(5));
 
         client = factory.newHazelcastClient(config);

--- a/hazelcast/src/test/java/com/hazelcast/client/oome/OomeOnClientAuthenticationMain.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/oome/OomeOnClientAuthenticationMain.java
@@ -34,8 +34,7 @@ public class OomeOnClientAuthenticationMain {
     public static void main(String[] args) {
         HazelcastInstance hz = Hazelcast.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClusterPassword("foo");
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(0);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         for (int k = 0; k < 1000000; k++) {
             System.out.println("At:" + k);

--- a/hazelcast/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
@@ -60,7 +60,7 @@ public class ClientScheduledExecutorServiceBasicTest extends ScheduledExecutorSe
     @Override
     public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
         ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         return factory.newHazelcastClient(config).getScheduledExecutorService(name);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/standalone/ClientEntryListenerDisconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/standalone/ClientEntryListenerDisconnectTest.java
@@ -56,9 +56,8 @@ public class ClientEntryListenerDisconnectTest {
         clientConfig.setClusterName("test").setClusterPassword("test");
         clientConfig.getNetworkConfig()
                 .addAddress("localhost:6701", "localhost:6702")
-                .setConnectionAttemptLimit(100)
                 .setSmartRouting(false);
-
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         IMap<Integer, GenericEvent> mapClient = client.getMap("test");
 

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -280,7 +280,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
                 .addNearCacheConfig(new NearCacheConfig(MAP_NAME))
                 .addNearCacheConfig(new NearCacheConfig(CACHE_NAME));
 
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(20);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         HazelcastInstance clientInstance = hazelcastFactory.newHazelcastClient(clientConfig);
         return getHazelcastClientInstanceImpl(clientInstance);

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicOnClusterRestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicOnClusterRestartTest.java
@@ -64,7 +64,7 @@ public class ClientReliableTopicOnClusterRestartTest {
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         String topicName = "topic";
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance hazelcastClient = hazelcastFactory.newHazelcastClient(clientConfig);
         HazelcastInstance hazelcastClient2 = hazelcastFactory.newHazelcastClient(clientConfig);
         ITopic<Integer> topic = hazelcastClient.getReliableTopic(topicName);
@@ -95,7 +95,7 @@ public class ClientReliableTopicOnClusterRestartTest {
     public void shouldContinue_OnClusterRestart_afterInvocationTimeout() throws InterruptedException {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         int invocationTimeoutSeconds = 2;
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), String.valueOf(invocationTimeoutSeconds));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
@@ -132,7 +132,7 @@ public class ClientReliableTopicOnClusterRestartTest {
     public void shouldContinue_OnClusterRestart_whenDataLoss_LossTolerant_afterInvocationTimeout() throws InterruptedException {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         int invocationTimeoutSeconds = 2;
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), String.valueOf(invocationTimeoutSeconds));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
@@ -176,7 +176,7 @@ public class ClientReliableTopicOnClusterRestartTest {
     public void shouldFail_OnClusterRestart_whenDataLoss_notLossTolerant() {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final AtomicLong messageCount = new AtomicLong();

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
@@ -307,7 +307,7 @@ public class ClientReliableTopicTest extends HazelcastTestSupport {
         final HazelcastInstance ownerMember = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ClientConnectionStrategyConfig.ReconnectMode.ASYNC);
         String topicName = "topic";
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
@@ -73,7 +73,7 @@ public class ClientTxnMapTest {
     public void setup() {
         hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         client = hazelcastFactory.newHazelcastClient(clientConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
@@ -61,8 +61,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
     public void testTransactionBeginShouldFail_onDisconnectedState() {
         Hazelcast.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        final CountDownLatch testFinished = new CountDownLatch(1);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
@@ -88,7 +87,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
     public void testNewTransactionContextShouldFail_onDisconnectedState() {
         Hazelcast.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
@@ -113,7 +112,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
     public void testXAShouldFail_onDisconnectedState() throws Throwable {
         Hazelcast.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnReconnectModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnReconnectModeTest.java
@@ -64,7 +64,7 @@ public class ClientTxnReconnectModeTest {
     @Test(expected = OperationTimeoutException.class)
     public void testNewTransactionContext_ReconnectMode_ON() throws Throwable {
         ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         config.getNetworkConfig().setSmartRouting(smartRouting);
         config.getConnectionStrategyConfig().setAsyncStart(true);
         config.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
@@ -80,7 +80,7 @@ public class ClientTxnReconnectModeTest {
     @Test(expected = HazelcastClientOfflineException.class)
     public void testNewTransactionContext_ReconnectMode_ASYNC() throws Throwable {
         ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         config.getNetworkConfig().setSmartRouting(smartRouting);
         config.getConnectionStrategyConfig().setAsyncStart(true);
 
@@ -96,7 +96,7 @@ public class ClientTxnReconnectModeTest {
     @Test(expected = HazelcastClientNotActiveException.class)
     public void testNewTransactionContext_After_shutdown() throws Throwable {
         ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         config.getNetworkConfig().setSmartRouting(smartRouting);
         config.getConnectionStrategyConfig().setAsyncStart(true);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
@@ -61,7 +61,7 @@ public class TxnMapDeserializationTest extends HazelcastTestSupport {
                         return new SampleIdentified();
                     }
                 });
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         client.getMap("test").put(EXISTING_KEY, EXISTING_VALUE);

--- a/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -98,7 +98,7 @@ public class ClientUserCodeDeploymentTest extends HazelcastTestSupport {
         ClientUserCodeDeploymentConfig clientUserCodeDeploymentConfig = new ClientUserCodeDeploymentConfig();
         clientUserCodeDeploymentConfig.addClass("usercodedeployment.IncrementingEntryProcessor");
         config.setUserCodeDeploymentConfig(clientUserCodeDeploymentConfig.setEnabled(true));
-        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
@@ -106,7 +106,7 @@ public class ClientStateListenerTest extends ClientTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         ClientStateListener listener = new ClientStateListener(clientConfig);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
@@ -145,7 +145,7 @@ public class ClientStateListenerTest extends ClientTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         final ClientStateListener listener = new ClientStateListener(clientConfig);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
 
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
@@ -186,7 +186,6 @@ public class DeclarativeConfigFileHelper {
                 + HAZELCAST_CLIENT_START_TAG
                 + "  <instance-name>" + instanceName + "</instance-name>"
                 + "  <connection-strategy async-start=\"true\" reconnect-mode=\"OFF\">"
-                + "    <connection-retry enabled=\"false\" />"
                 + "  </connection-strategy>"
                 + HAZELCAST_CLIENT_END_TAG;
     }
@@ -213,9 +212,7 @@ public class DeclarativeConfigFileHelper {
                 + "  instance-name: " + instanceName + "\n"
                 + "  connection-strategy:\n"
                 + "    async-start: true\n"
-                + "    reconnect-mode: OFF\n"
-                + "    connection-retry:\n"
-                + "      enabled: false";
+                + "    reconnect-mode: OFF\n";
     }
 
     private String yamlFailoverClientConfig(int tryCount) {

--- a/hazelcast/src/test/resources/hazelcast-client-c1.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.xml
@@ -32,7 +32,6 @@
     </network>
 
     <connection-strategy async-start="true" reconnect-mode="OFF">
-        <connection-retry enabled="false"/>
     </connection-strategy>
 
 </hazelcast-client>

--- a/hazelcast/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
@@ -20,11 +20,8 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd">
 
-<connection-strategy async-start="true" />
+    <connection-strategy async-start="true"/>
 
-<network>
-    <connection-attempt-limit>9999</connection-attempt-limit>
-</network>
     <listeners>
         <listener>com.hazelcast.client.connectionstrategy.ConfiguredBehaviourTestXmlConfig$AsyncStartListener</listener>
     </listeners>

--- a/hazelcast/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
@@ -24,11 +24,18 @@
         <property name="hazelcast.discovery.enabled">true</property>
     </properties>
 
+    <connection-strategy>
+        <connection-retry>
+            <multiplier>2</multiplier>
+            <max-backoff-millis>2000</max-backoff-millis>
+            <initial-backoff-millis>1000</initial-backoff-millis>
+            <jitter>0</jitter>
+            <fail-on-max-backoff>true</fail-on-max-backoff>
+        </connection-retry>
+    </connection-strategy>
     <network>
         <aws enabled="false"/>
         <connection-timeout>5000</connection-timeout>
-        <connection-attempt-period>500</connection-attempt-period>
-        <connection-attempt-limit>1</connection-attempt-limit>
         <smart-routing>true</smart-routing>
         <redo-operation>true</redo-operation>
         <discovery-strategies>

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -79,8 +79,6 @@
         <smart-routing>true</smart-routing>
         <redo-operation>true</redo-operation>
         <connection-timeout>60000</connection-timeout>
-        <connection-attempt-period>3000</connection-attempt-period>
-        <connection-attempt-limit>2</connection-attempt-limit>
         <socket-options>
             <tcp-no-delay>false</tcp-no-delay>
             <keep-alive>true</keep-alive>
@@ -287,11 +285,11 @@
     </query-caches>
 
     <connection-strategy async-start="true" reconnect-mode="ASYNC">
-        <connection-retry enabled="true">
+        <connection-retry>
             <initial-backoff-millis>2000</initial-backoff-millis>
             <max-backoff-millis>60000</max-backoff-millis>
             <multiplier>3</multiplier>
-            <fail-on-max-backoff>true</fail-on-max-backoff>
+            <fail-on-max-backoff>false</fail-on-max-backoff>
             <jitter>0.5</jitter>
         </connection-retry>
     </connection-strategy>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -62,8 +62,6 @@ hazelcast-client:
     smart-routing: true
     redo-operation: true
     connection-timeout: 60000
-    connection-attempt-period: 3000
-    connection-attempt-limit: 2
     socket-options:
       tcp-no-delay: false
       keep-alive: true
@@ -275,11 +273,10 @@ hazelcast-client:
     async-start: true
     reconnect-mode: ASYNC
     connection-retry:
-      enabled: true
       initial-backoff-millis: 2000
       max-backoff-millis: 60000
       multiplier: 3
-      fail-on-max-backoff: true
+      fail-on-max-backoff: false
       jitter: 0.5
 
   reliable-topic:

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -29,6 +29,5 @@
             <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">
             </discovery-strategy>
         </discovery-strategies>
-        <connection-attempt-limit>2147483647</connection-attempt-limit> <!-- Integer.MAX_VALUE -->
     </network>
 </hazelcast-client>


### PR DESCRIPTION
They are removed in favor of ConnectionRetryConfig.
ConnectionRetryConfig enabled is also removed. It is enabled always.

Attempt limit and period configurations in tests changed with appropriate ConnectionRetryConfig configs.

EE counterpart https://github.com/hazelcast/hazelcast-enterprise/pull/3206