### PR TITLE
Refactor mutation observers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -33,9 +33,7 @@ import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.QueryRunner;
 import com.hazelcast.map.impl.query.ResultProcessorRegistry;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
-import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.map.impl.recordstore.RecordStoreMutationObserver;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.PartitioningStrategy;
@@ -47,7 +45,6 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -191,18 +188,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
     UUID addLocalListenerAdapter(ListenerAdapter listenerAdaptor, String mapName);
 
     IndexCopyBehavior getIndexCopyBehavior();
-
-    /**
-     * Returns the collection of the {@link RecordStoreMutationObserver}s
-     * for the given map's partition that need to be added in record
-     * store construction time in order to ensure no {@link RecordStore}
-     * mutations are missed.
-     *
-     * @param mapName     The name of the map
-     * @param partitionId The partition
-     * @return The collection of the observers
-     */
-    Collection<RecordStoreMutationObserver<Record>> createRecordStoreMutationObservers(String mapName, int partitionId);
 
     ValueComparator getValueComparatorOf(InMemoryFormat inMemoryFormat);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
@@ -22,109 +22,117 @@ import com.hazelcast.nio.serialization.Data;
 import java.util.Collection;
 import java.util.LinkedList;
 
-class CompositeRecordStoreMutationObserver<R extends Record> implements RecordStoreMutationObserver<R> {
+import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
 
-    private final Collection<RecordStoreMutationObserver<R>> mutationObservers = new LinkedList<>();
+class CompositeMutationObserver<R extends Record> implements MutationObserver<R> {
 
-    CompositeRecordStoreMutationObserver(Collection<RecordStoreMutationObserver<R>> mutationObservers) {
-        this.mutationObservers.addAll(mutationObservers);
+    private Collection<MutationObserver<R>> mutationObservers;
+
+    CompositeMutationObserver() {
+    }
+
+    void add(MutationObserver<R> mutationObserver) {
+        if (mutationObservers == null) {
+            mutationObservers = new LinkedList<>();
+        }
+        mutationObservers.add(mutationObserver);
     }
 
     @Override
     public void onClear() {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onClear();
         }
     }
 
     @Override
     public void onPutRecord(Data key, R record) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onPutRecord(key, record);
         }
     }
 
     @Override
     public void onReplicationPutRecord(Data key, R record) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onReplicationPutRecord(key, record);
         }
     }
 
     @Override
     public void onUpdateRecord(Data key, R record, Object newValue) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onUpdateRecord(key, record, newValue);
         }
     }
 
     @Override
     public void onRemoveRecord(Data key, R record) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onRemoveRecord(key, record);
         }
     }
 
     @Override
     public void onEvictRecord(Data key, R record) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onEvictRecord(key, record);
         }
     }
 
     @Override
     public void onLoadRecord(Data key, R record) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onLoadRecord(key, record);
         }
     }
 
     @Override
     public void onDestroy(boolean internal) {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onDestroy(internal);
         }
     }
 
     @Override
     public void onReset() {
-        if (mutationObservers.isEmpty()) {
+        if (isEmpty(mutationObservers)) {
             return;
         }
 
-        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+        for (MutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onReset();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1300,7 +1300,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
      * only releases internal resources of backing data structure.
      *
      * @param isDuringShutdown {@link Storage#clear(boolean)}
-     * @param internal         see {@link RecordStoreMutationObserver#onDestroy(boolean)}}
+     * @param internal         see {@link MutationObserver#onDestroy(boolean)}}
      */
     public void destroyStorageAfterClear(boolean isDuringShutdown, boolean internal) {
         clearStorage(isDuringShutdown);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
@@ -23,14 +23,14 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.services.ObjectNamespace;
 
-public class EventJournalWriterRecordStoreMutationObserver implements RecordStoreMutationObserver {
+public class EventJournalWriterMutationObserver implements MutationObserver {
     private final MapEventJournal eventJournal;
     private final int partitionId;
     private final EventJournalConfig eventJournalConfig;
     private final ObjectNamespace objectNamespace;
 
-    public EventJournalWriterRecordStoreMutationObserver(MapEventJournal eventJournal, MapContainer mapContainer,
-                                                         int partitionId) {
+    public EventJournalWriterMutationObserver(MapEventJournal eventJournal, MapContainer mapContainer,
+                                              int partitionId) {
         this.eventJournal = eventJournal;
         this.partitionId = partitionId;
         this.eventJournalConfig = mapContainer.getEventJournalConfig();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl.recordstore;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MetadataInitializer;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
@@ -34,13 +34,13 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
  * no need for removing metadata on remove events because metadata is
  * stored inside record. It is removed with the record.
  */
-public class JsonMetadataRecordStoreMutationObserver implements RecordStoreMutationObserver<Record> {
+public class JsonMetadataMutationObserver implements MutationObserver<Record> {
 
-    private InternalSerializationService serializationService;
+    private SerializationService serializationService;
     private MetadataInitializer metadataInitializer;
 
-    public JsonMetadataRecordStoreMutationObserver(InternalSerializationService serializationService,
-                                                   MetadataInitializer metadataInitializer) {
+    public JsonMetadataMutationObserver(SerializationService serializationService,
+                                        MetadataInitializer metadataInitializer) {
         this.serializationService = serializationService;
         this.metadataInitializer = metadataInitializer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
  *
  * @param <R> The type of the records in the observed {@link RecordStore}
  */
-public interface RecordStoreMutationObserver<R extends Record> {
+public interface MutationObserver<R extends Record> {
     /**
      * Called if the observed {@link RecordStore} is cleared
      */


### PR DESCRIPTION
ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3254

Change List:
- Renamed `RecordStoreMutationObserver` to `MutationObserver`
- Simplified addition of `MutationObserver` and moved related code to `RecordStore` 