### PR TITLE
Revert naming clientName -> clusterName

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -74,7 +74,7 @@ import static org.springframework.util.Assert.isTrue;
  * <b>Sample Spring XML for Hazelcast Client:</b>
  * <pre>{@code
  *   <hz:client id="client">
- *      <hz:client-name>${cluster.name}</hz:client-name>
+ *      <hz:cluster-name>${cluster.name}</hz:cluster-name>
  *      <hz:network
  *          connection-timeout="1000"
  *          redo-operation="true"
@@ -147,8 +147,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             handleClientAttributes(rootNode);
             for (Node node : childElements(rootNode)) {
                 String nodeName = cleanNodeName(node);
-                if ("client-name".equals(nodeName)) {
-                    configBuilder.addPropertyValue("clientName", getTextContent(node));
+                if ("cluster-name".equals(nodeName)) {
+                    configBuilder.addPropertyValue("clusterName", getTextContent(node));
                 } else if ("properties".equals(nodeName)) {
                     handleProperties(node, configBuilder);
                 } else if ("network".equals(nodeName)) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -1506,7 +1506,7 @@
                 <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="client-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="cluster-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="labels" type="labels" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="backup-ack-to-client-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -26,14 +26,12 @@ import com.hazelcast.client.config.ClientFlakeIdGeneratorConfig;
 import com.hazelcast.client.config.ClientIcmpPingConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.ClientReliableTopicConfig;
-import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.config.ClientUserCodeDeploymentConfig;
 import com.hazelcast.client.config.ConnectionRetryConfig;
 import com.hazelcast.client.config.ProxyFactoryConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.AwsConfig;
-import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
@@ -58,7 +56,6 @@ import com.hazelcast.topic.ITopic;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.security.Credentials;
-import com.hazelcast.spring.security.DummyCredentialsFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import org.junit.AfterClass;
@@ -132,9 +129,6 @@ public class TestClientApplicationContext {
     @Resource(name = "client14-reliable-topic")
     private HazelcastClientProxy hazelcastReliableTopic;
 
-    @Resource(name = "client15-credentials-factory")
-    private HazelcastClientProxy credentialsFactory;
-
     @Resource(name = "client16-name-and-labels")
     private HazelcastClientProxy namedClient;
 
@@ -202,10 +196,6 @@ public class TestClientApplicationContext {
         ClientConfig config = client.getClientConfig();
         assertEquals("13", config.getProperty("hazelcast.client.retry.count"));
         assertEquals(1000, config.getNetworkConfig().getConnectionTimeout());
-
-        ClientConfig config2 = client2.getClientConfig();
-
-        assertEquals(credentials, config2.getSecurityConfig().getCredentialsIdentityConfig().getCredentials());
 
         client.getMap("default").put("Q", "q");
         client2.getMap("default").put("X", "x");
@@ -432,13 +422,6 @@ public class TestClientApplicationContext {
     }
 
     @Test
-    public void testCredentialsFactory() {
-        ClientSecurityConfig securityConfig = credentialsFactory.getClientConfig().getSecurityConfig();
-        CredentialsFactoryConfig credentialsFactoryConfig = securityConfig.getCredentialsFactoryConfig();
-        assertTrue(credentialsFactoryConfig.getImplementation() instanceof DummyCredentialsFactory);
-    }
-
-    @Test
     public void testClientIcmpConfig() {
         ClientIcmpPingConfig icmpPingConfig = icmpPingTestClient.getClientConfig()
                 .getNetworkConfig().getClientIcmpPingConfig();
@@ -491,7 +474,7 @@ public class TestClientApplicationContext {
 
     @Test
     public void testInstanceNameConfig() {
-        assertEquals("clientName", namedClient.getName());
+        assertEquals("clusterName", namedClient.getName());
     }
 
     @Test

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
@@ -55,8 +55,8 @@ public class TestSpringClientFailoverContext {
         ClientFailoverConfig failoverConfig = blueGreenClient.client.getFailoverConfig();
         List<ClientConfig> clientConfigs = failoverConfig.getClientConfigs();
         assertEquals(2, clientConfigs.size());
-        assertEquals("spring-cluster", clientConfigs.get(0).getClientName());
-        assertEquals("alternativeClusterName", clientConfigs.get(1).getClientName());
+        assertEquals("spring-cluster", clientConfigs.get(0).getClusterName());
+        assertEquals("alternativeClusterName", clientConfigs.get(1).getClusterName());
         assertEquals(5, failoverConfig.getTryCount());
         blueGreenClient.shutdown();
     }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -58,7 +58,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
@@ -65,7 +65,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" depends-on="instance">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:properties>
             <hz:property name="hazelcast.client.retry.count">13</hz:property>
         </hz:properties>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -66,6 +66,7 @@
     </hz:hazelcast>
 
     <hz:client id="client">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
@@ -144,10 +145,6 @@
                                class-name="com.hazelcast.nio.serialization.CustomSerializationTest$FooXmlSerializer"/>
             </hz:serializers>
         </hz:serialization>
-
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
 
         <hz:proxy-factories>
             <hz:proxy-factory class-name="com.hazelcast.spring.DummyProxyFactory" service="MyService"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
@@ -49,7 +49,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000">
         </hz:network>
     </hz:client>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -58,7 +58,7 @@
 
     <hz:client-failover id="blueGreenClient" try-count="5" lazy-init="true">
         <hz:client>
-            <hz:client-name>${cluster.name}</hz:client-name>
+            <hz:cluster-name>${cluster.name}</hz:cluster-name>
             <hz:network>
                 <hz:member>127.0.0.1:5701</hz:member>
             </hz:network>
@@ -67,7 +67,7 @@
         </hz:client>
 
         <hz:client>
-            <hz:client-name>alternativeClusterName</hz:client-name>
+            <hz:cluster-name>alternativeClusterName</hz:cluster-name>
             <hz:network>
                 <hz:member>127.0.0.1:5702</hz:member>
             </hz:network>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -57,7 +57,7 @@
     </hz:hazelcast>
 
     <hz:client id="client">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:properties>
             <hz:property name="hazelcast.client.retry.count">13</hz:property>
         </hz:properties>
@@ -77,6 +77,7 @@
     </hz:client>
 
     <hz:client id="client2">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
@@ -90,12 +91,10 @@
                                tcp-no-delay="false"/>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
     </hz:client>
 
     <hz:client id="client3">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
@@ -107,10 +106,6 @@
                                reuse-address="false"
                                tcp-no-delay="false"/>
         </hz:network>
-
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
 
         <hz:listeners>
             <hz:listener class-name="com.hazelcast.spring.DummyMembershipListener"/>
@@ -175,6 +170,7 @@
     </hz:client>
 
     <hz:client id="client4">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
@@ -191,12 +187,10 @@
                     tag-key="sample-tag-key" tag-value="sample-tag-value"/>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
     </hz:client>
 
     <hz:client id="client5">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:connection-strategy>
             <hz:connection-retry>
                 <hz:fail-on-max-backoff>false</hz:fail-on-max-backoff>
@@ -207,20 +201,14 @@
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
     </hz:client>
 
     <hz:client id="client6">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
 
         <hz:query-caches>
             <hz:query-cache name="my-query-cache-1" mapName="map-name">
@@ -255,6 +243,7 @@
     </hz:client>
 
     <hz:client id="client7-empty-serialization-config">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
@@ -268,33 +257,25 @@
                                tcp-no-delay="false"/>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
         <hz:serialization></hz:serialization>
     </hz:client>
 
     <hz:client id="client8">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
         <hz:connection-strategy async-start="true" reconnect-mode="ASYNC"/>
     </hz:client>
 
     <hz:client id="client9-user-code-deployment-test">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
 
         <hz:user-code-deployment enabled="false">
             <hz:jarPaths>
@@ -308,19 +289,17 @@
     </hz:client>
 
     <hz:client id="client10-flakeIdGenerator">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
-
         <hz:flake-id-generator name="gen1" prefetchCount="3" prefetchValidityMillis="3000"/>
     </hz:client>
 
     <hz:client id="client11-icmp-ping">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
@@ -333,13 +312,10 @@
             </hz:icmp-ping>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
-
     </hz:client>
 
     <hz:client id="client12-hazelcast-cloud">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
@@ -348,20 +324,14 @@
             </hz:hazelcast-cloud>
         </hz:network>
 
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
     </hz:client>
 
     <hz:client id="client13-exponential-connection-retry">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
 
         <hz:connection-strategy async-start="true" reconnect-mode="ASYNC">
             <hz:connection-retry>
@@ -375,14 +345,11 @@
     </hz:client>
 
     <hz:client id="client14-reliable-topic">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-
-        <hz:security>
-            <hz:credentials-ref>credentials</hz:credentials-ref>
-        </hz:security>
 
         <!--<hz:reliable-topic name="rel-topic" topic-overload-policy="DISCARD_NEWEST" read-batch-size="100"/>-->
         <hz:reliable-topic name="rel-topic">
@@ -391,31 +358,20 @@
         </hz:reliable-topic>
     </hz:client>
 
-    <hz:client id="client15-credentials-factory">
-        <hz:client-name>${cluster.name}</hz:client-name>
-        <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
-        </hz:network>
-        <hz:security>
-            <hz:credentials-factory implementation="dummyCredentialsFactory"/>
-        </hz:security>
-    </hz:client>
-
     <hz:client id="client16-name-and-labels">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-        <hz:instance-name>clientName</hz:instance-name>
+        <hz:instance-name>clusterName</hz:instance-name>
         <hz:labels>
             <hz:label>foo</hz:label>
         </hz:labels>
     </hz:client>
 
     <hz:client id="client17-backupAckToClient">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -42,7 +42,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -44,7 +44,7 @@
 
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:spring-aware/>
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -64,7 +64,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:client-name>${cluster.name}</hz:client-name>
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -93,7 +93,7 @@ public class ClientConfig {
      */
     private int executorPoolSize = -1;
     private String instanceName;
-    private String clientName = Config.DEFAULT_CLUSTER_NAME;
+    private String clusterName = Config.DEFAULT_CLUSTER_NAME;
     private ConfigPatternMatcher configPatternMatcher = new MatchingPointConfigPatternMatcher();
     private final Map<String, NearCacheConfig> nearCacheConfigMap;
     private final Map<String, ClientReliableTopicConfig> reliableTopicConfigMap;
@@ -126,7 +126,7 @@ public class ClientConfig {
     public ClientConfig(ClientConfig config) {
         properties = new Properties();
         properties.putAll(config.properties);
-        clientName = config.clientName;
+        clusterName = config.clusterName;
         securityConfig = new ClientSecurityConfig(config.securityConfig);
         networkConfig = new ClientNetworkConfig(config.networkConfig);
         loadBalancer = config.loadBalancer;
@@ -733,20 +733,17 @@ public class ClientConfig {
     }
 
     /**
-     * Returns the client name. The name is used as a username in the client protocol authentication message by default. If full
-     * credential object is necessary for the client's authentication, then identity configuration within
-     * {@link ClientSecurityConfig} class should be used. The default authentication method on client protocol just compares
-     * provided {@code clientName} against the {@code clusterName} defined in the Hazelcast member's configuration.
+     * Returns the configured cluster name. The name is send as part of client authentication message and may be verified on the
+     * member.
      *
-     * @see #getSecurityConfig()
-     * @return the configured client name
+     * @return the configured cluster name
      */
-    public String getClientName() {
-        return clientName;
+    public String getClusterName() {
+        return clusterName;
     }
 
-    public ClientConfig setClientName(String clientName) {
-        this.clientName = clientName;
+    public ClientConfig setClusterName(String clusterName) {
+        this.clusterName = clusterName;
         return this;
     }
 
@@ -912,7 +909,7 @@ public class ClientConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(backupAckToClientEnabled, classLoader, clientName, configPatternMatcher, connectionStrategyConfig,
+        return Objects.hash(backupAckToClientEnabled, classLoader, clusterName, configPatternMatcher, connectionStrategyConfig,
                 executorPoolSize, flakeIdGeneratorConfigMap, instanceName, labels, listenerConfigs, loadBalancer,
                 managedContext, metricsConfig, nativeMemoryConfig, nearCacheConfigMap, networkConfig, properties,
                 proxyFactoryConfigs, queryCacheConfigs, reliableTopicConfigMap, securityConfig, serializationConfig,
@@ -933,7 +930,7 @@ public class ClientConfig {
         }
         ClientConfig other = (ClientConfig) obj;
         return backupAckToClientEnabled == other.backupAckToClientEnabled && Objects.equals(classLoader, other.classLoader)
-                && Objects.equals(clientName, other.clientName)
+                && Objects.equals(clusterName, other.clusterName)
                 && Objects.equals(configPatternMatcher, other.configPatternMatcher)
                 && Objects.equals(connectionStrategyConfig, other.connectionStrategyConfig)
                 && executorPoolSize == other.executorPoolSize
@@ -957,7 +954,7 @@ public class ClientConfig {
     public String toString() {
         return "ClientConfig{"
                 + "properties=" + properties
-                + ", clientName=" + clientName
+                + ", clusterName=" + clusterName
                 + ", securityConfig=" + securityConfig
                 + ", networkConfig=" + networkConfig
                 + ", loadBalancer=" + loadBalancer

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -733,7 +733,7 @@ public class ClientConfig {
     }
 
     /**
-     * Returns the configured cluster name. The name is send as part of client authentication message and may be verified on the
+     * Returns the configured cluster name. The name is sent as part of client authentication message and may be verified on the
      * member.
      *
      * @return the configured cluster name

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -101,7 +101,7 @@ public final class ClientConfigXmlGenerator {
 
         //InstanceName
         gen.node("instance-name", clientConfig.getInstanceName());
-        gen.node("client-name", clientConfig.getClientName());
+        gen.node("cluster-name", clientConfig.getClusterName());
         //attributes
         gen.appendLabels(clientConfig.getLabels());
         //Properties

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
@@ -141,8 +141,8 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             handleLabels(node);
         } else if (BACKUP_ACK_TO_CLIENT.isEqual(nodeName)) {
             handleBackupAckToClient(node);
-        } else if ("client-name".equals(nodeName)) {
-            clientConfig.setClientName(getTextContent(node));
+        } else if ("cluster-name".equals(nodeName)) {
+            clientConfig.setClusterName(getTextContent(node));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -161,15 +161,15 @@ public class ClientNetworkConfig {
     }
 
     /**
-     * @param connectionTimeout Timeout value in millis for nodes to accept client connection requests.
+     * @param connectionTimeoutInMillis Timeout value in millis for nodes to accept client connection requests.
      *                          A zero value means wait until connection established or an error occurs.
      * @return configured {@link com.hazelcast.client.config.ClientNetworkConfig} for chaining
      */
-    public ClientNetworkConfig setConnectionTimeout(int connectionTimeout) {
-        if (connectionTimeout < 0) {
+    public ClientNetworkConfig setConnectionTimeout(int connectionTimeoutInMillis) {
+        if (connectionTimeoutInMillis < 0) {
             throw new IllegalArgumentException("connectionTimeout cannot be negative");
         }
-        this.connectionTimeout = connectionTimeout;
+        this.connectionTimeout = connectionTimeoutInMillis;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -110,7 +110,7 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      * clusterConnectionTimestamp
      * credentials.principal
      * clientAddress
-     * clientName
+     * clusterName
      * enterprise
      * lastStatisticsCollectionTime
      * nearcache.&lt;example\.fastmap&gt;.creationTime

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/CandidateClusterContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/CandidateClusterContext.java
@@ -27,17 +27,17 @@ import com.hazelcast.spi.discovery.integration.DiscoveryService;
  */
 public class CandidateClusterContext {
 
-    private final String clientName;
+    private final String clusterName;
     private final AddressProvider addressProvider;
     private final DiscoveryService discoveryService;
     private final ICredentialsFactory credentialsFactory;
     private final SocketInterceptor socketInterceptor;
     private final ChannelInitializerProvider channelInitializerProvider;
 
-    public CandidateClusterContext(String clientName, AddressProvider addressProvider, DiscoveryService discoveryService,
+    public CandidateClusterContext(String clusterName, AddressProvider addressProvider, DiscoveryService discoveryService,
                                    ICredentialsFactory credentialsFactory, SocketInterceptor socketInterceptor,
                                    ChannelInitializerProvider channelInitializerProvider) {
-        this.clientName = clientName;
+        this.clusterName = clusterName;
         this.addressProvider = addressProvider;
         this.discoveryService = discoveryService;
         this.credentialsFactory = credentialsFactory;
@@ -69,8 +69,8 @@ public class CandidateClusterContext {
         return socketInterceptor;
     }
 
-    public String getClientName() {
-        return clientName;
+    public String getClusterName() {
+        return clusterName;
     }
 
     public ChannelInitializerProvider getChannelInitializerProvider() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryServiceBuilder.java
@@ -88,7 +88,7 @@ class ClientDiscoveryServiceBuilder {
             SocketInterceptor interceptor = initSocketInterceptor(networkConfig.getSocketInterceptorConfig());
             ICredentialsFactory credentialsFactory = initCredentialsFactory(config);
             if (credentialsFactory == null) {
-                credentialsFactory = new StaticCredentialsFactory(new UsernamePasswordCredentials(config.getClientName(), ""));
+                credentialsFactory = new StaticCredentialsFactory(new UsernamePasswordCredentials(null, null));
             }
             credentialsFactory.configure(cs -> {
                 throw new UnsupportedCallbackException(cs[0]);
@@ -103,7 +103,7 @@ class ClientDiscoveryServiceBuilder {
 
             final SSLConfig sslConfig = networkConfig.getSSLConfig();
             final SocketOptions socketOptions = networkConfig.getSocketOptions();
-            contexts.add(new CandidateClusterContext(config.getClientName(), provider, discoveryService, credentialsFactory,
+            contexts.add(new CandidateClusterContext(config.getClusterName(), provider, discoveryService, credentialsFactory,
                     interceptor, qualifier -> clientExtension.createChannelInitializer(sslConfig, socketOptions)));
         }
         return new ClientDiscoveryService(configsTryCount, contexts);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -419,7 +419,7 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public String getClusterName() {
-        return instance.getClientConfig().getClientName();
+        return instance.getClientConfig().getClusterName();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
@@ -51,16 +51,16 @@ public class ClientLoggingService implements LoggingService {
     private final String instanceName;
     private volatile String versionMessage;
 
-    public ClientLoggingService(String clientName, String loggingType, BuildInfo buildInfo, String instanceName) {
+    public ClientLoggingService(String clusterName, String loggingType, BuildInfo buildInfo, String instanceName) {
         this.loggerFactory = Logger.newLoggerFactory(loggingType);
         this.buildInfo = buildInfo;
         this.instanceName = instanceName;
-        updateClientName(clientName);
+        updateClusterName(clusterName);
     }
 
-    public void updateClientName(String clientName) {
+    public void updateClusterName(String clusterName) {
         JetBuildInfo jetBuildInfo = buildInfo.getJetBuildInfo();
-        this.versionMessage = instanceName + " [" + clientName + "]"
+        this.versionMessage = instanceName + " [" + clusterName + "]"
                 + (jetBuildInfo != null ? " [" + jetBuildInfo.getVersion() + "]" : "")
                 + " [" + buildInfo.getVersion() + "] ";
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -194,8 +194,8 @@ public final class FailoverClientConfigSupport {
 
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})
     private static void checkValidAlternative(ClientConfig mainConfig, ClientConfig alternativeConfig) {
-        String mainClusterName = mainConfig.getClientName();
-        String alterNativeClusterName = alternativeConfig.getClientName();
+        String mainClusterName = mainConfig.getClusterName();
+        String alterNativeClusterName = alternativeConfig.getClusterName();
 
         checkValidAlternativeForNetwork(mainConfig, alternativeConfig);
 
@@ -266,8 +266,8 @@ public final class FailoverClientConfigSupport {
 
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})
     private static void checkValidAlternativeForNetwork(ClientConfig mainConfig, ClientConfig alternativeConfig) {
-        String mainClusterName = mainConfig.getClientName();
-        String alterNativeClusterName = alternativeConfig.getClientName();
+        String mainClusterName = mainConfig.getClusterName();
+        String alterNativeClusterName = alternativeConfig.getClusterName();
 
         ClientNetworkConfig mainNetworkConfig = mainConfig.getNetworkConfig();
         ClientNetworkConfig alternativeNetworkConfig = alternativeConfig.getNetworkConfig();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -215,7 +215,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         }
 
         String loggingType = config.getProperty(GroupProperty.LOGGING_TYPE.getName());
-        loggingService = new ClientLoggingService(config.getClientName(),
+        loggingService = new ClientLoggingService(config.getClusterName(),
                 loggingType, BuildInfoProvider.getBuildInfo(), instanceName);
         ClassLoader classLoader = config.getClassLoader();
         properties = new HazelcastProperties(config.getProperties());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -539,12 +539,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 resolvedClusterId = clusterId;
             }
 
+            String clusterName = currentClusterContext.getClusterName();
             if (credentials instanceof PasswordCredentials) {
                 PasswordCredentials cr = (PasswordCredentials) credentials;
-                return ClientAuthenticationCodec
-                        .encodeRequest(cr.getName(), cr.getPassword(), clientUuid, ClientTypes.JAVA,
-                                serializationVersion, BuildInfoProvider.getBuildInfo().getVersion(), client.getName(),
-                                labels, clusterPartitionCount, resolvedClusterId);
+                return ClientAuthenticationCodec.encodeRequest(clusterName, cr.getName(),
+                        cr.getPassword(), clientUuid, ClientTypes.JAVA, serializationVersion,
+                        BuildInfoProvider.getBuildInfo().getVersion(), client.getName(), labels, clusterPartitionCount,
+                        resolvedClusterId);
             } else {
                 Data data;
                 if (credentials instanceof TokenCredentials) {
@@ -552,9 +553,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 } else {
                     data = ss.toData(credentials);
                 }
-                return ClientAuthenticationCustomCodec.encodeRequest(data, clientUuid, ClientTypes.JAVA, serializationVersion,
-                        BuildInfoProvider.getBuildInfo().getVersion(), client.getName(),
-                        labels, clusterPartitionCount, resolvedClusterId);
+                return ClientAuthenticationCustomCodec.encodeRequest(clusterName, data,
+                        clientUuid, ClientTypes.JAVA, serializationVersion, BuildInfoProvider.getBuildInfo().getVersion(),
+                        client.getName(), labels, clusterPartitionCount, resolvedClusterId);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClusterConnectorServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClusterConnectorServiceImpl.java
@@ -165,7 +165,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
 
     private void connectToClusterInternal() {
         CandidateClusterContext currentClusterContext = discoveryService.current();
-        logger.info("Trying to connect to cluster with client name: " + currentClusterContext.getClusterName());
+        logger.info("Trying to connect to cluster with cluster name: " + currentClusterContext.getClusterName());
         if (connectToCandidate(currentClusterContext)) {
             return;
         }
@@ -176,7 +176,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
         while (discoveryService.hasNext() && client.getLifecycleService().isRunning()) {
             CandidateClusterContext candidateClusterContext = discoveryService.next();
             beforeClusterSwitch(candidateClusterContext);
-            logger.info("Trying to connect to next cluster with client name: " + candidateClusterContext.getClusterName());
+            logger.info("Trying to connect to next cluster with cluster name: " + candidateClusterContext.getClusterName());
 
             if (connectToCandidate(candidateClusterContext)) {
                 //reset queryCache context, publishes eventLostEvent to all caches
@@ -207,7 +207,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
         //non retryable client messages will fail immediately
         //retryable client messages will be retried but they will wait for new partition table
         client.getConnectionManager().beforeClusterSwitch(context);
-        //update logger with new client name
+        //update logger with new cluster name
         ((ClientLoggingService) client.getLoggingService()).updateClusterName(context.getClusterName());
     }
 
@@ -242,7 +242,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
             }
 
         } while (waitStrategy.sleep());
-        logger.warning("Unable to connect to any address for client name: " + context.getClusterName()
+        logger.warning("Unable to connect to any address for cluster name: " + context.getClusterName()
                 + ". The following addresses were tried: " + triedAddresses);
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClusterConnectorServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClusterConnectorServiceImpl.java
@@ -165,7 +165,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
 
     private void connectToClusterInternal() {
         CandidateClusterContext currentClusterContext = discoveryService.current();
-        logger.info("Trying to connect to cluster with client name: " + currentClusterContext.getClientName());
+        logger.info("Trying to connect to cluster with client name: " + currentClusterContext.getClusterName());
         if (connectToCandidate(currentClusterContext)) {
             return;
         }
@@ -176,7 +176,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
         while (discoveryService.hasNext() && client.getLifecycleService().isRunning()) {
             CandidateClusterContext candidateClusterContext = discoveryService.next();
             beforeClusterSwitch(candidateClusterContext);
-            logger.info("Trying to connect to next cluster with client name: " + candidateClusterContext.getClientName());
+            logger.info("Trying to connect to next cluster with client name: " + candidateClusterContext.getClusterName());
 
             if (connectToCandidate(candidateClusterContext)) {
                 //reset queryCache context, publishes eventLostEvent to all caches
@@ -208,7 +208,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
         //retryable client messages will be retried but they will wait for new partition table
         client.getConnectionManager().beforeClusterSwitch(context);
         //update logger with new client name
-        ((ClientLoggingService) client.getLoggingService()).updateClientName(context.getClientName());
+        ((ClientLoggingService) client.getLoggingService()).updateClusterName(context.getClusterName());
     }
 
     private boolean connectToCandidate(CandidateClusterContext context) {
@@ -242,7 +242,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
             }
 
         } while (waitStrategy.sleep());
-        logger.warning("Unable to connect to any address for client name: " + context.getClientName()
+        logger.warning("Unable to connect to any address for client name: " + context.getClusterName()
                 + ". The following addresses were tried: " + triedAddresses);
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("a3808dbca9a7d760dd0ae1f5342896b3")
+@Generated("15fa7bbbc1c0257e01b97438dcf15ba7")
 public final class ClientAuthenticationCodec {
     //hex: 0x000200
     public static final int REQUEST_MESSAGE_TYPE = 512;
@@ -61,14 +61,21 @@ public final class ClientAuthenticationCodec {
     public static class RequestParameters {
 
         /**
-         * Name of the user for authentication.
+         * Cluster name that will client connect to.
          */
-        public java.lang.String username;
+        public java.lang.String clusterName;
+
+        /**
+         * Name of the user for authentication.
+         * Used in case Client Identity Config, otherwise it should be passed null.
+         */
+        public @Nullable java.lang.String username;
 
         /**
          * Password for the user.
+         * Used in case Client Identity Config, otherwise it should be passed null.
          */
-        public java.lang.String password;
+        public @Nullable java.lang.String password;
 
         /**
          * Unique string identifying the connected client uniquely.
@@ -113,7 +120,7 @@ public final class ClientAuthenticationCodec {
         public @Nullable java.util.UUID clusterId;
     }
 
-    public static ClientMessage encodeRequest(java.lang.String username, java.lang.String password, @Nullable java.util.UUID uuid, java.lang.String clientType, byte serializationVersion, java.lang.String clientHazelcastVersion, java.lang.String clientName, java.util.Collection<java.lang.String> labels, int partitionCount, @Nullable java.util.UUID clusterId) {
+    public static ClientMessage encodeRequest(java.lang.String clusterName, @Nullable java.lang.String username, @Nullable java.lang.String password, @Nullable java.util.UUID uuid, java.lang.String clientType, byte serializationVersion, java.lang.String clientHazelcastVersion, java.lang.String clientName, java.util.Collection<java.lang.String> labels, int partitionCount, @Nullable java.util.UUID clusterId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
         clientMessage.setAcquiresResource(false);
@@ -125,8 +132,9 @@ public final class ClientAuthenticationCodec {
         encodeInt(initialFrame.content, REQUEST_PARTITION_COUNT_FIELD_OFFSET, partitionCount);
         encodeUUID(initialFrame.content, REQUEST_CLUSTER_ID_FIELD_OFFSET, clusterId);
         clientMessage.add(initialFrame);
-        StringCodec.encode(clientMessage, username);
-        StringCodec.encode(clientMessage, password);
+        StringCodec.encode(clientMessage, clusterName);
+        CodecUtil.encodeNullable(clientMessage, username, StringCodec::encode);
+        CodecUtil.encodeNullable(clientMessage, password, StringCodec::encode);
         StringCodec.encode(clientMessage, clientType);
         StringCodec.encode(clientMessage, clientHazelcastVersion);
         StringCodec.encode(clientMessage, clientName);
@@ -142,8 +150,9 @@ public final class ClientAuthenticationCodec {
         request.serializationVersion = decodeByte(initialFrame.content, REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET);
         request.partitionCount = decodeInt(initialFrame.content, REQUEST_PARTITION_COUNT_FIELD_OFFSET);
         request.clusterId = decodeUUID(initialFrame.content, REQUEST_CLUSTER_ID_FIELD_OFFSET);
-        request.username = StringCodec.decode(iterator);
-        request.password = StringCodec.decode(iterator);
+        request.clusterName = StringCodec.decode(iterator);
+        request.username = CodecUtil.decodeNullable(iterator, StringCodec::decode);
+        request.password = CodecUtil.decodeNullable(iterator, StringCodec::decode);
         request.clientType = StringCodec.decode(iterator);
         request.clientHazelcastVersion = StringCodec.decode(iterator);
         request.clientName = StringCodec.decode(iterator);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("396b5adfabb358c9516498784e6ef3bc")
+@Generated("8b039de7195bcd0e4871ba040d3626d5")
 public final class ClientAuthenticationCustomCodec {
     //hex: 0x000300
     public static final int REQUEST_MESSAGE_TYPE = 768;
@@ -59,6 +59,11 @@ public final class ClientAuthenticationCustomCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class RequestParameters {
+
+        /**
+         * Cluster name that will client connect to.
+         */
+        public java.lang.String clusterName;
 
         /**
          * Secret byte array for authentication.
@@ -108,7 +113,7 @@ public final class ClientAuthenticationCustomCodec {
         public @Nullable java.util.UUID clusterId;
     }
 
-    public static ClientMessage encodeRequest(com.hazelcast.nio.serialization.Data credentials, @Nullable java.util.UUID uuid, java.lang.String clientType, byte serializationVersion, java.lang.String clientHazelcastVersion, java.lang.String clientName, java.util.Collection<java.lang.String> labels, int partitionCount, @Nullable java.util.UUID clusterId) {
+    public static ClientMessage encodeRequest(java.lang.String clusterName, com.hazelcast.nio.serialization.Data credentials, @Nullable java.util.UUID uuid, java.lang.String clientType, byte serializationVersion, java.lang.String clientHazelcastVersion, java.lang.String clientName, java.util.Collection<java.lang.String> labels, int partitionCount, @Nullable java.util.UUID clusterId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
         clientMessage.setAcquiresResource(false);
@@ -120,6 +125,7 @@ public final class ClientAuthenticationCustomCodec {
         encodeInt(initialFrame.content, REQUEST_PARTITION_COUNT_FIELD_OFFSET, partitionCount);
         encodeUUID(initialFrame.content, REQUEST_CLUSTER_ID_FIELD_OFFSET, clusterId);
         clientMessage.add(initialFrame);
+        StringCodec.encode(clientMessage, clusterName);
         DataCodec.encode(clientMessage, credentials);
         StringCodec.encode(clientMessage, clientType);
         StringCodec.encode(clientMessage, clientHazelcastVersion);
@@ -136,6 +142,7 @@ public final class ClientAuthenticationCustomCodec {
         request.serializationVersion = decodeByte(initialFrame.content, REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET);
         request.partitionCount = decodeInt(initialFrame.content, REQUEST_PARTITION_COUNT_FIELD_OFFSET);
         request.clusterId = decodeUUID(initialFrame.content, REQUEST_CLUSTER_ID_FIELD_OFFSET);
+        request.clusterName = StringCodec.decode(iterator);
         request.credentials = DataCodec.decode(iterator);
         request.clientType = StringCodec.decode(iterator);
         request.clientHazelcastVersion = StringCodec.decode(iterator);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
@@ -50,6 +50,7 @@ public class AuthenticationCustomCredentialsMessageTask
         UUID uuid = parameters.uuid;
         assert uuid != null;
         clientUuid = uuid;
+        clusterName = parameters.clusterName;
         credentials = new SimpleTokenCredentials(parameters.credentials.toByteArray());
         clientSerializationVersion = parameters.serializationVersion;
         clientVersion = parameters.clientHazelcastVersion;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
@@ -43,6 +43,7 @@ public class AuthenticationMessageTask extends AuthenticationBaseMessageTask<Cli
         if (uuid != null) {
             clientUuid = uuid;
         }
+        clusterName = parameters.clusterName;
         credentials = new UsernamePasswordCredentials(parameters.username, parameters.password);
         clientSerializationVersion = parameters.serializationVersion;
         clientVersion = parameters.clientHazelcastVersion;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -86,6 +86,9 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
                 int flags = firstFrame.flags;
                 if (ClientMessage.isFlagSet(flags, UNFRAGMENTED_MESSAGE)) {
                     handleMessage(activeReader.getClientMessage());
+                } else if (!trusted) {
+                    throw new IllegalStateException(
+                            "Fragmented client messages are not allowed before the client is authenticated.");
                 } else {
                     ClientMessage.ForwardFrameIterator frameIterator = activeReader.getClientMessage().frameIterator();
                     //ignore the fragmentationFrame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/xa/XAResourceProxy.java
@@ -188,12 +188,12 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
         }
         String otherClusterName = null;
         if (xaResource instanceof XAResourceProxy) {
-            otherClusterName = ((XAResourceProxy) xaResource).getClientName();
+            otherClusterName = ((XAResourceProxy) xaResource).getClusterName();
         }
         if (xaResource instanceof XAResourceImpl) {
             otherClusterName = ((XAResourceImpl) xaResource).getClusterName();
         }
-        return getClientName().equals(otherClusterName);
+        return getClusterName().equals(otherClusterName);
     }
 
     @Override
@@ -229,13 +229,13 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
         return Thread.currentThread().getId();
     }
 
-    private String getClientName() {
+    private String getClusterName() {
         ClientTransactionManagerService transactionManager = getContext().getTransactionManager();
-        return transactionManager.getClientName();
+        return transactionManager.getClusterName();
     }
 
     @Override
     public String toString() {
-        return "HazelcastXaResource{" + getClientName() + '}';
+        return "HazelcastXaResource{" + getClusterName() + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientTransactionManagerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientTransactionManagerService.java
@@ -44,5 +44,5 @@ public interface ClientTransactionManagerService {
      */
     TransactionContext newXATransactionContext(Xid xid, int timeoutInSeconds);
 
-    String getClientName();
+    String getClusterName();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientTransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientTransactionManagerServiceImpl.java
@@ -103,8 +103,8 @@ public class ClientTransactionManagerServiceImpl implements ClientTransactionMan
     }
 
     @Override
-    public String getClientName() {
-        return client.getClientConfig().getClientName();
+    public String getClusterName() {
+        return client.getClientConfig().getClusterName();
     }
 
     public ClientConnection connect() throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -326,7 +326,7 @@ public class Statistics {
             stats.append(STAT_SEPARATOR).append("clientAddress").append(KEY_VALUE_SEPARATOR)
                     .append(mainConnection.getLocalSocketAddress().getAddress().getHostAddress());
 
-            addStat(stats, "clientName", client.getName());
+            addStat(stats, "clusterName", client.getName());
 
             ClientConnectionManagerImpl connectionManager = (ClientConnectionManagerImpl) client.getConnectionManager();
             Credentials credentials = connectionManager.getLastCredentials();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -373,7 +373,9 @@ public class ClusterJoinManager {
             }
             String endpoint = joinRequest.getAddress().getHost();
             try {
-                LoginContext loginContext = node.securityContext.createMemberLoginContext(credentials, connection);
+                String remoteClusterName = joinRequest.getConfigCheck().getClusterName();
+                LoginContext loginContext = node.securityContext.createMemberLoginContext(remoteClusterName, credentials,
+                        connection);
                 loginContext.login();
             } catch (LoginException e) {
                 throw new SecurityException(format("Authentication has failed for %s @%s, cause: %s",

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.spi.properties.GroupProperty.APPLICATION_VALIDATION_TOKEN;
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
@@ -61,7 +60,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
 
         // Copying all properties relevant for checking
         properties.put(PARTITION_COUNT.getName(), config.getProperty(PARTITION_COUNT.getName()));
-        properties.put(APPLICATION_VALIDATION_TOKEN.getName(), config.getProperty(APPLICATION_VALIDATION_TOKEN.getName()));
 
         // Copying cluster settings
         this.clusterName = config.getClusterName();
@@ -95,7 +93,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
         verifyJoiner(found);
         verifyPartitionGroup(found);
         verifyPartitionCount(found);
-        verifyApplicationValidationToken(found);
         return true;
     }
 
@@ -108,15 +105,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
      */
     public String getClusterName() {
         return clusterName;
-    }
-
-    private void verifyApplicationValidationToken(ConfigCheck found) {
-        String expectedValidationToken = properties.get(APPLICATION_VALIDATION_TOKEN.getName());
-        String foundValidationToken = found.properties.get(APPLICATION_VALIDATION_TOKEN.getName());
-        if (!equals(expectedValidationToken, foundValidationToken)) {
-            throw new ConfigMismatchException("Incompatible '" + APPLICATION_VALIDATION_TOKEN + "'! expected: "
-                    + expectedValidationToken + ", found: " + foundValidationToken);
-        }
     }
 
     private void verifyPartitionCount(ConfigCheck found) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -103,6 +103,13 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
         return equals(clusterName, found.clusterName);
     }
 
+    /**
+     * @return the clusterName
+     */
+    public String getClusterName() {
+        return clusterName;
+    }
+
     private void verifyApplicationValidationToken(ConfigCheck found) {
         String expectedValidationToken = properties.get(APPLICATION_VALIDATION_TOKEN.getName());
         String foundValidationToken = found.properties.get(APPLICATION_VALIDATION_TOKEN.getName());

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
@@ -36,23 +36,27 @@ public interface SecurityContext {
 
     /**
      * Creates member {@link LoginContext}.
-     *
+     * @param clusterName TODO
      * @param credentials member credentials
      * @param connection member connection
+     *
      * @return {@link LoginContext}
      * @throws LoginException
      */
-    LoginContext createMemberLoginContext(Credentials credentials, Connection connection) throws LoginException;
+    LoginContext createMemberLoginContext(String clusterName, Credentials credentials, Connection connection)
+            throws LoginException;
 
     /**
      * Creates client {@link LoginContext}.
      *
+     * @param clusterName cluster name reported on the client protocol
      * @param credentials client credentials
      * @param connection client connection
      * @return {@link LoginContext}
      * @throws LoginException
      */
-    LoginContext createClientLoginContext(Credentials credentials, Connection connection) throws LoginException;
+    LoginContext createClientLoginContext(String clusterName, Credentials credentials, Connection connection)
+            throws LoginException;
 
     /**
      * Returns current {@link ICredentialsFactory}.

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
@@ -36,7 +36,7 @@ public interface SecurityContext {
 
     /**
      * Creates member {@link LoginContext}.
-     * @param clusterName TODO
+     * @param clusterName cluster name received from the connecting member
      * @param credentials member credentials
      * @param connection member connection
      *

--- a/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.security;
 
-import static java.util.Objects.requireNonNull;
-
 import java.io.IOException;
 
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -42,8 +40,8 @@ public class UsernamePasswordCredentials implements PasswordCredentials, Portabl
     }
 
     public UsernamePasswordCredentials(String username, String password) {
-        this.name = requireNonNull(username, "Username has to be provided.");
-        this.password = requireNonNull(password, "Password has to be provided.");
+        this.name = username;
+        this.password = password;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -53,29 +53,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public final class GroupProperty {
 
     /**
-     * Use this property to verify that Hazelcast nodes only join the cluster
-     * when their 'application' level configuration is the same.
-     * <p>
-     * If you have multiple machines, you want to make sure that each machine
-     * that joins the cluster has exactly the same 'application level' settings
-     * (such as settings that are not part of the Hazelcast configuration, maybe
-     * some file path). To prevent the machines with potentially different
-     * application level configuration from forming a cluster, you can set this
-     * property.
-     * <p>
-     * You could use actual values, such as string paths, but you can also use
-     * an md5 hash. We make a guarantee that nodes will form a cluster (become a
-     * member) only if the token is an exact match. If this token is different,
-     * the member can't be started and therefore you will get the guarantee that
-     * all members in the cluster will have exactly the same application validation
-     * token.
-     * <p>
-     * This validation token will be checked before a member joins the cluster.
-     */
-    public static final HazelcastProperty APPLICATION_VALIDATION_TOKEN
-            = new HazelcastProperty("hazelcast.application.validation.token");
-
-    /**
      * Total number of partitions in the Hazelcast cluster.
      */
     public static final HazelcastProperty PARTITION_COUNT

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -26,7 +26,7 @@
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="config-replacers" type="config-replacers" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="client-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="cluster-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="backup-ack-to-client-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
                 <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -79,7 +79,7 @@
     </config-replacers>
 
     <!--
-        Specifies the cluster name. It's send as part of the client authentication message to Hazelcast
+        Specifies the cluster name. It's sent as part of the client authentication message to Hazelcast
         member(s).
     -->
     <cluster-name>dev</cluster-name>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -79,10 +79,10 @@
     </config-replacers>
 
     <!--
-        Specifies the client name. It's a name used for client authentication to the cluster and its value is
-        the same as cluster name by default.
+        Specifies the cluster name. It's send as part of the client authentication message to Hazelcast
+        member(s).
     -->
-    <client-name>dev</client-name>
+    <cluster-name>dev</cluster-name>
 
     <!--
         When Hazelcast instances are created, they are put in a global registry with their creation names.

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -68,8 +68,8 @@ hazelcast-client:
           secretKeyAlgorithm: DES
           secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
   #
-  # Specifies the name of the client
-  client-name: dev
+  # Specifies the cluster name
+  cluster-name: dev
   #
   # When Hazelcast instances are created, they are put in a global registry with their creation names.
   # "instance-name" gives you the ability to get a specific Hazelcast instance from this registry

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2163,7 +2163,7 @@
                     defined with the <property> sub-element nested in the <properties>. The <property> element has the attribute
                     "name" used to define the name of the attribute. The value of the property is defined in the body.
                 * <username-password>
-                    Defines a static UsernamePasswordCredentials instance as the client's identity. It has mandatory
+                    Defines a static UsernamePasswordCredentials instance as the member's identity. It has mandatory
                      "username" and "password" attributes.
                 * <token>
                     Defines a static TokenCredentials instance as the client's identity. It can have attribute "encoding".

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2155,7 +2155,7 @@ hazelcast:
   #      defined with the <property> sub-element nested in the <properties>. The <property> element has the attribute
   #      "name" used to define the name of the attribute. The value of the property is defined in the body.
   #  * username-password
-  #      Defines a static UsernamePasswordCredentials instance as the client's identity. It has mandatory
+  #      Defines a static UsernamePasswordCredentials instance as the member's identity. It has mandatory
   #       "username" and "password" attributes.
   #  * token
   #      Defines a static TokenCredentials instance as the client's identity. It has a "value" and

--- a/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
@@ -87,7 +87,7 @@ public class ThreadLeakClientTest {
     public void testThreadLeakWhenClientCanNotStartDueToAuthenticationError() {
         Hazelcast.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
-        config.setClientName("invalid cluster");
+        config.setClusterName("invalid cluster");
         Set<Thread> testStartThreads = getThreads();
         try {
             HazelcastClient.newHazelcastClient(config);

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientOutBoundPortTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientOutBoundPortTest.java
@@ -50,7 +50,7 @@ public class ClientOutBoundPortTest {
         Hazelcast.newHazelcastInstance(config1);
 
         ClientConfig config2 = new ClientConfig();
-        config2.setClientName("client-out-test");
+        config2.setClusterName("client-out-test");
         config2.getNetworkConfig().setOutboundPortDefinitions(Arrays.asList("34700", "34703-34705"));
         HazelcastInstance client = HazelcastClient.newHazelcastClient(config2);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -79,7 +79,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         Hazelcast.newHazelcastInstance(config2);
 
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("bar");
+        clientConfig.setClusterName("bar");
         final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
         final IMap<Object, Object> map = client.getMap("map");

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -109,7 +109,7 @@ public class ClientServiceTest extends ClientTestSupport {
     public void testNumberOfClients_afterUnAuthenticatedClient() {
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("wrongName");
+        clientConfig.setClusterName("wrongName");
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         try {
             hazelcastFactory.newHazelcastClient(clientConfig);
@@ -125,7 +125,7 @@ public class ClientServiceTest extends ClientTestSupport {
         final HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance();
         final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("wrongName");
+        clientConfig.setClusterName("wrongName");
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         try {
             hazelcastFactory.newHazelcastClient(clientConfig);
@@ -144,7 +144,7 @@ public class ClientServiceTest extends ClientTestSupport {
         final HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance();
         final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("wrongName");
+        clientConfig.setClusterName("wrongName");
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         try {
             hazelcastFactory.newHazelcastClient(clientConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
@@ -52,7 +52,7 @@ public class ClientTimeoutTest {
     @Test(timeout = 20000, expected = IllegalStateException.class)
     public void testTimeoutToOutsideNetwork() {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("dev");
+        clientConfig.setClusterName("dev");
 
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
         networkConfig.addAddress("8.8.8.8:5701");

--- a/hazelcast/src/test/java/com/hazelcast/client/ClusterNameTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClusterNameTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientNameTest {
+public class ClusterNameTest {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
@@ -46,7 +46,7 @@ public class ClientNameTest {
     }
 
     @Test
-    public void test_clientName_overClientInstance() {
+    public void test_clusterName_overClientInstance() {
         hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
@@ -58,7 +58,7 @@ public class ClientNameTest {
     }
 
     @Test
-    public void test_clientName_overGetConnectedClients() {
+    public void test_clusterName_overGetConnectedClients() {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
@@ -72,15 +72,15 @@ public class ClientNameTest {
     }
 
     @Test
-    public void test_clientName_overClientConnectedEvent() {
+    public void test_clusterName_overClientConnectedEvent() {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final CountDownLatch clientConnected = new CountDownLatch(1);
 
-        final AtomicReference<String> clientName = new AtomicReference<String>();
+        final AtomicReference<String> clusterName = new AtomicReference<String>();
         instance.getClientService().addClientListener(new ClientListener() {
             @Override
             public void clientConnected(Client client) {
-                clientName.set(client.getName());
+                clusterName.set(client.getName());
                 clientConnected.countDown();
             }
 
@@ -96,15 +96,15 @@ public class ClientNameTest {
         hazelcastFactory.newHazelcastClient(clientConfig);
 
         assertOpenEventually(clientConnected);
-        assertEquals(name, clientName.get());
+        assertEquals(name, clusterName.get());
     }
 
     @Test
-    public void test_clientName_overClientDisconnectedEvent() {
+    public void test_clusterName_overClientDisconnectedEvent() {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final CountDownLatch clientDisconnected = new CountDownLatch(1);
 
-        final AtomicReference<String> clientName = new AtomicReference<String>();
+        final AtomicReference<String> clusterName = new AtomicReference<String>();
         instance.getClientService().addClientListener(new ClientListener() {
             @Override
             public void clientConnected(Client client) {
@@ -113,7 +113,7 @@ public class ClientNameTest {
 
             @Override
             public void clientDisconnected(Client client) {
-                clientName.set(client.getName());
+                clusterName.set(client.getName());
                 clientDisconnected.countDown();
             }
         });
@@ -125,6 +125,6 @@ public class ClientNameTest {
         client.shutdown();
 
         assertOpenEventually(clientDisconnected);
-        assertEquals(name, clientName.get());
+        assertEquals(name, clusterName.get());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
@@ -319,7 +319,7 @@ public class HazelcastClientConfigResolutionTest {
             instance = HazelcastClient.newHazelcastClient();
             ClientConfig config = getClientConfig(instance);
 
-            assertEquals("dev", config.getClientName());
+            assertEquals("dev", config.getClusterName());
         } finally {
             member.shutdown();
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
@@ -45,7 +45,7 @@ public class FailoverConfigTest {
     public void testAllClientConfigsAreHandledInMultipleClientConfigSupport() {
         Set<String> allClientConfigMethods = new HashSet<>();
         Collections.addAll(allClientConfigMethods, "setProperty", "getProperty", "getClassLoader", "getProperties",
-                "setProperties", "getLabels", "getClientName", "getSecurityConfig", "isSmartRouting", "setSmartRouting",
+                "setProperties", "getLabels", "getClusterName", "getSecurityConfig", "isSmartRouting", "setSmartRouting",
                 "getSocketInterceptorConfig", "setSocketInterceptorConfig", "getConnectionAttemptPeriod",
                 "setConnectionAttemptPeriod", "getConnectionAttemptLimit", "setConnectionAttemptLimit", "getConnectionTimeout",
                 "setConnectionTimeout", "addAddress", "setAddresses", "getAddresses", "isRedoOperation", "setRedoOperation",
@@ -54,7 +54,7 @@ public class FailoverConfigTest {
                 "addListenerConfig", "addProxyFactoryConfig", "getNearCacheConfig", "getNearCacheConfigMap",
                 "setNearCacheConfigMap", "getFlakeIdGeneratorConfigMap", "findFlakeIdGeneratorConfig",
                 "getFlakeIdGeneratorConfig", "addFlakeIdGeneratorConfig", "setFlakeIdGeneratorConfigMap",
-                "setReliableTopicConfigMap", "getReliableTopicConfigMap", "getCredentials", "setCredentials", "setClientName",
+                "setReliableTopicConfigMap", "getReliableTopicConfigMap", "getCredentials", "setCredentials", "setClusterName",
                 "getListenerConfigs", "setListenerConfigs", "getLoadBalancer", "setLoadBalancer", "setClassLoader",
                 "getManagedContext", "setManagedContext", "getExecutorPoolSize", "setExecutorPoolSize", "getProxyFactoryConfigs",
                 "setProxyFactoryConfigs", "getSerializationConfig", "setSerializationConfig", "getNativeMemoryConfig",
@@ -98,7 +98,7 @@ public class FailoverConfigTest {
     }
 
     @Test
-    public void testClientConfigWithSameClientName() {
+    public void testClientConfigWithSameClusterName() {
         ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
         clientFailoverConfig.addClientConfig(new ClientConfig());
         clientFailoverConfig.addClientConfig(new ClientConfig());
@@ -106,12 +106,12 @@ public class FailoverConfigTest {
     }
 
     @Test
-    public void testClientConfigWithDifferentClientName() {
+    public void testClientConfigWithDifferentClusterName() {
         ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
         clientFailoverConfig.addClientConfig(new ClientConfig());
 
         ClientConfig alternativeConfig = new ClientConfig();
-        alternativeConfig.setClientName("alternative");
+        alternativeConfig.setClusterName("alternative");
         clientFailoverConfig.addClientConfig(alternativeConfig);
 
         resolveClientFailoverConfig(clientFailoverConfig);
@@ -123,7 +123,7 @@ public class FailoverConfigTest {
         clientFailoverConfig.addClientConfig(new ClientConfig());
 
         ClientConfig alternativeConfig = new ClientConfig();
-        alternativeConfig.setClientName("alternative");
+        alternativeConfig.setClusterName("alternative");
         alternativeConfig.setProperty("newProperty", "newValue");
         clientFailoverConfig.addClientConfig(alternativeConfig);
 
@@ -136,7 +136,7 @@ public class FailoverConfigTest {
         clientFailoverConfig.addClientConfig(new ClientConfig());
 
         ClientConfig alternativeConfig = new ClientConfig();
-        alternativeConfig.setClientName("alternative");
+        alternativeConfig.setClusterName("alternative");
         CredentialsFactoryConfig credentialsFactoryConfig = new CredentialsFactoryConfig();
         credentialsFactoryConfig.setClassName("CustomCredentials");
         alternativeConfig.getSecurityConfig().setCredentialsFactoryConfig(credentialsFactoryConfig);
@@ -149,7 +149,7 @@ public class FailoverConfigTest {
     public void test_throwsException_whenFailoverConfigIsIntended_butPassedNull() {
         ClientFailoverConfig clientFailoverConfig = resolveClientFailoverConfig(null);
         assertEquals(1, clientFailoverConfig.getClientConfigs().size());
-        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getClientName());
+        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getClusterName());
     }
 
     @Test(expected = InvalidConfigurationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverTest.java
@@ -60,14 +60,14 @@ public class FailoverTest extends ClientTestSupport {
 
         HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config2);
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("dev1");
+        clientConfig.setClusterName("dev1");
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
         Member member1 = (Member) instance1.getLocalEndpoint();
         Address address1 = member1.getAddress();
         networkConfig.setAddresses(Collections.singletonList(address1.getHost() + ":" + address1.getPort()));
 
         ClientConfig clientConfig2 = new ClientConfig();
-        clientConfig2.setClientName("dev2");
+        clientConfig2.setClusterName("dev2");
         ClientNetworkConfig networkConfig2 = clientConfig2.getNetworkConfig();
         Member member2 = (Member) instance2.getLocalEndpoint();
         Address address2 = member2.getAddress();

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -127,7 +127,7 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
         String instanceName = "ClientInstanceTest";
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("cluster1");
+        clientConfig.setClusterName("cluster1");
         clientConfig.setInstanceName(instanceName);
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
@@ -146,7 +146,7 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
     @Test
     public void testGetPreConfiguredCache() {
         ClientConfig config = new ClientConfig();
-        config.setClientName("cluster1");
+        config.setClusterName("cluster1");
 
         for (int i = 0; i < 4; i++) {
             HazelcastInstance client = HazelcastClient.newHazelcastClient(config);

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -49,7 +49,7 @@ public class ClientCacheCreationTest extends CacheCreationTest {
         ClientConfig clientConfig = null;
         if (hzConfig != null) {
             clientConfig = new ClientConfig();
-            clientConfig.setClientName(hzConfig.getClusterName());
+            clientConfig.setClusterName(hzConfig.getClusterName());
             clientConfig.getNetworkConfig().setAddresses(singletonList("127.0.0.1"));
         }
         return HazelcastClientCachingProvider.createCachingProvider(HazelcastClient.newHazelcastClient(clientConfig));

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -374,7 +374,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
 
     @Test
     public void testClusterName() {
-        assertEquals("dev", fullClientConfig.getClientName());
+        assertEquals("dev", fullClientConfig.getClusterName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientFailoverConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientFailoverConfigBuilderTest.java
@@ -71,8 +71,8 @@ public abstract class AbstractClientFailoverConfigBuilderTest {
     void assertSampleFailoverConfig(ClientFailoverConfig config) {
         List<ClientConfig> clientConfigs = fullClientConfig.getClientConfigs();
         assertEquals(2, clientConfigs.size());
-        assertEquals("cluster1", clientConfigs.get(0).getClientName());
-        assertEquals("cluster2", clientConfigs.get(1).getClientName());
+        assertEquals("cluster1", clientConfigs.get(0).getClusterName());
+        assertEquals("cluster2", clientConfigs.get(1).getClusterName());
         assertEquals(4, config.getTryCount());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
@@ -72,7 +72,7 @@ public class ClientConfigTest {
         hazelcastFactory.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName(clusterName);
+        clientConfig.setClusterName(clusterName);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         assertEquals(clusterName, client.getConfig().getClusterName());

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -87,10 +87,10 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         //escape xml value
         //escape xml attribute
         NearCacheConfig nearCacheConfig = new NearCacheConfig(toEscape);
-        clientConfig.setClientName(toEscape).addNearCacheConfig(nearCacheConfig);
+        clientConfig.setClusterName(toEscape).addNearCacheConfig(nearCacheConfig);
 
         ClientConfig actual = newConfigViaGenerator();
-        assertEquals(clientConfig.getClientName(), actual.getClientName());
+        assertEquals(clientConfig.getClusterName(), actual.getClusterName());
         assertEquals(toEscape, actual.getNearCacheConfig(toEscape).getName());
     }
 
@@ -121,9 +121,9 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
     @Test
     public void cluster() {
         String name = randomString();
-        clientConfig.setClientName(name);
+        clientConfig.setClusterName(name);
         ClientConfig actual = newConfigViaGenerator();
-        assertEquals(name, actual.getClientName());
+        assertEquals(name, actual.getClusterName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
@@ -163,7 +163,7 @@ public class XmlClientConfigBuilderResolutionTest {
     @Test
     public void testResolveDefault() {
         ClientConfig config = new XmlClientConfigBuilder().build();
-        assertEquals("dev", config.getClientName());
+        assertEquals("dev", config.getClusterName());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -92,7 +92,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     @Test(expected = InvalidConfigurationException.class)
     public void testInvalidRootElement() {
         String xml = "<hazelcast>"
-                + "<client-name>dev</client-name>"
+                + "<cluster-name>dev</cluster-name>"
                 + "</hazelcast>";
         buildConfig(xml);
     }
@@ -111,7 +111,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     @Test
     public void loadingThroughSystemProperty_existingFile() throws IOException {
         String xml = HAZELCAST_CLIENT_START_TAG
-                + "    <client-name>foobar</client-name>\n"
+                + "    <cluster-name>foobar</cluster-name>\n"
                 + "</hazelcast-client>";
 
         File file = File.createTempFile("foo", ".xml");
@@ -124,7 +124,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
 
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder();
         ClientConfig config = configBuilder.build();
-        assertEquals("foobar", config.getClientName());
+        assertEquals("foobar", config.getClusterName());
     }
 
     @Override
@@ -141,7 +141,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
 
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder();
         ClientConfig config = configBuilder.build();
-        assertEquals("foobar-xml", config.getClientName());
+        assertEquals("foobar-xml", config.getClusterName());
         assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory", config.getNetworkConfig().getSSLConfig().getFactoryClassName());
         assertEquals(128, config.getNetworkConfig().getSocketOptions().getBufferSize());
         assertFalse(config.getNetworkConfig().getSocketOptions().isKeepAlive());

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -238,11 +238,11 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
                 + "        </replacer>\n"
                 + "        <replacer class-name='" + IdentityReplacer.class.getName() + "'/>\n"
                 + "    </config-replacers>\n"
-                + "    <client-name>${java.version} $ID{dev}</client-name>\n"
+                + "    <cluster-name>${java.version} $ID{dev}</cluster-name>\n"
                 + "    <instance-name>$ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}</instance-name>\n"
                 + HAZELCAST_CLIENT_END_TAG;
         ClientConfig config = buildConfig(xml, System.getProperties());
-        assertEquals(System.getProperty("java.version") + " dev", config.getClientName());
+        assertEquals(System.getProperty("java.version") + " dev", config.getClusterName());
         assertEquals("My very secret secret", config.getInstanceName());
     }
 
@@ -253,7 +253,7 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
                 + "    <config-replacers>\n"
                 + "        <replacer class-name='" + EncryptionReplacer.class.getName() + "'/>\n"
                 + "    </config-replacers>\n"
-                + "    <client-name>$ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}</client-name>\n"
+                + "    <cluster-name>$ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}</cluster-name>\n"
                 + HAZELCAST_CLIENT_END_TAG;
         buildConfig(xml, System.getProperties());
     }
@@ -272,10 +272,10 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
                 + "            </properties>\n"
                 + "        </replacer>\n"
                 + "    </config-replacers>\n"
-                + "    <client-name>$T{p1} $T{p2} $T{p3} $T{p4} $T{p5}</client-name>\n"
+                + "    <cluster-name>$T{p1} $T{p2} $T{p3} $T{p4} $T{p5}</cluster-name>\n"
                 + HAZELCAST_CLIENT_END_TAG;
         ClientConfig clientConfig = buildConfig(xml, System.getProperties());
-        assertEquals("a property  another property <test/> $T{p5}", clientConfig.getClientName());
+        assertEquals("a property  another property <test/> $T{p5}", clientConfig.getClusterName());
     }
 
 
@@ -289,10 +289,10 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
     @Test
     public void testNoConfigReplacersMissingProperties() {
         String xml = HAZELCAST_CLIENT_START_TAG
-                + "    <client-name>${noSuchPropertyAvailable}</client-name>\n"
+                + "    <cluster-name>${noSuchPropertyAvailable}</cluster-name>\n"
                 + HAZELCAST_CLIENT_END_TAG;
         ClientConfig config = buildConfig(xml, System.getProperties());
-        assertEquals("${noSuchPropertyAvailable}", config.getClientName());
+        assertEquals("${noSuchPropertyAvailable}", config.getClusterName());
     }
 
     @Override
@@ -303,7 +303,7 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
                 + HAZELCAST_CLIENT_END_TAG;
 
         ClientConfig config = buildConfig(xml);
-        assertEquals("cluster1", config.getClientName());
+        assertEquals("cluster1", config.getClusterName());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderTest.java
@@ -47,7 +47,7 @@ public class XmlClientFailoverConfigBuilderTest extends AbstractClientFailoverCo
     @Test(expected = InvalidConfigurationException.class)
     public void testInvalidRootElement() {
         String xml = "<hazelcast>"
-                + "<client-name>dev</client-name>"
+                + "<cluster-name>dev</cluster-name>"
                 + "</hazelcast>";
         buildConfig(xml);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
@@ -209,7 +209,7 @@ public class YamlClientConfigBuilderResolutionTest {
     @Test
     public void testResolveDefault() {
         ClientConfig config = new YamlClientConfigBuilder().build();
-        assertEquals("dev", config.getClientName());
+        assertEquals("dev", config.getClusterName());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -103,7 +103,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
     public void loadingThroughSystemProperty_existingFile() throws IOException {
         String yaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name: foobar";
+                + "  cluster-name: foobar";
 
         File file = File.createTempFile("foo", ".yaml");
         file.deleteOnExit();
@@ -115,7 +115,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
 
         YamlClientConfigBuilder configBuilder = new YamlClientConfigBuilder();
         ClientConfig config = configBuilder.build();
-        assertEquals("foobar", config.getClientName());
+        assertEquals("foobar", config.getClusterName());
     }
 
     @Override
@@ -132,7 +132,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
 
         YamlClientConfigBuilder configBuilder = new YamlClientConfigBuilder();
         ClientConfig config = configBuilder.build();
-        assertEquals("foobar-yaml", config.getClientName());
+        assertEquals("foobar-yaml", config.getClusterName());
         assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory",
                 config.getNetworkConfig().getSSLConfig().getFactoryClassName());
         assertEquals(128, config.getNetworkConfig().getSocketOptions().getBufferSize());

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
@@ -275,10 +275,10 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
                 + "          secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1\n"
                 + "          secretKeyAlgorithm: DES\n"
                 + "      - class-name: " + AbstractConfigImportVariableReplacementTest.IdentityReplacer.class.getName() + "\n"
-                + "  client-name: ${java.version} $ID{dev}\n"
+                + "  cluster-name: ${java.version} $ID{dev}\n"
                 + "  instance-name: $ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}";
         ClientConfig config = buildConfig(yaml, System.getProperties());
-        assertEquals(System.getProperty("java.version") + " dev", config.getClientName());
+        assertEquals(System.getProperty("java.version") + " dev", config.getClusterName());
         assertEquals("My very secret secret", config.getInstanceName());
     }
 
@@ -290,7 +290,7 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
                 + "  config-replacers:\n"
                 + "    replacers:\n"
                 + "      - class-name: " + EncryptionReplacer.class.getName() + "\n"
-                + "    client-name: $ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}\n";
+                + "    cluster-name: $ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}\n";
         buildConfig(yaml, System.getProperties());
     }
 
@@ -308,9 +308,9 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
                 + "          p2: \"\"\n"
                 + "          p3: another property\n"
                 + "          p4: <test/>\n"
-                + "  client-name: $T{p1} $T{p2} $T{p3} $T{p4} $T{p5}";
+                + "  cluster-name: $T{p1} $T{p2} $T{p3} $T{p4} $T{p5}";
         ClientConfig config = buildConfig(yaml, System.getProperties());
-        assertEquals("a property  another property <test/> $T{p5}", config.getClientName());
+        assertEquals("a property  another property <test/> $T{p5}", config.getClusterName());
     }
 
     @Override
@@ -318,10 +318,10 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
     public void testNoConfigReplacersMissingProperties() {
         String yaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name: ${noSuchPropertyAvailable}";
+                + "  cluster-name: ${noSuchPropertyAvailable}";
 
         ClientConfig clientConfig = buildConfig(yaml, System.getProperties());
-        assertEquals("${noSuchPropertyAvailable}", clientConfig.getClientName());
+        assertEquals("${noSuchPropertyAvailable}", clientConfig.getClusterName());
     }
 
     @Override
@@ -333,7 +333,7 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
                 + "    - classpath:hazelcast-client-c1.yaml";
 
         ClientConfig config = buildConfig(yaml);
-        assertEquals("cluster1", config.getClientName());
+        assertEquals("cluster1", config.getClusterName());
     }
 
     @Override
@@ -366,16 +366,16 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
         FileOutputStream os = new FileOutputStream(file);
         String importedYaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name: name1";
+                + "  cluster-name: name1";
         writeStringToStreamAndClose(os, importedYaml);
 
         String yaml = ""
                 + "hazelcast-client:\n"
                 + "  import:\n"
                 + "    - ${config.location}\n"
-                + "  client-name: name2";
+                + "  cluster-name: name2";
 
-        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/client-name"));
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/cluster-name"));
 
         buildConfig(yaml, "config.location", file.getAbsolutePath());
     }
@@ -386,17 +386,17 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
         FileOutputStream os = new FileOutputStream(file);
         String importedYaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name: name";
+                + "  cluster-name: name";
         writeStringToStreamAndClose(os, importedYaml);
 
         String yaml = ""
                 + "hazelcast-client:\n"
                 + "  import:\n"
                 + "    - ${config.location}\n"
-                + "  client-name: name";
+                + "  cluster-name: name";
 
         ClientConfig config = buildConfig(yaml, "config.location", file.getAbsolutePath());
-        assertEquals("name", config.getClientName());
+        assertEquals("name", config.getClusterName());
     }
 
     @Test
@@ -405,17 +405,17 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
         FileOutputStream os = new FileOutputStream(file);
         String importedYaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name: name1";
+                + "  cluster-name: name1";
         writeStringToStreamAndClose(os, importedYaml);
 
         String yaml = ""
                 + "hazelcast-client:\n"
                 + "  import:\n"
                 + "    - ${config.location}\n"
-                + "  client-name:\n"
+                + "  cluster-name:\n"
                 + "    - seqName: {}";
 
-        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/client-name"));
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/cluster-name"));
 
         buildConfig(yaml, "config.location", file.getAbsolutePath());
     }
@@ -426,16 +426,16 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
         FileOutputStream os = new FileOutputStream(file);
         String importedYaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name: name1";
+                + "  cluster-name: name1";
         writeStringToStreamAndClose(os, importedYaml);
 
         String yaml = ""
                 + "hazelcast-client:\n"
                 + "  import:\n"
                 + "    - ${config.location}\n"
-                + "  client-name: {}";
+                + "  cluster-name: {}";
 
-        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/client-name"));
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/cluster-name"));
 
         buildConfig(yaml, "config.location", file.getAbsolutePath());
     }
@@ -446,7 +446,7 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
         FileOutputStream os = new FileOutputStream(file);
         String importedYaml = ""
                 + "hazelcast-client:\n"
-                + "  client-name:\n"
+                + "  cluster-name:\n"
                 + "    - seqname";
         writeStringToStreamAndClose(os, importedYaml);
 
@@ -454,9 +454,9 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
                 + "hazelcast-client:\n"
                 + "  import:\n"
                 + "    - ${config.location}\n"
-                + "  client-name: {}";
+                + "  cluster-name: {}";
 
-        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/client-name"));
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast-client/cluster-name"));
 
         buildConfig(yaml, "config.location", file.getAbsolutePath());
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
@@ -133,7 +133,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         UUID uuid = UUID.randomUUID();
         UUID ownerUuid = UUID.randomUUID();
         UUID clusterId = UUID.randomUUID();
-        ClientMessage message = ClientAuthenticationCodec.encodeRequest("user", "pass",
+        ClientMessage message = ClientAuthenticationCodec.encodeRequest("cluster", "user", "pass",
                 uuid, "JAVA", (byte) 1,
                 "1.0", "name", labels, 271, clusterId);
         AtomicReference<ClientMessage> reference = new AtomicReference<>(message);
@@ -166,6 +166,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
 
         ClientAuthenticationCodec.RequestParameters parameters = ClientAuthenticationCodec.decodeRequest(resultingMessage.get());
 
+        assertEquals("cluster", parameters.clusterName);
         assertEquals("user", parameters.username);
         assertEquals("pass", parameters.password);
         assertEquals(uuid, parameters.uuid);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitterTest.java
@@ -44,20 +44,21 @@ public class ClientMessageSplitterTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() throws Exception {
+        String clientName = generateRandomString(1000);
         String username = generateRandomString(1000);
         String password = generateRandomString(1000);
         UUID uuid = UUID.randomUUID();
         String clientType = generateRandomString(1000);
         String clientSerializationVersion = generateRandomString(1000);
-        String clientName = generateRandomString(1000);
+        String clusterName = generateRandomString(1000);
         UUID clusterId = UUID.randomUUID();
         LinkedList<String> labels = new LinkedList<>();
         for (int i = 0; i < 10; i++) {
             labels.add(generateRandomString(1000));
         }
 
-        clientMessage = ClientAuthenticationCodec.encodeRequest(username, password, uuid,
-                clientType, (byte) 1, clientSerializationVersion, clientName, labels, 1, clusterId);
+        clientMessage = ClientAuthenticationCodec.encodeRequest(clientName, username, password, uuid,
+                clientType, (byte) 1, clientSerializationVersion, clusterName, labels, 1, clusterId);
     }
 
     @Test
@@ -69,7 +70,7 @@ public class ClientMessageSplitterTest extends HazelcastTestSupport {
     public void testGetSubFrames() {
         List<ClientMessage> fragments = getFragments(128, clientMessage);
         ClientMessage.ForwardFrameIterator originalIterator = clientMessage.frameIterator();
-        assertEquals(18, fragments.size());
+        assertEquals(19, fragments.size());
 
         assertFragments(fragments, originalIterator);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientClusterProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientClusterProxyTest.java
@@ -58,7 +58,7 @@ public class ClientClusterProxyTest extends HazelcastTestSupport {
         factory.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName(config.getClusterName());
+        clientConfig.setClusterName(config.getClusterName());
         return factory.newHazelcastClient(clientConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ProxyEqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ProxyEqualityTest.java
@@ -63,7 +63,7 @@ public class ProxyEqualityTest {
         hazelcastFactoryClusterA.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName(clusterAName);
+        clientConfig.setClusterName(clusterAName);
         client1ClusterA = hazelcastFactoryClusterA.newHazelcastClient(clientConfig);
         client2ClusterA = hazelcastFactoryClusterA.newHazelcastClient(clientConfig);
 
@@ -74,7 +74,7 @@ public class ProxyEqualityTest {
         hazelcastFactoryClusterB.newHazelcastInstance(config);
 
         clientConfig = new ClientConfig();
-        clientConfig.setClientName(clusterBName);
+        clientConfig.setClusterName(clusterBName);
         client1ClusterB = hazelcastFactoryClusterB.newHazelcastClient(clientConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -64,7 +64,7 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
 
         final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         clientConnectionManager = new ClientConnectionManagerImpl(clientInstanceImpl);
-        ICredentialsFactory factory = new StaticCredentialsFactory(new UsernamePasswordCredentials("dev", ""));
+        ICredentialsFactory factory = new StaticCredentialsFactory(new UsernamePasswordCredentials(null, null));
         clientConnectionManager.start();
         ChannelInitializerProvider channelInitializerProvider = new ChannelInitializerProvider() {
 
@@ -73,7 +73,7 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
                 return clientInstanceImpl.getClientExtension().createChannelInitializer();
             }
         };
-        clientConnectionManager.beforeClusterSwitch(new CandidateClusterContext("client1", provider, null,
+        clientConnectionManager.beforeClusterSwitch(new CandidateClusterContext("dev", provider, null,
                 factory, null, channelInitializerProvider));
         clientConnectionManager.getOrConnect(new Address("127.0.0.1", 5701));
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
@@ -43,7 +43,6 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -54,6 +53,7 @@ import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.internal.util.StringUtil.UTF8_CHARSET;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -213,7 +213,7 @@ public class ClientMessageProtectionTest {
 
     private ClientMessage createAuthenticationMessage(HazelcastInstance hz, String clientName) {
         return ClientAuthenticationCodec.encodeRequest(hz.getConfig().getClusterName(), null, null, UUID.randomUUID(), "FOO",
-                (byte) 1, clientName, "xxx", new ArrayList<>(), -1, null);
+                (byte) 1, clientName, "xxx", emptyList(), -1, null);
     }
 
     private ClientMessage readResponse(InputStream is) throws IOException, EOFException {

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -54,6 +54,7 @@ public class ClientMessageSplitAndBuildTest {
     private ClientMessage clientMessage2;
 
     private ClientMessage createMessage() {
+        String clusterName = generateRandomString(1000);
         String username = generateRandomString(1000);
         String password = generateRandomString(1000);
         UUID uuid = UuidUtil.newUnsecureUUID();
@@ -68,7 +69,7 @@ public class ClientMessageSplitAndBuildTest {
             labels.add(generateRandomString(1000));
         }
 
-        return ClientAuthenticationCodec.encodeRequest(username, password, uuid, clientType,
+        return ClientAuthenticationCodec.encodeRequest(clusterName, username, password, uuid, clientType,
                 (byte) 1, clientSerializationVersion, clientName, labels, 1, clusterId);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/SplitBrainProtectionTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/SplitBrainProtectionTestUtil.java
@@ -38,7 +38,7 @@ public class SplitBrainProtectionTestUtil {
         Address address = getNode(instance).address;
         clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
         clientConfig.getNetworkConfig().setSmartRouting(false);
-        clientConfig.setClientName(instance.getConfig().getClusterName());
+        clientConfig.setClusterName(instance.getConfig().getClusterName());
         return clientConfig;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/standalone/ClientEntryListenerDisconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/standalone/ClientEntryListenerDisconnectTest.java
@@ -52,7 +52,7 @@ public class ClientEntryListenerDisconnectTest {
         Hazelcast.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setClientName("test");
+        clientConfig.setClusterName("test");
         clientConfig.getNetworkConfig()
                 .addAddress("localhost:6701", "localhost:6702")
                 .setSmartRouting(false);

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestAwareClientFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestAwareClientFactory.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.config.Config.DEFAULT_CLUSTER_NAME;
 import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
 
 /**
@@ -43,13 +44,16 @@ public class TestAwareClientFactory extends TestAwareInstanceFactory {
 
     /**
      * Creates new client instance which uses in its network configuration the first member created by this factory. The value
-     * {@link com.hazelcast.test.AbstractHazelcastClassRunner#getTestMethodName()} is used as a cluster cluster name.
+     * {@link com.hazelcast.test.AbstractHazelcastClassRunner#getTestMethodName()} is used as the cluster name if it's not
+     * changed already.
      */
     public HazelcastInstance newHazelcastClient(ClientConfig config) {
         if (config == null) {
             config = new ClientConfig();
         }
-        config.setClientName(getTestMethodName());
+        if (DEFAULT_CLUSTER_NAME.equals(config.getClusterName())) {
+            config.setClusterName(getTestMethodName());
+        }
         List<HazelcastInstance> members = getOrInitInstances(perMethodMembers);
         if (members.isEmpty()) {
             throw new IllegalStateException("Members have to be created first");

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
@@ -94,20 +94,6 @@ public class ConfigCheckTest {
     }
 
     @Test
-    public void whenDifferentApplicationValidationToken_thenConfigurationMismatchException() {
-        Config config1 = new Config();
-        config1.setProperty(GroupProperty.APPLICATION_VALIDATION_TOKEN.getName(), "foo");
-
-        Config config2 = new Config();
-        config2.setProperty(GroupProperty.APPLICATION_VALIDATION_TOKEN.getName(), "bar");
-
-        ConfigCheck configCheck1 = new ConfigCheck(config1, "joiner");
-        ConfigCheck configCheck2 = new ConfigCheck(config2, "joiner");
-
-        assertIsCompatibleThrowsConfigMismatchException(configCheck1, configCheck2);
-    }
-
-    @Test
     public void whenGroupPartitionEnabledMismatch_thenConfigurationMismatchException() {
         Config config1 = new Config();
         config1.getPartitionGroupConfig().setEnabled(false);

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
@@ -173,11 +173,11 @@ public class HazelcastPropertiesTest {
 
     @Test
     public void getSystemProperty() {
-        GroupProperty.APPLICATION_VALIDATION_TOKEN.setSystemProperty("token");
+        GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("12");
 
-        assertEquals("token", GroupProperty.APPLICATION_VALIDATION_TOKEN.getSystemProperty());
+        assertEquals("12", GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getSystemProperty());
 
-        System.clearProperty(GroupProperty.APPLICATION_VALIDATION_TOKEN.getName());
+        System.clearProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName());
     }
 
     @Test
@@ -259,7 +259,7 @@ public class HazelcastPropertiesTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getTimeUnit_noTimeUnitProperty() {
-        defaultProperties.getMillis(GroupProperty.APPLICATION_VALIDATION_TOKEN);
+        defaultProperties.getMillis(GroupProperty.AUDIT_LOG_ENABLED);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.config.Config.DEFAULT_CLUSTER_NAME;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
 import static com.hazelcast.test.HazelcastTestSupport.getAddress;
@@ -97,13 +98,15 @@ public class TestAwareInstanceFactory {
     /**
      * Creates new member instance with TCP join configured. Uses
      * {@link com.hazelcast.test.AbstractHazelcastClassRunner#getTestMethodName()}
-     * as the cluster name.
+     * as the cluster name if it's not changed already.
      */
     public HazelcastInstance newHazelcastInstance(Config config, NodeContext nodeCtx) {
         if (config == null) {
             config = new Config();
         }
-        config.setClusterName(getTestMethodName());
+        if (DEFAULT_CLUSTER_NAME.equals(config.getClusterName())) {
+            config.setClusterName(getTestMethodName());
+        }
         List<HazelcastInstance> members = getOrInitInstances(perMethodMembers);
 
         // Prepare Unified Networking (legacy)

--- a/hazelcast/src/test/resources/hazelcast-client-c1.foobar
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.foobar
@@ -20,7 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
-    <client-name>cluster1-foobar</client-name>
+    <cluster-name>cluster1-foobar</cluster-name>
 
     <network>
         <cluster-members>

--- a/hazelcast/src/test/resources/hazelcast-client-c1.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.xml
@@ -20,7 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd">
 
-    <client-name>cluster1</client-name>
+    <cluster-name>cluster1</cluster-name>
 
     <network>
         <cluster-members>

--- a/hazelcast/src/test/resources/hazelcast-client-c1.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 hazelcast-client:
-  client-name: cluster1
+  cluster-name: cluster1
 
   network:
     cluster-members:

--- a/hazelcast/src/test/resources/hazelcast-client-c2.foobar
+++ b/hazelcast/src/test/resources/hazelcast-client-c2.foobar
@@ -20,7 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
-    <client-name>cluster2-foobar</client-name>
+    <cluster-name>cluster2-foobar</cluster-name>
 
     <network>
         <cluster-members>

--- a/hazelcast/src/test/resources/hazelcast-client-c2.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-c2.xml
@@ -20,7 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd">
 
-    <client-name>cluster2</client-name>
+    <cluster-name>cluster2</cluster-name>
 
     <network>
         <cluster-members>

--- a/hazelcast/src/test/resources/hazelcast-client-c2.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-c2.yaml
@@ -14,7 +14,7 @@
 
 hazelcast-client:
 
-  client-name: cluster2
+  cluster-name: cluster2
 
   network:
     cluster-members:

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -46,7 +46,7 @@
         </replacer>
     </config-replacers>
 
-    <client-name>dev</client-name>
+    <cluster-name>dev</cluster-name>
 
     <instance-name>CLIENT_NAME</instance-name>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -34,7 +34,7 @@ hazelcast-client:
           secretKeyAlgorithm: DES
           secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
 
-  client-name: dev
+  cluster-name: dev
   instance-name: CLIENT_NAME
   license-key: HAZELCAST_ENTERPRISE_LICENSE_KEY
   properties:

--- a/hazelcast/src/test/resources/test-hazelcast-client.foobar
+++ b/hazelcast/src/test/resources/test-hazelcast-client.foobar
@@ -20,7 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
-    <client-name>foobar-foobar</client-name>
+    <cluster-name>foobar-foobar</cluster-name>
     <network>
         <ssl enabled="true">
             <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>

--- a/hazelcast/src/test/resources/test-hazelcast-client.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.xml
@@ -20,7 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
-    <client-name>foobar-xml</client-name>
+    <cluster-name>foobar-xml</cluster-name>
     <network>
         <ssl enabled="true">
             <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>

--- a/hazelcast/src/test/resources/test-hazelcast-client.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 hazelcast-client:
-  client-name: foobar-yaml
+  cluster-name: foobar-yaml
   network:
     ssl:
       enabled: true


### PR DESCRIPTION
The group name in client configuration was first renamed to cluster name and subsequently to the client-name (see #15651) as part of security config changes in Hazelcast 4.
After the discussion with the client team, we are reverting the name to the **cluster name** and a new field will be introduced into the client protocol authentication messages (hazelcast/hazelcast-client-protocol#248).
The cluster name sent by the client will be used by members to verify the connecting party when the security is not enabled on the members.