### PR TITLE
Canonicalize "__key#" to "__key." in indexes and queries (#15817)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -34,7 +34,11 @@ public final class PredicateUtils {
 
     private static final int MAX_INDEX_COMPONENTS = 255;
 
-    private static final Pattern THIS_PATTERN = Pattern.compile("^this\\.");
+    private static final String THIS_DOT = "this.";
+
+    private static final String KEY_HASH = "__key#";
+
+    private static final String KEY_DOT = "__key.";
 
     private static final Pattern COMMA_PATTERN = Pattern.compile("\\s*,\\s*");
 
@@ -86,15 +90,25 @@ public final class PredicateUtils {
     }
 
     /**
-     * Produces canonical attribute representation by stripping an unnecessary
-     * "this." qualifier from the passed attribute, if any.
+     * Produces canonical attribute representation in the following way:
+     *
+     * <ol>
+     * <li>Strips an unnecessary "this." qualifier from the passed attribute.
+     * <li>Replaces "__key#" qualifier with "__key.".
+     * </ol>
      *
      * @param attribute the attribute to canonicalize.
      * @return the canonicalized attribute representation.
      * @see #constructCanonicalCompositeIndexName
      */
     public static String canonicalizeAttribute(String attribute) {
-        return THIS_PATTERN.matcher(attribute).replaceFirst("");
+        if (attribute.startsWith(THIS_DOT)) {
+            return attribute.substring(THIS_DOT.length());
+        }
+        if (attribute.startsWith(KEY_HASH)) {
+            return KEY_DOT + attribute.substring(KEY_HASH.length());
+        }
+        return attribute;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableTest.ChildPortableObject;
@@ -50,6 +51,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -952,6 +954,41 @@ public class QueryBasicTest extends HazelcastTestSupport {
         testQueryUsingPortableObject(config, name);
     }
 
+    @Test
+    public void testIndexesOnKeyAttributes() {
+        String name = randomMapName();
+        Config config = smallInstanceConfig();
+        config.getMapConfig(name)
+                .addMapIndexConfig(new MapIndexConfig("__key.a", false))
+                .addMapIndexConfig(new MapIndexConfig("__key#b", true));
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<CompositeKey, Integer> map = instance.getMap(name);
+        map.addIndex("__key.c", true);
+        map.addIndex("__key#d", false);
+
+        for (int i = 0; i < 10; i++) {
+            map.put(new CompositeKey(i), i);
+        }
+
+        Map<String, LocalIndexStats> stats = map.getLocalMapStats().getIndexStats();
+        assertEquals(0, stats.get("__key.a").getQueryCount());
+        assertEquals(0, stats.get("__key.b").getQueryCount());
+        assertEquals(0, stats.get("__key.c").getQueryCount());
+        assertEquals(0, stats.get("__key.d").getQueryCount());
+
+        map.values(Predicates.equal("__key.a", 5));
+        map.values(Predicates.equal("__key#b", 5));
+        map.values(Predicates.equal("__key#c", 5));
+        map.values(Predicates.equal("__key.d", 5));
+
+        stats = map.getLocalMapStats().getIndexStats();
+        assertEquals(1, stats.get("__key.a").getQueryCount());
+        assertEquals(1, stats.get("__key.b").getQueryCount());
+        assertEquals(1, stats.get("__key.c").getQueryCount());
+        assertEquals(1, stats.get("__key.d").getQueryCount());
+    }
+
     private void testQueryUsingNestedPortableObject(Config config, String name) {
         addPortableFactories(config);
 
@@ -971,4 +1008,34 @@ public class QueryBasicTest extends HazelcastTestSupport {
         values = map.values(new SqlPredicate("child.child.timestamp > 0"));
         assertEquals(1, values.size());
     }
+
+    public static class CompositeKey implements Serializable {
+
+        private final int a;
+        private final int b;
+        private final int c;
+        private final int d;
+
+        public CompositeKey(int value) {
+            a = b = c = d = value;
+        }
+
+        public int getA() {
+            return a;
+        }
+
+        public int getB() {
+            return b;
+        }
+
+        public int getC() {
+            return c;
+        }
+
+        public int getD() {
+            return d;
+        }
+
+    }
+
 }


### PR DESCRIPTION
(cherry-picked from 9e333aa)

Fixes: https://github.com/hazelcast/hazelcast/issues/15808