### PR TITLE
Persist and restore active CP members list

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
@@ -18,6 +18,7 @@ package com.hazelcast.cp.internal;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.internal.exception.CannotCreateRaftGroupException;
 import com.hazelcast.cp.internal.operation.ChangeRaftGroupMembershipOp;
 import com.hazelcast.cp.internal.operation.DefaultRaftReplicateOp;
@@ -223,7 +224,7 @@ public class RaftInvocationManager {
         return raftInvocationContext;
     }
 
-    public CPMemberInfo getCPMember(RaftEndpoint endpoint) {
+    CPMember getCPMember(RaftEndpoint endpoint) {
         return endpoint != null ? raftInvocationContext.getCPMember(endpoint.getUuid()) : null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -836,7 +836,8 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
         return getMetadataGroupId().getSeed() == ((RaftGroupId) groupId).getSeed();
     }
 
-    public boolean updateInvocationManagerMembers(long groupIdSeed, long membersCommitIndex, Collection<CPMemberInfo> members) {
+    public boolean updateInvocationManagerMembers(long groupIdSeed, long membersCommitIndex,
+            Collection<? extends CPMember> members) {
         return invocationManager.getRaftInvocationContext().setMembers(groupIdSeed, membersCommitIndex, members);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/CPMetadataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/CPMetadataStore.java
@@ -20,6 +20,7 @@ import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.internal.RaftGroupId;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * Persists and restores CP member metadata of the local member.
@@ -57,6 +58,20 @@ public interface CPMetadataStore {
      * is not not known yet CP member discovery will run.
      */
     CPMember readLocalCPMember() throws IOException;
+
+    /**
+     * Persists active CP members list.
+     * @param members CP members
+     * @param commitIndex member list commit index
+     */
+    void persistActiveCPMembers(Collection<? extends CPMember> members, long commitIndex) throws IOException;
+
+    /**
+     * Reads active CP members and the commit index.
+     * @param members collection to append read members
+     * @return the member list commit index
+     */
+    long readActiveCPMembers(Collection<CPMember> members) throws IOException;
 
     /**
      * Persists group id of the METADATA group.

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/NopCPMetadataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/NopCPMetadataStore.java
@@ -19,6 +19,8 @@ package com.hazelcast.cp.internal.persistence;
 import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.internal.RaftGroupId;
 
+import java.util.Collection;
+
 /**
  * Used when CP Subsystem works transiently (its state is not persisted).
  */
@@ -51,6 +53,15 @@ public final class NopCPMetadataStore implements CPMetadataStore {
     @Override
     public CPMember readLocalCPMember() {
         return null;
+    }
+
+    @Override
+    public void persistActiveCPMembers(Collection<? extends CPMember> members, long commitIndex) {
+    }
+
+    @Override
+    public long readActiveCPMembers(Collection<CPMember> members) {
+        return 0;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/HazelcastRaftTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/HazelcastRaftTestSupport.java
@@ -57,7 +57,7 @@ public abstract class HazelcastRaftTestSupport extends HazelcastTestSupport {
         return createHazelcastInstanceFactory();
     }
 
-    protected RaftNodeImpl waitAllForLeaderElection(HazelcastInstance[] instances, CPGroupId groupId) {
+    protected static RaftNodeImpl waitAllForLeaderElection(HazelcastInstance[] instances, CPGroupId groupId) {
         assertTrueEventually(() -> {
             RaftNodeImpl leaderNode = getLeaderNode(instances, groupId);
             int leaderTerm = getTerm(leaderNode);
@@ -135,11 +135,11 @@ public abstract class HazelcastRaftTestSupport extends HazelcastTestSupport {
               .setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
     }
 
-    protected RaftNodeImpl getLeaderNode(HazelcastInstance[] instances, CPGroupId groupId) {
+    protected static RaftNodeImpl getLeaderNode(HazelcastInstance[] instances, CPGroupId groupId) {
         return getRaftNode(getLeaderInstance(instances, groupId), groupId);
     }
 
-    protected HazelcastInstance getLeaderInstance(HazelcastInstance[] instances, CPGroupId groupId) {
+    protected static HazelcastInstance getLeaderInstance(HazelcastInstance[] instances, CPGroupId groupId) {
         RaftNodeImpl[] raftNodeRef = new RaftNodeImpl[1];
         assertTrueEventually(() -> {
             for (HazelcastInstance instance : instances) {
@@ -166,7 +166,7 @@ public abstract class HazelcastRaftTestSupport extends HazelcastTestSupport {
         throw new AssertionError();
     }
 
-    protected HazelcastInstance getRandomFollowerInstance(HazelcastInstance[] instances, CPGroupId groupId) {
+    protected static HazelcastInstance getRandomFollowerInstance(HazelcastInstance[] instances, CPGroupId groupId) {
         RaftNodeImpl[] raftNodeRef = new RaftNodeImpl[1];
         assertTrueEventually(() -> {
             for (HazelcastInstance instance : instances) {


### PR DESCRIPTION
Additionally, acquire `CPMetadataStore` lazily, instead of acquiring
it in constructor. Because, `CPPersistenceService` and/or `CPMetadataStore`
might not be ready at that time.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3263

_Please review EE PR first!_