### PR TITLE
Fix SessionManagerServiceTest.sessionHeartbeatsAreSent_whenSessionInUse

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 
 public abstract class AbstractProxySessionManagerTest extends HazelcastRaftTestSupport {
 
-    private static final int sessionTTLSeconds = 5;
+    private static final int sessionTTLSeconds = 10;
 
     HazelcastInstance[] members;
     protected RaftGroupId groupId;
@@ -193,7 +193,8 @@ public abstract class AbstractProxySessionManagerTest extends HazelcastRaftTestS
     }
 
     private SessionAccessor getSessionAccessor() {
-        return getNodeEngineImpl(members[0]).getService(RaftSessionService.SERVICE_NAME);
+        HazelcastInstance leaderInstance = getLeaderInstance(members, groupId);
+        return getNodeEngineImpl(leaderInstance).getService(RaftSessionService.SERVICE_NAME);
     }
 
     @Override


### PR DESCRIPTION
- Query session on CP group leader, otherwise request can go to a follower
which does not have the session info yet.
- Increase session ttl to avoid pause/hiccup effect

Fixes #15735