### PR TITLE
Move Client Statistics properties to the public ClientProperty class

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientStatisticsCodec;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.ClientType;
+import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.metrics.Gauge;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -32,7 +33,6 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,19 +45,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * it will be scheduled for periodic statistics collection and sent.
  */
 public class Statistics {
-    /**
-     * Use to enable the client statistics collection.
-     * <p>
-     * The default is false.
-     */
-    public static final HazelcastProperty ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled", false);
-
-    /**
-     * The period in seconds the statistics run.
-     */
-    public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty("hazelcast.client.statistics.period.seconds", 3,
-            SECONDS);
-
     private static final String NEAR_CACHE_CATEGORY_PREFIX = "nc.";
     private static final char STAT_SEPARATOR = ',';
     private static final char KEY_VALUE_SEPARATOR = '=';
@@ -76,7 +63,7 @@ public class Statistics {
 
     public Statistics(final HazelcastClientInstanceImpl clientInstance) {
         this.properties = clientInstance.getProperties();
-        this.enabled = properties.getBoolean(ENABLED);
+        this.enabled = properties.getBoolean(ClientProperty.STATISTICS_ENABLED);
         this.client = clientInstance;
         this.enterprise = BuildInfoProvider.getBuildInfo().isEnterprise();
         this.metricsRegistry = clientInstance.getMetricsRegistry();
@@ -90,10 +77,10 @@ public class Statistics {
             return;
         }
 
-        long periodSeconds = properties.getSeconds(PERIOD_SECONDS);
+        long periodSeconds = properties.getSeconds(ClientProperty.STATISTICS_PERIOD_SECONDS);
         if (periodSeconds <= 0) {
-            long defaultValue = Long.parseLong(PERIOD_SECONDS.getDefaultValue());
-            logger.warning("Provided client statistics " + PERIOD_SECONDS.getName()
+            long defaultValue = Long.parseLong(ClientProperty.STATISTICS_PERIOD_SECONDS.getDefaultValue());
+            logger.warning("Provided client statistics " + ClientProperty.STATISTICS_PERIOD_SECONDS.getName()
                     + " cannot be less than or equal to 0. You provided " + periodSeconds
                     + " seconds as the configuration. Client will use the default value of " + defaultValue + " instead.");
             periodSeconds = defaultValue;

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -225,6 +225,20 @@ public final class ClientProperty {
     public static final HazelcastProperty FAIL_ON_INDETERMINATE_OPERATION_STATE
             = new HazelcastProperty("hazelcast.client.operation.fail.on.indeterminate.state", false);
 
+    /**
+     * Use to enable the client statistics collection.
+     * <p>
+     * The default is false.
+     */
+    public static final HazelcastProperty STATISTICS_ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled",
+            false);
+
+    /**
+     * The period in seconds the statistics run.
+     */
+    public static final HazelcastProperty STATISTICS_PERIOD_SECONDS = new HazelcastProperty(
+            "hazelcast.client.statistics.period.seconds", 3, SECONDS);
+
     private ClientProperty() {
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -320,7 +320,6 @@ public class ClientStatisticsTest extends ClientTestSupport {
     private static Map<String, String> getStats(HazelcastClientInstanceImpl client, ClientEngineImpl clientEngine) {
         Map<UUID, String> clientStatistics = clientEngine.getClientStatistics();
         assertNotNull("clientStatistics should not be null", clientStatistics);
-        System.out.println("FATAL " + clientStatistics.size());
         assertEquals("clientStatistics.size() should be 1", 1, clientStatistics.size());
         Set<Map.Entry<UUID, String>> entries = clientStatistics.entrySet();
         Map.Entry<UUID, String> statEntry = entries.iterator().next();

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.statistics.Statistics;
+import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -240,8 +241,8 @@ public class ClientStatisticsTest extends ClientTestSupport {
         final ClientEngineImpl clientEngine = getClientEngineImpl(hazelcastInstance);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setProperty(Statistics.ENABLED.getName(), "false");
-        clientConfig.setProperty(Statistics.PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS));
+        clientConfig.setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "false");
+        clientConfig.setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS));
 
         hazelcastFactory.newHazelcastClient(clientConfig);
 
@@ -274,8 +275,8 @@ public class ClientStatisticsTest extends ClientTestSupport {
 
     private HazelcastClientInstanceImpl createHazelcastClient() {
         ClientConfig clientConfig = new ClientConfig()
-                .setProperty(Statistics.ENABLED.getName(), "true")
-                .setProperty(Statistics.PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS))
+                .setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "true")
+                .setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS))
                 // add IMap and ICache with Near Cache config
                 .addNearCacheConfig(new NearCacheConfig(MAP_NAME))
                 .addNearCacheConfig(new NearCacheConfig(CACHE_NAME));


### PR DESCRIPTION
Moved Client Statistics properties to the public ClientProperty class.

Replaces PR https://github.com/hazelcast/hazelcast/pull/13361