### PR TITLE
Move WanPublisherState to wan package from config

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -102,7 +102,7 @@ import com.hazelcast.config.VaultSecureStoreConfig;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
 import com.hazelcast.config.WanConsumerConfig;
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -39,6 +39,7 @@ import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.query.impl.IndexUtils;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import com.hazelcast.wan.WanPublisherState;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanBatchReplicationPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanBatchReplicationPublisherConfig.java
@@ -19,6 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.wan.WanPublisherState;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -33,6 +33,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.version.Version;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.wan.impl.AddWanConfigResult;
 import com.hazelcast.wan.impl.WanReplicationService;
 
@@ -530,7 +531,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
      * @param command the HTTP command
      * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
      *                                      named character encoding is not supported
-     * @see com.hazelcast.config.WanPublisherState#PAUSED
+     * @see WanPublisherState#PAUSED
      */
     private void handleWanPausePublisher(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
@@ -557,7 +558,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
      * @param command the HTTP command
      * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
      *                                      named character encoding is not supported
-     * @see com.hazelcast.config.WanPublisherState#STOPPED
+     * @see WanPublisherState#STOPPED
      */
     private void handleWanStopPublisher(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
@@ -584,7 +585,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
      * @param command the HTTP command
      * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
      *                                      named character encoding is not supported
-     * @see com.hazelcast.config.WanPublisherState#REPLICATING
+     * @see WanPublisherState#REPLICATING
      */
     private void handleWanResumePublisher(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTO.java
@@ -26,7 +26,7 @@ import com.hazelcast.config.KubernetesConfig;
 import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.operation;
 
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.spi.impl.operationservice.AbstractLocalOperation;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.wan.impl.WanReplicationService;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.request;
 
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ChangeWanStateOperation;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -17,7 +17,7 @@
 
 package com.hazelcast.monitor;
 
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.wan.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
 import com.hazelcast.wan.WanSyncStats;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
@@ -17,7 +17,7 @@
 
 package com.hazelcast.monitor.impl;
 
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.wan.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanPublisherState.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanPublisherState.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.config;
+package com.hazelcast.wan;
 
 import com.hazelcast.wan.impl.WanReplicationService;
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -43,6 +43,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import com.hazelcast.wan.WanPublisherState;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/hazelcast/src/test/java/com/hazelcast/config/WanBatchReplicationPublisherConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanBatchReplicationPublisherConfigTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.wan.WanPublisherState;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import com.hazelcast.wan.WanPublisherState;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import com.hazelcast.wan.WanPublisherState;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management;
 
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.management.request.ChangeWanStateRequest;
 import com.hazelcast.internal.json.JsonObject;
@@ -29,9 +29,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.config.WanPublisherState.PAUSED;
-import static com.hazelcast.config.WanPublisherState.REPLICATING;
-import static com.hazelcast.config.WanPublisherState.STOPPED;
+import static com.hazelcast.wan.WanPublisherState.PAUSED;
+import static com.hazelcast.wan.WanPublisherState.REPLICATING;
+import static com.hazelcast.wan.WanPublisherState.STOPPED;
 import static com.hazelcast.internal.util.JsonUtil.getString;
 import static org.junit.Assert.assertNotEquals;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTOTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.config.KubernetesConfig;
 import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.monitor.impl;
 
 
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.test.HazelcastParallelClassRunner;


### PR DESCRIPTION
Moving `WanPublisherState` from `com.hazelcast.config` to
`com.hazelcast.wan`. The enum is used to configure initial publisher
state of `WanBatchReplicationPublisherConfig`. Besides that, the same
enum is used internally the WAN implementation and on
`LocalWanPublisherStats` too, therefore it fits better in the wan
package than in config.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3243