### PR TITLE
Adds logging when old selection keys have ready ops while being rebuilt

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_BasicTest.java
@@ -17,9 +17,11 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.nio.tcp.TcpIpConnection_AbstractBasicTest;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -27,6 +29,9 @@ import org.junit.runner.RunWith;
 @Category(QuickTest.class)
 public class SelectWithSelectorFix_TcpIpConnection_BasicTest
         extends TcpIpConnection_AbstractBasicTest {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug-nio.xml");
 
     @Before
     public void setup() throws Exception {

--- a/hazelcast/src/test/resources/log4j2-debug-nio.xml
+++ b/hazelcast/src/test/resources/log4j2-debug-nio.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.instance" level="debug"/>
+        <Logger name="com.hazelcast.cluster" level="debug"/>
+        <Logger name="com.hazelcast.internal.cluster" level="debug"/>
+        <Logger name="com.hazelcast.internal.partition" level="debug"/>
+        <Logger name="com.hazelcast.internal.networking" level="debug"/>
+        <Logger name="com.hazelcast.spi.hotrestart.cluster" level="debug"/>
+        <Logger name="com.hazelcast.test.mocknetwork" level="debug"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR introduces debug logging during selector rebuild when operating with the select-with-fix selector mode.

Test failures #15706 & #15628 may be due to the single packet write in the test coinciding with selector being rebuilt. It is probable that the read notification might be received on the old `SelectionKey` while it is being rebuilt and before the new `SelectionKey` is registered (in https://github.com/hazelcast/hazelcast/blob/64a2a9bdaa1a3544bc23c4b32c4fe519b510faf4/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java#L394-L420).