### PR TITLE
Undeprecate GetCommandProcessor.handle

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandProcessor.java
@@ -28,7 +28,7 @@ public class GetCommandProcessor extends MemcacheCommandProcessor<GetCommand> {
         this.entryConverter = entryConverter;
     }
 
-    @Deprecated
+    @Override
     public void handle(GetCommand getCommand) {
         String memcacheKey = getCommand.getKey();
         MapNameAndKeyPair mapNameAndKeyPair = parseMemcacheKey(memcacheKey);


### PR DESCRIPTION
Was deprecated by mistake.