### PR TITLE
Undeprecate (ByteArray)ObjectDataInput(Stream).readLine

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -291,8 +291,8 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
         return Bits.readInt(data, position, byteOrder == ByteOrder.BIG_ENDIAN);
     }
 
-    @Deprecated
-    public final String readLine() throws EOFException {
+    @Override
+    public final String readLine() {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -286,9 +286,9 @@ public class ObjectDataInputStream extends VersionedObjectDataInput implements C
         return new String[0];
     }
 
-    @Deprecated
-    public String readLine() throws IOException {
-        return dataInput.readLine();
+    @Override
+    public String readLine() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -303,10 +303,9 @@ public class ObjectDataInputStreamFinalMethodsTest {
         assertArrayEquals(new String[]{" "}, bytes);
     }
 
-    @Test
-    public void testReadLine() throws Exception {
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadLine() {
         inMockedDis.readLine();
-        verify(mockedDis).readLine();
     }
 
     @Test


### PR DESCRIPTION
Can't be deprecated since it overrides java.io.DataInput.readLine.

Also, readLine on ObjectDataInputStream is no longer supported: it
doesn't handle non-ASCII characters and there is no symmetrical method
on ObjectDataOutputStream. `ObjectDataInputStream.readUTF` should be
used instead.