### PR TITLE
Remove Comparison.NOT_EQUAL in indexes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 import static com.hazelcast.query.impl.Comparison.GREATER;
 import static com.hazelcast.query.impl.Comparison.GREATER_OR_EQUAL;
-import static com.hazelcast.query.impl.Comparison.LESS;
 import static com.hazelcast.query.impl.CompositeValue.NEGATIVE_INFINITY;
 import static com.hazelcast.query.impl.CompositeValue.POSITIVE_INFINITY;
 import static java.util.Collections.emptySet;
@@ -270,11 +269,6 @@ public class AttributeIndexRegistry {
         @Override
         public Set<QueryableEntry> getRecords(Comparison comparison, Comparable value) {
             switch (comparison) {
-                case NOT_EQUAL:
-                    Set<QueryableEntry> result = new HashSet<QueryableEntry>();
-                    result.addAll(delegate.getRecords(LESS, new CompositeValue(width, value, NEGATIVE_INFINITY)));
-                    result.addAll(delegate.getRecords(GREATER, new CompositeValue(width, value, POSITIVE_INFINITY)));
-                    return result;
                 case LESS:
                     CompositeValue lessFrom = new CompositeValue(width, NULL, POSITIVE_INFINITY);
                     CompositeValue lessTo = new CompositeValue(width, value, NEGATIVE_INFINITY);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Comparison.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Comparison.java
@@ -23,11 +23,6 @@ package com.hazelcast.query.impl;
 public enum Comparison {
 
     /**
-     * !=
-     */
-    NOT_EQUAL,
-
-    /**
      * &lt;
      */
     LESS,

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
@@ -148,13 +148,6 @@ public class OrderedIndexStore extends BaseIndexStore {
                 case GREATER_OR_EQUAL:
                     subMap = recordMap.tailMap(searchedValue, true);
                     break;
-                case NOT_EQUAL:
-                    for (Map.Entry<Comparable, Map<Data, QueryableEntry>> entry : recordMap.entrySet()) {
-                        if (Comparables.compare(searchedValue, entry.getKey()) != 0) {
-                            copyToMultiResultSet(results, entry.getValue());
-                        }
-                    }
-                    return results;
                 default:
                     throw new IllegalArgumentException("Unrecognized comparison: " + comparison);
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
@@ -179,9 +179,6 @@ public class UnorderedIndexStore extends BaseIndexStore {
                     case GREATER_OR_EQUAL:
                         valid = result <= 0;
                         break;
-                    case NOT_EQUAL:
-                        valid = result != 0;
-                        break;
                     default:
                         throw new IllegalStateException("Unrecognized comparison: " + comparison);
                 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
@@ -86,9 +86,6 @@ public class IndexFirstComponentDecoratorTest {
         assertEquals(expected.getRecords(new Comparable[]{100, 101, 102}), actual.getRecords(new Comparable[]{100, 101, 102}));
         assertEquals(expected.getRecords(new Comparable[]{10, 20, 30, 30}), actual.getRecords(new Comparable[]{10, 20, 30, 30}));
 
-        assertEquals(expected.getRecords(Comparison.NOT_EQUAL, 50), actual.getRecords(Comparison.NOT_EQUAL, 50));
-        assertEquals(expected.getRecords(Comparison.NOT_EQUAL, -1), actual.getRecords(Comparison.NOT_EQUAL, -1));
-
         assertEquals(expected.getRecords(Comparison.LESS, 50), actual.getRecords(Comparison.LESS, 50));
         assertEquals(expected.getRecords(Comparison.LESS, 99), actual.getRecords(Comparison.LESS, 99));
         assertEquals(expected.getRecords(Comparison.LESS, 100), actual.getRecords(Comparison.LESS, 100));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -221,7 +221,6 @@ public class IndexTest {
         }
 
         assertEquals(2, strIndex.getRecords((Comparable) null).size());
-        assertEquals(998, strIndex.getRecords(Comparison.NOT_EQUAL, null).size());
     }
 
     private class TestPortableFactory implements PortableFactory {
@@ -517,9 +516,6 @@ public class IndexTest {
         assertEquals(2, index.getRecords(Comparison.GREATER, 66L).size());
         assertEquals(3, index.getRecords(Comparison.GREATER_OR_EQUAL, 66L).size());
         assertEquals(3, index.getRecords(Comparison.GREATER_OR_EQUAL, 61L).size());
-        assertEquals(3, index.getRecords(Comparison.NOT_EQUAL, 61L).size());
-        assertEquals(2, index.getRecords(Comparison.NOT_EQUAL, 66L).size());
-        assertEquals(1, index.getRecords(Comparison.NOT_EQUAL, 555L).size());
         assertEquals(3, index.getRecords(new Comparable[]{66L, 555L, 34234L}).size());
         assertEquals(2, index.getRecords(new Comparable[]{555L, 34234L}).size());
 


### PR DESCRIPTION
It's never used for the actual query execution, all the functionality
around it is basically an unreachable code.

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3237