### PR TITLE
EntryLoaderSimpleTest enhancement (#15677)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.mapstore;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.EntryView;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -336,7 +337,8 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     private void assertExpiredEventually(IMap map, String prefix, int from, int to) {
         assertTrueEventually(() -> {
             for (int i = from; i < to; i++) {
-                assertNull(map.get(prefix + i));
+                EntryView entryView = map.getEntryView(prefix + i);
+                assertNull("Current time: " + System.currentTimeMillis(), entryView);
             }
         });
     }


### PR DESCRIPTION
Changed the implementation of the `assertExpiredEventually()` method to use an `EntryView` so that the failed assert provides more complete information about the entry (key, value, TTL, etc.).

Relates to https://github.com/hazelcast/hazelcast/issues/15677