### PR TITLE
[BACKPORT] Only expose CompletionStage in public API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystemManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystemManagementService.java
@@ -19,10 +19,10 @@ package com.hazelcast.cp;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Collection;
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -105,13 +105,13 @@ public interface CPSubsystemManagementService {
     /**
      * Returns all active CP group ids.
      */
-    InternalCompletableFuture<Collection<CPGroupId>> getCPGroupIds();
+    CompletionStage<Collection<CPGroupId>> getCPGroupIds();
 
     /**
      * Returns the active CP group with the given name.
      * There can be at most one active CP group with a given name.
      */
-    InternalCompletableFuture<CPGroup> getCPGroup(String name);
+    CompletionStage<CPGroup> getCPGroup(String name);
 
     /**
      * Unconditionally destroys the given active CP group without using
@@ -133,12 +133,12 @@ public interface CPSubsystemManagementService {
      * This method is idempotent. It has no effect if the given CP group is
      * already destroyed.
      */
-    InternalCompletableFuture<Void> forceDestroyCPGroup(String groupName);
+    CompletionStage<Void> forceDestroyCPGroup(String groupName);
 
     /**
      * Returns the current list of CP members
      */
-    InternalCompletableFuture<Collection<CPMember>> getCPMembers();
+    CompletionStage<Collection<CPMember>> getCPMembers();
 
     /**
      * Promotes the local Hazelcast member to the CP role.
@@ -169,7 +169,7 @@ public interface CPSubsystemManagementService {
      * If the local member is a lite member, the returned {@code Future} object
      * throws {@link IllegalStateException}.
      */
-    InternalCompletableFuture<Void> promoteToCPMember();
+    CompletionStage<Void> promoteToCPMember();
 
     /**
      * Removes the given unreachable CP member from the active CP members list
@@ -188,7 +188,7 @@ public interface CPSubsystemManagementService {
      * @throws IllegalArgumentException if the given CP member is already
      *         removed from CP Subsystem
      */
-    InternalCompletableFuture<Void> removeCPMember(UUID cpMemberUuid);
+    CompletionStage<Void> removeCPMember(UUID cpMemberUuid);
 
     /**
      * Wipes and resets the whole CP Subsystem state and initializes it
@@ -236,7 +236,7 @@ public interface CPSubsystemManagementService {
      *         is smaller than {@link CPSubsystemConfig#getCPMemberCount()}
      *
      */
-    InternalCompletableFuture<Void> restart();
+    CompletionStage<Void> restart();
 
     /**
      * Returns whether the CP discovery process is completed or not.

--- a/hazelcast/src/main/java/com/hazelcast/cp/session/CPSessionManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/session/CPSessionManagementService.java
@@ -17,9 +17,9 @@
 package com.hazelcast.cp.session;
 
 import com.hazelcast.config.cp.CPSubsystemConfig;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Collection;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This interface offers API for managing CP sessions.
@@ -35,7 +35,7 @@ public interface CPSessionManagementService {
      * Returns a non-null collection of CP sessions that are currently active
      * in the given CP group.
      */
-    InternalCompletableFuture<Collection<CPSession>> getAllSessions(String groupName);
+    CompletionStage<Collection<CPSession>> getAllSessions(String groupName);
 
     /**
      * If a Hazelcast instance that owns a CP session crashes, its CP session
@@ -45,6 +45,6 @@ public interface CPSessionManagementService {
      * and actually crashed, this method can be used for closing the session and
      * releasing its resources immediately.
      */
-    InternalCompletableFuture<Boolean> forceCloseSession(String groupName, long sessionId);
+    CompletionStage<Boolean> forceCloseSession(String groupName, long sessionId);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.ascii.rest;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.cp.CPGroup;
@@ -36,10 +37,9 @@ import com.hazelcast.internal.nio.EndpointManager;
 import com.hazelcast.internal.nio.NetworkingService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.StringUtil;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Collection;
+import java.util.concurrent.CompletionStage;
 
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.MIME_TEXT_PLAIN;
@@ -192,7 +192,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
     }
 
     private void handleGetCPGroupIds(final HttpGetCommand command) {
-        InternalCompletableFuture<Collection<CPGroupId>> f = getCpSubsystemManagementService().getCPGroupIds();
+        CompletionStage<Collection<CPGroupId>> f = getCpSubsystemManagementService().getCPGroupIds();
         f.whenCompleteAsync((groupIds, t) -> {
             if (t == null) {
                 JsonArray arr = new JsonArray();
@@ -239,7 +239,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
     private void handleGetCPGroupByName(final HttpGetCommand command) {
         String prefix = URI_CP_GROUPS_URL + "/";
         String groupName = command.getURI().substring(prefix.length()).trim();
-        InternalCompletableFuture<CPGroup> f = getCpSubsystemManagementService().getCPGroup(groupName);
+        CompletionStage<CPGroup> f = getCpSubsystemManagementService().getCPGroup(groupName);
         f.whenCompleteAsync((group, t) -> {
             if (t == null) {
                 if (group != null) {
@@ -268,7 +268,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
     }
 
     private void handleGetCPMembers(final HttpGetCommand command) {
-        InternalCompletableFuture<Collection<CPMember>> f = getCpSubsystemManagementService().getCPMembers();
+        CompletionStage<Collection<CPMember>> f = getCpSubsystemManagementService().getCPMembers();
         f.whenCompleteAsync((cpMembers, t) -> {
             if (t == null) {
                 JsonArray arr = new JsonArray();

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
@@ -73,7 +73,8 @@ public class FencedLockClientBasicTest extends FencedLockBasicTest {
     public void test_sessionIsClosedOnCPSubsystemReset() throws Exception {
         lock.lock();
 
-        instances[0].getCPSubsystem().getCPSubsystemManagementService().restart().get();
+        instances[0].getCPSubsystem().getCPSubsystemManagementService().restart()
+                    .toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPGroupRebalanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPGroupRebalanceTest.java
@@ -62,7 +62,8 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
         createRaftGroups(instances, groupCount);
 
         HazelcastInstance metadataLeader = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
-        Collection<CPMember> cpMembers = metadataLeader.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = metadataLeader.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                                       .toCompletableFuture().get();
 
         rebalanceLeaderships(metadataLeader);
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPLiteMemberTest.java
@@ -72,7 +72,8 @@ public class CPLiteMemberTest extends HazelcastRaftTestSupport {
         assertTrue(awaitUntilDiscoveryCompleted(hz4_lite, 60));
         assertTrue(awaitUntilDiscoveryCompleted(hz5, 60));
 
-        Collection<CPMember> cpMembers = hz5.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = hz5.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                            .toCompletableFuture().get();
         // Lite members are not part of CP member list
         assertNotCpMember(hz2_lite, cpMembers);
         assertNotCpMember(hz4_lite, cpMembers);
@@ -101,13 +102,15 @@ public class CPLiteMemberTest extends HazelcastRaftTestSupport {
         assertTrue(awaitUntilDiscoveryCompleted(hz_lite, 60));
 
         try {
-            hz_lite.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().get();
+            hz_lite.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+                   .toCompletableFuture().get();
             fail("CP member promotion should have failed!");
         } catch (ExecutionException e) {
             assertInstanceOf(IllegalStateException.class, e.getCause());
         }
 
-        Collection<CPMember> cpMembers = hz1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = hz1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                            .toCompletableFuture().get();
         assertEquals(3, cpMembers.size());
         assertNotCpMember(hz_lite, cpMembers);
     }
@@ -125,9 +128,11 @@ public class CPLiteMemberTest extends HazelcastRaftTestSupport {
         assertTrue(awaitUntilDiscoveryCompleted(hz_lite, 60));
 
         hz_lite.getCluster().promoteLocalLiteMember();
-        hz_lite.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().get();
+        hz_lite.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+               .toCompletableFuture().get();
 
-        Collection<CPMember> cpMembers = hz1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = hz1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                            .toCompletableFuture().get();
         assertEquals(4, cpMembers.size());
 
         Set<Address> cpAddresses = cpMembers.stream().map(CPMember::getAddress).collect(Collectors.toSet());

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -287,7 +287,8 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         CPGroupId groupId = createNewRaftGroup(instances[0], "id", cpNodeCount);
 
-        CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup("id").get();
+        CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup("id")
+                                    .toCompletableFuture().get();
         assertNotNull(group);
         assertEquals(groupId, group.id());
 
@@ -342,7 +343,8 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         CPGroupId groupId = createNewRaftGroup(instances[0], "id", 3);
 
-        CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup("id").get();
+        CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup("id")
+                                    .toCompletableFuture().get();
         assertNotNull(group);
         assertEquals(groupId, group.id());
 
@@ -375,7 +377,8 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         CPGroupId groupId = createNewRaftGroup(instances[0], "id", 3);
 
-        CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup("id").get();
+        CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup("id")
+                                    .toCompletableFuture().get();
         assertNotNull(group);
         assertEquals(groupId, group.id());
 
@@ -694,8 +697,10 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
     private CPMember findCommonEndpoint(HazelcastInstance instance, CPGroupId groupId1, CPGroupId groupId2)
             throws ExecutionException, InterruptedException {
-        CPGroup group1 = instance.getCPSubsystem().getCPSubsystemManagementService().getCPGroup(groupId1.getName()).get();
-        CPGroup group2 = instance.getCPSubsystem().getCPSubsystemManagementService().getCPGroup(groupId2.getName()).get();
+        CPGroup group1 = instance.getCPSubsystem().getCPSubsystemManagementService().getCPGroup(groupId1.getName())
+                                 .toCompletableFuture().get();
+        CPGroup group2 = instance.getCPSubsystem().getCPSubsystemManagementService().getCPGroup(groupId2.getName())
+                                 .toCompletableFuture().get();
 
         Set<CPMember> members = new HashSet<>(group1.members());
         members.retainAll(group2.members());

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
@@ -75,7 +75,8 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
         instances[instances.length - 1].shutdown();
 
         HazelcastInstance instance = factory.newHazelcastInstance(createConfig(3, 3));
-        instance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().get();
+        instance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+                .toCompletableFuture().get();
 
         // Read from local CP member, which should install snapshot after promotion.
         assertTrueEventually(() -> {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatchAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatchAdvancedTest.java
@@ -123,7 +123,8 @@ public class CountDownLatchAdvancedTest extends AbstractCountDownLatchAdvancedTe
         instances[1].shutdown();
 
         HazelcastInstance newInstance = factory.newHazelcastInstance(createConfig(groupSize, groupSize));
-        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().get();
+        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+                   .toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             CountDownLatchService service = getNodeEngineImpl(newInstance).getService(CountDownLatchService.SERVICE_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockAdvancedTest.java
@@ -124,7 +124,8 @@ public class FencedLockAdvancedTest extends AbstractFencedLockAdvancedTest {
         instanceToShutdown.shutdown();
 
         HazelcastInstance newInstance = factory.newHazelcastInstance(createConfig(groupSize, groupSize));
-        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().get();
+        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+                   .toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             RaftNodeImpl raftNode = getRaftNode(newInstance, groupId);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
@@ -92,6 +92,7 @@ public class FencedLockBasicTest extends AbstractFencedLockBasicTest {
         instances[0].getCPSubsystem()
                     .getCPSubsystemManagementService()
                     .forceDestroyCPGroup(lock.getGroupId().getName())
+                    .toCompletableFuture()
                     .get();
 
         try {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreAdvancedTest.java
@@ -117,7 +117,8 @@ public class SemaphoreAdvancedTest extends AbstractSemaphoreAdvancedTest {
         instances[1].shutdown();
 
         HazelcastInstance newInstance = factory.newHazelcastInstance(createConfig(groupSize, groupSize));
-        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().get();
+        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+                   .toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             SemaphoreService service = getNodeEngineImpl(newInstance).getService(SemaphoreService.SERVICE_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestCPSubsystemTest.java
@@ -459,7 +459,8 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
             }
         });
 
-        Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                                  .toCompletableFuture().get();
         assertEquals(4, cpMembers.size());
         assertNotNull(instance4.getCPSubsystem().getLocalCPMember());
     }
@@ -475,7 +476,8 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
 
         assertEquals(403, response.responseCode);
 
-        Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                                  .toCompletableFuture().get();
         assertEquals(3, cpMembers.size());
     }
 
@@ -491,7 +493,8 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
 
         assertEquals(200, response.responseCode);
 
-        Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().get();
+        Collection<CPMember> cpMembers = instance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
+                                                  .toCompletableFuture().get();
         assertEquals(3, cpMembers.size());
     }
 
@@ -506,6 +509,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
         CPGroup cpGroup1 = instance1.getCPSubsystem()
                                     .getCPSubsystemManagementService()
                                     .getCPGroup(DEFAULT_GROUP_NAME)
+                                    .toCompletableFuture()
                                     .get();
 
         sleepAtLeastMillis(10);
@@ -518,6 +522,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
         CPGroup cpGroup2 = instance1.getCPSubsystem()
                                     .getCPSubsystemManagementService()
                                     .getCPGroup(DEFAULT_GROUP_NAME)
+                                    .toCompletableFuture()
                                     .get();
 
         RaftGroupId id1 = (RaftGroupId) cpGroup1.id();
@@ -573,7 +578,8 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
         Collection<CPSession> sessions1 = instance1.getCPSubsystem()
                                                   .getCPSessionManagementService()
                                                   .getAllSessions(DEFAULT_GROUP_NAME)
-                                                  .get();
+                                                   .toCompletableFuture()
+                                                   .get();
 
         assertEquals(1, sessions1.size());
 
@@ -586,6 +592,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
         Collection<CPSession> sessions2 = instance1.getCPSubsystem()
                                                    .getCPSessionManagementService()
                                                    .getAllSessions(DEFAULT_GROUP_NAME)
+                                                   .toCompletableFuture()
                                                    .get();
 
         assertEquals(0, sessions2.size());
@@ -603,6 +610,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
         Collection<CPSession> sessions1 = instance1.getCPSubsystem()
                                                    .getCPSessionManagementService()
                                                    .getAllSessions(DEFAULT_GROUP_NAME)
+                                                   .toCompletableFuture()
                                                    .get();
 
         assertEquals(1, sessions1.size());
@@ -616,6 +624,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
         Collection<CPSession> sessions2 = instance1.getCPSubsystem()
                                                    .getCPSessionManagementService()
                                                    .getAllSessions(DEFAULT_GROUP_NAME)
+                                                   .toCompletableFuture()
                                                    .get();
 
         assertEquals(1, sessions2.size());


### PR DESCRIPTION
`InternalCompletableFuture` is not meant to be used for public APIs;
some usages were inadvertently exposed in CP APIs. Those are now
replaced with `CompletionStage`.

(cherry picked from commit 01c57530d457b384e6d44155a0192361a44ed5ba)

Backport of #15797 
EE adaptation PR is required