### PR TITLE
Handle WaitKeyCancelledException in Lock and Semaphore proxies

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/IAtomicLong.java
@@ -42,7 +42,7 @@ import java.util.concurrent.CompletionStage;
  * </pre>
  * <p>
  * IAtomicLong is accessed via {@link CPSubsystem#getAtomicLong(String)}.
- * It works ontop of the Raft consensus algorithm. It offers linearizability during crash
+ * It works on top of the Raft consensus algorithm. It offers linearizability during crash
  * failures and network partitions. It is CP with respect to the CAP principle.
  * If a network partition occurs, it remains available on at most one side
  * of the partition.

--- a/hazelcast/src/main/java/com/hazelcast/cp/ISemaphore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/ISemaphore.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.lock.FencedLock;
 import com.hazelcast.cp.session.CPSession;
 
@@ -236,20 +235,20 @@ public interface ISemaphore extends DistributedObject {
      * If some threads in the cluster are blocked for acquiring a permit, one
      * of them will unblock by acquiring the permit released by this call.
      * <p>
-     * If the underlying {@link ISemaphore} impl is the non-JDK compatible
-     * CP impl that is configured via {@link SemaphoreConfig} and fetched
-     * via {@link CPSubsystem}, then a thread can only release a permit which
+     * If the underlying {@link ISemaphore} is configured as non-JDK compatible
+     * via {@link SemaphoreConfig} then a thread can only release a permit which
      * it has acquired before. In other words, a thread cannot release a permit
      * without acquiring it first.
      * <p>
-     * Otherwise, which means the underlying impl is either the JDK compatible
-     * CP impl configured via {@link SemaphoreConfig} and fetched
-     * via {@link CPSubsystem}, or it is the old impl fetched via
-     * {@link HazelcastInstance#getSemaphore(String)}, there is no requirement
+     * Otherwise, which means the underlying impl is the JDK compatible
+     * Semaphore is configured via {@link SemaphoreConfig}, there is no requirement
      * that a thread that releases a permit must have acquired that permit by
      * calling one of the {@link #acquire()} methods. A thread can freely
      * release a permit without acquiring it first. In this case, correct usage
      * of a semaphore is established by programming convention in the application.
+     *
+     * @throws IllegalStateException if the Semaphore is non-JDK-compatible
+     *         and the caller does not have a permit
      */
     void release();
 
@@ -264,10 +263,8 @@ public interface ISemaphore extends DistributedObject {
      * it has acquired before. In other words, a thread cannot release a permit
      * without acquiring it first.
      * <p>
-     * Otherwise, which means the underlying impl is either the JDK compatible
-     * CP impl configured via {@link SemaphoreConfig} and fetched
-     * via {@link CPSubsystem}, or it is the old impl fetched via
-     * {@link HazelcastInstance#getSemaphore(String)}, there is no requirement
+     * Otherwise, which means the underlying impl is the JDK compatible
+     * Semaphore is configured via {@link SemaphoreConfig}, there is no requirement
      * that a thread that releases a permit must have acquired that permit by
      * calling one of the {@link #acquire()} methods. A thread can freely
      * release a permit without acquiring it first. In this case, correct usage
@@ -275,6 +272,8 @@ public interface ISemaphore extends DistributedObject {
      *
      * @param permits the number of permits to release
      * @throws IllegalArgumentException if {@code permits} is negative
+     * @throws IllegalStateException if the Semaphore is non-JDK-compatible
+     *         and the caller does not have a permit
      */
     void release(int permits);
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatch.java
@@ -60,7 +60,9 @@ public class CountDownLatch extends BlockingResource<AwaitInvocationKey> impleme
      */
     BiTuple<Integer, Collection<AwaitInvocationKey>> countDown(UUID invocationUuid, int expectedRound) {
         if (expectedRound > round) {
-            throw new IllegalArgumentException("expected round: " + expectedRound + ", actual round: " + round);
+            throw new IllegalStateException("Could not could count down the latch because expected round: " + expectedRound
+                    + " is bigger than the actual round: " + round + ". This can happen when CP Subsystem is used in the unsafe "
+                    + "mode if data loss occurs after the count reaches to zero and the latch is reinitialized.");
         }
 
         if (expectedRound < round) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/Lock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/Lock.java
@@ -124,6 +124,7 @@ public class Lock extends BlockingResource<LockInvocationKey> implements Identif
             return AcquireResult.waitKeyAdded(cancelledWaitKeys);
         }
 
+        ownerInvocationRefUids.put(BiTuple.of(endpoint, invocationUid), NOT_LOCKED);
         return AcquireResult.failed(cancelledWaitKeys);
     }
 
@@ -238,8 +239,7 @@ public class Lock extends BlockingResource<LockInvocationKey> implements Identif
     }
 
     private void removeInvocationRefUids(long sessionId) {
-        ownerInvocationRefUids.keySet()
-                              .removeIf(lockEndpointUUIDBiTuple -> lockEndpointUUIDBiTuple.element1.sessionId() == sessionId);
+        ownerInvocationRefUids.keySet().removeIf(t -> t.element1.sessionId() == sessionId);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractFencedLockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractFencedLockProxy.java
@@ -92,13 +92,14 @@ public abstract class AbstractFencedLockProxy extends SessionAwareProxy implemen
                     return;
                 }
 
-                throw new LockAcquireLimitReachedException("Lock[" + proxyName + "] reentrant lock limit is already reached!");
+                throw new LockAcquireLimitReachedException("Lock[" + objectName + "] reentrant lock limit is already reached!");
             } catch (SessionExpiredException e) {
                 invalidateSession(sessionId);
                 verifyNoLockedSessionIdPresent(threadId);
             } catch (WaitKeyCancelledException e) {
                 releaseSession(sessionId);
-                throw new IllegalMonitorStateException("Lock[" + proxyName + "] not acquired because its wait is cancelled!");
+                throw new IllegalMonitorStateException("Lock[" + objectName + "] not acquired because the lock call "
+                        + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
             } catch (Throwable t) {
                 if (t instanceof InterruptedException) {
                     throw (InterruptedException) t;
@@ -125,13 +126,14 @@ public abstract class AbstractFencedLockProxy extends SessionAwareProxy implemen
                     return fence;
                 }
 
-                throw new LockAcquireLimitReachedException("Lock[" + proxyName + "] reentrant lock limit is already reached!");
+                throw new LockAcquireLimitReachedException("Lock[" + objectName + "] reentrant lock limit is already reached!");
             } catch (SessionExpiredException e) {
                 invalidateSession(sessionId);
                 verifyNoLockedSessionIdPresent(threadId);
             } catch (WaitKeyCancelledException e) {
                 releaseSession(sessionId);
-                throw new IllegalMonitorStateException("Lock[" + proxyName + "] not acquired because its wait is cancelled!");
+                throw new IllegalMonitorStateException("Lock[" + objectName + "] not acquired because the lock call "
+                        + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreService.java
@@ -114,7 +114,8 @@ public class SemaphoreService extends AbstractBlockingService<AcquireInvocationK
         }
 
         if (!result.success()) {
-            throw new IllegalArgumentException();
+            throw new IllegalStateException("Could not release " + permits + " permits in Semaphore[" + name
+                    + "] because the caller has acquired less than " + permits + " permits");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/AbstractFencedLockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/AbstractFencedLockAdvancedTest.java
@@ -179,7 +179,7 @@ public abstract class AbstractFencedLockAdvancedTest extends HazelcastRaftTestSu
         long sessionId = sessionService.getAllSessions(groupId).get().iterator().next().id();
 
         getRaftInvocationManager(proxyInstance)
-                .invoke(groupId, new UnlockOp(objectName, sessionId, getThreadId(), newUnsecureUUID())).join();
+                .invoke(groupId, new UnlockOp(objectName, sessionId, getThreadId(), newUnsecureUUID())).joinInternal();
 
         assertTrueEventually(() -> {
             for (HazelcastInstance instance : instances) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/AbstractFencedLockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/AbstractFencedLockBasicTest.java
@@ -496,7 +496,7 @@ public abstract class AbstractFencedLockBasicTest extends HazelcastRaftTestSuppo
 
     private void closeSession(HazelcastInstance instance, CPGroupId groupId, long sessionId) {
         RaftService service = getNodeEngineImpl(instance).getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager().invoke(groupId, new CloseSessionOp(sessionId)).join();
+        service.getInvocationManager().invoke(groupId, new CloseSessionOp(sessionId)).joinInternal();
     }
 
     static void assertValidFence(long fence) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSemaphoreAdvancedTest.java
@@ -308,7 +308,7 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
         long sessionId = getSessionManager().getSession(groupId);
         UUID invUid = newUnsecureUUID();
 
-        invokeRaftOp(groupId, new ReleasePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).join();
+        invokeRaftOp(groupId, new ReleasePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).joinInternal();
 
         spawn(() -> {
             try {
@@ -318,7 +318,7 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
             }
         });
 
-        invokeRaftOp(groupId, new ReleasePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).join();
+        invokeRaftOp(groupId, new ReleasePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).joinInternal();
     }
 
     @Test
@@ -333,8 +333,8 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
         assertNotEquals(NO_SESSION_ID, sessionId);
         UUID invUid = newUnsecureUUID();
 
-        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).join();
-        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).join();
+        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).joinInternal();
+        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, 1)).joinInternal();
 
         assertEquals(2, semaphore.availablePermits());
     }
@@ -351,8 +351,8 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
         assertNotEquals(NO_SESSION_ID, sessionId);
         UUID invUid = newUnsecureUUID();
 
-        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, -1)).join();
-        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, -1)).join();
+        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, -1)).joinInternal();
+        invokeRaftOp(groupId, new ChangePermitsOp(objectName, sessionId, getThreadId(), invUid, -1)).joinInternal();
 
         assertEquals(1, semaphore.availablePermits());
     }
@@ -366,14 +366,14 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
         assertNotEquals(NO_SESSION_ID, sessionId);
         UUID invUid = newUnsecureUUID();
 
-        int drained1 = this.<Integer>invokeRaftOp(groupId, new DrainPermitsOp(objectName, sessionId, getThreadId(), invUid)).join();
+        int drained1 = this.<Integer>invokeRaftOp(groupId, new DrainPermitsOp(objectName, sessionId, getThreadId(), invUid)).joinInternal();
 
         assertEquals(3, drained1);
         assertEquals(0, semaphore.availablePermits());
 
         spawn(() -> semaphore.increasePermits(1)).get();
 
-        int drained2 = this.<Integer>invokeRaftOp(groupId, new DrainPermitsOp(objectName, sessionId, getThreadId(), invUid)).join();
+        int drained2 = this.<Integer>invokeRaftOp(groupId, new DrainPermitsOp(objectName, sessionId, getThreadId(), invUid)).joinInternal();
 
         assertEquals(3, drained2);
         assertEquals(1, semaphore.availablePermits());
@@ -454,7 +454,7 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
 
         RaftOp op = new ExpireWaitKeysOp(SemaphoreService.SERVICE_NAME,
                 Collections.singletonList(acquireWaitTimeoutKeyRef[0]));
-        invokeRaftOp(groupId, op).join();
+        invokeRaftOp(groupId, op).joinInternal();
 
         assertTrueEventually(() -> {
             NodeEngineImpl nodeEngine = getNodeEngineImpl(primaryInstance);
@@ -466,8 +466,8 @@ public abstract class AbstractSemaphoreAdvancedTest extends HazelcastRaftTestSup
 
         assertTrueEventually(() -> assertEquals(1, semaphore.availablePermits()));
 
-        assertFalse(f1.join());
-        assertFalse(f2.join());
+        assertFalse(f1.joinInternal());
+        assertFalse(f2.joinInternal());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSemaphoreFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSemaphoreFailureTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         return sessionManagerService.getOrCreateUniqueThreadId(groupId);
     }
 
-    @Test
+    @Test(timeout = 300_000)
     public void testRetriedAcquireDoesNotCancelPendingAcquireRequestWhenAlreadyAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -112,7 +112,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }, 10);
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testNewAcquireCancelsPendingAcquireRequestWhenAlreadyAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -143,7 +143,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testNewAcquireCancelsPendingAcquireRequestWhenNotAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -176,7 +176,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testTryAcquireWithTimeoutCancelsPendingAcquireRequestWhenAlreadyAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -207,7 +207,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testNewTryAcquireWithTimeoutCancelsPendingAcquireRequestWhenNotAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -240,7 +240,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testNewTryAcquireWithoutTimeoutCancelsPendingAcquireRequestWhenAlreadyAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -271,7 +271,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testNewTryAcquireWithoutTimeoutCancelsPendingAcquireRequestsWhenNotAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -304,7 +304,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testReleaseCancelsPendingAcquireRequestWhenPermitsAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -337,7 +337,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test
+    @Test(timeout = 300_000)
     public void testReleaseCancelsPendingAcquireRequestWhenNoPermitsAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -362,7 +362,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
 
         try {
             semaphore.release();
-        } catch (IllegalArgumentException ignored) {
+        } catch (IllegalStateException ignored) {
         }
 
         try {
@@ -372,7 +372,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testDrainCancelsPendingAcquireRequestWhenNotAcquired() throws InterruptedException {
         semaphore.init(1);
         semaphore.acquire();
@@ -404,7 +404,7 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         }
     }
 
-    @Test(timeout = 300000)
+    @Test(timeout = 300_000)
     public void testRetriedAcquireReceivesPermitsOnlyOnce() throws InterruptedException, ExecutionException {
         semaphore.init(1);
         semaphore.acquire();
@@ -453,13 +453,13 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
 
         spawn(() -> semaphore.increasePermits(3)).get();
 
-        f1.join();
-        f2.join();
+        f1.joinInternal();
+        f2.joinInternal();
 
         assertEquals(2, semaphore.availablePermits());
     }
 
-    @Test
+    @Test(timeout = 300_000)
     public void testExpiredAndRetriedTryAcquireRequestReceivesFailureResponse() throws InterruptedException, ExecutionException {
         assumeFalse(isJDKCompatible());
 
@@ -475,17 +475,17 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         InternalCompletableFuture<Boolean> f1 = invocationManager.invoke(groupId,
                 new AcquirePermitsOp(objectName, sessionId, threadId, invUid, 1, SECONDS.toMillis(5)));
 
-        assertFalse(f1.join());
+        assertFalse(f1.joinInternal());
 
         spawn(() -> semaphore.release()).get();
 
         InternalCompletableFuture<Boolean> f2 = invocationManager.invoke(groupId,
                 new AcquirePermitsOp(objectName, sessionId, threadId, invUid, 1, SECONDS.toMillis(5)));
 
-        assertFalse(f2.join());
+        assertFalse(f2.joinInternal());
     }
 
-    @Test
+    @Test(timeout = 300_000)
     public void testRetriedDrainRequestIsNotProcessedAgain() throws InterruptedException, ExecutionException {
         assumeFalse(isJDKCompatible());
 
@@ -501,14 +501,14 @@ public abstract class AbstractSemaphoreFailureTest extends HazelcastRaftTestSupp
         InternalCompletableFuture<Integer> f1 = invocationManager
                 .invoke(groupId, new DrainPermitsOp(objectName, sessionId, threadId, invUid));
 
-        assertEquals(0, (int) f1.join());
+        assertEquals(0, (int) f1.joinInternal());
 
         spawn(() -> semaphore.release()).get();
 
         InternalCompletableFuture<Integer> f2 = invocationManager
                 .invoke(groupId, new DrainPermitsOp(objectName, sessionId, threadId, invUid));
 
-        assertEquals(0, (int) f2.join());
+        assertEquals(0, (int) f2.joinInternal());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSessionAwareSemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/AbstractSessionAwareSemaphoreBasicTest.java
@@ -140,7 +140,7 @@ public abstract class AbstractSessionAwareSemaphoreBasicTest extends HazelcastRa
         assertEquals(7, semaphore.availablePermits());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testRelease_whenNotAcquired() throws InterruptedException {
         assertTrue(semaphore.init(7));
         semaphore.acquire(1);


### PR DESCRIPTION
WaitKeyCancelledException is an internal exception. It is handled inside
Lock and Semaphore proxies and high-level exceptions are thrown with
clear error messages.

Additional minor fixes:
* Throw IllegalStateException instead of IllegalArgumentException from
ISemaphore.release() if no sufficient permits are acquired.
* Throw IllegalStateException with proper exception message from
ICountDownLatch.countDown() if data loss occurs in the CP Subsystem
unsafe mode.
* Memoize response of unsuccessful FencedLock.tryLock() call.