### PR TITLE
Delay Raft node creation if local CP member is not initialized

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -750,6 +750,11 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
             return;
         }
 
+        if (getLocalCPMember() == null) {
+            logger.warning("Not creating Raft node for " + groupId + " because local CP member is not initialized yet.");
+            return;
+        }
+
         nodeLock.readLock().lock();
         try {
             if (destroyedGroupIds.contains(groupId)) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/NopCPMetadataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/NopCPMetadataStore.java
@@ -36,7 +36,7 @@ public final class NopCPMetadataStore implements CPMetadataStore {
 
     @Override
     public boolean tryMarkAPMember() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
On CP member promotion, a new CP member can create Raft nodes before its
local CP member field is not initialized yet. This can create
non-determinism problems for CP groups that rely on the local CP member
information (currently only the METADATA CP group). To prevent this,
Raft node creation is delayed until the local CP member field is
initialized.

This commit completes https://github.com/hazelcast/hazelcast/commit/7867abb117bf964a22cd204d29d54f28b54fe1e4