### PR TITLE
correct the frame to byte conversion logic in ClientMessageProtection…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -185,10 +184,6 @@ public class ClientMessageProtectionTest {
     }
 
     @Test
-    @Ignore
-    /**
-     * Ignore until issue https://github.com/hazelcast/hazelcast/issues/15658 is resolved
-     */
     public void testAccumulatedMessageSizeOverflow() throws IOException {
         Config config = smallInstanceConfig();
         HazelcastInstance hz = factory.newHazelcastInstance(config);
@@ -255,7 +250,7 @@ public class ClientMessageProtectionTest {
         ByteBuffer buffer = ByteBuffer.allocateDirect(frameSize);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         buffer.putInt(frameSize);
-        if (isLastFrame) {
+        if (!isLastFrame) {
             buffer.putShort((short) frame.flags);
         } else {
             buffer.putShort((short) (frame.flags | IS_FINAL_FLAG));


### PR DESCRIPTION
…Test

Formerly, `frameAsBytes` method was adding the `IS_FINAL_FLAG` to the frames that are not final. So, in the `testAccumulatedMessageSizeOverflow`, we were writing the initial frame of the authentication message as a final frame which causes member to try to handle that message and sometimes reject the connection before the `os.write(byteBufferToBytes(buffer))` line. 

So, we were getting socket reset exceptions (indicating that the connection is closed) instead of the expected EOF exception. 

fixes #15658 