### PR TITLE
[Test ClientClusterRestartEventTest.testSingleMemberRestart] Make test client not shutdown due to max connection attempt

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -75,7 +75,7 @@ public class ClientClusterRestartEventTest {
     public void testSingleMemberRestart() {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(newConfig());
         Member oldMember = instance.getCluster().getLocalMember();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(newClientConfig());
 
         final CountDownLatch memberAdded = new CountDownLatch(1);
         final CountDownLatch memberRemoved = new CountDownLatch(1);


### PR DESCRIPTION
Added client config to client instantiation do that connection is being retried indefinitely until the server comes up.

fixes https://github.com/hazelcast/hazelcast/issues/15203