### PR TITLE
Fixes back pressure enabled due to write through

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
@@ -126,6 +126,10 @@ class BackpressureRegulator {
     }
 
     private int getMaxConcurrentInvocations(HazelcastProperties props) {
+        if (disabled) {
+            return Integer.MAX_VALUE;
+        }
+
         int invocationsPerPartition = props.getInteger(BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION);
         if (invocationsPerPartition < 1) {
             throw new IllegalArgumentException("Can't have '" + BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -57,6 +57,15 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testWriteThroughDoesntEnableBackPressure() {
+        Config config = new Config();
+        HazelcastProperties hazelcastProperties = new HazelcastProperties(config);
+        BackpressureRegulator regulator = new BackpressureRegulator(hazelcastProperties, logger);
+        CallIdSequence callIdSequence = regulator.newCallIdSequence(ConcurrencyDetection.createEnabled(1000));
+        assertEquals(Integer.MAX_VALUE, callIdSequence.getMaxConcurrentInvocations());
+    }
+
+    @Test
     public void testBackPressureDisabledByDefault() {
         Config config = new Config();
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config);
@@ -75,7 +84,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testConstruction_OneSyncWindow_syncOnEveryCall() {
+    public void testConstruction_OneSyncWindowB_syncOnEveryCall() {
         Config config = new Config();
         config.setProperty(BACKPRESSURE_ENABLED.getName(), "true");
         config.setProperty(BACKPRESSURE_SYNCWINDOW.getName(), "1");


### PR DESCRIPTION
The problem was that write through requires the
CallIdSequenceBackpressureCounter because it needs
to know the number of inflight invocations to
determine if the system is concurrent or not.

However it will then pick up the default number of
invocations that should only be picked up when
back pressure is enabled.

so this fixes that; if back pressure is disabled, then
Integer.MAX_VALUE is the maximum inflight invocations
whic is the same as saying there is no back pressure.