### PR TITLE
Add dynamic metric support for gauges

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/AbstractGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/AbstractGauge.java
@@ -17,12 +17,16 @@
 package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.Metric;
+import com.hazelcast.internal.metrics.ProbeFunction;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicReference;
 
 abstract class AbstractGauge implements Metric {
 
     protected final MetricsRegistryImpl metricsRegistry;
     protected final String name;
-    private volatile ProbeInstance probeInstance;
+    protected long lastCollectionId = Long.MIN_VALUE;
 
     AbstractGauge(MetricsRegistryImpl metricsRegistry, String name) {
         this.metricsRegistry = metricsRegistry;
@@ -34,16 +38,95 @@ abstract class AbstractGauge implements Metric {
         return name;
     }
 
-    void clearProbeInstance() {
-        probeInstance = null;
+    public abstract void onProbeInstanceSet(ProbeInstance probeInstance);
+
+    abstract MetricValueCatcher getCatcherOrNull();
+
+    final void onCollectionCompleted(long collectionId) {
+        if (lastCollectionId != collectionId) {
+            MetricValueCatcher catcher = getCatcherOrNull();
+            if (catcher != null && catcher instanceof AbstractMetricValueCatcher) {
+                ((AbstractMetricValueCatcher) catcher).clearCachedValue();
+                ((AbstractMetricValueCatcher) catcher).clearCachedMetricSourceRef();
+            }
+        }
     }
 
-    ProbeInstance getProbeInstance() {
-        ProbeInstance probeInstance = this.probeInstance;
-        if (probeInstance == null) {
-            probeInstance = metricsRegistry.getProbeInstance(name);
-            this.probeInstance = probeInstance;
+    abstract class AbstractMetricValueCatcher implements MetricValueCatcher {
+        private final AtomicReference<DynamicMetricSourceReference> dynamicMetricRef = new AtomicReference<>();
+
+        @Override
+        public final void catchMetricValue(long collectionId, Object source, ProbeFunction function) {
+            lastCollectionId = collectionId;
+            if (function == null || source == null) {
+                clearCachedValue();
+            } else {
+                DynamicMetricSourceReference cachedMetricRef = dynamicMetricRef.get();
+                if (cachedMetricRef == null || source != cachedMetricRef.source() || function != cachedMetricRef.function()) {
+                    dynamicMetricRef.set(new DynamicMetricSourceReference(source, function));
+                    clearCachedValue();
+                }
+            }
         }
-        return probeInstance;
+
+        final <T> T readBase(MetricValueExtractorFunction<T> extractorFn, MetricCachedValueReaderFunction<T> readCachedFn) {
+            // called from LongGaugeImpl#read() and DoubleGaugeImpl#read()
+            // it does boxing and unboxing through the passed function
+            // parameters as the trade-off of the mostly shared code base
+
+            // check if we have a usable cached dynamic metric reference
+            // if so, read the value from it
+            DynamicMetricSourceReference cachedMetricRef = dynamicMetricRef.get();
+            if (cachedMetricRef != null) {
+                // need to make local copies since source and function
+                // is accessed through weak references
+                Object source = cachedMetricRef.source();
+                ProbeFunction function = cachedMetricRef.function();
+
+                if (source != null && function != null) {
+                    return extractorFn.extractValue(name, source, function, metricsRegistry);
+                } else {
+                    clearCachedMetricSourceRef();
+                }
+            }
+
+            // otherwise use the the cached value
+            return readCachedFn.readCachedValue();
+        }
+
+        abstract void clearCachedValue();
+
+        final void clearCachedMetricSourceRef() {
+            dynamicMetricRef.lazySet(null);
+        }
+
+    }
+
+    private static final class DynamicMetricSourceReference {
+        private final WeakReference<Object> sourceRef;
+        private final WeakReference<ProbeFunction> functionRef;
+
+        DynamicMetricSourceReference(Object source, ProbeFunction function) {
+            this.sourceRef = new WeakReference<>(source);
+            this.functionRef = new WeakReference<>(function);
+        }
+
+        Object source() {
+            return sourceRef.get();
+        }
+
+        ProbeFunction function() {
+            return functionRef.get();
+        }
+    }
+
+    @FunctionalInterface
+    interface MetricValueExtractorFunction<T> {
+        T extractValue(String name, Object source, ProbeFunction function, MetricsRegistryImpl metricsRegistry);
+    }
+
+    @FunctionalInterface
+    interface MetricCachedValueReaderFunction<T> {
+        T readCachedValue();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/AbstractGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/AbstractGauge.java
@@ -90,7 +90,7 @@ abstract class AbstractGauge implements Metric {
                 }
             }
 
-            // otherwise use the the cached value
+            // otherwise use the cached value
             return readCachedFn.readCachedValue();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
@@ -58,7 +58,10 @@ class DoubleGaugeImpl extends AbstractGauge implements DoubleGauge {
 
     @Override
     MetricValueCatcher getCatcherOrNull() {
-        return gaugeSource instanceof DoubleMetricValueCatcher ? (DoubleMetricValueCatcher) gaugeSource : null;
+        // we take a defensive copy, since this.gaugeSource might be changed
+        // between the instanceof and the casting
+        DoubleGaugeSource gaugeSourceCopy = this.gaugeSource;
+        return gaugeSourceCopy instanceof DoubleMetricValueCatcher ? (DoubleMetricValueCatcher) gaugeSourceCopy : null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
@@ -23,29 +23,56 @@ import com.hazelcast.internal.metrics.ProbeFunction;
 
 class DoubleGaugeImpl extends AbstractGauge implements DoubleGauge {
 
-    private static final double DEFAULT_VALUE = 0d;
+    static final double DEFAULT_VALUE = 0d;
+
+    /**
+     * The value of this gauge is read out from this gauge source. Needed
+     * to handle static and dynamic metrics transparently for the gauge
+     * internals.
+     * <p/>
+     * If this gauge is created for a static metric, this is a
+     * {@link ProbeInstanceGaugeSource} instance, otherwise a
+     * {@link DoubleMetricValueCatcher} instance. The latter is used to
+     * catch the value of the dynamic metric this gauge is created for.
+     * If a static metric with metric id matching this gauge's name is
+     * created after creating this gauge, the
+     * {@link DoubleMetricValueCatcher} instance is replaced with a
+     * {@link ProbeInstanceGaugeSource} instance.
+     */
+    private volatile DoubleGaugeSource gaugeSource;
 
     DoubleGaugeImpl(MetricsRegistryImpl metricsRegistry, String name) {
         super(metricsRegistry, name);
+        ProbeInstance probeInstance = metricsRegistry.getProbeInstance(name);
+        if (probeInstance != null) {
+            this.gaugeSource = new ProbeInstanceGaugeSource(probeInstance);
+        } else {
+            this.gaugeSource = new DoubleMetricValueCatcher();
+        }
+    }
+
+    @Override
+    public void onProbeInstanceSet(ProbeInstance probeInstance) {
+        gaugeSource = new ProbeInstanceGaugeSource(probeInstance);
+    }
+
+    @Override
+    MetricValueCatcher getCatcherOrNull() {
+        return gaugeSource instanceof DoubleMetricValueCatcher ? (DoubleMetricValueCatcher) gaugeSource : null;
     }
 
     @Override
     public double read() {
-        ProbeInstance probeInstance = getProbeInstance();
+        return gaugeSource.read();
+    }
 
-        ProbeFunction function = null;
-        Object source = null;
+    @Override
+    public void render(StringBuilder stringBuilder) {
+        stringBuilder.append(read());
+    }
 
-        if (probeInstance != null) {
-            function = probeInstance.function;
-            source = probeInstance.source;
-        }
-
-        if (function == null || source == null) {
-            clearProbeInstance();
-            return DEFAULT_VALUE;
-        }
-
+    private static double getMetricValue(String gaugeName, Object source, ProbeFunction function,
+                                         MetricsRegistryImpl metricsRegistry) {
         try {
             if (function instanceof LongProbeFunction) {
                 LongProbeFunction longFunction = (LongProbeFunction) function;
@@ -55,13 +82,73 @@ class DoubleGaugeImpl extends AbstractGauge implements DoubleGauge {
                 return doubleFunction.get(source);
             }
         } catch (Exception e) {
-            metricsRegistry.logger.warning("Failed to access the probe: " + name, e);
+            metricsRegistry.logger.warning("Failed to access the probe: " + gaugeName, e);
             return DEFAULT_VALUE;
         }
     }
 
-    @Override
-    public void render(StringBuilder stringBuilder) {
-        stringBuilder.append(read());
+    /**
+     * Local interface used to transparently back this gauge with static
+     * or dynamic metrics.
+     *
+     * @see #gaugeSource
+     */
+    private interface DoubleGaugeSource {
+        double read();
+    }
+
+    private final class DoubleMetricValueCatcher extends AbstractMetricValueCatcher implements DoubleGaugeSource {
+        private volatile double value = DEFAULT_VALUE;
+
+        @Override
+        public void catchMetricValue(long collectionId, long value) {
+            lastCollectionId = collectionId;
+            this.value = value;
+            clearCachedMetricSourceRef();
+        }
+
+        @Override
+        public void catchMetricValue(long collectionId, double value) {
+            lastCollectionId = collectionId;
+            this.value = value;
+            clearCachedMetricSourceRef();
+        }
+
+        @Override
+        public double read() {
+            return readBase(DoubleGaugeImpl::getMetricValue, () -> value);
+        }
+
+        @Override
+        void clearCachedValue() {
+            value = DEFAULT_VALUE;
+        }
+    }
+
+    private final class ProbeInstanceGaugeSource implements DoubleGaugeSource {
+
+        private volatile ProbeInstance probeInstance;
+
+        private ProbeInstanceGaugeSource(ProbeInstance probeInstance) {
+            this.probeInstance = probeInstance;
+        }
+
+        @Override
+        public double read() {
+            ProbeFunction function = null;
+            Object source = null;
+
+            if (probeInstance != null) {
+                function = probeInstance.function;
+                source = probeInstance.source;
+            }
+
+            if (function == null || source == null) {
+                probeInstance = null;
+                return DEFAULT_VALUE;
+            }
+
+            return getMetricValue(name, source, function, metricsRegistry);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -17,35 +17,81 @@
 package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.Gauge;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.ProbeFunction;
 
+/**
+ * {@link Gauge} implementation that can be used to the last seen value
+ * as long from a particular metric.
+ * <p/>
+ * This implementation distinguishes between static and dynamic metric
+ * sources. The dynamic metrics are by design discovered during the
+ * collection cycle, while for the static metrics there is always a
+ * {@link ProbeInstance} that the gauge's value can be read from. Rendering
+ * the most up-to-date value is a spoken goal of the gauges, hence we need
+ * this distinction between the logic that reads out the value of the gauge
+ * from the metrics' sources. This distinction is done by introducing the
+ * internal {@link LongGaugeSource} interface and two internal
+ * implementations:
+ * <ul>
+ * <li>{@link ProbeInstanceGaugeSource} for static metrics and</li>
+ * <li>{@link LongMetricValueCatcher} for dynamic metrics</li>
+ * </ul>
+ */
 class LongGaugeImpl extends AbstractGauge implements LongGauge {
 
-    private static final long DEFAULT_VALUE = 0;
+    static final long DEFAULT_VALUE = 0;
+
+    /**
+     * The value of this gauge is read out from this gauge source. Needed
+     * to handle static and dynamic metrics transparently for the gauge
+     * internals.
+     * <p/>
+     * If this gauge is created for a static metric, this is a
+     * {@link ProbeInstanceGaugeSource} instance, otherwise a
+     * {@link LongMetricValueCatcher} instance. The latter is used to
+     * catch the value of the dynamic metric this gauge is created for.
+     * If a static metric with metric id matching this gauge's name is
+     * created after creating this gauge, the
+     * {@link LongMetricValueCatcher} instance is replaced with a
+     * {@link ProbeInstanceGaugeSource} instance.
+     */
+    private volatile LongGaugeSource gaugeSource;
 
     LongGaugeImpl(MetricsRegistryImpl metricsRegistry, String name) {
         super(metricsRegistry, name);
+        ProbeInstance probeInstance = metricsRegistry.getProbeInstance(name);
+        if (probeInstance != null) {
+            this.gaugeSource = new ProbeInstanceGaugeSource(probeInstance);
+        } else {
+            this.gaugeSource = new LongMetricValueCatcher();
+        }
     }
 
     @Override
     public long read() {
-        ProbeInstance probeInstance = getProbeInstance();
+        return gaugeSource.read();
+    }
 
-        ProbeFunction function = null;
-        Object source = null;
+    @Override
+    LongMetricValueCatcher getCatcherOrNull() {
+        return gaugeSource instanceof LongMetricValueCatcher ? (LongMetricValueCatcher) gaugeSource : null;
+    }
 
-        if (probeInstance != null) {
-            function = probeInstance.function;
-            source = probeInstance.source;
-        }
+    @Override
+    public void render(StringBuilder stringBuilder) {
+        stringBuilder.append(read());
+    }
 
-        if (function == null || source == null) {
-            clearProbeInstance();
-            return DEFAULT_VALUE;
-        }
+    @Override
+    public void onProbeInstanceSet(ProbeInstance probeInstance) {
+        gaugeSource = new ProbeInstanceGaugeSource(probeInstance);
+    }
 
+    private static long getMetricValue(String gaugeName, Object source, ProbeFunction function,
+                                       MetricsRegistryImpl metricsRegistry) {
         try {
             if (function instanceof LongProbeFunction) {
                 LongProbeFunction longFunction = (LongProbeFunction) function;
@@ -56,13 +102,67 @@ class LongGaugeImpl extends AbstractGauge implements LongGauge {
                 return Math.round(doubleResult);
             }
         } catch (Exception e) {
-            metricsRegistry.logger.warning("Failed to access the probe: " + name, e);
+            metricsRegistry.logger.warning("Failed to access the probe: " + gaugeName, e);
             return DEFAULT_VALUE;
         }
     }
 
-    @Override
-    public void render(StringBuilder stringBuilder) {
-        stringBuilder.append(read());
+    private interface LongGaugeSource {
+        long read();
+    }
+
+    private final class LongMetricValueCatcher extends AbstractMetricValueCatcher implements LongGaugeSource {
+        private volatile long value = DEFAULT_VALUE;
+
+        @Override
+        public void catchMetricValue(long collectionId, long value) {
+            lastCollectionId = collectionId;
+            this.value = value;
+            clearCachedMetricSourceRef();
+        }
+
+        @Override
+        public void catchMetricValue(long collectionId, double value) {
+            lastCollectionId = collectionId;
+            this.value = Math.round(value);
+            clearCachedMetricSourceRef();
+        }
+
+        @Override
+        public long read() {
+            return readBase(LongGaugeImpl::getMetricValue, () -> value);
+        }
+
+        @Override
+        void clearCachedValue() {
+            value = DEFAULT_VALUE;
+        }
+    }
+
+    private final class ProbeInstanceGaugeSource implements LongGaugeSource {
+
+        private volatile ProbeInstance probeInstance;
+
+        private ProbeInstanceGaugeSource(ProbeInstance probeInstance) {
+            this.probeInstance = probeInstance;
+        }
+
+        @Override
+        public long read() {
+            ProbeFunction function = null;
+            Object source = null;
+
+            if (probeInstance != null) {
+                function = probeInstance.function;
+                source = probeInstance.source;
+            }
+
+            if (function == null || source == null) {
+                probeInstance = null;
+                return DEFAULT_VALUE;
+            }
+
+            return getMetricValue(name, source, function, metricsRegistry);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -77,7 +77,10 @@ class LongGaugeImpl extends AbstractGauge implements LongGauge {
 
     @Override
     LongMetricValueCatcher getCatcherOrNull() {
-        return gaugeSource instanceof LongMetricValueCatcher ? (LongMetricValueCatcher) gaugeSource : null;
+        // we take a defensive copy, since this.gaugeSource might be changed
+        // between the instanceof and the casting
+        LongGaugeSource gaugeSourceCopy = this.gaugeSource;
+        return gaugeSourceCopy instanceof LongMetricValueCatcher ? (LongMetricValueCatcher) gaugeSourceCopy : null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -42,7 +42,7 @@ import com.hazelcast.internal.metrics.ProbeFunction;
  */
 class LongGaugeImpl extends AbstractGauge implements LongGauge {
 
-    static final long DEFAULT_VALUE = 0;
+    static final long DEFAULT_VALUE = 0L;
 
     /**
      * The value of this gauge is read out from this gauge source. Needed

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricValueCatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricValueCatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.ProbeFunction;
+
+/**
+ * Interface used for catching values of the dynamic metrics. The primary
+ * use case for this interface is updating gauges with values of dynamic
+ * metrics.
+ */
+interface MetricValueCatcher {
+    /**
+     * Catches metric value from a source object with a {@link ProbeFunction}.
+     *
+     * @param collectionId  The identifier of the metric collection cycle
+     *                      calling this method
+     * @param source        The object to read the value from
+     * @param function      The probe function that reads the value from the
+     *                      {@code source} object
+     */
+    void catchMetricValue(long collectionId, Object source, ProbeFunction function);
+
+    /**
+     * Catches long value.
+     *
+     * @param collectionId  The identifier of the metric collection cycle
+     *                      calling this method
+     * @param value         The value
+     */
+    void catchMetricValue(long collectionId, long value);
+
+    /**
+     * Catches double value.
+     *
+     * @param collectionId  The identifier of the metric collection cycle
+     *                      calling this method
+     * @param value         The value
+     */
+    void catchMetricValue(long collectionId, double value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpNetworkingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpNetworkingService.java
@@ -128,7 +128,8 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
             refreshStatsTask.registerMetrics(metricsRegistry);
         }
 
-        metricsRegistry.registerDynamicMetricsProvider(new MetricsProvider(acceptorRef, endpointManagers));
+        metricsRegistry
+                .registerDynamicMetricsProvider(new MetricsProvider(acceptorRef, endpointManagers, unifiedEndpointManager));
     }
 
     private void initEndpointManager(Config config, IOService ioService,
@@ -363,11 +364,14 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
     private static final class MetricsProvider implements DynamicMetricsProvider {
         private final AtomicReference<TcpIpAcceptor> acceptorRef;
         private final ConcurrentMap<EndpointQualifier, EndpointManager<TcpIpConnection>> endpointManagers;
+        private final TcpIpUnifiedEndpointManager unifiedEndpointManager;
 
         private MetricsProvider(AtomicReference<TcpIpAcceptor> acceptorRef,
-                                ConcurrentMap<EndpointQualifier, EndpointManager<TcpIpConnection>> endpointManagers) {
+                                ConcurrentMap<EndpointQualifier, EndpointManager<TcpIpConnection>> endpointManagers,
+                                TcpIpUnifiedEndpointManager unifiedEndpointManager) {
             this.acceptorRef = acceptorRef;
             this.endpointManagers = endpointManagers;
+            this.unifiedEndpointManager = unifiedEndpointManager;
         }
 
         @Override
@@ -385,6 +389,8 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
                     ((DynamicMetricsProvider) manager).provideDynamicMetrics(taggerSupplier, context);
                 }
             }
+
+            unifiedEndpointManager.provideDynamicMetrics(taggerSupplier, context);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpUnifiedEndpointManager.java
@@ -18,6 +18,9 @@ package com.hazelcast.internal.nio.tcp;
 
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.metrics.MetricTagger;
+import com.hazelcast.internal.metrics.MetricTaggerSupplier;
+import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.nio.IOService;
@@ -105,5 +108,13 @@ class TcpIpUnifiedEndpointManager
     @Probe(name = "textCount", level = MANDATORY)
     public int getCurrentTextConnections() {
         return getTextConnections().size();
+    }
+
+    @Override
+    public void provideDynamicMetrics(MetricTaggerSupplier taggerSupplier, MetricsCollectionContext context) {
+        super.provideDynamicMetrics(taggerSupplier, context);
+
+        MetricTagger tagger = taggerSupplier.getMetricTagger("tcp.connection");
+        context.collect(tagger, this);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImplTest.java
@@ -18,23 +18,35 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricTagger;
+import com.hazelcast.internal.metrics.MetricTaggerSupplier;
+import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.lang.ref.WeakReference;
+
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
+import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class DoubleGaugeImplTest {
+public class DoubleGaugeImplTest extends HazelcastTestSupport {
     private MetricsRegistryImpl metricsRegistry;
 
     @Before
@@ -42,11 +54,32 @@ public class DoubleGaugeImplTest {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
-    class SomeObject {
+    class SomeObject implements DynamicMetricsProvider {
         @Probe
         long longField = 10;
         @Probe
         double doubleField = 10.8;
+
+        @Override
+        public void provideDynamicMetrics(MetricTaggerSupplier taggerSupplier, MetricsCollectionContext context) {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, this);
+        }
+    }
+
+    class NullableDynamicMetricsProvider implements DynamicMetricsProvider {
+        SomeObject someObject = new SomeObject();
+
+        @Override
+        public void provideDynamicMetrics(MetricTaggerSupplier taggerSupplier, MetricsCollectionContext context) {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            if (someObject != null) {
+                context.collect(tagger, someObject);
+            } else {
+                context.collect(tagger, "longField", INFO, COUNT, 142);
+                context.collect(tagger, "doubleField", INFO, COUNT, 142.42D);
+            }
+        }
     }
 
     // ============ readDouble ===========================
@@ -113,4 +146,186 @@ public class DoubleGaugeImplTest {
         DoubleGauge gauge = metricsRegistry.newDoubleGauge("foo.doubleField");
         assertEquals(someObject.doubleField, gauge.read(), 0.1);
     }
+
+    @Test
+    public void whenCreatedForDynamicDoubleMetricWithExtractedValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.doubleField = 41.65D;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(41.65D, doubleGauge.read(), 10E-6);
+
+        someObject.doubleField = 42.65D;
+        assertEquals(42.65D, doubleGauge.read(), 10E-6);
+
+    }
+
+    @Test
+    public void whenCreatedForDynamicLongMetricWithExtractedValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(42D, doubleGauge.read(), 10E-6);
+
+        someObject.longField = 43;
+        assertEquals(43D, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenCreatedForDynamicLongMetricWithProvidedValue() {
+        DoubleGaugeImplTest.SomeObject someObject = new DoubleGaugeImplTest.SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(
+                (taggerSupplier, context) -> context
+                        .collect(taggerSupplier.getMetricTagger("foo"), "longField", INFO, BYTES, 42));
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(42, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenCreatedForDynamicDoubleMetricWithProvidedValue() {
+        DoubleGaugeImplTest.SomeObject someObject = new DoubleGaugeImplTest.SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(
+                (taggerSupplier, context) -> context
+                        .collect(taggerSupplier.getMetricTagger("foo"), "doubleField", INFO, BYTES, 41.65D));
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(41.65, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenCacheDynamicMetricSourceGcdReadsDefault() {
+        NullableDynamicMetricsProvider metricsProvider = new NullableDynamicMetricsProvider();
+        WeakReference<SomeObject> someObjectWeakRef = new WeakReference<>(metricsProvider.someObject);
+        metricsProvider.someObject.doubleField = 42.42D;
+        metricsRegistry.registerDynamicMetricsProvider(metricsProvider);
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42.42D, doubleGauge.read(), 10E-6);
+
+        metricsProvider.someObject = null;
+        System.gc();
+        // wait for someObject to get GCd - should have already happened
+        assertTrueEventually(() -> assertNull(someObjectWeakRef.get()));
+
+        assertEquals(DoubleGaugeImpl.DEFAULT_VALUE, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenCacheDynamicMetricSourceReplacedWithConcreteValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.doubleField = 42.42D;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42.42D, doubleGauge.read(), 10E-6);
+
+        metricsRegistry.deregisterDynamicMetricsProvider(someObject);
+
+        metricsRegistry.registerDynamicMetricsProvider((taggerSupplier, context) -> {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, "doubleField", INFO, COUNT, 142.42D);
+        });
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(142.42D, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenCacheDynamicMetricValueReplacedWithCachedMetricSource() {
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // provide concrete value
+        DynamicMetricsProvider concreteProvider = (taggerSupplier, context) -> {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, "doubleField", INFO, COUNT, 142.42D);
+        };
+        metricsRegistry.registerDynamicMetricsProvider(concreteProvider);
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(142.42D, doubleGauge.read(), 10E-6);
+
+        metricsRegistry.deregisterDynamicMetricsProvider(concreteProvider);
+
+        // provide metric source to be cached
+        SomeObject someObject = new SomeObject();
+        someObject.doubleField = 42.42D;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42.42D, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenNotVisitedWithCachedMetricSourceReadsDefault() {
+        DoubleGaugeImplTest.SomeObject someObject = new DoubleGaugeImplTest.SomeObject();
+        someObject.doubleField = 42.42D;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42.42D, doubleGauge.read(), 10E-6);
+
+        // clears the cached metric source
+        metricsRegistry.deregisterDynamicMetricsProvider(someObject);
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(DoubleGaugeImpl.DEFAULT_VALUE, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenNotVisitedWithCachedValueReadsDefault() {
+        DynamicMetricsProvider concreteProvider = (taggerSupplier, context) -> {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, "doubleField", INFO, COUNT, 42.42D);
+        };
+        metricsRegistry.registerDynamicMetricsProvider(concreteProvider);
+        DoubleGauge doubleGauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42.42D, doubleGauge.read(), 10E-6);
+
+        // clears the cached metric source
+        metricsRegistry.deregisterDynamicMetricsProvider(concreteProvider);
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(DoubleGaugeImpl.DEFAULT_VALUE, doubleGauge.read(), 10E-6);
+    }
+
+    @Test
+    public void whenProbeRegisteredAfterGauge() {
+        DoubleGauge gauge = metricsRegistry.newDoubleGauge("foo.doubleField");
+
+        SomeObject someObject = new SomeObject();
+        metricsRegistry.registerStaticMetrics(someObject, "foo");
+
+        assertEquals(someObject.doubleField, gauge.read(), 10E-6);
+    }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LongGaugeImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LongGaugeImplTest.java
@@ -17,25 +17,37 @@
 package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricTagger;
+import com.hazelcast.internal.metrics.MetricTaggerSupplier;
+import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.lang.ref.WeakReference;
+
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
+import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static java.lang.Math.round;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class LongGaugeImplTest {
+public class LongGaugeImplTest extends HazelcastTestSupport {
 
     private MetricsRegistryImpl metricsRegistry;
 
@@ -44,11 +56,32 @@ public class LongGaugeImplTest {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
-    class SomeObject {
+    class SomeObject implements DynamicMetricsProvider {
         @Probe
         long longField = 10;
         @Probe
         double doubleField = 10.8;
+
+        @Override
+        public void provideDynamicMetrics(MetricTaggerSupplier taggerSupplier, MetricsCollectionContext context) {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, this);
+        }
+    }
+
+    class NullableDynamicMetricsProvider implements DynamicMetricsProvider {
+        SomeObject someObject = new SomeObject();
+
+        @Override
+        public void provideDynamicMetrics(MetricTaggerSupplier taggerSupplier, MetricsCollectionContext context) {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            if (someObject != null) {
+                context.collect(tagger, someObject);
+            } else {
+                context.collect(tagger, "longField", INFO, COUNT, 142);
+                context.collect(tagger, "doubleField", INFO, COUNT, 142.42D);
+            }
+        }
     }
 
     @Test
@@ -136,5 +169,185 @@ public class LongGaugeImplTest {
                 (LongProbeFunction) o -> 11);
 
         assertEquals(11, gauge.read());
+    }
+
+    @Test
+    public void whenCreatedForDynamicLongMetricWithExtractedValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(42, longGauge.read());
+
+        someObject.longField = 43;
+        assertEquals(43, longGauge.read());
+    }
+
+    @Test
+    public void whenCreatedForDynamicDoubleMetricWithExtractedValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.doubleField = 41.65D;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(42, longGauge.read());
+
+        someObject.doubleField = 42.65D;
+        assertEquals(43, longGauge.read());
+    }
+
+    @Test
+    public void whenCreatedForDynamicLongMetricWithProvidedValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(
+                (taggerSupplier, context) -> context
+                        .collect(taggerSupplier.getMetricTagger("foo"), "longField", INFO, BYTES, 42));
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(42, longGauge.read());
+    }
+
+    @Test
+    public void whenCreatedForDynamicDoubleMetricWithProvidedValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(
+                (taggerSupplier, context) -> context
+                        .collect(taggerSupplier.getMetricTagger("foo"), "doubleField", INFO, BYTES, 41.65D));
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.doubleField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(42, longGauge.read());
+    }
+
+    @Test
+    public void whenCacheDynamicMetricSourceGcdReadsDefault() {
+        NullableDynamicMetricsProvider metricsProvider = new NullableDynamicMetricsProvider();
+        WeakReference<SomeObject> someObjectWeakRef = new WeakReference<>(metricsProvider.someObject);
+        metricsProvider.someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(metricsProvider);
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42, longGauge.read());
+
+        metricsProvider.someObject = null;
+        System.gc();
+        // wait for someObject to get GCd - should have already happened
+        assertTrueEventually(() -> assertNull(someObjectWeakRef.get()));
+
+        assertEquals(LongGaugeImpl.DEFAULT_VALUE, longGauge.read());
+    }
+
+    @Test
+    public void whenCacheDynamicMetricSourceReplacedWithConcreteValue() {
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42, longGauge.read());
+
+        metricsRegistry.deregisterDynamicMetricsProvider(someObject);
+
+        metricsRegistry.registerDynamicMetricsProvider((taggerSupplier, context) -> {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, "longField", INFO, COUNT, 142);
+        });
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(142, longGauge.read());
+    }
+
+    @Test
+    public void whenCacheDynamicMetricValueReplacedWithCachedMetricSource() {
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // provide concrete value
+        DynamicMetricsProvider concreteProvider = (taggerSupplier, context) -> {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, "longField", INFO, COUNT, 142);
+        };
+        metricsRegistry.registerDynamicMetricsProvider(concreteProvider);
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(142, longGauge.read());
+
+        metricsRegistry.deregisterDynamicMetricsProvider(concreteProvider);
+
+        // provide metric source to be cached
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42, longGauge.read());
+    }
+
+    @Test
+    public void whenNotVisitedWithCachedMetricSourceReadsDefault() {
+        SomeObject someObject = new SomeObject();
+        someObject.longField = 42;
+        metricsRegistry.registerDynamicMetricsProvider(someObject);
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42, longGauge.read());
+
+        // clears the cached metric source
+        metricsRegistry.deregisterDynamicMetricsProvider(someObject);
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(LongGaugeImpl.DEFAULT_VALUE, longGauge.read());
+    }
+
+    @Test
+    public void whenNotVisitedWithCachedValueReadsDefault() {
+        DynamicMetricsProvider concreteProvider = (taggerSupplier, context) -> {
+            MetricTagger tagger = taggerSupplier.getMetricTagger("foo");
+            context.collect(tagger, "longField", INFO, COUNT, 42);
+        };
+        metricsRegistry.registerDynamicMetricsProvider(concreteProvider);
+        LongGaugeImpl longGauge = metricsRegistry.newLongGauge("foo.longField");
+
+        // needed to collect dynamic metrics and update the gauge created from them
+        metricsRegistry.collect(mock(MetricsCollector.class));
+        assertEquals(42, longGauge.read());
+
+        // clears the cached metric source
+        metricsRegistry.deregisterDynamicMetricsProvider(concreteProvider);
+        metricsRegistry.collect(mock(MetricsCollector.class));
+
+        assertEquals(LongGaugeImpl.DEFAULT_VALUE, longGauge.read());
+    }
+
+    @Test
+    public void whenProbeRegisteredAfterGauge() {
+        LongGauge gauge = metricsRegistry.newLongGauge("foo.longField");
+
+        SomeObject someObject = new SomeObject();
+        metricsRegistry.registerStaticMetrics(someObject, "foo");
+
+        assertEquals(someObject.longField, gauge.read());
     }
 }


### PR DESCRIPTION
This change adds dynamic metric support for gauges. Prior to this change
gauges were updated from static metrics only.

Dynamic metrics are supported by introducing `MetricValueCatcher` that
catches the values of the dynamic metrics during the collection cycle.

The dynamic metrics provided as concrete values by calling
`collect(MetricTagger, String, ProbeLevel, ProbeUnit, long)` or
`collect(MetricTagger, String, ProbeLevel, ProbeUnit, double)` on
`MetricsCollectionContext` are cached by values, so the `gauge.read()`
calls return the last updated value for the metric.

The dynamic metrics provided through collected objects by calling
`MetricsCollectionContext#collect(MetricTagger, Object)` are cached by
source object. Once the given metric source object is discovered in a
collection cycle, the object gets cached inside the gauge and every
`gauge#read()` returns the most current value of the metric. This
caching doesn't prevent the source object to get GCd since the gauges
reference it through `WeakReference`s.

Besides allowing the metric source object to get GCd, the gauges that
are not "visited" during a metric collection cycle get reset therefore
no stale values are read once the backing dynamic  metrics sources
disappear. This is true even if the metric source object is still alive.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3274

Fixes #15718
Fixes hazelcast/hazelcast-enterprise/issues/3216