### PR TITLE
Refactors ProxyService to distinguish local-only and cluster-wide proxy creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -229,7 +229,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     }
 
     @Override
-    public DistributedObject createDistributedObject(String cacheNameWithPrefix) {
+    public DistributedObject createDistributedObject(String cacheNameWithPrefix, boolean local) {
         try {
             /*
              * In here, cacheNameWithPrefix is the full cache name.
@@ -261,7 +261,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
             checkMergePolicySupportsInMemoryFormat(cacheConfig.getName(), mergePolicy, cacheConfig.getInMemoryFormat(), true,
                     logger);
 
-            if (putCacheConfigIfAbsent(cacheConfig) == null) {
+            if (putCacheConfigIfAbsent(cacheConfig) == null && !local) {
                 // if the cache config was not previously known, ensure the new cache config
                 // becomes available on all members before the proxy is returned to the caller
                 createCacheConfigOnAllMembers(PreJoinCacheConfig.of(cacheConfig));
@@ -274,7 +274,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
         deleteCache(objectName, null, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -115,12 +115,12 @@ public class CardinalityEstimatorService
     }
 
     @Override
-    public CardinalityEstimatorProxy createDistributedObject(String objectName) {
+    public CardinalityEstimatorProxy createDistributedObject(String objectName, boolean local) {
         return new CardinalityEstimatorProxy(objectName, nodeEngine, this);
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
         containers.remove(objectName);
         splitBrainProtectionConfigCache.remove(objectName);
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -89,7 +89,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         CollectionContainer container = getContainerMap().remove(name);
         if (container != null) {
             container.destroy();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
@@ -83,7 +83,7 @@ public class ListService extends CollectionService {
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectId) {
+    public DistributedObject createDistributedObject(String objectId, boolean local) {
         return new ListProxyImpl(objectId, nodeEngine, this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -257,7 +257,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     }
 
     @Override
-    public QueueProxyImpl createDistributedObject(String objectId) {
+    public QueueProxyImpl createDistributedObject(String objectId, boolean local) {
         QueueConfig queueConfig = nodeEngine.getConfig().findQueueConfig(objectId);
         checkQueueConfig(queueConfig, nodeEngine.getSplitBrainMergePolicyProvider());
 
@@ -265,7 +265,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         QueueContainer container = containerMap.remove(name);
         if (container != null) {
             container.destroy();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
@@ -83,13 +83,13 @@ public class SetService extends CollectionService {
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectId) {
+    public DistributedObject createDistributedObject(String objectId, boolean local) {
         return new SetProxyImpl(objectId, nodeEngine, this);
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
-        super.destroyDistributedObject(name);
+    public void destroyDistributedObject(String name, boolean local) {
+        super.destroyDistributedObject(name, local);
         splitBrainProtectionConfigCache.remove(name);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
@@ -99,12 +99,12 @@ public class DistributedDurableExecutorService implements ManagedService, Remote
     }
 
     @Override
-    public DistributedObject createDistributedObject(String name) {
+    public DistributedObject createDistributedObject(String name, boolean local) {
         return new DurableExecutorServiceProxy(nodeEngine, this, name);
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         shutdownExecutors.remove(name);
         nodeEngine.getExecutionService().shutdownDurableExecutor(name);
         removeAllContainers(name);

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -168,12 +168,12 @@ public class DistributedExecutorService implements ManagedService, RemoteService
     }
 
     @Override
-    public ExecutorServiceProxy createDistributedObject(String name) {
+    public ExecutorServiceProxy createDistributedObject(String name, boolean local) {
         return new ExecutorServiceProxy(name, nodeEngine, this);
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         shutdownExecutors.remove(name);
         executionService.shutdownExecutor(name);
         statsMap.remove(name);

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -68,12 +68,12 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService,
     }
 
     @Override
-    public DistributedObject createDistributedObject(String name) {
+    public DistributedObject createDistributedObject(String name, boolean local) {
         return new FlakeIdGeneratorProxy(name, nodeEngine, this);
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         statsMap.remove(name);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/PNCounterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/PNCounterService.java
@@ -148,12 +148,12 @@ public class PNCounterService implements
     }
 
     @Override
-    public PNCounterProxy createDistributedObject(String objectName) {
+    public PNCounterProxy createDistributedObject(String objectName, boolean local) {
         return new PNCounterProxy(objectName, nodeEngine, this);
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
         counters.remove(objectName);
         statsMap.remove(objectName);
         splitBrainProtectionConfigCache.remove(objectName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/LongRegisterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/LongRegisterService.java
@@ -75,12 +75,12 @@ public class LongRegisterService implements ManagedService, RemoteService, Migra
     }
 
     @Override
-    public LongRegisterProxy createDistributedObject(String name) {
+    public LongRegisterProxy createDistributedObject(String name, boolean local) {
         return new LongRegisterProxy(name, nodeEngine, this);
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         registers.remove(name);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/RemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/RemoteService.java
@@ -27,17 +27,40 @@ import com.hazelcast.core.DistributedObject;
 public interface RemoteService {
 
     /**
-     * Creates a distributed object.
+     * Creates a distributed object on the local member only (when {@code local} is
+     * {@code true}) or cluster-wide.
      *
      * @param objectName the name for the created distributed object
+     * @param local      when {@code true} then only perform required proxy creation
+     *                   actions on the local member, otherwise perform cluster-wide
+     *                   proxy creation.
      * @return the created distributed object
      */
-    DistributedObject createDistributedObject(String objectName);
+    DistributedObject createDistributedObject(String objectName, boolean local);
 
     /**
      * Destroys a distributed object.
      *
      * @param objectName the name of the distributed object to destroy
      */
-    void destroyDistributedObject(String objectName);
+    void destroyDistributedObject(String objectName, boolean local);
+
+    /**
+     * Creates a distributed object on the cluster.
+     *
+     * @param objectName the name for the created distributed object
+     * @return the created distributed object
+     */
+    default DistributedObject createDistributedObject(String objectName) {
+        return createDistributedObject(objectName, false);
+    }
+
+    /**
+     * Destroys a distributed object on the cluster.
+     *
+     * @param objectName the name of the distributed object to destroy
+     */
+    default void destroyDistributedObject(String objectName) {
+        destroyDistributedObject(objectName, false);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/RemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/RemoteService.java
@@ -28,7 +28,7 @@ public interface RemoteService {
 
     /**
      * Creates a distributed object on the local member only (when {@code local} is
-     * {@code true}) or cluster-wide.
+     * {@code true}), else cluster-wide.
      *
      * @param objectName the name for the created distributed object
      * @param local      when {@code true} then only perform required proxy creation

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -46,7 +46,7 @@ class MapRemoteService implements RemoteService {
     }
 
     @Override
-    public DistributedObject createDistributedObject(String name) {
+    public DistributedObject createDistributedObject(String name, boolean local) {
         Config config = nodeEngine.getConfig();
         MapConfig mapConfig = config.findMapConfig(name);
         SplitBrainMergePolicyProvider mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
@@ -67,7 +67,7 @@ class MapRemoteService implements RemoteService {
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         mapServiceContext.destroyMap(name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -164,13 +164,13 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectName) {
-        return remoteService.createDistributedObject(objectName);
+    public DistributedObject createDistributedObject(String objectName, boolean local) {
+        return remoteService.createDistributedObject(objectName, local);
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
-        remoteService.destroyDistributedObject(objectName);
+    public void destroyDistributedObject(String objectName, boolean local) {
+        remoteService.destroyDistributedObject(objectName, local);
         splitBrainProtectionAwareService.onDestroy(objectName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -186,7 +186,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
     }
 
     @Override
-    public DistributedObject createDistributedObject(String name) {
+    public DistributedObject createDistributedObject(String name, boolean local) {
         MultiMapConfig multiMapConfig = nodeEngine.getConfig().findMultiMapConfig(name);
         checkMultiMapConfig(multiMapConfig, nodeEngine.getSplitBrainMergePolicyProvider());
 
@@ -194,7 +194,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         for (MultiMapPartitionContainer container : partitionContainers) {
             if (container != null) {
                 container.destroyMultiMap(name);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -184,7 +184,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectName) {
+    public DistributedObject createDistributedObject(String objectName, boolean local) {
         ReplicatedMapConfig replicatedMapConfig = getReplicatedMapConfig(objectName);
         checkReplicatedMapConfig(replicatedMapConfig, mergePolicyProvider);
         if (nodeEngine.getLocalMember().isLiteMember()) {
@@ -202,7 +202,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
         if (nodeEngine.getLocalMember().isLiteMember()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -131,7 +131,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectName) {
+    public DistributedObject createDistributedObject(String objectName, boolean local) {
         RingbufferConfig ringbufferConfig = getRingbufferConfig(objectName);
         checkRingbufferConfig(ringbufferConfig, nodeEngine.getSplitBrainMergePolicyProvider());
 
@@ -139,7 +139,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         destroyContainer(getRingbufferPartitionId(name), getRingbufferNamespace(name));
         nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, name);
         splitBrainProtectionConfigCache.remove(name);

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -167,7 +167,7 @@ public class DistributedScheduledExecutorService
     }
 
     @Override
-    public DistributedObject createDistributedObject(String name) {
+    public DistributedObject createDistributedObject(String name, boolean local) {
         ScheduledExecutorConfig executorConfig = nodeEngine.getConfig().findScheduledExecutorConfig(name);
         checkScheduledExecutorConfig(executorConfig, nodeEngine.getSplitBrainMergePolicyProvider());
 
@@ -175,7 +175,7 @@ public class DistributedScheduledExecutorService
     }
 
     @Override
-    public void destroyDistributedObject(String name) {
+    public void destroyDistributedObject(String name, boolean local) {
         if (shutdownExecutors.remove(name) == null) {
             nodeEngine.getExecutionService().shutdownScheduledDurableExecutor(name);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -175,7 +175,7 @@ public final class ProxyRegistry {
             if (!proxyService.nodeEngine.isRunning()) {
                 throw new HazelcastInstanceNotActiveException();
             }
-            proxyFuture = createProxy(name, publishEvent, initialize);
+            proxyFuture = createProxy(name, publishEvent, initialize, false);
             if (proxyFuture == null) {
                 return getOrCreateProxyFuture(name, publishEvent, initialize);
             }
@@ -191,7 +191,8 @@ public final class ProxyRegistry {
      * @param initialize   true if he DistributedObject proxy object should be initialized.
      * @return The DistributedObject instance if it is created by this method, null otherwise.
      */
-    public DistributedObjectFuture createProxy(String name, boolean publishEvent, boolean initialize) {
+    public DistributedObjectFuture createProxy(String name, boolean publishEvent, boolean initialize,
+                                               boolean local) {
         if (proxies.containsKey(name)) {
             return null;
         }
@@ -205,14 +206,14 @@ public final class ProxyRegistry {
             return null;
         }
 
-        return doCreateProxy(name, publishEvent, initialize, proxyFuture);
+        return doCreateProxy(name, publishEvent, initialize, proxyFuture, local);
     }
 
     private DistributedObjectFuture doCreateProxy(String name, boolean publishEvent, boolean initialize,
-                                                  DistributedObjectFuture proxyFuture) {
+                                                  DistributedObjectFuture proxyFuture, boolean local) {
         DistributedObject proxy;
         try {
-            proxy = service.createDistributedObject(name);
+            proxy = service.createDistributedObject(name, local);
             if (initialize && proxy instanceof InitializingObject) {
                 try {
                     ((InitializingObject) proxy).initialize();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -131,7 +131,7 @@ public class ProxyServiceImpl
         checkObjectNameNotNull(name);
 
         ProxyRegistry registry = getOrCreateRegistry(serviceName);
-        registry.createProxy(name, true, true);
+        registry.createProxy(name, true, true, false);
         createdCounter.inc();
     }
 
@@ -239,7 +239,7 @@ public class ProxyServiceImpl
             try {
                 final ProxyRegistry registry = getOrCreateRegistry(serviceName);
                 if (!registry.contains(eventPacket.getName())) {
-                    registry.createProxy(eventPacket.getName(), false, true);
+                    registry.createProxy(eventPacket.getName(), false, true, true);
                     // listeners will be called if proxy is created here.
                 }
             } catch (HazelcastInstanceNotActiveException ignored) {
@@ -248,7 +248,7 @@ public class ProxyServiceImpl
         } else {
             final ProxyRegistry registry = registries.get(serviceName);
             if (registry != null) {
-                registry.destroyProxy(eventPacket.getName(), false);
+                registry.destroyProxy(eventPacket.getName(), true);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -248,7 +248,7 @@ public class ProxyServiceImpl
         } else {
             final ProxyRegistry registry = registries.get(serviceName);
             if (registry != null) {
-                registry.destroyProxy(eventPacket.getName(), true);
+                registry.destroyProxy(eventPacket.getName(), false);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -131,7 +131,7 @@ public class ProxyServiceImpl
         checkObjectNameNotNull(name);
 
         ProxyRegistry registry = getOrCreateRegistry(serviceName);
-        registry.createProxy(name, true, true, false);
+        registry.createProxy(name, true, false);
         createdCounter.inc();
     }
 
@@ -239,7 +239,7 @@ public class ProxyServiceImpl
             try {
                 final ProxyRegistry registry = getOrCreateRegistry(serviceName);
                 if (!registry.contains(eventPacket.getName())) {
-                    registry.createProxy(eventPacket.getName(), false, true, true);
+                    registry.createProxy(eventPacket.getName(), true, true);
                     // listeners will be called if proxy is created here.
                 }
             } catch (HazelcastInstanceNotActiveException ignored) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -124,7 +124,7 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         @Override
         public void run() {
             try {
-                registry.createProxy(proxyInfo.getObjectName(), false, true);
+                registry.createProxy(proxyInfo.getObjectName(), false, true, true);
             } catch (CacheNotExistsException e) {
                 // this can happen when a cache destroy event is received
                 // after the cache config is replicated during join (pre-join)

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -124,7 +124,7 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         @Override
         public void run() {
             try {
-                registry.createProxy(proxyInfo.getObjectName(), false, true, true);
+                registry.createProxy(proxyInfo.getObjectName(), true, true);
             } catch (CacheNotExistsException e) {
                 // this can happen when a cache destroy event is received
                 // after the cache config is replicated during join (pre-join)

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -107,7 +107,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     }
 
     @Override
-    public ITopic createDistributedObject(String name) {
+    public ITopic createDistributedObject(String name, boolean local) {
         TopicConfig topicConfig = nodeEngine.getConfig().findTopicConfig(name);
 
         if (topicConfig.isGlobalOrderingEnabled()) {
@@ -118,7 +118,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     }
 
     @Override
-    public void destroyDistributedObject(String objectId) {
+    public void destroyDistributedObject(String objectId, boolean local) {
         statsMap.remove(objectId);
         nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, objectId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
@@ -52,13 +52,13 @@ public class ReliableTopicService implements ManagedService, RemoteService, Stat
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectName) {
+    public DistributedObject createDistributedObject(String objectName, boolean local) {
         ReliableTopicConfig topicConfig = nodeEngine.getConfig().findReliableTopicConfig(objectName);
         return new ReliableTopicProxy(objectName, nodeEngine, this, topicConfig);
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
         statsMap.remove(objectName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
@@ -75,12 +75,12 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
     }
 
     @Override
-    public DistributedObject createDistributedObject(String objectName) {
+    public DistributedObject createDistributedObject(String objectName, boolean local) {
         return xaResource;
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
     }
 
     public TransactionContext newXATransactionContext(Xid xid, UUID ownerUuid, int timeout, boolean originatedFromClient) {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ProxyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ProxyFactoryTest.java
@@ -129,12 +129,12 @@ public class ProxyFactoryTest {
     private class CustomService implements RemoteService {
 
         @Override
-        public DistributedObject createDistributedObject(String objectName) {
+        public DistributedObject createDistributedObject(String objectName, boolean local) {
             return new CustomClientProxy(SERVICE_NAME, objectName, context);
         }
 
         @Override
-        public void destroyDistributedObject(String objectName) {
+        public void destroyDistributedObject(String objectName, boolean local) {
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
@@ -185,12 +185,12 @@ public class DistributedObjectTest extends HazelcastTestSupport {
         static final String NAME = "TestInitializingObjectService";
 
         @Override
-        public DistributedObject createDistributedObject(final String objectName) {
+        public DistributedObject createDistributedObject(final String objectName, boolean local) {
             return new TestInitializingObject(objectName);
         }
 
         @Override
-        public void destroyDistributedObject(final String objectName) {
+        public void destroyDistributedObject(final String objectName, boolean local) {
         }
     }
 
@@ -288,12 +288,12 @@ public class DistributedObjectTest extends HazelcastTestSupport {
         static final String NAME = "FailingInitializingObjectService";
 
         @Override
-        public DistributedObject createDistributedObject(String objectName) {
+        public DistributedObject createDistributedObject(String objectName, boolean local) {
             throw new HazelcastException("Object creation is not allowed!");
         }
 
         @Override
-        public void destroyDistributedObject(final String objectName) {
+        public void destroyDistributedObject(final String objectName, boolean local) {
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
@@ -286,12 +286,12 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
         }
 
         @Override
-        public DistributedObject createDistributedObject(String objectName) {
+        public DistributedObject createDistributedObject(String objectName, boolean local) {
             return new DummyTransactionalObject(serviceName, objectName, null);
         }
 
         @Override
-        public void destroyDistributedObject(String objectName) {
+        public void destroyDistributedObject(String objectName, boolean local) {
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteService.java
+++ b/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteService.java
@@ -23,12 +23,12 @@ public class TestRemoteService implements RemoteService {
     public static final String SERVICE_NAME = "TestRemoteService";
 
     @Override
-    public DistributedObject createDistributedObject(String objectName) {
+    public DistributedObject createDistributedObject(String objectName, boolean local) {
         return new TestDistributedObject(objectName);
     }
 
     @Override
-    public void destroyDistributedObject(String objectName) {
+    public void destroyDistributedObject(String objectName, boolean local) {
 
     }
 }


### PR DESCRIPTION
Motivation: proxies can be created or destroyed as a result of receiving a proxy created/destroyed event from a remote member. In this case of event-triggered proxy creation, we only need to deal with local member proxy creation and avoid cluster-wide operations otherwise we risk deadlocking the event thread.