### PR TITLE
Remove LoginModuleConfig.get/setImplementation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
@@ -75,15 +75,6 @@ public class LoginModuleConfig {
         return className;
     }
 
-    @Deprecated
-    /**
-     * @deprecated Not supported, to be removed in 4.0. Use {@link #getClassName()} instead
-     * @since 3.9
-     */
-    public Object getImplementation() {
-        throw new UnsupportedOperationException("Deprecated operation. Use getClassName instead.");
-    }
-
     public Properties getProperties() {
         return properties;
     }
@@ -95,15 +86,6 @@ public class LoginModuleConfig {
     public LoginModuleConfig setClassName(String className) {
         this.className = className;
         return this;
-    }
-
-    @Deprecated
-    /**
-     * @deprecated Not supported, to be removed in 4.0. User {@link #setClassName(String)} instead
-     * @since 3.9
-     */
-    public LoginModuleConfig setImplementation(Object implementation) {
-        throw new UnsupportedOperationException("Deprecated operation. Use setClassName instead.");
     }
 
     public LoginModuleConfig setUsage(LoginModuleUsage usage) {


### PR DESCRIPTION
Deprecated and no longer supported, replaced with get/setClassName.