### PR TITLE
[Test Fix] Check backup listener number drops to 0 eventually.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -265,6 +265,6 @@ public class ListenerLeakTest extends HazelcastTestSupport {
 
         client.shutdown();
         Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
-        assertEquals(0, backupListeners.size());
+        assertTrueEventually(() -> assertEquals(0, backupListeners.size()));
     }
 }


### PR DESCRIPTION
Check backup listener number drops to 0 eventually.

fixes https://github.com/hazelcast/hazelcast/issues/15755