### PR TITLE
Add AdvancedNetworkStatsDTO to TimedMemberState

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -115,12 +115,10 @@ public class TimedMemberStateFactory {
     }
 
     public void init() {
-        instance.node.nodeEngine.getExecutionService().scheduleWithRepetition(new Runnable() {
-            @Override
-            public void run() {
-                memberStateSafe = instance.getPartitionService().isLocalMemberSafe();
-            }
-        }, INITIAL_PARTITION_SAFETY_CHECK_DELAY, PARTITION_SAFETY_CHECK_PERIOD, TimeUnit.SECONDS);
+        instance.node.nodeEngine.getExecutionService().scheduleWithRepetition(
+                () -> memberStateSafe = instance.getPartitionService().isLocalMemberSafe(),
+                INITIAL_PARTITION_SAFETY_CHECK_DELAY, PARTITION_SAFETY_CHECK_PERIOD, TimeUnit.SECONDS
+        );
     }
 
     public TimedMemberState createTimedMemberState() {
@@ -130,7 +128,7 @@ public class TimedMemberStateFactory {
         TimedMemberState timedMemberState = new TimedMemberState();
         createMemberState(memberState, services);
         timedMemberState.setMaster(instance.node.isMaster());
-        timedMemberState.setMemberList(new ArrayList<String>());
+        timedMemberState.setMemberList(new ArrayList<>());
         Set<Member> memberSet = instance.getCluster().getMembers();
         for (Member member : memberSet) {
             MemberImpl memberImpl = (MemberImpl) member;
@@ -157,7 +155,7 @@ public class TimedMemberStateFactory {
         return new LocalMemoryStatsImpl(instance.getMemoryStats());
     }
 
-    protected LocalOperationStats getOperationStats() {
+    private LocalOperationStats getOperationStats() {
         return new LocalOperationStatsImpl(instance.node);
     }
 
@@ -234,7 +232,7 @@ public class TimedMemberStateFactory {
         memberState.setClusterHotRestartStatus(state);
     }
 
-    protected void createNodeState(MemberStateImpl memberState) {
+    private void createNodeState(MemberStateImpl memberState) {
         Node node = instance.node;
         ClusterService cluster = instance.node.clusterService;
         NodeStateImpl nodeState = new NodeStateImpl(cluster.getClusterState(), node.getState(),

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -32,12 +32,16 @@ import com.hazelcast.cp.CPMember;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.hotrestart.HotRestartService;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.crdt.pncounter.PNCounterService;
+import com.hazelcast.internal.management.dto.AdvancedNetworkStatsDTO;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
+import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.nio.AggregateEndpointManager;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.map.impl.MapService;
@@ -76,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.ToLongFunction;
 
 import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
@@ -205,6 +210,12 @@ public class TimedMemberStateFactory {
         createWanSyncState(memberState);
 
         memberState.setClientStats(node.clientEngine.getClientStatistics());
+
+        AggregateEndpointManager aggregateEndpointManager = node.getNetworkingService().getAggregateEndpointManager();
+        memberState.setInboundNetworkStats(createAdvancedNetworkStats(aggregateEndpointManager.getNetworkStats(),
+                NetworkStats::getBytesReceived));
+        memberState.setOutboundNetworkStats(createAdvancedNetworkStats(aggregateEndpointManager.getNetworkStats(),
+                NetworkStats::getBytesSent));
     }
 
     private void createHotRestartState(MemberStateImpl memberState) {
@@ -417,8 +428,16 @@ public class TimedMemberStateFactory {
         return ++count;
     }
 
-
     private ICacheService getCacheService() {
         return instance.node.nodeEngine.getService(ICacheService.SERVICE_NAME);
+    }
+
+    private AdvancedNetworkStatsDTO createAdvancedNetworkStats(Map<EndpointQualifier, NetworkStats> stats,
+                                                               ToLongFunction<NetworkStats> getBytesFn) {
+        AdvancedNetworkStatsDTO statsDTO = new AdvancedNetworkStatsDTO();
+        for (Map.Entry<EndpointQualifier, NetworkStats> entry : stats.entrySet()) {
+            statsDTO.incBytesTransceived(entry.getKey().getType(), getBytesFn.applyAsLong(entry.getValue()));
+        }
+        return statsDTO;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AdvancedNetworkStatsDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AdvancedNetworkStatsDTO.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.JsonSerializable;
+import com.hazelcast.internal.nio.AggregateEndpointManager;
+
+import java.util.EnumMap;
+
+import static com.hazelcast.internal.util.JsonUtil.getObject;
+
+/**
+ * A JSON representation of {@link AggregateEndpointManager#getNetworkStats()} grouped by protocol type.
+ */
+public class AdvancedNetworkStatsDTO implements JsonSerializable {
+
+    private final EnumMap<ProtocolType, Long> bytesTransceived = new EnumMap<>(ProtocolType.class);
+
+    public AdvancedNetworkStatsDTO() {
+    }
+
+    public void incBytesTransceived(ProtocolType type, long bytes) {
+        Long prev = bytesTransceived.get(type);
+        bytesTransceived.put(type, prev != null ? prev + bytes : bytes);
+    }
+
+    public long getBytesTransceived(ProtocolType type) {
+        Long bytes = bytesTransceived.get(type);
+        return bytes != null ? bytes : 0;
+    }
+
+    /**
+     * For serializing the stats before sending to Management Center.
+     *
+     * @return the JSON representation of this object
+     */
+    @Override
+    public JsonObject toJson() {
+        JsonObject bytesTransceivedJson = new JsonObject();
+        for (ProtocolType type : ProtocolType.valuesAsSet()) {
+            bytesTransceivedJson.add(type.name(), getBytesTransceived(type));
+        }
+
+        JsonObject result = new JsonObject();
+        result.add("bytesTransceived", bytesTransceivedJson);
+        return result;
+    }
+
+    /**
+     * Extracts the state from the given {@code json} object and mutates the
+     * state of this object.
+     *
+     * @param json the JSON object carrying state for this object
+     */
+    @Override
+    public void fromJson(JsonObject json) {
+        JsonObject bytesTransceivedJson = getObject(json, "bytesTransceived", null);
+        if (bytesTransceivedJson != null) {
+            for (ProtocolType type : ProtocolType.valuesAsSet()) {
+                bytesTransceived.put(type, bytesTransceivedJson.getLong(type.name(), 0));
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AdvancedNetworkStatsDTO{"
+                + "bytesTransceived=" + bytesTransceived
+                + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.management.JsonSerializable;
+import com.hazelcast.internal.management.dto.AdvancedNetworkStatsDTO;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.management.dto.MXBeansDTO;
@@ -87,6 +88,8 @@ public class MemberStateImpl implements MemberState {
     private HotRestartState hotRestartState = new HotRestartStateImpl();
     private ClusterHotRestartStatusDTO clusterHotRestartStatus = new ClusterHotRestartStatusDTO();
     private WanSyncState wanSyncState = new WanSyncStateImpl();
+    private AdvancedNetworkStatsDTO inboundNetworkStats = new AdvancedNetworkStatsDTO();
+    private AdvancedNetworkStatsDTO outboundNetworkStats = new AdvancedNetworkStatsDTO();
 
     public MemberStateImpl() {
     }
@@ -327,6 +330,22 @@ public class MemberStateImpl implements MemberState {
         this.clientStats = clientStats;
     }
 
+    public AdvancedNetworkStatsDTO getInboundNetworkStats() {
+        return inboundNetworkStats;
+    }
+
+    public void setInboundNetworkStats(AdvancedNetworkStatsDTO inboundNetworkStats) {
+        this.inboundNetworkStats = inboundNetworkStats;
+    }
+
+    public AdvancedNetworkStatsDTO getOutboundNetworkStats() {
+        return outboundNetworkStats;
+    }
+
+    public void setOutboundNetworkStats(AdvancedNetworkStatsDTO outboundNetworkStats) {
+        this.outboundNetworkStats = outboundNetworkStats;
+    }
+
     @Override
     public JsonObject toJson() {
         final JsonObject root = new JsonObject();
@@ -392,6 +411,8 @@ public class MemberStateImpl implements MemberState {
             clientStatsObject.add(entry.getKey().toString(), entry.getValue());
         }
         root.add("clientStats", clientStatsObject);
+        root.add("inboundNetworkStats", inboundNetworkStats.toJson());
+        root.add("outboundNetworkStats", outboundNetworkStats.toJson());
         return root;
     }
 
@@ -536,6 +557,16 @@ public class MemberStateImpl implements MemberState {
         for (JsonObject.Member next : getObject(json, "clientStats")) {
             clientStats.put(UUID.fromString(next.getName()), next.getValue().asString());
         }
+        JsonObject jsonInboundNetworkStats = getObject(json, "inboundNetworkStats", null);
+        if (jsonInboundNetworkStats != null) {
+            inboundNetworkStats = new AdvancedNetworkStatsDTO();
+            inboundNetworkStats.fromJson(jsonInboundNetworkStats);
+        }
+        JsonObject jsonOutboundNetworkStats = getObject(json, "outboundNetworkStats", null);
+        if (jsonOutboundNetworkStats != null) {
+            outboundNetworkStats = new AdvancedNetworkStatsDTO();
+            outboundNetworkStats.fromJson(jsonOutboundNetworkStats);
+        }
     }
 
     @Override
@@ -564,6 +595,8 @@ public class MemberStateImpl implements MemberState {
                 + ", wanSyncState=" + wanSyncState
                 + ", flakeIdStats=" + flakeIdGeneratorStats
                 + ", clientStats=" + clientStats
+                + ", inboundNetworkStats=" + inboundNetworkStats
+                + ", outboundNetworkStats=" + outboundNetworkStats
                 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -213,8 +213,8 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         assertEquals("someStats", deserializedClientStats.get(clientUuid));
 
         assertNotNull(deserialized.getInboundNetworkStats());
-        assertEquals(42, (long) deserialized.getInboundNetworkStats().getBytesTransceived(ProtocolType.MEMBER));
+        assertEquals(42, deserialized.getInboundNetworkStats().getBytesTransceived(ProtocolType.MEMBER));
         assertNotNull(deserialized.getOutboundNetworkStats());
-        assertEquals(24, (long) deserialized.getOutboundNetworkStats().getBytesTransceived(ProtocolType.MEMBER));
+        assertEquals(24, deserialized.getOutboundNetworkStats().getBytesTransceived(ProtocolType.MEMBER));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.management.TimedMemberState;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
+import com.hazelcast.internal.management.dto.AdvancedNetworkStatsDTO;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.monitor.HotRestartState;
@@ -106,6 +107,11 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         Map<UUID, String> clientStats = new HashMap<>();
         clientStats.put(clientUuid, "someStats");
 
+        AdvancedNetworkStatsDTO inboundNetworkStats = new AdvancedNetworkStatsDTO();
+        inboundNetworkStats.incBytesTransceived(ProtocolType.MEMBER, 42);
+        AdvancedNetworkStatsDTO outboundNetworkStats = new AdvancedNetworkStatsDTO();
+        outboundNetworkStats.incBytesTransceived(ProtocolType.MEMBER, 24);
+
         Map<EndpointQualifier, Address> endpoints = new HashMap<>();
         endpoints.put(EndpointQualifier.MEMBER, new Address("127.0.0.1", 5701));
         endpoints.put(EndpointQualifier.resolve(ProtocolType.WAN, "MyWAN"), new Address("127.0.0.1", 5901));
@@ -138,6 +144,8 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         memberState.setHotRestartState(hotRestartState);
         memberState.setWanSyncState(wanSyncState);
         memberState.setClientStats(clientStats);
+        memberState.setInboundNetworkStats(inboundNetworkStats);
+        memberState.setOutboundNetworkStats(outboundNetworkStats);
 
         MemberStateImpl deserialized = new MemberStateImpl();
         deserialized.fromJson(memberState.toJson());
@@ -203,5 +211,10 @@ public class MemberStateImplTest extends HazelcastTestSupport {
 
         Map<UUID, String> deserializedClientStats = deserialized.getClientStats();
         assertEquals("someStats", deserializedClientStats.get(clientUuid));
+
+        assertNotNull(deserialized.getInboundNetworkStats());
+        assertEquals(42, (long) deserialized.getInboundNetworkStats().getBytesTransceived(ProtocolType.MEMBER));
+        assertNotNull(deserialized.getOutboundNetworkStats());
+        assertEquals(24, (long) deserialized.getOutboundNetworkStats().getBytesTransceived(ProtocolType.MEMBER));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
@@ -285,7 +285,7 @@ class MockNetworkingService
 
         @Override
         public NetworkStats getNetworkStats() {
-            return null;
+            return new MockNetworkStats();
         }
 
         private class MockConnLifecycleListener
@@ -334,6 +334,20 @@ class MockNetworkingService
                 }
                 send(packet, target, this);
             }
+        }
+
+        private static class MockNetworkStats implements NetworkStats {
+
+            @Override
+            public long getBytesReceived() {
+                return 0;
+            }
+
+            @Override
+            public long getBytesSent() {
+                return 0;
+            }
+
         }
     }
 


### PR DESCRIPTION
* Partial forward-port of #15541
* Adds `AdvancedNetworkStatsDTO` to `TimedMemberState`, as MC 4.0 will be consuming `TimedMemberState`

MC counterpart PR: https://github.com/hazelcast/management-center/pull/2232