### PR TITLE
Add initial permit count config to Semaphore

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -470,6 +470,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         semaphoreConfigBuilder.addPropertyValue("name", value);
                     } else if ("jdk-compatible".equals(nodeName)) {
                         semaphoreConfigBuilder.addPropertyValue("JDKCompatible", getBooleanValue(value));
+                    } else if ("initial-permits".equals(nodeName)) {
+                        semaphoreConfigBuilder.addPropertyValue("initialPermits", getIntegerValue("initial-permits", value));
                     }
                 }
                 AbstractBeanDefinition beanDefinition = semaphoreConfigBuilder.getBeanDefinition();

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -4678,6 +4678,15 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="initial-permits" type="xs:unsignedInt" minOccurs="0" maxOccurs="1"
+                        default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of permits to initialize the Semaphore. If a positive value is
+                        set, the Semaphore is initialized with the given number of permits.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
     </xs:complexType>
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1403,6 +1403,8 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(semaphoreConfig2);
         assertTrue(semaphoreConfig1.isJDKCompatible());
         assertFalse(semaphoreConfig2.isJDKCompatible());
+        assertEquals(1, semaphoreConfig1.getInitialPermits());
+        assertEquals(2, semaphoreConfig2.getInitialPermits());
         FencedLockConfig lockConfig1 = cpSubsystemConfig.findLockConfig("lock1");
         FencedLockConfig lockConfig2 = cpSubsystemConfig.findLockConfig("lock2");
         assertNotNull(lockConfig1);

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -898,10 +898,12 @@
                     <hz:semaphore>
                         <hz:name>sem1</hz:name>
                         <hz:jdk-compatible>true</hz:jdk-compatible>
+                        <hz:initial-permits>1</hz:initial-permits>
                     </hz:semaphore>
                     <hz:semaphore>
                         <hz:name>sem2</hz:name>
                         <hz:jdk-compatible>false</hz:jdk-compatible>
+                        <hz:initial-permits>2</hz:initial-permits>
                     </hz:semaphore>
                 </hz:semaphores>
                 <hz:locks>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1532,6 +1532,7 @@ public class ConfigXmlGenerator {
             gen.open("semaphore")
                     .node("name", semaphoreConfig.getName())
                     .node("jdk-compatible", semaphoreConfig.isJDKCompatible())
+                    .node("initial-permits", semaphoreConfig.getInitialPermits())
                     .close();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -2889,6 +2889,8 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                     semaphoreConfig.setName(value);
                 } else if ("jdk-compatible".equals(nodeName)) {
                     semaphoreConfig.setJDKCompatible(Boolean.parseBoolean(value));
+                } else if ("initial-permits".equals(nodeName)) {
+                    semaphoreConfig.setInitialPermits(Integer.parseInt(value));
                 }
             }
             cpSubsystemConfig.addSemaphoreConfig(semaphoreConfig);

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -842,6 +842,8 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
                 String value = getTextContent(subChild).trim();
                 if ("jdk-compatible".equals(nodeName)) {
                     semaphoreConfig.setJDKCompatible(Boolean.parseBoolean(value));
+                } else if ("initial-permits".equals(nodeName)) {
+                    semaphoreConfig.setInitialPermits(Integer.parseInt(value));
                 }
             }
             cpSubsystemConfig.addSemaphoreConfig(semaphoreConfig);

--- a/hazelcast/src/main/java/com/hazelcast/config/cp/FencedLockConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/FencedLockConfig.java
@@ -17,7 +17,8 @@
 package com.hazelcast.config.cp;
 
 import com.hazelcast.cp.lock.FencedLock;
-import com.hazelcast.internal.util.Preconditions;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 
 /**
  * Contains configuration options for {@link FencedLock}
@@ -99,7 +100,7 @@ public class FencedLockConfig {
      * Sets the number of lock acquires a lock holder can perform.
      */
     public FencedLockConfig setLockAcquireLimit(int lockAcquireLimit) {
-        Preconditions.checkTrue(lockAcquireLimit >= 0, "reentrant lock acquire limit cannot be negative");
+        checkNotNegative(lockAcquireLimit, "reentrant lock acquire limit cannot be negative");
         this.lockAcquireLimit = lockAcquireLimit;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/cp/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/SemaphoreConfig.java
@@ -21,6 +21,8 @@ import com.hazelcast.cp.ISemaphore;
 
 import java.util.concurrent.Semaphore;
 
+import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
+
 /**
  * Contains configuration options for CP {@link ISemaphore}
  */
@@ -31,6 +33,11 @@ public class SemaphoreConfig {
      * of CP {@link ISemaphore}
      */
     public static final boolean DEFAULT_SEMAPHORE_JDK_COMPATIBILITY = false;
+
+    /**
+     * Default value for the initial permit count of Semaphores.
+     */
+    public static final int DEFAULT_INITIAL_PERMITS = 0;
 
 
     /**
@@ -59,6 +66,12 @@ public class SemaphoreConfig {
      */
     private boolean jdkCompatible = DEFAULT_SEMAPHORE_JDK_COMPATIBILITY;
 
+    /**
+     * Number of permits to initialize the Semaphore. If a positive value is
+     * set, the Semaphore is initialized with the given number of permits.
+     */
+    private int initialPermits = DEFAULT_INITIAL_PERMITS;
+
     public SemaphoreConfig() {
         super();
     }
@@ -67,14 +80,16 @@ public class SemaphoreConfig {
         this.name = name;
     }
 
-    public SemaphoreConfig(String name, boolean jdkCompatible) {
+    public SemaphoreConfig(String name, boolean jdkCompatible, int initialPermits) {
         this.name = name;
         this.jdkCompatible = jdkCompatible;
+        this.initialPermits = initialPermits;
     }
 
     SemaphoreConfig(SemaphoreConfig config) {
         this.name = config.name;
         this.jdkCompatible = config.jdkCompatible;
+        this.initialPermits = config.initialPermits;
     }
 
     /**
@@ -108,8 +123,25 @@ public class SemaphoreConfig {
         return this;
     }
 
+    /**
+     * Returns initial permit count of the Semaphore
+     */
+    public int getInitialPermits() {
+        return initialPermits;
+    }
+
+    /**
+     * Sets initial permit count of the Semaphore
+     */
+    public SemaphoreConfig setInitialPermits(int initialPermits) {
+        checkNotNegative(initialPermits, "initial permits cannot be negative");
+        this.initialPermits = initialPermits;
+        return this;
+    }
+
     @Override
     public String toString() {
-        return "SemaphoreConfig{" + "name='" + name + ", jdkCompatible=" + jdkCompatible + '\'' + '}';
+        return "SemaphoreConfig{" + "name='" + name + '\'' + ", jdkCompatible=" + jdkCompatible + ", initialPermits="
+                + initialPermits + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreService.java
@@ -50,10 +50,6 @@ public class SemaphoreService extends AbstractBlockingService<AcquireInvocationK
         super(nodeEngine);
     }
 
-    private SemaphoreConfig getConfig(String name) {
-        return nodeEngine.getConfig().getCPSubsystemConfig().findSemaphoreConfig(name);
-    }
-
     public boolean initSemaphore(CPGroupId groupId, String name, int permits) {
         try {
             Collection<AcquireInvocationKey> acquired = getOrInitRegistry(groupId).init(name, permits);
@@ -65,8 +61,12 @@ public class SemaphoreService extends AbstractBlockingService<AcquireInvocationK
         }
     }
 
+    private SemaphoreConfig getConfig(String name) {
+        return nodeEngine.getConfig().getCPSubsystemConfig().findSemaphoreConfig(name);
+    }
+
     public int availablePermits(CPGroupId groupId, String name) {
-        SemaphoreRegistry registry = getRegistryOrNull(groupId);
+        SemaphoreRegistry registry = getOrInitRegistry(groupId);
         return registry != null ? registry.availablePermits(name) : 0;
     }
 
@@ -157,7 +157,12 @@ public class SemaphoreService extends AbstractBlockingService<AcquireInvocationK
 
     @Override
     protected SemaphoreRegistry createNewRegistry(CPGroupId groupId) {
-        return new SemaphoreRegistry(groupId);
+        return new SemaphoreRegistry(groupId, raftService.getConfig());
+    }
+
+    @Override
+    protected void onRegistryRestored(SemaphoreRegistry registry) {
+        registry.setCpSubsystemConfig(raftService.getConfig());
     }
 
     @Override

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -4675,6 +4675,15 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="initial-permits" type="xs:unsignedInt" minOccurs="0" maxOccurs="1"
+                        default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of permits to initialize the Semaphore. If a positive value is
+                        set, the Semaphore is initialized with the given number of permits.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
     </xs:complexType>
 

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3293,10 +3293,12 @@
             <semaphore>
                 <name>sem1</name>
                 <jdk-compatible>true</jdk-compatible>
+                <initial-permits>1</initial-permits>
             </semaphore>
             <semaphore>
                 <name>sem2</name>
                 <jdk-compatible>false</jdk-compatible>
+                <initial-permits>2</initial-permits>
             </semaphore>
         </semaphores>
         <locks>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3224,8 +3224,10 @@ hazelcast:
     semaphores:
       sem1:
         jdk-compatible: true
+        initial-permits: 1
       sem2:
         jdk-compatible: false
+        initial-permits: 2
     locks:
       lock1:
         lock-acquire-limit: 1

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -586,6 +586,10 @@ public class ConfigCompatibilityChecker {
                 if (e.getValue().isJDKCompatible() != s2.isJDKCompatible()) {
                     return false;
                 }
+
+                if (e.getValue().getInitialPermits() != s2.getInitialPermits()) {
+                    return false;
+                }
             }
 
             Map<String, FencedLockConfig> locks1 = c1.getLockConfigs();

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1439,8 +1439,8 @@ public class ConfigXmlGeneratorTest {
                 .setAppendRequestBackoffTimeoutInMillis(50);
 
         config.getCPSubsystemConfig()
-                .addSemaphoreConfig(new SemaphoreConfig("sem1", true))
-                .addSemaphoreConfig(new SemaphoreConfig("sem2", false));
+                .addSemaphoreConfig(new SemaphoreConfig("sem1", true, 1))
+                .addSemaphoreConfig(new SemaphoreConfig("sem2", false, 2));
 
         config.getCPSubsystemConfig()
                 .addLockConfig(new FencedLockConfig("lock1", 1))

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3118,10 +3118,12 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    <semaphore>\n"
                 + "      <name>sem1</name>\n"
                 + "      <jdk-compatible>true</jdk-compatible>\n"
+                + "      <initial-permits>1</initial-permits>\n"
                 + "    </semaphore>\n"
                 + "    <semaphore>\n"
                 + "      <name>sem2</name>\n"
                 + "      <jdk-compatible>false</jdk-compatible>\n"
+                + "      <initial-permits>2</initial-permits>\n"
                 + "    </semaphore>\n"
                 + "  </semaphores>\n"
                 + "  <locks>\n"
@@ -3161,6 +3163,8 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertNotNull(semaphoreConfig2);
         assertTrue(semaphoreConfig1.isJDKCompatible());
         assertFalse(semaphoreConfig2.isJDKCompatible());
+        assertEquals(1, semaphoreConfig1.getInitialPermits());
+        assertEquals(2, semaphoreConfig2.getInitialPermits());
         FencedLockConfig lockConfig1 = cpSubsystemConfig.findLockConfig("lock1");
         FencedLockConfig lockConfig2 = cpSubsystemConfig.findLockConfig("lock2");
         assertNotNull(lockConfig1);

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3392,8 +3392,10 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    semaphores:\n"
                 + "      sem1:\n"
                 + "        jdk-compatible: true\n"
+                + "        initial-permits: 1\n"
                 + "      sem2:\n"
                 + "        jdk-compatible: false\n"
+                + "        initial-permits: 2\n"
                 + "    locks:\n"
                 + "      lock1:\n"
                 + "        lock-acquire-limit: 1\n"
@@ -3424,6 +3426,8 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertNotNull(semaphoreConfig2);
         assertTrue(semaphoreConfig1.isJDKCompatible());
         assertFalse(semaphoreConfig2.isJDKCompatible());
+        assertEquals(1, semaphoreConfig1.getInitialPermits());
+        assertEquals(2, semaphoreConfig2.getInitialPermits());
         FencedLockConfig lockConfig1 = cpSubsystemConfig.findLockConfig("lock1");
         FencedLockConfig lockConfig2 = cpSubsystemConfig.findLockConfig("lock2");
         assertNotNull(lockConfig1);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreAdvancedTest.java
@@ -141,7 +141,8 @@ public class SemaphoreAdvancedTest extends AbstractSemaphoreAdvancedTest {
         cpSubsystemConfig.setSessionTimeToLiveSeconds(10);
         cpSubsystemConfig.setSessionHeartbeatIntervalSeconds(1);
 
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, false);
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig();
+        semaphoreConfig.setName(objectName);
         cpSubsystemConfig.addSemaphoreConfig(semaphoreConfig);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreFailureTest.java
@@ -42,7 +42,7 @@ public abstract class SemaphoreFailureTest extends AbstractSemaphoreFailureTest 
     protected Config createConfig(int cpNodeCount, int groupSize) {
         Config config = super.createConfig(cpNodeCount, groupSize);
 
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, isJDKCompatible());
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, isJDKCompatible(), 0);
         config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreInitialPermitsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreInitialPermitsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.datastructures.semaphore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.cp.CPSubsystemConfig;
+import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.ISemaphore;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SemaphoreInitialPermitsTest extends HazelcastRaftTestSupport {
+
+    @Parameters(name = "cpSubsystemEnabled:{0}, jdkCompatible:{1}, initialPermits:{2}")
+    public static Collection<Object> parameters() {
+        return asList(
+                new Object[]{false, false, 0},
+                new Object[]{false, false, 1},
+                new Object[]{false, true, 0},
+                new Object[]{false, true, 1},
+                new Object[]{true, false, 0},
+                new Object[]{true, false, 1},
+                new Object[]{true, true, 0},
+                new Object[]{true, true, 1});
+    }
+
+    @Parameter(0)
+    public boolean cpSubsystemEnabled;
+
+    @Parameter(1)
+    public boolean jdkCompatible;
+
+    @Parameter(2)
+    public int initialPermits;
+
+    private final String objectName = "semaphore1";
+
+    private ISemaphore semaphore;
+
+    @Before
+    public void init() {
+        factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = newInstances(3, 3, 0);
+        semaphore = instances[0].getCPSubsystem().getSemaphore(objectName);
+    }
+
+    @Test
+    public void testSemaphoreAlreadyInitialized() {
+        assumeTrue(initialPermits > 0);
+
+        assertTrue(semaphore.availablePermits() > 0);
+        assertFalse(semaphore.init(10));
+    }
+
+    @Test
+    public void testSemaphoreInit() {
+        assumeTrue(initialPermits == 0);
+
+        assertEquals(0, semaphore.availablePermits());
+        assertTrue(semaphore.init(10));
+    }
+
+    @Override
+    protected Config createConfig(int cpNodeCount, int groupSize) {
+        Config config = super.createConfig(cpNodeCount, groupSize);
+        CPSubsystemConfig cpSubsystemConfig = config.getCPSubsystemConfig();
+
+        if (cpSubsystemEnabled) {
+            cpSubsystemConfig.setCPMemberCount(cpNodeCount).setGroupSize(groupSize);
+        }
+
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, jdkCompatible, initialPermits);
+        cpSubsystemConfig.addSemaphoreConfig(semaphoreConfig);
+        return config;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreBasicTest.java
@@ -57,7 +57,8 @@ public class SessionAwareSemaphoreBasicTest extends AbstractSessionAwareSemaphor
     protected Config createConfig(int cpNodeCount, int groupSize) {
         Config config = super.createConfig(cpNodeCount, groupSize);
 
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, false);
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig();
+        semaphoreConfig.setName(objectName);
         config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionlessSemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionlessSemaphoreBasicTest.java
@@ -51,7 +51,7 @@ public class SessionlessSemaphoreBasicTest extends AbstractSessionlessSemaphoreB
     protected Config createConfig(int cpNodeCount, int groupSize) {
         Config config = super.createConfig(cpNodeCount, groupSize);
 
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, true);
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, true, 0);
         config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSemaphoreAdvancedTest.java
@@ -68,7 +68,8 @@ public class UnsafeSemaphoreAdvancedTest extends AbstractSemaphoreAdvancedTest {
         cpSubsystemConfig.setSessionTimeToLiveSeconds(10);
         cpSubsystemConfig.setSessionHeartbeatIntervalSeconds(1);
 
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, false);
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig();
+        semaphoreConfig.setName(objectName);
         cpSubsystemConfig.addSemaphoreConfig(semaphoreConfig);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSemaphoreFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSemaphoreFailureTest.java
@@ -42,7 +42,7 @@ public abstract class UnsafeSemaphoreFailureTest extends AbstractSemaphoreFailur
     @Override
     protected HazelcastInstance[] createInstances() {
         Config config = new Config();
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, isJDKCompatible());
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, isJDKCompatible(), 0);
         config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
         return factory.newInstances(config, 2);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSessionAwareSemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSessionAwareSemaphoreBasicTest.java
@@ -60,7 +60,8 @@ public class UnsafeSessionAwareSemaphoreBasicTest extends AbstractSessionAwareSe
     @Override
     protected HazelcastInstance[] createInstances() {
         Config config = new Config();
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, false);
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName);
+        semaphoreConfig.setName(objectName);
         config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
         return factory.newInstances(config, 2);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSessionlessSemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/UnsafeSessionlessSemaphoreBasicTest.java
@@ -40,7 +40,7 @@ public class UnsafeSessionlessSemaphoreBasicTest extends AbstractSessionlessSema
     @Override
     protected HazelcastInstance[] createInstances() {
         Config config = new Config();
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, true);
+        SemaphoreConfig semaphoreConfig = new SemaphoreConfig(objectName, true, 0);
         config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
         return factory.newInstances(config, 2);
     }


### PR DESCRIPTION
Semaphores can be configured with initial number of permits and can be
used without calling init().

Fixes #15208