### PR TITLE
Remove EnumSet litter from MetricsCollectionCycle

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -16,11 +16,58 @@
 
 package com.hazelcast.internal.metrics;
 
+import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * Enum representing the target platforms of the metrics collection.
  */
 public enum MetricTarget {
+
+    // Note: ordinals of this enum are used for 32-bit bitset (#bitset);
+    // thus if it ever gets bigger than 32 values, convert it to 64-bit bitset
     MANAGEMENT_CENTER,
     JMX,
-    DIAGNOSTICS
+    DIAGNOSTICS;
+
+    private static final Int2ObjectHashMap<Set<MetricTarget>> BITSET_TO_SET_CACHE = new Int2ObjectHashMap<>();
+
+    static {
+        putInSetCache(MANAGEMENT_CENTER);
+        putInSetCache(JMX);
+        putInSetCache(DIAGNOSTICS);
+        putInSetCache(MANAGEMENT_CENTER, JMX);
+        putInSetCache(MANAGEMENT_CENTER, DIAGNOSTICS);
+        putInSetCache(JMX, DIAGNOSTICS);
+        putInSetCache(MANAGEMENT_CENTER, JMX, DIAGNOSTICS);
+    }
+
+    /**
+     * Returns set based on the given array of {@link MetricTarget}.
+     * Set objects are returned from a preliminary warmed up cache, so this method has no memory overhead.
+     *
+     * @param targets   input array
+     * @return          set containing all items from the input array
+     */
+    public static Set<MetricTarget> asSet(MetricTarget[] targets) {
+        return BITSET_TO_SET_CACHE.get(bitset(targets));
+    }
+
+    private static int bitset(MetricTarget[] targets) {
+        int bitset = 0;
+        for (MetricTarget target : targets) {
+            bitset |= 1 << target.ordinal();
+        }
+        return bitset;
+    }
+
+    private static void putInSetCache(MetricTarget... targets) {
+        EnumSet<MetricTarget> targetsSet = EnumSet.noneOf(MetricTarget.class);
+        Collections.addAll(targetsSet, targets);
+        BITSET_TO_SET_CACHE.put(bitset(targets), targetsSet);
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -27,8 +27,8 @@ import java.util.Set;
  */
 public enum MetricTarget {
 
-    // Note: ordinals of this enum are used for 32-bit bitset (#bitset);
-    // thus if it ever gets bigger than 32 values, convert it to 64-bit bitset
+    // Note: ordinals of this enum are used for 32-bit bitset (see #bitset);
+    // thus if it ever gets bigger than 32 values, start using 64-bit bitset
     MANAGEMENT_CENTER,
     JMX,
     DIAGNOSTICS;

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Enum representing the target platforms of the metrics collection.
  */
@@ -53,6 +55,9 @@ public enum MetricTarget {
      * @return          set containing all items from the input array
      */
     public static Set<MetricTarget> asSet(MetricTarget[] targets) {
+        if (targets.length == 0) {
+            return emptySet();
+        }
         return BITSET_TO_SET_CACHE.get(bitset(targets));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -30,8 +30,6 @@ import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -151,9 +149,7 @@ class MetricsCollectionCycle {
         MetricTarget[] excludedTargets = probe.excludedTargets();
 
         if (excludedTargets.length > 0) {
-            EnumSet<MetricTarget> metricTargets = EnumSet.noneOf(MetricTarget.class);
-            Collections.addAll(metricTargets, excludedTargets);
-            return metricTargets;
+            return MetricTarget.asSet(excludedTargets);
         }
 
         return emptySet();

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -139,17 +139,7 @@ class MetricsCollectionCycle {
     private Set<MetricTarget> getExcludedTargets(Object object) {
         if (object instanceof ProbeAware) {
             Probe probe = ((ProbeAware) object).getProbe();
-            return getExcludedTargets(probe);
-        }
-
-        return emptySet();
-    }
-
-    private Set<MetricTarget> getExcludedTargets(Probe probe) {
-        MetricTarget[] excludedTargets = probe.excludedTargets();
-
-        if (excludedTargets.length > 0) {
-            return MetricTarget.asSet(excludedTargets);
+            return MetricTarget.asSet(probe.excludedTargets());
         }
 
         return emptySet();

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricTargetTest.java
@@ -26,11 +26,9 @@ import org.junit.runner.RunWith;
 import static com.hazelcast.internal.metrics.MetricTarget.DIAGNOSTICS;
 import static com.hazelcast.internal.metrics.MetricTarget.JMX;
 import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
-import static com.hazelcast.internal.metrics.MetricTarget.asSet;
 import static com.hazelcast.test.HazelcastTestSupport.assertContainsAll;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -38,19 +36,21 @@ public class MetricTargetTest {
 
     @Test
     public void testAsSet_returnsSameObjects() {
-        assertTrue("set objects must be cached and reused",
-                asSet(new MetricTarget[]{MANAGEMENT_CENTER}) == asSet(new MetricTarget[]{MANAGEMENT_CENTER}));
+        assertSame(
+                MetricTarget.asSet(new MetricTarget[]{MANAGEMENT_CENTER}),
+                MetricTarget.asSet(new MetricTarget[]{MANAGEMENT_CENTER})
+        );
     }
 
     @Test
     public void testAsSet_ignoresPermutations() {
-        assertEquals(
-                asSet(new MetricTarget[]{MANAGEMENT_CENTER}),
-                asSet(new MetricTarget[]{MANAGEMENT_CENTER, MANAGEMENT_CENTER})
+        assertSame(
+                MetricTarget.asSet(new MetricTarget[]{MANAGEMENT_CENTER}),
+                MetricTarget.asSet(new MetricTarget[]{MANAGEMENT_CENTER, MANAGEMENT_CENTER})
         );
-        assertEquals(
-                asSet(new MetricTarget[]{JMX, MANAGEMENT_CENTER}),
-                asSet(new MetricTarget[]{MANAGEMENT_CENTER, JMX})
+        assertSame(
+                MetricTarget.asSet(new MetricTarget[]{JMX, MANAGEMENT_CENTER}),
+                MetricTarget.asSet(new MetricTarget[]{MANAGEMENT_CENTER, JMX})
         );
     }
 
@@ -66,7 +66,7 @@ public class MetricTargetTest {
     }
 
     private void assertAsSetContainsAll(MetricTarget... targets) {
-        assertContainsAll(asSet(targets), asList(targets));
+        assertContainsAll(MetricTarget.asSet(targets), asList(targets));
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricTargetTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.metrics.MetricTarget.DIAGNOSTICS;
+import static com.hazelcast.internal.metrics.MetricTarget.JMX;
+import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
+import static com.hazelcast.internal.metrics.MetricTarget.asSet;
+import static com.hazelcast.test.HazelcastTestSupport.assertContainsAll;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MetricTargetTest {
+
+    @Test
+    public void testAsSet_returnsSameObjects() {
+        assertTrue("set objects must be cached and reused",
+                asSet(new MetricTarget[]{MANAGEMENT_CENTER}) == asSet(new MetricTarget[]{MANAGEMENT_CENTER}));
+    }
+
+    @Test
+    public void testAsSet_ignoresPermutations() {
+        assertEquals(
+                asSet(new MetricTarget[]{MANAGEMENT_CENTER}),
+                asSet(new MetricTarget[]{MANAGEMENT_CENTER, MANAGEMENT_CENTER})
+        );
+        assertEquals(
+                asSet(new MetricTarget[]{JMX, MANAGEMENT_CENTER}),
+                asSet(new MetricTarget[]{MANAGEMENT_CENTER, JMX})
+        );
+    }
+
+    @Test
+    public void testAsSet_supportsAllCombinations() {
+        assertAsSetContainsAll(MANAGEMENT_CENTER);
+        assertAsSetContainsAll(JMX);
+        assertAsSetContainsAll(DIAGNOSTICS);
+        assertAsSetContainsAll(DIAGNOSTICS, JMX);
+        assertAsSetContainsAll(DIAGNOSTICS, MANAGEMENT_CENTER);
+        assertAsSetContainsAll(MANAGEMENT_CENTER, JMX);
+        assertAsSetContainsAll(MANAGEMENT_CENTER, JMX, DIAGNOSTICS);
+    }
+
+    private void assertAsSetContainsAll(MetricTarget... targets) {
+        assertContainsAll(asSet(targets), asList(targets));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricTargetTest.java
@@ -56,6 +56,7 @@ public class MetricTargetTest {
 
     @Test
     public void testAsSet_supportsAllCombinations() {
+        assertAsSetContainsAll();
         assertAsSetContainsAll(MANAGEMENT_CENTER);
         assertAsSetContainsAll(JMX);
         assertAsSetContainsAll(DIAGNOSTICS);


### PR DESCRIPTION
Implements enhancement described here: https://github.com/hazelcast/hazelcast/pull/15667#discussion_r331541195