### PR TITLE
Re-adjust test expiry times and remove unneeded test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerTimeoutTest.java
@@ -36,50 +36,23 @@ import static org.junit.Assert.assertNull;
 public class ExpirationManagerTimeoutTest extends HazelcastTestSupport {
 
     @Test
-    public void afterShortExpirationEntryShouldBeAway() throws InterruptedException {
+    public void locking_does_not_cause_expired_keys_live_forever() {
         final String KEY = "key";
 
         final HazelcastInstance node = createHazelcastInstance();
         try {
             IMap<String, String> map = node.getMap("test");
             // after 1 second entry should be evicted
-            map.set(KEY, "value", 1500, TimeUnit.MILLISECONDS);
+            map.set(KEY, "value", 4, TimeUnit.SECONDS);
             // short time after adding it to the map, all ok
             map.lock(KEY);
             Object object = map.get(KEY);
             map.unlock(KEY);
             assertNotNull(object);
 
-            sleepAtLeastMillis(1700);
+            sleepAtLeastSeconds(5);
 
             // more than one second after adding it, now it should be away
-            map.lock(KEY);
-            object = map.get(KEY);
-            map.unlock(KEY);
-            assertNull(object);
-        } finally {
-            node.shutdown();
-        }
-    }
-
-    @Test
-    public void afterLongerExpirationEntryShouldBeAway() throws InterruptedException {
-        final String KEY = "key";
-
-        final HazelcastInstance node = createHazelcastInstance();
-        try {
-            IMap<String, String> map = node.getMap("test");
-            // after 3 second entry should be evicted
-            map.set(KEY, "value", 3, TimeUnit.SECONDS);
-            // short time after adding it to the map, all ok
-            map.lock(KEY);
-            Object object = map.get(KEY);
-            map.unlock(KEY);
-            assertNotNull(object);
-
-            sleepAtLeastMillis(3600);
-
-            // More than 3 seconds after adding it, now it should be away
             map.lock(KEY);
             object = map.get(KEY);
             map.unlock(KEY);


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/15079

Made test less time sensitive by using longer expiry times.