### PR TITLE
Fixes HazelcastTestFactory thread-safety problem. If a new instance w…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorRaceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorRaceTest.java
@@ -16,13 +16,11 @@
 
 package com.hazelcast.client.bluegreen;
 
-
 import com.hazelcast.client.impl.ClientEndpoint;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.ClientSelectors;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -57,32 +55,22 @@ public class ClientSelectorRaceTest extends HazelcastTestSupport {
         LinkedList<Thread> threads = new LinkedList<Thread>();
         int numberOfClients = 100;
         for (int i = 0; i < numberOfClients; i++) {
-            Thread thread = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    hazelcastFactory.newHazelcastClient();
-                }
-            });
+            Thread thread = new Thread(hazelcastFactory::newHazelcastClient);
             thread.start();
             threads.add(thread);
 
         }
 
-        Thread.sleep(10);
         clientEngineImpl.applySelector(ClientSelectors.none());
 
         for (Thread thread : threads) {
             thread.join();
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                Collection<ClientEndpoint> endpoints = clientEngineImpl.getEndpointManager().getEndpoints();
-                assertEquals(0, endpoints.size());
-            }
+        assertTrueEventually(() -> {
+            Collection<ClientEndpoint> endpoints = clientEngineImpl.getEndpointManager().getEndpoints();
+            assertEquals(0, endpoints.size());
         });
-
 
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -35,12 +35,13 @@ import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
     private final boolean mockNetwork = TestEnvironment.isMockNetwork();
-    private final List<HazelcastClientInstanceImpl> clients = new ArrayList<HazelcastClientInstanceImpl>(10);
+    private final List<HazelcastClientInstanceImpl> clients = Collections.synchronizedList(new ArrayList<>(10));
     private final TestClientRegistry clientRegistry = new TestClientRegistry(getRegistry());
 
     public TestHazelcastFactory(int initialPort, String... addresses) {


### PR DESCRIPTION
Fixes HazelcastTestFactory thread-safety problem. If a new instance was being created during terminateAll or shutdownAll, this was a race.

Also cleanup the test by deleting the unneeded extra sleep.

fixes https://github.com/hazelcast/hazelcast/issues/15739