### PR TITLE
Fix possible metrics (de)registration livelock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -69,7 +69,8 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     private final ConcurrentMap<String, ProbeInstance> probeInstances = new ConcurrentHashMap<String, ProbeInstance>();
 
     // use ConcurrentReferenceHashMap to allow unreferenced Class instances to be garbage collected
-    private final ConcurrentMap<Class<?>, SourceMetadata> metadataMap = new ConcurrentReferenceHashMap<Class<?>, SourceMetadata>();
+    private final ConcurrentMap<Class<?>, SourceMetadata> metadataMap =
+            new ConcurrentReferenceHashMap<Class<?>, SourceMetadata>();
     private final LockStripe lockStripe = new LockStripe();
 
     private final AtomicLong modCount = new AtomicLong();

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -98,7 +98,7 @@ if [ -z "$ADDRESS" ]; then
     ADDRESS="127.0.0.1"
 fi
 
-command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit -1; }
+command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit 255; }
 
 URL_BASE="${URL_SCHEME}://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster"
 CURL_CMD="curl $CURL_ARGS"


### PR DESCRIPTION
The `incrementMod` method used a get+CAS in an infinite loop. This is
prone to a livelock when many threads contend to run it. The commit
updates this with incrementing an AtomicInteger which uses the CPU's
fetch-and-add instruction and should not be susceptible to this.

Fixes #15503