### PR TITLE
Changes signature of AbstractInvocationFuture#defaultExecutor for JDK9+

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -908,7 +908,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
     }
 
-    protected Executor defaultExecutor() {
+    public Executor defaultExecutor() {
         return DEFAULT_ASYNC_EXECUTOR;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTes
         }
 
         @Override
-        protected Executor defaultExecutor() {
+        public Executor defaultExecutor() {
             return executor;
         }
 


### PR DESCRIPTION
JDK9 introduces `public CompletableFuture#defaultExecutor()`; the same
method is defined in `AbstractInvocationFuture extends CompletableFuture`
but with protected access -> compilation fails on JDK9+. Making the
method public resolves the issue.

Fixes #15699 