### PR TITLE
Add back MapConfigRequest for MC

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -88,8 +88,13 @@ public class MapConfig implements SplitBrainMergeTypeProvider,
      */
     public static final MetadataPolicy DEFAULT_METADATA_POLICY = MetadataPolicy.CREATE_ON_UPDATE;
 
+    /**
+     * Default value of whether statistics are enabled or not
+     */
+    public static final boolean DEFAULT_STATISTICS_ENABLED = true;
+
     private boolean readBackupData;
-    private boolean statisticsEnabled = true;
+    private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
     private int backupCount = DEFAULT_BACKUP_COUNT;
     private int asyncBackupCount = MIN_BACKUP_COUNT;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -42,6 +42,7 @@ import com.hazelcast.internal.management.request.GetCacheEntryRequest;
 import com.hazelcast.internal.management.request.GetClusterStateRequest;
 import com.hazelcast.internal.management.request.GetMapEntryRequest;
 import com.hazelcast.internal.management.request.GetMemberSystemPropertiesRequest;
+import com.hazelcast.internal.management.request.MapConfigRequest;
 import com.hazelcast.internal.management.request.MemberConfigRequest;
 import com.hazelcast.internal.management.request.PromoteMemberRequest;
 import com.hazelcast.internal.management.request.RunGcRequest;
@@ -608,6 +609,7 @@ public class ManagementCenterService {
 
         private void registerConfigRequests() {
             register(new GetMemberSystemPropertiesRequest());
+            register(new MapConfigRequest());
             register(new MemberConfigRequest());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.management;
 
+import com.hazelcast.internal.management.dto.MapConfigDTO;
 import com.hazelcast.internal.management.dto.PermissionConfigDTO;
 import com.hazelcast.internal.management.operation.ChangeClusterStateOperation;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
@@ -26,9 +27,9 @@ import com.hazelcast.internal.management.operation.UpdatePermissionConfigOperati
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
-import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.internal.util.ConstructorFunction;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MANAGEMENT_DS_FACTORY;
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MANAGEMENT_DS_FACTORY_ID;
@@ -62,6 +63,7 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
         constructors[SCRIPT_EXECUTOR] = arg -> new ScriptExecutorOperation();
         constructors[UPDATE_MANAGEMENT_CENTER_URL] = arg -> new UpdateManagementCenterUrlOperation();
         constructors[UPDATE_MAP_CONFIG] = arg -> new UpdateMapConfigOperation();
+        constructors[MAP_CONFIG_DTO] = arg -> new MapConfigDTO();
         constructors[UPDATE_PERMISSION_CONFIG_OPERATION] = arg -> new UpdatePermissionConfigOperation();
         constructors[PERMISSION_CONFIG_DTO] = arg -> new PermissionConfigDTO();
         constructors[SET_LICENSE] = arg -> new SetLicenseOperation();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
@@ -38,7 +38,6 @@ import static com.hazelcast.config.MapConfig.DEFAULT_METADATA_POLICY;
 import static com.hazelcast.config.MapConfig.DEFAULT_STATISTICS_ENABLED;
 import static com.hazelcast.internal.util.JsonUtil.getBoolean;
 import static com.hazelcast.internal.util.JsonUtil.getInt;
-import static com.hazelcast.internal.util.JsonUtil.getObject;
 import static com.hazelcast.internal.util.JsonUtil.getString;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MetadataPolicy;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+import com.hazelcast.internal.management.ManagementDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+import static com.hazelcast.internal.util.JsonUtil.getBoolean;
+import static com.hazelcast.internal.util.JsonUtil.getInt;
+import static com.hazelcast.internal.util.JsonUtil.getObject;
+import static com.hazelcast.internal.util.JsonUtil.getString;
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+
+/**
+ * Serializable adapter for {@link com.hazelcast.config.MapConfig}
+ */
+public class MapConfigDTO implements JsonSerializable, IdentifiedDataSerializable {
+
+    private MapConfig mapConfig;
+
+    public MapConfigDTO() {
+    }
+
+    public MapConfigDTO(MapConfig mapConfig) {
+        this.mapConfig = mapConfig;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+
+        String name = mapConfig.getName();
+        if (!isNullOrEmpty(name)) {
+            root.add("name", name);
+        }
+
+        String splitBrainProtectionName = mapConfig.getSplitBrainProtectionName();
+        if (!isNullOrEmpty(splitBrainProtectionName)) {
+            root.add("splitBrainProtectionName", splitBrainProtectionName);
+        }
+
+        root.add("maxSize", mapConfig.getMaxSizeConfig().getSize());
+        root.add("maxSizePolicy", mapConfig.getMaxSizeConfig().getMaxSizePolicy().toString());
+        root.add("evictionPolicy", mapConfig.getEvictionPolicy().name());
+        root.add("memoryFormat", mapConfig.getInMemoryFormat().toString());
+        root.add("cacheDeserializedValues", mapConfig.getCacheDeserializedValues().toString());
+        root.add("metadataPolicy", mapConfig.getMetadataPolicy().toString());
+        root.add("backupCount", mapConfig.getBackupCount());
+        root.add("asyncBackupCount", mapConfig.getAsyncBackupCount());
+        root.add("ttl", mapConfig.getTimeToLiveSeconds());
+        root.add("maxIdle", mapConfig.getMaxIdleSeconds());
+        root.add("readBackupData", mapConfig.isReadBackupData());
+        root.add("statisticsEnabled", mapConfig.isStatisticsEnabled());
+        root.add("mergePolicy", new MergePolicyConfigDTO(mapConfig.getMergePolicyConfig()).toJson());
+        root.add("mapStoreConfig", new MapStoreConfigDTO(mapConfig.getMapStoreConfig()).toJson());
+
+        NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
+        if (nearCacheConfig != null) {
+            root.add("nearCacheConfig", new NearCacheConfigDTO(nearCacheConfig).toJson());
+        }
+
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        mapConfig = new MapConfig();
+
+        JsonValue name = json.get("name");
+        if (name != null && !name.isNull()) {
+            mapConfig.setName(getString(json, "name"));
+        }
+
+        JsonValue splitBrainProtectionName = json.get("splitBrainProtectionName");
+        if (splitBrainProtectionName != null && !splitBrainProtectionName.isNull()) {
+            mapConfig.setSplitBrainProtectionName(getString(json, "splitBrainProtectionName"));
+        }
+
+        mapConfig.setMaxSizeConfig(new MaxSizeConfig().setSize(getInt(json, "maxSize"))
+                .setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.valueOf(getString(json, "maxSizePolicy"))));
+        mapConfig.setEvictionPolicy(EvictionPolicy.valueOf(getString(json, "evictionPolicy")));
+        mapConfig.setInMemoryFormat(InMemoryFormat.valueOf(getString(json, "memoryFormat")));
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.valueOf(getString(json, "cacheDeserializedValues")));
+        mapConfig.setMetadataPolicy(MetadataPolicy.valueOf(getString(json, "metadataPolicy")));
+        mapConfig.setBackupCount(getInt(json, "backupCount"));
+        mapConfig.setAsyncBackupCount(getInt(json, "asyncBackupCount"));
+        mapConfig.setTimeToLiveSeconds(getInt(json, "ttl"));
+        mapConfig.setMaxIdleSeconds(getInt(json, "maxIdle"));
+        mapConfig.setReadBackupData(getBoolean(json, "readBackupData"));
+        mapConfig.setStatisticsEnabled(getBoolean(json, "statisticsEnabled"));
+
+        MergePolicyConfigDTO mergePolicyConfigDTO = new MergePolicyConfigDTO();
+        mergePolicyConfigDTO.fromJson(getObject(json, "mergePolicy"));
+        mapConfig.setMergePolicyConfig(mergePolicyConfigDTO.getConfig());
+
+        MapStoreConfigDTO mapStoreConfigDTO = new MapStoreConfigDTO();
+        mapStoreConfigDTO.fromJson(getObject(json, "mapStoreConfig"));
+        mapConfig.setMapStoreConfig(mapStoreConfigDTO.getConfig());
+
+        JsonValue nearCacheConfig = json.get("nearCacheConfig");
+        if (nearCacheConfig != null && !nearCacheConfig.isNull()) {
+            NearCacheConfigDTO nearCacheConfigDTO = new NearCacheConfigDTO();
+            nearCacheConfigDTO.fromJson(nearCacheConfig.asObject());
+            mapConfig.setNearCacheConfig(nearCacheConfigDTO.getConfig());
+        }
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(mapConfig.getName());
+        out.writeUTF(mapConfig.getSplitBrainProtectionName());
+        out.writeInt(mapConfig.getMaxSizeConfig().getSize());
+        out.writeUTF(mapConfig.getMaxSizeConfig().getMaxSizePolicy().toString());
+        out.writeUTF(mapConfig.getEvictionPolicy().name());
+        out.writeUTF(mapConfig.getInMemoryFormat().toString());
+        out.writeUTF(mapConfig.getCacheDeserializedValues().toString());
+        out.writeUTF(mapConfig.getMetadataPolicy().toString());
+        out.writeInt(mapConfig.getBackupCount());
+        out.writeInt(mapConfig.getAsyncBackupCount());
+        out.writeInt(mapConfig.getTimeToLiveSeconds());
+        out.writeInt(mapConfig.getMaxIdleSeconds());
+        out.writeBoolean(mapConfig.isReadBackupData());
+        out.writeBoolean(mapConfig.isStatisticsEnabled());
+        out.writeObject(mapConfig.getMergePolicyConfig());
+        out.writeObject(mapConfig.getMapStoreConfig());
+        out.writeObject(mapConfig.getNearCacheConfig());
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        mapConfig = new MapConfig();
+        mapConfig.setName(in.readUTF());
+        mapConfig.setSplitBrainProtectionName(in.readUTF());
+        mapConfig.setMaxSizeConfig(
+                new MaxSizeConfig()
+                        .setSize(in.readInt())
+                        .setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.valueOf(in.readUTF())));
+        mapConfig.setEvictionPolicy(EvictionPolicy.valueOf(in.readUTF()));
+        mapConfig.setInMemoryFormat(InMemoryFormat.valueOf(in.readUTF()));
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.valueOf(in.readUTF()));
+        mapConfig.setMetadataPolicy(MetadataPolicy.valueOf(in.readUTF()));
+        mapConfig.setBackupCount(in.readInt());
+        mapConfig.setAsyncBackupCount(in.readInt());
+        mapConfig.setTimeToLiveSeconds(in.readInt());
+        mapConfig.setMaxIdleSeconds(in.readInt());
+        mapConfig.setReadBackupData(in.readBoolean());
+        mapConfig.setStatisticsEnabled(in.readBoolean());
+        mapConfig.setMergePolicyConfig(in.readObject());
+        mapConfig.setMapStoreConfig(in.readObject());
+        mapConfig.setNearCacheConfig(in.readObject());
+    }
+
+    public MapConfig getConfig() {
+        return mapConfig;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ManagementDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ManagementDataSerializerHook.MAP_CONFIG_DTO;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
@@ -33,6 +33,9 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_CACHED_DESERIALIZED_VALUES;
+import static com.hazelcast.config.MapConfig.DEFAULT_METADATA_POLICY;
+import static com.hazelcast.config.MapConfig.DEFAULT_STATISTICS_ENABLED;
 import static com.hazelcast.internal.util.JsonUtil.getBoolean;
 import static com.hazelcast.internal.util.JsonUtil.getInt;
 import static com.hazelcast.internal.util.JsonUtil.getObject;
@@ -79,7 +82,7 @@ public class MapConfigDTO implements JsonSerializable, IdentifiedDataSerializabl
         root.add("maxIdle", mapConfig.getMaxIdleSeconds());
         root.add("readBackupData", mapConfig.isReadBackupData());
         root.add("statisticsEnabled", mapConfig.isStatisticsEnabled());
-        root.add("mergePolicy", new MergePolicyConfigDTO(mapConfig.getMergePolicyConfig()).toJson());
+        root.add("mergePolicy", mapConfig.getMergePolicyConfig().getPolicy());
         root.add("mapStoreConfig", new MapStoreConfigDTO(mapConfig.getMapStoreConfig()).toJson());
 
         NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
@@ -108,22 +111,29 @@ public class MapConfigDTO implements JsonSerializable, IdentifiedDataSerializabl
                 .setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.valueOf(getString(json, "maxSizePolicy"))));
         mapConfig.setEvictionPolicy(EvictionPolicy.valueOf(getString(json, "evictionPolicy")));
         mapConfig.setInMemoryFormat(InMemoryFormat.valueOf(getString(json, "memoryFormat")));
-        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.valueOf(getString(json, "cacheDeserializedValues")));
-        mapConfig.setMetadataPolicy(MetadataPolicy.valueOf(getString(json, "metadataPolicy")));
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.valueOf(
+                getString(json, "cacheDeserializedValues", DEFAULT_CACHED_DESERIALIZED_VALUES.name())));
+        mapConfig.setMetadataPolicy(
+                MetadataPolicy.valueOf(getString(json, "metadataPolicy", DEFAULT_METADATA_POLICY.name())));
         mapConfig.setBackupCount(getInt(json, "backupCount"));
         mapConfig.setAsyncBackupCount(getInt(json, "asyncBackupCount"));
         mapConfig.setTimeToLiveSeconds(getInt(json, "ttl"));
         mapConfig.setMaxIdleSeconds(getInt(json, "maxIdle"));
         mapConfig.setReadBackupData(getBoolean(json, "readBackupData"));
-        mapConfig.setStatisticsEnabled(getBoolean(json, "statisticsEnabled"));
+        mapConfig.setStatisticsEnabled(
+                getBoolean(json, "statisticsEnabled", DEFAULT_STATISTICS_ENABLED));
 
-        MergePolicyConfigDTO mergePolicyConfigDTO = new MergePolicyConfigDTO();
-        mergePolicyConfigDTO.fromJson(getObject(json, "mergePolicy"));
-        mapConfig.setMergePolicyConfig(mergePolicyConfigDTO.getConfig());
+        String mergePolicy = getString(json, "mergePolicy", null);
+        if (mergePolicy != null) {
+            mapConfig.getMergePolicyConfig().setPolicy(mergePolicy);
+        }
 
-        MapStoreConfigDTO mapStoreConfigDTO = new MapStoreConfigDTO();
-        mapStoreConfigDTO.fromJson(getObject(json, "mapStoreConfig"));
-        mapConfig.setMapStoreConfig(mapStoreConfigDTO.getConfig());
+        JsonValue mapStoreConfig = json.get("mapStoreConfig");
+        if (mapStoreConfig != null && !mapStoreConfig.isNull()) {
+            MapStoreConfigDTO mapStoreConfigDTO = new MapStoreConfigDTO();
+            mapStoreConfigDTO.fromJson(mapStoreConfig.asObject());
+            mapConfig.setMapStoreConfig(mapStoreConfigDTO.getConfig());
+        }
 
         JsonValue nearCacheConfig = json.get("nearCacheConfig");
         if (nearCacheConfig != null && !nearCacheConfig.isNull()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/MapConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/MapConfigRequest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.request;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.internal.management.dto.MapConfigDTO;
+import com.hazelcast.internal.management.operation.GetMapConfigOperation;
+import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
+import com.hazelcast.internal.json.JsonObject;
+
+import java.util.Set;
+
+import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
+import static com.hazelcast.internal.util.JsonUtil.getBoolean;
+import static com.hazelcast.internal.util.JsonUtil.getObject;
+import static com.hazelcast.internal.util.JsonUtil.getString;
+
+/**
+ * Request for updating map configuration from Management Center.
+ */
+public class MapConfigRequest implements ConsoleRequest {
+
+    private String mapName;
+    private MapConfigDTO config;
+    private boolean update;
+
+    public MapConfigRequest() {
+    }
+
+    public MapConfigRequest(String mapName, MapConfigDTO config, boolean update) {
+        this.mapName = mapName;
+        this.config = config;
+        this.update = update;
+    }
+
+    @Override
+    public int getType() {
+        return ConsoleRequestConstants.REQUEST_TYPE_MAP_CONFIG;
+    }
+
+    @Override
+    public void writeResponse(ManagementCenterService mcs, JsonObject root) {
+        final JsonObject result = new JsonObject();
+        result.add("update", update);
+        if (update) {
+            final Set<Member> members = mcs.getHazelcastInstance().getCluster().getMembers();
+            for (Member member : members) {
+                UpdateMapConfigOperation operation = new UpdateMapConfigOperation(
+                        mapName,
+                        config.getConfig().getTimeToLiveSeconds(),
+                        config.getConfig().getMaxIdleSeconds(),
+                        config.getConfig().getMaxSizeConfig().getSize(),
+                        config.getConfig().getMaxSizeConfig().getMaxSizePolicy().getId(),
+                        config.getConfig().isReadBackupData(),
+                        config.getConfig().getEvictionPolicy().getId());
+                resolveFuture(mcs.callOnMember(member, operation));
+            }
+            result.add("updateResult", "success");
+        } else {
+            MapConfig cfg = (MapConfig) resolveFuture(mcs.callOnThis(new GetMapConfigOperation(mapName)));
+            if (cfg != null) {
+                result.add("hasMapConfig", true);
+                result.add("mapConfig", new MapConfigDTO(cfg).toJson());
+            } else {
+                result.add("hasMapConfig", false);
+            }
+        }
+        root.add("result", result);
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        mapName = getString(json, "mapName");
+        update = getBoolean(json, "update");
+        config = new MapConfigDTO();
+        config.fromJson(getObject(json, "config"));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MapConfigRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MapConfigRequestTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.management.dto.MapConfigDTO;
+import com.hazelcast.internal.management.request.MapConfigRequest;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.util.JsonUtil.getBoolean;
+import static com.hazelcast.internal.util.JsonUtil.getObject;
+import static com.hazelcast.internal.util.JsonUtil.getString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MapConfigRequestTest extends HazelcastTestSupport {
+
+    private ManagementCenterService managementCenterService;
+    private String mapName;
+    private MapConfigDTO dto;
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        managementCenterService = getNode(instances[0]).getManagementCenterService();
+        mapName = randomMapName();
+        dto = new MapConfigDTO(new MapConfig("MapConfigRequestTest"));
+    }
+
+    @Test
+    public void testGetMapConfig() {
+        MapConfigRequest request = new MapConfigRequest(mapName, dto, false);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertFalse(getBoolean(result, "update"));
+        assertTrue(getBoolean(result, "hasMapConfig", false));
+        final MapConfigDTO adapter = new MapConfigDTO();
+        adapter.fromJson(getObject(result, "mapConfig"));
+        MapConfig mapConfig = adapter.getConfig();
+
+        assertNotNull(mapConfig);
+        assertEquals("default", mapConfig.getName());
+    }
+
+    @Test
+    public void testUpdateMapConfig() {
+        MapConfigRequest request = new MapConfigRequest(mapName, dto, true);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals("success", getString(result, "updateResult"));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/MapConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/MapConfigDTOTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.config.ConfigCompatibilityChecker;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MapConfigDTOTest {
+
+    @Parameterized.Parameter(0)
+    public MapConfig mapConfig;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {defaultMapConfig()},
+                {fullMapConfig()},
+        });
+    }
+
+    private static final String MAP_NAME = "map-name";
+    private static final ConfigCompatibilityChecker.MapConfigChecker MAP_CONFIG_CHECKER
+            = new ConfigCompatibilityChecker.MapConfigChecker();
+
+    static MapConfig defaultMapConfig() {
+        return new MapConfig(MAP_NAME);
+    }
+
+    static MapConfig fullMapConfig() {
+        MapConfig mapConfig = new MapConfig(MAP_NAME);
+        mapConfig.setBackupCount(2)
+                .setAsyncBackupCount(3)
+                .setCacheDeserializedValues(CacheDeserializedValues.ALWAYS)
+                .setEvictionPolicy(EvictionPolicy.RANDOM)
+                .setInMemoryFormat(InMemoryFormat.NATIVE)
+                .setSplitBrainProtectionName("triple");
+
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE);
+        nearCacheConfig.getPreloaderConfig().setEnabled(false).setStoreIntervalSeconds(11)
+                .setStoreInitialDelaySeconds(33).setDirectory("storeHere");
+        mapConfig.setNearCacheConfig(nearCacheConfig);
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
+        mapStoreConfig.setClassName("map-store-impl-class-name");
+        mapConfig.setMapStoreConfig(mapStoreConfig);
+
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
+        mergePolicyConfig.setBatchSize(111);
+        mergePolicyConfig.setPolicy(PassThroughMergePolicy.class.getName());
+
+        return mapConfig;
+    }
+
+    @Test
+    public void cloned_config_with_json_serialization_equals_given_config() {
+        MapConfig clonedConfig = cloneWithJsonSerialization(mapConfig);
+        assertTrue("Expected: " + mapConfig + ", got:" + clonedConfig,
+                MAP_CONFIG_CHECKER.check(mapConfig, clonedConfig));
+    }
+
+    @Test
+    public void cloned_config_with_json_serialization_equals_default_config() {
+        MapConfig clonedConfig = cloneWithJsonSerialization(mapConfig);
+        assertTrue("Expected: " + mapConfig + ", got:" + clonedConfig,
+                MAP_CONFIG_CHECKER.check(mapConfig, clonedConfig));
+    }
+
+    private static MapConfig cloneWithJsonSerialization(MapConfig expected) {
+        MapConfigDTO dto = new MapConfigDTO(expected);
+
+        JsonObject json = dto.toJson();
+        MapConfigDTO deserialized = new MapConfigDTO(null);
+        deserialized.fromJson(json);
+
+        return deserialized.getConfig();
+    }
+
+    @Test
+    public void cloned_config_with_data_serialization_equals_given_config() {
+        MapConfig clonedConfig = cloneWithDataSerialization(mapConfig);
+        assertTrue("Expected: " + mapConfig + ", got:" + clonedConfig,
+                MAP_CONFIG_CHECKER.check(mapConfig, clonedConfig));
+    }
+
+    private static MapConfig cloneWithDataSerialization(MapConfig givenConfig) {
+        DefaultSerializationServiceBuilder defaultSerializationServiceBuilder
+                = new DefaultSerializationServiceBuilder();
+        SerializationService ss = defaultSerializationServiceBuilder
+                .setVersion(InternalSerializationService.VERSION_1).build();
+
+        MapConfigDTO givenDTO = new MapConfigDTO(givenConfig);
+        Data serializedDTO = ss.toData(givenDTO);
+        MapConfigDTO deserializedDTO = ss.toObject(serializedDTO);
+
+        return deserializedDTO.getConfig();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/MapConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/MapConfigDTOTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MapConfigDTOTest {
 
-    @Parameterized.Parameter(0)
+    @Parameterized.Parameter()
     public MapConfig mapConfig;
 
     @Parameterized.Parameters(name = "{0}")
@@ -62,11 +63,11 @@ public class MapConfigDTOTest {
     private static final ConfigCompatibilityChecker.MapConfigChecker MAP_CONFIG_CHECKER
             = new ConfigCompatibilityChecker.MapConfigChecker();
 
-    static MapConfig defaultMapConfig() {
+    private static MapConfig defaultMapConfig() {
         return new MapConfig(MAP_NAME);
     }
 
-    static MapConfig fullMapConfig() {
+    private static MapConfig fullMapConfig() {
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setBackupCount(2)
                 .setAsyncBackupCount(3)
@@ -95,13 +96,6 @@ public class MapConfigDTOTest {
 
     @Test
     public void cloned_config_with_json_serialization_equals_given_config() {
-        MapConfig clonedConfig = cloneWithJsonSerialization(mapConfig);
-        assertTrue("Expected: " + mapConfig + ", got:" + clonedConfig,
-                MAP_CONFIG_CHECKER.check(mapConfig, clonedConfig));
-    }
-
-    @Test
-    public void cloned_config_with_json_serialization_equals_default_config() {
         MapConfig clonedConfig = cloneWithJsonSerialization(mapConfig);
         assertTrue("Expected: " + mapConfig + ", got:" + clonedConfig,
                 MAP_CONFIG_CHECKER.check(mapConfig, clonedConfig));


### PR DESCRIPTION
There's a small chance that MC 4.0 will not contain communication model related changes. For this reason, MC uses the new client operations only in a feature branch. Until we merge the feature branch back to MC master branch, we need to support the old way of executing operations on the cluster. This PR reverts back changes made in a [previous PR](https://github.com/hazelcast/hazelcast/pull/15662) removing support for MapConfigRequest and also fixes it so that it works with the current MC.

Closes https://github.com/hazelcast/management-center/issues/2250