### PR TITLE
Fix thread safety issue in CP Subsystem management tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/HazelcastRaftTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/HazelcastRaftTestSupport.java
@@ -19,11 +19,13 @@ package com.hazelcast.cp.internal;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.internal.raft.QueryPolicy;
 import com.hazelcast.cp.internal.raft.impl.RaftEndpoint;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cp.internal.raftop.metadata.GetRaftGroupOp;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import org.junit.After;
@@ -216,8 +218,13 @@ public abstract class HazelcastRaftTestSupport extends HazelcastTestSupport {
         return (RaftNodeImpl) getRaftService(instance).getRaftNode(groupId);
     }
 
-    public static CPGroupSummary getRaftGroupLocally(HazelcastInstance instance, CPGroupId groupId) {
-        return getRaftService(instance).getMetadataGroupManager().getGroup(groupId);
+    public static CPGroupSummary queryRaftGroupLocally(HazelcastInstance instance, CPGroupId groupId) {
+        RaftNodeImpl raftNode = getRaftNode(instance, getMetadataGroupId(instance));
+        if (raftNode == null) {
+            return null;
+        }
+
+        return (CPGroupSummary) raftNode.query(new GetRaftGroupOp(groupId), QueryPolicy.ANY_LOCAL).joinInternal();
     }
 
     public static RaftGroupId getMetadataGroupId(HazelcastInstance instance) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -383,7 +383,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         assertNotNull(group);
         assertEquals(groupId, group.id());
 
-        final CPMember[] groupMembers = group.members().toArray(new CPMember[0]);
+        CPMember[] groupMembers = group.members().toArray(new CPMember[0]);
 
         assertTrueEventually(() -> {
             for (CPMember member : groupMembers) {
@@ -447,10 +447,9 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         unblockCommunicationBetween(leader, follower);
 
-        HazelcastInstance f = follower;
         assertTrueEventually(() -> {
             for (CPGroupId groupId : groupIds) {
-                assertNotNull(getRaftNode(f, groupId));
+                assertNotNull(getRaftNode(follower, groupId));
             }
         });
     }
@@ -596,11 +595,11 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         RaftNodeImpl leaderNode = waitAllForLeaderElection(Arrays.copyOf(instances, 3), INITIAL_METADATA_GROUP_ID);
         HazelcastInstance leader = getInstance(leaderNode.getLocalMember());
-        CPGroup g3Group = getRaftGroupLocally(leader, g3);
+        CPGroup g3Group = queryRaftGroupLocally(leader, g3);
         assertThat(g3Group.members(), not(hasItem(endpoint3)));
         assertThat(g3Group.members(), not(hasItem(endpoint4)));
 
-        CPGroup g4Group = getRaftGroupLocally(leader, g4);
+        CPGroup g4Group = queryRaftGroupLocally(leader, g4);
         boolean b3 = g4Group.members().contains(endpoint3);
         boolean b4 = g4Group.members().contains(endpoint4);
         assertTrue(b3 ^ b4);


### PR DESCRIPTION
Some tests read CP group data locally but MetadataGroupManager is not
thread safe for all local data access patterns. Relevant tests are
updated to query local data by respecting to our Raft threading model.

Fixes #15771