### PR TITLE
Remove deprecated DistributedObjectEvent.getObjectId

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
@@ -68,16 +68,6 @@ public class DistributedObjectEvent {
     }
 
     /**
-     * Returns the identifier of related DistributedObject.
-     *
-     * @return the identifier of DistributedObject
-     * @deprecated since 3.5. Please use {@link #getObjectName()} instead.
-     */
-    public Object getObjectId() {
-        return getObjectName();
-    }
-
-    /**
      * Returns the name of related DistributedObject.
      *
      * @return the name of DistributedObject


### PR DESCRIPTION
Replaced with getObjectName.