### PR TITLE
Rename CPSubsystemManagementService.restart() to .reset()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
@@ -321,7 +321,7 @@ import java.util.UUID;
  * Otherwise, it means that CP Subsystem has lost its majority irrevocably.
  * </strong> In this case, the only solution is to wipe-out the whole CP
  * Subsystem state by performing a force-reset via
- * {@link CPSubsystemManagementService#restart()}.</li>
+ * {@link CPSubsystemManagementService#reset()}.</li>
  * </ul>
  * <p>
  * <strong>When {@link CPSubsystemConfig#getCPMemberCount()} is greater than
@@ -355,7 +355,7 @@ import java.util.UUID;
  * management tasks can be performed on CP Subsystem. For instance, a new CP
  * group cannot be created. The only solution is to perform a force-reset
  * which wipes-out the whole CP Subsystem state via
- * {@link CPSubsystemManagementService#restart()}.</li>
+ * {@link CPSubsystemManagementService#reset()}.</li>
  * </ul>
  *
  * @see CPSubsystemConfig

--- a/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystemManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystemManagementService.java
@@ -227,7 +227,7 @@ public interface CPSubsystemManagementService {
      * <strong>Use with caution:
      * This method is NOT idempotent and multiple invocations can break
      * the whole system! After calling this API, you must observe the system
-     * to see if the restart process is successfully completed or failed
+     * to see if the reset process is successfully completed or failed
      * before making another call.</strong>
      *
      * @throws IllegalStateException When this method is called on
@@ -236,7 +236,7 @@ public interface CPSubsystemManagementService {
      *         is smaller than {@link CPSubsystemConfig#getCPMemberCount()}
      *
      */
-    CompletionStage<Void> restart();
+    CompletionStage<Void> reset();
 
     /**
      * Returns whether the CP discovery process is completed or not.

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftServiceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftServiceDataSerializerHook.java
@@ -22,7 +22,7 @@ import com.hazelcast.cp.internal.operation.DefaultRaftReplicateOp;
 import com.hazelcast.cp.internal.operation.DestroyRaftGroupOp;
 import com.hazelcast.cp.internal.operation.GetLeadedGroupsOp;
 import com.hazelcast.cp.internal.operation.RaftQueryOp;
-import com.hazelcast.cp.internal.operation.RestartCPMemberOp;
+import com.hazelcast.cp.internal.operation.ResetCPMemberOp;
 import com.hazelcast.cp.internal.operation.unsafe.UnsafeRaftBackupOp;
 import com.hazelcast.cp.internal.operation.unsafe.UnsafeRaftQueryOp;
 import com.hazelcast.cp.internal.operation.unsafe.UnsafeRaftReplicateOp;
@@ -111,7 +111,7 @@ public final class RaftServiceDataSerializerHook implements DataSerializerHook {
     public static final int GET_RAFT_GROUP_IDS_OP = 37;
     public static final int GET_ACTIVE_RAFT_GROUP_IDS_OP = 38;
     public static final int RAFT_PRE_JOIN_OP = 39;
-    public static final int RESTART_CP_MEMBER_OP = 40;
+    public static final int RESET_CP_MEMBER_OP = 40;
     public static final int GROUP_MEMBERSHIP_CHANGE = 41;
     public static final int UNSAFE_RAFT_REPLICATE_OP = 42;
     public static final int UNSAFE_RAFT_QUERY_OP = 43;
@@ -212,8 +212,8 @@ public final class RaftServiceDataSerializerHook implements DataSerializerHook {
                     return new GetActiveRaftGroupIdsOp();
                 case RAFT_PRE_JOIN_OP:
                     return new RaftServicePreJoinOp();
-                case RESTART_CP_MEMBER_OP:
-                    return new RestartCPMemberOp();
+                case RESET_CP_MEMBER_OP:
+                    return new ResetCPMemberOp();
                 case GROUP_MEMBERSHIP_CHANGE:
                     return new CPGroupMembershipChange();
                 case UNSAFE_RAFT_REPLICATE_OP:

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/ResetCPMemberOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/ResetCPMemberOp.java
@@ -33,14 +33,14 @@ import static com.hazelcast.spi.impl.executionservice.ExecutionService.SYSTEM_EX
 /**
  * Resets CP state of a member and restarts CP Subsystem initialization process
  */
-public class RestartCPMemberOp extends Operation implements RaftSystemOperation, IdentifiedDataSerializable {
+public class ResetCPMemberOp extends Operation implements RaftSystemOperation, IdentifiedDataSerializable {
 
     private long seed;
 
-    public RestartCPMemberOp() {
+    public ResetCPMemberOp() {
     }
 
-    public RestartCPMemberOp(long seed) {
+    public ResetCPMemberOp(long seed) {
         this.seed = seed;
     }
 
@@ -51,21 +51,21 @@ public class RestartCPMemberOp extends Operation implements RaftSystemOperation,
 
     private final class OffloadImpl extends Offload {
         private OffloadImpl() {
-            super(RestartCPMemberOp.this);
+            super(ResetCPMemberOp.this);
         }
 
         @Override
         public void start() {
-            getNodeEngine().getExecutionService().execute(SYSTEM_EXECUTOR, new RestartLocalTask());
+            getNodeEngine().getExecutionService().execute(SYSTEM_EXECUTOR, new ResetLocalTask());
         }
     }
 
-    private class RestartLocalTask implements Runnable {
+    private class ResetLocalTask implements Runnable {
         @Override
         public void run() {
             RaftService service = getService();
             try {
-                service.restartLocal(seed);
+                service.resetLocal(seed);
                 sendResponse(null);
             } catch (Exception e) {
                 sendResponse(e);
@@ -90,7 +90,7 @@ public class RestartCPMemberOp extends Operation implements RaftSystemOperation,
 
     @Override
     public int getClassId() {
-        return RaftServiceDataSerializerHook.RESTART_CP_MEMBER_OP;
+        return RaftServiceDataSerializerHook.RESET_CP_MEMBER_OP;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -69,7 +69,7 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
 
     // CP Subsystem
     public static final String URI_CP_SUBSYSTEM_BASE_URL = "/hazelcast/rest/cp-subsystem";
-    public static final String URI_RESTART_CP_SUBSYSTEM_URL = URI_CP_SUBSYSTEM_BASE_URL + "/restart";
+    public static final String URI_RESET_CP_SUBSYSTEM_URL = URI_CP_SUBSYSTEM_BASE_URL + "/reset";
     public static final String URI_CP_GROUPS_URL = URI_CP_SUBSYSTEM_BASE_URL + "/groups";
     public static final String URI_CP_SESSIONS_SUFFIX = "/sessions";
     public static final String URI_REMOVE_SUFFIX = "/remove";

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -120,8 +120,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             } else if (uri.startsWith(URI_CP_GROUPS_URL)) {
                 handleCPGroup(command);
                 sendResponse = false;
-            } else if (uri.startsWith(URI_RESTART_CP_SUBSYSTEM_URL)) {
-                handleResetAndInitCPSubsystem(command);
+            } else if (uri.startsWith(URI_RESET_CP_SUBSYSTEM_URL)) {
+                handleResetCPSubsystem(command);
                 sendResponse = false;
             } else if (uri.startsWith(URI_LICENSE_INFO)) {
                 handleSetLicense(command);
@@ -743,10 +743,10 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                         });
     }
 
-    private void handleResetAndInitCPSubsystem(final HttpPostCommand command) throws UnsupportedEncodingException {
+    private void handleResetCPSubsystem(final HttpPostCommand command) throws UnsupportedEncodingException {
         if (checkCredentials(command)) {
             getCpSubsystem().getCPSubsystemManagementService()
-                            .restart()
+                            .reset()
                             .whenCompleteAsync((response, t) -> {
                                 if (t == null) {
                                     command.send200();

--- a/hazelcast/src/main/resources/cp-subsystem.sh
+++ b/hazelcast/src/main/resources/cp-subsystem.sh
@@ -26,7 +26,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "     It must be called only when a CP group loses its majority."
     echo "     All CP data structure proxies created before the force-destroy step will fail."
     echo "     If you create a new proxy for a CP data structure that is mapped to the destroyed CP group, the CP group will be initialized from scratch."
-    echo "     Please note that you cannot force-destroy the METADATA CP group. If you lose majority of the METADATA CP group, you have to restart the CP subsystem."
+    echo "     Please note that you cannot force-destroy the METADATA CP group. If you lose majority of the METADATA CP group, you have to reset CP Subsystem."
     echo "  - 'get-members' returns the list of active CP members in the cluster."
     echo "     Please note that even if a CP member has left the cluster, it is not automatically removed from the active CP member list immediately."
     echo "  - 'remove-member' removes the given CP member (-m) from the active CP member list."
@@ -37,7 +37,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "  - 'force-close-session' closes the given CP session (-s) on the given CP group (-c)."
     echo "     Once the CP session is closed, all CP resources (locks, semaphore permits, etc.) will be released."
     echo "     Before force-closing a CP session, please make sure that owner endpoint of the CP session is crashed and will not show up."
-    echo "  - 'restart' wipes out all CP subsystem state and restarts it from scratch."
+    echo "  - 'reset' wipes out all CP subsystem state and restarts it from scratch."
     echo "     Please call this API only on the Hazelcast master member (i.e., the first member in the Hazelcast cluster member list)."
     echo "     Please make sure that you call this API only once. Once you make the call, please observe the cluster to see if the CP subsystem initialization is successful."
     echo "If you query a non-existing CP group or a CP session, the call fails with 'Not found'."
@@ -352,9 +352,9 @@ if [[ "$OPERATION" = "force-close-session" ]]; then
     exit ${INTERNAL_ERROR_RETURN_VALUE}
 fi
 
-if [[ "$OPERATION" = "restart" ]]; then
-    echo "Restarting the CP subsystem on ${ADDRESS}:${PORT}."
-    response=$(${CURL_CMD} --data "${CLUSTERNAME}&${PASSWORD}" "${URL_BASE}/restart")
+if [[ "$OPERATION" = "reset" ]]; then
+    echo "Resetting the CP subsystem on ${ADDRESS}:${PORT}."
+    response=$(${CURL_CMD} --data "${CLUSTERNAME}&${PASSWORD}" "${URL_BASE}/reset")
     json=$(echo "$response" | head -n 1)
     status_code=$(echo "$response" | tail -n1)
 
@@ -371,5 +371,5 @@ if [[ "$OPERATION" = "restart" ]]; then
     exit ${INTERNAL_ERROR_RETURN_VALUE}
 fi
 
-echo "Not a valid CP subsystem operation! Operations: 'get-local-member' | 'get-groups' || 'get-group' || 'force-destroy-group' || 'get-members' || 'remove-member' || 'promote-member' || 'get-sessions' || 'force-close-session' || 'restart'"
+echo "Not a valid CP subsystem operation! Operations: 'get-local-member' | 'get-groups' || 'get-group' || 'force-destroy-group' || 'get-members' || 'remove-member' || 'promote-member' || 'get-sessions' || 'force-close-session' || 'reset'"
 exit ${INVALID_ARGUMENT_RETURN_VALUE}

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
@@ -73,8 +73,7 @@ public class FencedLockClientBasicTest extends FencedLockBasicTest {
     public void test_sessionIsClosedOnCPSubsystemReset() throws Exception {
         lock.lock();
 
-        instances[0].getCPSubsystem().getCPSubsystemManagementService().restart()
-                    .toCompletableFuture().get();
+        instances[0].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -298,8 +298,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         newInstances[2] = factory.newHazelcastInstance(config);
 
         assertClusterSizeEventually(3, newInstances);
-        newInstances[0].getCPSubsystem().getCPSubsystemManagementService().restart()
-                       .toCompletableFuture().get();
+        newInstances[0].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
         waitUntilCPDiscoveryCompleted(newInstances);
 
         long newGroupIdSeed = getRaftService(newInstances[0]).getMetadataGroupManager().getGroupIdSeed();
@@ -347,8 +346,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         instances[1] = factory.newHazelcastInstance(config);
         instances[2] = factory.newHazelcastInstance(config);
 
-        instance.getCPSubsystem().getCPSubsystemManagementService().restart()
-                .toCompletableFuture().get();
+        instance.getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
 
         List<CPMemberInfo> newEndpoints = getRaftInvocationManager(instance).<List<CPMemberInfo>>query(getMetadataGroupId(instance),
                 new GetActiveCPMembersOp(), LINEARIZABLE).get();
@@ -367,8 +365,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         Config config = createConfig(3, 3);
         instances[0] = factory.newHazelcastInstance(config);
 
-        instances[1].getCPSubsystem().getCPSubsystemManagementService().restart()
-                    .toCompletableFuture().get();
+        instances[1].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
 
         List<CPMemberInfo> newEndpoints = invocationManager.<List<CPMemberInfo>>query(getMetadataGroupId(instances[2]),
                 new GetActiveCPMembersOp(), LINEARIZABLE).get();
@@ -556,8 +553,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         FencedLock lock = instances[3].getCPSubsystem().getLock("lock");
         lock.lock();
 
-        instances[0].getCPSubsystem().getCPSubsystemManagementService().restart()
-                    .toCompletableFuture().get();
+        instances[0].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             ProxySessionManagerService service = getNodeEngineImpl(instances[3]).getService(ProxySessionManagerService.SERVICE_NAME);
@@ -723,7 +719,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         assertClusterSizeEventually(3, instances[0], newInstance1, newInstance2);
 
-        instances[0].getCPSubsystem().getCPSubsystemManagementService().restart().toCompletableFuture().get();
+        instances[0].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
 
         RaftGroupId newMetadataGroupId = getRaftService(instances[0]).getMetadataGroupId();
         assertTrue(newMetadataGroupId.getSeed() > INITIAL_METADATA_GROUP_ID.getSeed());
@@ -811,8 +807,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         assertClusterSizeEventually(3, instances[0], newInstance1, newInstance2);
 
-        instances[0].getCPSubsystem().getCPSubsystemManagementService().restart()
-                    .toCompletableFuture().get();
+        instances[0].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
 
         RaftGroupId newMetadataGroupId = getRaftService(instances[0]).getMetadataGroupId();
         assertTrue(newMetadataGroupId.getSeed() > INITIAL_METADATA_GROUP_ID.getSeed());

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.cp.CPGroup;
 import com.hazelcast.cp.CPGroup.CPGroupStatus;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPMember;
-import com.hazelcast.cp.internal.operation.RestartCPMemberOp;
+import com.hazelcast.cp.internal.operation.ResetCPMemberOp;
 import com.hazelcast.cp.internal.raft.impl.RaftEndpoint;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
 import com.hazelcast.cp.internal.raftop.metadata.CreateRaftGroupOp;
@@ -665,7 +665,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         for (HazelcastInstance instance : Arrays.copyOf(instances, nodeCount - 1)) {
             Address address = instance.getCluster().getLocalMember().getAddress();
             getNodeEngineImpl(instance).getOperationService()
-                                       .invokeOnTarget(RaftService.SERVICE_NAME, new RestartCPMemberOp(seed), address).get();
+                                       .invokeOnTarget(RaftService.SERVICE_NAME, new ResetCPMemberOp(seed), address).get();
         }
 
         // wait for the cp discovery process to start

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -353,7 +353,7 @@ public class HTTPCommunicator {
     }
 
     public ConnectionResponse restart(String clusterName, String groupPassword) throws IOException {
-        String url = address + "cp-subsystem/restart";
+        String url = address + "cp-subsystem/reset";
         return doPost(url, clusterName, groupPassword);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestCPSubsystemTest.java
@@ -35,7 +35,6 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -446,12 +445,9 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
 
         waitUntilCPDiscoveryCompleted(instance1, instance2, instance3, instance4);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                ConnectionResponse response = new HTTPCommunicator(instance4).promoteCPMember(clusterName, null);
-                assertEquals(200, response.responseCode);
-            }
+        assertTrueEventually(() -> {
+            ConnectionResponse response = new HTTPCommunicator(instance4).promoteCPMember(clusterName, null);
+            assertEquals(200, response.responseCode);
         });
 
         Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
@@ -494,7 +490,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_resetAndInit() throws ExecutionException, InterruptedException, IOException {
+    public void test_reset() throws ExecutionException, InterruptedException, IOException {
         HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
         Hazelcast.newHazelcastInstance(config);
         Hazelcast.newHazelcastInstance(config);
@@ -527,7 +523,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_resetAndInit_withInvalidCredentials() throws IOException {
+    public void test_reset_withInvalidCredentials() throws IOException {
         HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance instance3 = Hazelcast.newHazelcastInstance(config);


### PR DESCRIPTION
We have CPSubsystemManagementService.restart() to wipe-out and reset
the whole CP Subsystem in case of permanent loss of majority. After CP
Subsystem Persistence work is done, it turned out that .restart() is a
bad choice for this functionality because it creates confusion with
restarting CP members by using persistence. This PR renames this method
to .reset() to eliminate this confusion.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3249
Ref Manual PR: https://github.com/hazelcast/hazelcast-reference-manual/pull/735