### PR TITLE
Use DONE_VOID_BACKUP in CP unsafe mode when op is blocked

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
@@ -44,7 +44,7 @@ public class UnsafeRaftReplicateOp extends AbstractUnsafeRaftOp implements Backu
         if (response == PostponedResponse.INSTANCE) {
             RaftService service = getService();
             service.registerUnsafeWaitingOperation(groupId, commitIndex, this);
-            return CallStatus.DONE_VOID;
+            return CallStatus.DONE_VOID_BACKUP;
         }
         return CallStatus.DONE_RESPONSE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/CallStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/CallStatus.java
@@ -53,6 +53,11 @@ public class CallStatus {
     public static final int OFFLOAD_ORDINAL = 3;
 
     /**
+     * The ordinal value for an {@link #DONE_VOID_BACKUP}.
+     */
+    public static final int DONE_VOID_BACKUP_ORDINAL = 4;
+
+    /**
      * Signals that the Operation is done running and that a response is ready
      * to be returned. Most of the normal operations like IAtomicLong.get will
      * fall in this category.
@@ -66,6 +71,12 @@ public class CallStatus {
      * cluster operations) that don't return a response.
      */
     public static final CallStatus DONE_VOID = new CallStatus(DONE_VOID_ORDINAL);
+
+    /**
+     * Signals that the Operation is done running, its backup should be sent,
+     * but no response will be returned.
+     */
+    public static final CallStatus DONE_VOID_BACKUP = new CallStatus(DONE_VOID_BACKUP_ORDINAL);
 
     /**
      * Indicates that the call could not complete because waiting is required.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -70,6 +70,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_RESPONSE_ORDINAL;
+import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_VOID_BACKUP_ORDINAL;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_VOID_ORDINAL;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.OFFLOAD_ORDINAL;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.WAIT_ORDINAL;
@@ -229,6 +230,10 @@ class OperationRunnerImpl extends OperationRunner implements StaticMetricsProvid
                 break;
             case WAIT_ORDINAL:
                 nodeEngine.getOperationParker().park((BlockingOperation) op);
+                break;
+            case DONE_VOID_BACKUP_ORDINAL:
+                backupHandler.sendBackups(op);
+                op.afterRun();
                 break;
             default:
                 throw new IllegalStateException();


### PR DESCRIPTION
`DONE_VOID_BACKUP` is used when response won't be sent
but backups should be replicated.
It's between `DONE_RESPONSE` and `DONE_VOID`.

CP Subsystem's wait/notify mechanism is different from regular
Hazelcast wait/notify. Latter re-executes the waiting operation
when it's notified and after execution of operation its backups
are replicated.
In CP Subsystem wait/notify, when blocked operation is notified
with a response directly, operation is not re-executed.
Currently all blocking operations are idempotent
but they don't have to be. So, re-executing an operation may
cause double execution or have side-effects.

Master: https://github.com/hazelcast/hazelcast/pull/15725