### PR TITLE
Backport https://github.com/hazelcast/hazelcast/pull/15830

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorRaceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorRaceTest.java
@@ -68,7 +68,6 @@ public class ClientSelectorRaceTest extends HazelcastTestSupport {
 
         }
 
-        Thread.sleep(10);
         clientEngineImpl.applySelector(ClientSelectors.none());
 
         for (Thread thread : threads) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -34,12 +34,14 @@ import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
     private final boolean mockNetwork = TestEnvironment.isMockNetwork();
-    private final List<HazelcastClientInstanceImpl> clients = new ArrayList<HazelcastClientInstanceImpl>(10);
+    private final List<HazelcastClientInstanceImpl> clients = Collections
+            .synchronizedList(new ArrayList<HazelcastClientInstanceImpl>(10));
     private final TestClientRegistry clientRegistry = new TestClientRegistry(getRegistry());
 
     public TestHazelcastFactory(int initialPort, String... addresses) {


### PR DESCRIPTION
Backport https://github.com/hazelcast/hazelcast/pull/15830

Fixes HazelcastTestFactory thread-safety problem. If a new instance was being created during terminateAll or shutdownAll, this was a race.

Also cleanup the test by deleting the unneeded extra sleep.