### PR TITLE
Fixed flaky ThreadLeakTest

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -93,8 +93,9 @@ public final class ThreadLeakTestUtils {
     private static Set<Thread> getNonSystemAndNonCommonPoolThreads(Map<Thread, StackTraceElement[]> stackTraces) {
         Set<Thread> nonSystemThreads = new HashSet<>();
         for (Thread thread : stackTraces.keySet()) {
-            if (thread.getThreadGroup().getParent() != null && !thread.getName().contains("ForkJoinPool.commonPool")) {
-                // non-system thread
+            ThreadGroup threadGroup = thread.getThreadGroup();
+            if (threadGroup != null && threadGroup.getParent() != null && !thread.getName().contains("ForkJoinPool.commonPool")) {
+                // non-system alive thread
                 nonSystemThreads.add(thread);
             }
         }

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -81,12 +81,24 @@ public final class ThreadLeakTestUtils {
 
     public static Thread[] getAndLogThreads(String message, Set<Thread> oldThreads) {
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
-        Thread[] joinableThreads = getJoinableThreads(oldThreads, stackTraces.keySet());
+        Set<Thread> nonSystemNonCommonPoolThreads = getNonSystemAndNonCommonPoolThreads(stackTraces);
+        Thread[] joinableThreads = getJoinableThreads(oldThreads, nonSystemNonCommonPoolThreads);
         if (joinableThreads.length == 0) {
             return null;
         }
         logThreads(stackTraces, joinableThreads, message);
         return joinableThreads;
+    }
+
+    private static Set<Thread> getNonSystemAndNonCommonPoolThreads(Map<Thread, StackTraceElement[]> stackTraces) {
+        Set<Thread> nonSystemThreads = new HashSet<>();
+        for (Thread thread : stackTraces.keySet()) {
+            if (thread.getThreadGroup().getParent() != null && !thread.getName().contains("ForkJoinPool.commonPool")) {
+                // non-system thread
+                nonSystemThreads.add(thread);
+            }
+        }
+        return nonSystemThreads;
     }
 
     private static Thread[] getJoinableThreads(Set<Thread> oldThreads, Set<Thread> newThreads) {


### PR DESCRIPTION
Avoid scenario when the test is indefinitely joining JVM system thread(s)
assuming that the thread is created by HZ member/client.

Fixes: https://github.com/hazelcast/hazelcast/issues/15697