### PR TITLE
Remove deprecated LocalReplicatedMapStats.getReplicationEventCount

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalReplicatedMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalReplicatedMapStats.java
@@ -21,10 +21,4 @@ package com.hazelcast.monitor;
  * implementations.
  */
 public interface LocalReplicatedMapStats extends LocalMapStats {
-
-    /**
-     * @deprecated replication is no more handled by event system.
-     */
-    @Deprecated
-    long getReplicationEventCount();
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/EmptyLocalReplicatedMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/EmptyLocalReplicatedMapStats.java
@@ -57,11 +57,6 @@ public class EmptyLocalReplicatedMapStats implements LocalReplicatedMapStats {
     }
 
     @Override
-    public long getReplicationEventCount() {
-        return 0;
-    }
-
-    @Override
     public long getOwnedEntryCount() {
         return 0;
     }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -308,13 +308,6 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void setMerkleTreesCost(long merkleTreesCost) {
     }
 
-    @Probe
-    @Override
-    public long getReplicationEventCount() {
-        return 0;
-    }
-
-
     @Override
     public NearCacheStatsImpl getNearCacheStats() {
         throw new UnsupportedOperationException("Replicated map has no Near Cache!");

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/EmptyLocalReplicatedMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/EmptyLocalReplicatedMapStatsTest.java
@@ -60,7 +60,6 @@ public class EmptyLocalReplicatedMapStatsTest {
         assertEquals(0, localReplicatedMapStats.getMaxRemoveLatency());
         assertEquals(0, localReplicatedMapStats.getOtherOperationCount());
         assertEquals(0, localReplicatedMapStats.getEventOperationCount());
-        assertEquals(0, localReplicatedMapStats.getReplicationEventCount());
 
         assertEquals(0, localReplicatedMapStats.getHeapCost());
         assertEquals(0, localReplicatedMapStats.getMerkleTreesCost());


### PR DESCRIPTION
Always returns 0, looks like there is no replacement.

Documentation counterpart: https://github.com/hazelcast/hazelcast-reference-manual/pull/727