### PR TITLE
ClientMessage.toString fix to make it work correctly for fragmented messages

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -59,12 +59,9 @@ public class ClientMessageSplitAndBuildTest {
         String username = generateRandomString(1000);
         String password = generateRandomString(1000);
         UUID uuid = UuidUtil.newUnsecureUUID();
-        UUID ownerUuid = UuidUtil.newUnsecureUUID();
-        boolean isOwnerConnection = false;
         String clientType = generateRandomString(1000);
         String clientSerializationVersion = generateRandomString(1000);
         String clientName = generateRandomString(1000);
-        UUID clusterId = UuidUtil.newUnsecureUUID();
         LinkedList<String> labels = new LinkedList<>();
         for (int i = 0; i < 10; i++) {
             labels.add(generateRandomString(1000));
@@ -115,7 +112,6 @@ public class ClientMessageSplitAndBuildTest {
     @Test
     public void fragmentFieldAccessTest() {
         List<ClientMessage> fragments = getFragments(128, clientMessage1);
-        assertEquals(18, fragments.size());
         ClientMessage firstMessage = fragments.get(0);
         ClientMessage.ForwardFrameIterator forwardFrameIterator = firstMessage.frameIterator();
         // skip the first frame as it is the fragmentation frame

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCodec;
 import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.util.ClientMessageEncoder;
 import com.hazelcast.internal.networking.HandlerStatus;
+import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -111,6 +112,19 @@ public class ClientMessageSplitAndBuildTest {
         assertEquals(clientMessage1.getFrameLength(), resultingMessage.get().getFrameLength());
     }
 
+    @Test
+    public void fragmentFieldAccessTest() {
+        List<ClientMessage> fragments = getFragments(128, clientMessage1);
+        assertEquals(18, fragments.size());
+        ClientMessage firstMessage = fragments.get(0);
+        ClientMessage.ForwardFrameIterator forwardFrameIterator = firstMessage.frameIterator();
+        // skip the first frame as it is the fragmentation frame
+        forwardFrameIterator.next();
+        byte[] startFrameContent = forwardFrameIterator.next().content;
+        assertEquals(clientMessage1.getMessageType(), Bits.readIntL(startFrameContent, ClientMessage.TYPE_FIELD_OFFSET));
+        assertEquals(clientMessage1.getCorrelationId(),
+                Bits.readIntL(startFrameContent, ClientMessage.CORRELATION_ID_FIELD_OFFSET));
+    }
 
     @Test
     public void splitAndBuild_multipleMessages() {


### PR DESCRIPTION
Corrected the ClientMessage.toString to work correctly when fragmentation happens.