### PR TITLE
CP session state should be migrated/replicated in unsafe mode

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftServiceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftServiceDataSerializerHook.java
@@ -37,6 +37,7 @@ import com.hazelcast.cp.internal.operation.integration.PreVoteResponseOp;
 import com.hazelcast.cp.internal.operation.integration.TriggerLeaderElectionOp;
 import com.hazelcast.cp.internal.operation.integration.VoteRequestOp;
 import com.hazelcast.cp.internal.operation.integration.VoteResponseOp;
+import com.hazelcast.cp.internal.operation.unsafe.UnsafeStateReplicationOp;
 import com.hazelcast.cp.internal.raftop.GetInitialRaftGroupMembersIfCurrentGroupMemberOp;
 import com.hazelcast.cp.internal.raftop.NotifyTermChangeOp;
 import com.hazelcast.cp.internal.raftop.metadata.AddCPMemberOp;
@@ -121,6 +122,8 @@ public final class RaftServiceDataSerializerHook implements DataSerializerHook {
     public static final int GET_LEADED_GROUPS = 48;
     public static final int TRANSFER_LEADERSHIP_OP = 49;
     public static final int TRIGGER_LEADER_ELECTION_OP = 50;
+    public static final int UNSAFE_MODE_PARTITION_STATE = 51;
+    public static final int UNSAFE_STATE_REPLICATE_OP = 52;
 
     @Override
     public int getFactoryId() {
@@ -231,6 +234,10 @@ public final class RaftServiceDataSerializerHook implements DataSerializerHook {
                     return new TransferLeadershipOp();
                 case TRIGGER_LEADER_ELECTION_OP:
                     return new TriggerLeaderElectionOp();
+                case UNSAFE_MODE_PARTITION_STATE:
+                    return new UnsafeModePartitionState();
+                case UNSAFE_STATE_REPLICATE_OP:
+                    return new UnsafeStateReplicationOp();
                 default:
                     throw new IllegalArgumentException("Undefined type: " + typeId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/UnsafeModePartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/UnsafeModePartitionState.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * State for {@linkplain RaftService} used in UNSAFE mode.
+ * UnsafeModePartitionState keeps track of {@code commitIndex}
+ * and registrations of waiting operations, such as {@code FencedLock.lock()}.
+ * <p>
+ * UnsafeModePartitionState is replicated during migration
+ * with {@linkplain com.hazelcast.cp.internal.operation.unsafe.UnsafeStateReplicationOp UnsafeStateReplicationOp}.
+ */
+public class UnsafeModePartitionState implements IdentifiedDataSerializable {
+
+    private long commitIndex;
+    private final transient Map<Long, Operation> waitingOperations = new HashMap<>();
+
+    long nextCommitIndex() {
+        return ++commitIndex;
+    }
+
+    boolean registerWaitingOp(long commitIndex, Operation op) {
+        return waitingOperations.putIfAbsent(commitIndex, op) == null;
+    }
+
+    Operation removeWaitingOp(long index) {
+        return waitingOperations.remove(index);
+    }
+
+    Collection<Operation> getWaitingOps() {
+        return waitingOperations.values();
+    }
+
+    void apply(UnsafeModePartitionState state) {
+        commitIndex = state.commitIndex;
+        waitingOperations.clear();
+        waitingOperations.putAll(state.waitingOperations);
+    }
+
+    void reset() {
+        commitIndex = 0;
+        waitingOperations.clear();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return RaftServiceDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return RaftServiceDataSerializerHook.UNSAFE_MODE_PARTITION_STATE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeLong(commitIndex);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        commitIndex = in.readLong();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/AbstractUnsafeRaftOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/AbstractUnsafeRaftOp.java
@@ -61,7 +61,7 @@ public abstract class AbstractUnsafeRaftOp extends Operation implements Identifi
         if (op instanceof CallerAware) {
             ((CallerAware) op).setCaller(getCallerAddress(), getCallId());
         }
-        long commitIndex = service.nextUnsafeModeCommitIndex();
+        long commitIndex = service.nextUnsafeModeCommitIndex(groupId);
         response = op.setNodeEngine(nodeEngine).run(groupId, commitIndex);
         return handleResponse(commitIndex, response);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
@@ -43,7 +43,7 @@ public class UnsafeRaftReplicateOp extends AbstractUnsafeRaftOp implements Backu
     CallStatus handleResponse(long commitIndex, Object response) {
         if (response == PostponedResponse.INSTANCE) {
             RaftService service = getService();
-            service.registerUnsafeWaitingOperation(commitIndex, this);
+            service.registerUnsafeWaitingOperation(groupId, commitIndex, this);
             return CallStatus.DONE_VOID;
         }
         return CallStatus.DONE_RESPONSE;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeStateReplicationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeStateReplicationOp.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.operation.unsafe;
+
+import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
+import com.hazelcast.cp.internal.UnsafeModePartitionState;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+
+/**
+ * Partition-based replication operation to migrate {@linkplain RaftService}'s state in UNSAFE mode.
+ */
+public class UnsafeStateReplicationOp extends Operation implements IdentifiedDataSerializable {
+
+    private UnsafeModePartitionState state;
+
+    public UnsafeStateReplicationOp() {
+    }
+
+    public UnsafeStateReplicationOp(UnsafeModePartitionState state) {
+        this.state = state;
+    }
+
+    @Override
+    public void run() throws Exception {
+        RaftService service = getService();
+        service.applyUnsafeModeState(getPartitionId(), state);
+    }
+
+    @Override
+    public String getServiceName() {
+        return RaftService.SERVICE_NAME;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return RaftServiceDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return RaftServiceDataSerializerHook.UNSAFE_STATE_REPLICATE_OP;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(state);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        state = in.readObject();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/UnsafeFencedLockMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/UnsafeFencedLockMigrationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.datastructures.lock;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Future;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class UnsafeFencedLockMigrationTest extends HazelcastRaftTestSupport {
+
+    @Test
+    public void whenLockIsMigrated_thenSessionInformationShouldMigrate() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "2");
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+
+        // Create two locks on each partition,
+        // so one of them is guaranteed to be migrated
+        // after new instance is started.
+        FencedLock lock1 = hz1.getCPSubsystem().getLock(generateName(hz1, 0));
+        FencedLock lock2 = hz1.getCPSubsystem().getLock(generateName(hz1, 1));
+
+        lock1.lock();
+        lock2.lock();
+
+        // Start new instance to trigger migration
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        waitAllForSafeState(hz1, hz2);
+
+        // Unlock after lock is migrated
+        lock1.unlock();
+        lock2.unlock();
+    }
+
+    @Test
+    public void whenLockIsMigrated_thenWaitingOpsShouldBeNotified() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "2");
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+
+        // Create two locks on each partition,
+        // so one of them is guaranteed to be migrated
+        // after new instance is started.
+        FencedLock lock1 = hz1.getCPSubsystem().getLock(generateName(hz1, 0));
+        FencedLock lock2 = hz1.getCPSubsystem().getLock(generateName(hz1, 1));
+
+        lock1.lock();
+        lock2.lock();
+
+        Future waitingLock1 = spawn(lock1::lock);
+        Future waitingLock2 = spawn(lock2::lock);
+
+        // Ensure waiting op is registered
+        LockService lockService = getNodeEngineImpl(hz1).getService(LockService.SERVICE_NAME);
+        assertTrueEventually(() -> {
+            LockRegistry registry1 = lockService.getRegistryOrNull(lock1.getGroupId());
+            assertThat(registry1.getLiveOperations(), hasSize(1));
+
+            LockRegistry registry2 = lockService.getRegistryOrNull(lock2.getGroupId());
+            assertThat(registry2.getLiveOperations(), hasSize(1));
+        });
+
+        // Start new instance to trigger migration
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        waitAllForSafeState(hz1, hz2);
+
+        // Unlock after lock is migrated
+        lock1.unlock();
+        lock2.unlock();
+
+        // Waiting op is triggered after unlock
+        waitingLock1.get();
+        waitingLock2.get();
+    }
+
+    private String generateName(HazelcastInstance instance, int partitionId) {
+        return "lock@" + generateKeyForPartition(instance, partitionId);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/session/UnsafeSessionMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/session/UnsafeSessionMigrationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.session;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.RaftGroupId;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class UnsafeSessionMigrationTest extends HazelcastRaftTestSupport {
+
+    @Test
+    public void whenPartitionIsMigrated_thenSessionInformationShouldMigrate() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "2");
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        RaftGroupId group1 = getRaftService(hz1).createRaftGroupForProxy(generateName(hz1, 0));
+        RaftGroupId group2 = getRaftService(hz1).createRaftGroupForProxy(generateName(hz1, 1));
+
+        ProxySessionManagerService sessionManager = getSessionManager(hz1);
+
+        long session1 = sessionManager.acquireSession(group1);
+        long session2 = sessionManager.acquireSession(group2);
+
+        // Start new instance to trigger migration
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        waitAllForSafeState(hz1, hz2);
+
+        // Unlock after lock is migrated
+        sessionManager.heartbeat(group1, session1).joinInternal();
+        sessionManager.heartbeat(group2, session2).joinInternal();
+    }
+
+    private ProxySessionManagerService getSessionManager(HazelcastInstance instance) {
+        return getNodeEngineImpl(instance).getService(ProxySessionManagerService.SERVICE_NAME);
+    }
+
+    private String generateName(HazelcastInstance instance, int partitionId) {
+        return "group@" + generateKeyForPartition(instance, partitionId);
+    }
+}


### PR DESCRIPTION
In `unsafe` mode of CP Subsystem, `commitIndex` and session information
should be migrated via partitioning system. Also waiting operations
should be notified when partition primary is migrated.

4.0-BETA-1: https://github.com/hazelcast/hazelcast/pull/15709