### PR TITLE
Disables write-through and selection key wakeup with SELECT_WITH_FIX

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -164,12 +164,12 @@ public final class ClientProperty {
      * can be done correctly. This property sets the window the concurrency detection will signalling
      * that concurrency has been detected, even if there are no further updates in that window.
      *
-     * Normally in a concurrency system the windows keeps sliding forward so it will always remain
+     * Normally in a concurrent system the window keeps sliding forward so it will always remain
      * concurrent.
      *
-     * Setting it too high effectively disabled the optimization because once concurrency has been detected
+     * Setting it too high effectively disables the optimization because once concurrency has been detected
      * it will keep that way. Setting it too low could lead to suboptimal performance because the system
-     * will try write through and other optimization even though the system is concurrent.
+     * will try write through and other optimizations even though the system is concurrent.
      */
     public static final HazelcastProperty CONCURRENT_WINDOW_MS
             = new HazelcastProperty("hazelcast.client.concurrent.window.ms", 100, MILLISECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -292,12 +292,12 @@ public final class ClusterProperty {
      * This property sets the window the concurrency detection will signalling
      * that concurrency has been detected, even if there are no further updates in that window.
      *
-     * Normally in a concurrency system the windows keeps sliding forward so it will always remain
+     * Normally in a concurrent system the window keeps sliding forward so it will always remain
      * concurrent.
      *
-     * Setting it too high effectively disabled the optimization because once concurrency has been detected
+     * Setting it too high effectively disables the optimization because once concurrency has been detected
      * it will keep that way. Setting it too low could lead to suboptimal performance because the system
-     * will try write through and other optimization even though the system is concurrent.
+     * will try write through and other optimizations even though the system is concurrent.
      */
     public static final HazelcastProperty CONCURRENT_WINDOW_MS
             = new HazelcastProperty("hazelcast.concurrent.window.ms", 100, MILLISECONDS);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioNetworkingConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioNetworkingConfigurationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Tests configuration of write-through and selection key wake-up optimizations
+// with different selector modes.
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class NioNetworkingConfigurationTest {
+
+    @Parameterized.Parameters(name = "selectorMode={0},configured={1},expected={2}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]
+                {
+                        // selector mode, configured value, expected value
+                        {SelectorMode.SELECT, false, false},
+                        {SelectorMode.SELECT, true, true},
+                        {SelectorMode.SELECT_NOW, false, false},
+                        {SelectorMode.SELECT_NOW, true, true},
+                        {SelectorMode.SELECT_WITH_FIX, false, false},
+                        {SelectorMode.SELECT_WITH_FIX, true, false},
+                }
+        );
+    }
+
+    @Parameterized.Parameter
+    public SelectorMode selectorMode;
+
+    @Parameterized.Parameter(1)
+    public boolean configuredValue;
+
+    @Parameterized.Parameter(2)
+    public boolean expectedValue;
+
+    private NioNetworking.Context ctx;
+    private LoggingService loggingService;
+    private ILogger logger;
+
+    @Before
+    public void setup() {
+        loggingService = mock(LoggingService.class);
+        logger = mock(ILogger.class);
+        when(loggingService.getLogger(ArgumentMatchers.any(Class.class)))
+                .thenReturn(logger);
+
+        ctx = new NioNetworking.Context();
+        ctx.loggingService(loggingService);
+    }
+
+    @Test
+    public void testOptimizationsConfiguration() {
+        ctx.writeThroughEnabled(configuredValue)
+           .selectionKeyWakeupEnabled(configuredValue)
+           .selectorMode(selectorMode);
+        NioNetworking networking = new NioNetworking(ctx);
+
+        Assert.assertEquals(expectedValue, networking.isSelectionKeyWakeupEnabled());
+        Assert.assertEquals(expectedValue, networking.isWriteThroughEnabled());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_BasicTest.java
@@ -20,13 +20,11 @@ import com.hazelcast.internal.nio.tcp.TcpIpConnection_AbstractBasicTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-@Ignore
 public class SelectWithSelectorFix_TcpIpConnection_BasicTest
         extends TcpIpConnection_AbstractBasicTest {
 


### PR DESCRIPTION
Selector mode `SELECT_WITH_FIX` requires that a single thread accesses
the selector and its selection keys. This does not hold true when
write-through or selection key wake up optimizations are enabled, so
when `SELECT_WITH_FIX` selector mode is used, above optimizations are
disabled and a warning is logged.

Fixes #15706 
Fixes #15628 
Fixes #15840
Fixes #15983
Fixes #15941