### PR TITLE
Adds nullability checks and annotations to remaining services

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -35,6 +36,7 @@ public interface ClientService {
      *
      * @return all connected clients to this member
      */
+    @Nonnull
     Collection<Client> getConnectedClients();
 
     /**
@@ -46,7 +48,7 @@ public interface ClientService {
      * @return registration ID which can be used to remove the listener using the {@link #removeClientListener(UUID)} method
      * @throws java.lang.NullPointerException if clientListener is {@code null}
      */
-    UUID addClientListener(ClientListener clientListener);
+    @Nonnull UUID addClientListener(@Nonnull ClientListener clientListener);
 
     /**
      * Removes a ClientListener.
@@ -57,5 +59,5 @@ public interface ClientService {
      * @return {@code true} if registration is removed, {@code false} otherwise
      * @throws java.lang.NullPointerException if registration ID is {@code null}
      */
-    boolean removeClientListener(UUID registrationId);
+    boolean removeClientListener(@Nonnull UUID registrationId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
@@ -34,6 +34,10 @@ import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.lock.FencedLock;
 import com.hazelcast.cp.session.CPSessionManagementService;
 
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+
 /**
  * Client-side impl of the CP subsystem to create CP data structure proxies
  */
@@ -49,28 +53,38 @@ public class CPSubsystemImpl implements CPSubsystem {
         proxyFactory.init(context);
     }
 
+    @Nonnull
     @Override
-    public IAtomicLong getAtomicLong(String name) {
+    public IAtomicLong getAtomicLong(@Nonnull String name) {
+        checkNotNull(name, "Retrieving an atomic long instance with a null name is not allowed!");
         return proxyFactory.createProxy(AtomicLongService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> IAtomicReference<E> getAtomicReference(String name) {
+    public <E> IAtomicReference<E> getAtomicReference(@Nonnull String name) {
+        checkNotNull(name, "Retrieving an atomic reference instance with a null name is not allowed!");
         return proxyFactory.createProxy(AtomicRefService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public ICountDownLatch getCountDownLatch(String name) {
+    public ICountDownLatch getCountDownLatch(@Nonnull String name) {
+        checkNotNull(name, "Retrieving a count down latch instance with a null name is not allowed!");
         return proxyFactory.createProxy(CountDownLatchService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public FencedLock getLock(String name) {
+    public FencedLock getLock(@Nonnull String name) {
+        checkNotNull(name, "Retrieving an fenced lock instance with a null name is not allowed!");
         return proxyFactory.createProxy(LockService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public ISemaphore getSemaphore(String name) {
+    public ISemaphore getSemaphore(@Nonnull String name) {
+        checkNotNull(name, "Retrieving a semaphore instance with a null name is not allowed!");
         return proxyFactory.createProxy(SemaphoreService.SERVICE_NAME, name);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/proxy/ClientRaftProxyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/proxy/ClientRaftProxyFactory.java
@@ -38,6 +38,7 @@ import com.hazelcast.cp.internal.datastructures.lock.LockService;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.lock.FencedLock;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -62,7 +63,8 @@ public class ClientRaftProxyFactory {
         this.context = context;
     }
 
-    public <T extends DistributedObject> T createProxy(String serviceName, String proxyName) {
+    public @Nonnull
+    <T extends DistributedObject> T createProxy(String serviceName, String proxyName) {
         proxyName = withoutDefaultGroupName(proxyName);
         String objectName = getObjectNameForProxy(proxyName);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.impl.proxyservice.ProxyService;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.transaction.TransactionManagerService;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -55,6 +56,7 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      */
     boolean bind(ClientEndpoint endpoint);
 
+    @Nonnull
     Collection<Client> getClients();
 
     int getClientEndpointCount();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -64,6 +64,7 @@ import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.transaction.TransactionManagerService;
 
+import javax.annotation.Nonnull;
 import javax.security.auth.login.LoginException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -373,6 +374,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
+    @Nonnull
     @Override
     public Collection<Client> getClients() {
         Collection<ClientEndpoint> endpoints = endpointManager.getEndpoints();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientServiceProxy.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.NodeEngine;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -42,13 +43,15 @@ public final class ClientServiceProxy implements ClientService {
         this.nodeEngine = node.nodeEngine;
     }
 
+    @Nonnull
     @Override
     public Collection<Client> getConnectedClients() {
         return clientEngine.getClients();
     }
 
+    @Nonnull
     @Override
-    public UUID addClientListener(ClientListener clientListener) {
+    public UUID addClientListener(@Nonnull ClientListener clientListener) {
         checkNotNull(clientListener, "clientListener should not be null");
 
         EventService eventService = nodeEngine.getEventService();
@@ -58,7 +61,7 @@ public final class ClientServiceProxy implements ClientService {
     }
 
     @Override
-    public boolean removeClientListener(UUID registrationId) {
+    public boolean removeClientListener(@Nonnull UUID registrationId) {
         checkNotNull(registrationId, "registrationId should not be null");
 
         EventService eventService = nodeEngine.getEventService();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.transaction.TransactionManagerService;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -45,6 +46,7 @@ public class NoOpClientEngine implements ClientEngine {
         return true;
     }
 
+    @Nonnull
     @Override
     public Collection<Client> getClients() {
         return emptyList();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
@@ -27,24 +27,19 @@ import com.hazelcast.logging.LoggerFactory;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.internal.util.ConstructorFunction;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 public class ClientLoggingService implements LoggingService {
 
-    private final ConcurrentMap<String, ILogger> mapLoggers = new ConcurrentHashMap<String, ILogger>(100);
+    private final ConcurrentMap<String, ILogger> mapLoggers = new ConcurrentHashMap<>(100);
 
-    private final ConstructorFunction<String, ILogger> loggerConstructor
-            = new ConstructorFunction<String, ILogger>() {
-
-        @Override
-        public ILogger createNew(String key) {
-            return new DefaultLogger(key);
-        }
-    };
+    private final ConstructorFunction<String, ILogger> loggerConstructor = DefaultLogger::new;
 
     private final LoggerFactory loggerFactory;
     private final BuildInfo buildInfo;
@@ -66,20 +61,24 @@ public class ClientLoggingService implements LoggingService {
     }
 
     @Override
-    public void addLogListener(Level level, LogListener logListener) {
+    public void addLogListener(@Nonnull Level level, @Nonnull LogListener logListener) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void removeLogListener(LogListener logListener) {
+    public void removeLogListener(@Nonnull LogListener logListener) {
         throw new UnsupportedOperationException();
     }
 
-    public ILogger getLogger(String name) {
+    @Nonnull
+    public ILogger getLogger(@Nonnull String name) {
+        checkNotNull(name, "name must not be null");
         return getOrPutIfAbsent(mapLoggers, name, loggerConstructor);
     }
 
-    public ILogger getLogger(Class clazz) {
+    @Nonnull
+    public ILogger getLogger(@Nonnull Class clazz) {
+        checkNotNull(clazz, "class must not be null");
         return getOrPutIfAbsent(mapLoggers, clazz.getName(), loggerConstructor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -523,6 +523,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return getDistributedObject(ReplicatedMapService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
     public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
         checkNotNull(name, "Retrieving a topic instance with a null name is not allowed!");
@@ -593,12 +594,14 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return transactionManager;
     }
 
+    @Nonnull
     @Override
     public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a Flake ID-generator instance with a null name is not allowed!");
         return getDistributedObject(FlakeIdGeneratorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
     public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a cardinality estimator instance with a null name is not allowed!");
@@ -612,6 +615,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return getDistributedObject(PNCounterService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
     public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
         checkNotNull(name, "Retrieving a scheduled executor instance with a null name is not allowed!");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -188,11 +188,13 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
         return getClient().newTransactionContext(options);
     }
 
+    @Nonnull
     @Override
     public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         return getClient().getFlakeIdGenerator(name);
     }
 
+    @Nonnull
     @Override
     public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
         return getClient().getCardinalityEstimator(name);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/LifecycleServiceImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.internal.util.executor.PoolExecutorThreadFactory;
 
+import javax.annotation.Nonnull;
 import java.util.EventListener;
 import java.util.List;
 import java.util.UUID;
@@ -42,6 +43,7 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
 /**
@@ -89,15 +91,18 @@ public final class LifecycleServiceImpl implements LifecycleService {
         return client.getLoggingService().getLogger(LifecycleService.class);
     }
 
+    @Nonnull
     @Override
-    public UUID addLifecycleListener(LifecycleListener lifecycleListener) {
+    public UUID addLifecycleListener(@Nonnull LifecycleListener lifecycleListener) {
+        checkNotNull(lifecycleListener, "lifecycleListener must not be null");
         final UUID id = UuidUtil.newUnsecureUUID();
         lifecycleListeners.put(id, lifecycleListener);
         return id;
     }
 
     @Override
-    public boolean removeLifecycleListener(UUID registrationId) {
+    public boolean removeLifecycleListener(@Nonnull UUID registrationId) {
+        checkNotNull(registrationId, "registrationId must not be null");
         return lifecycleListeners.remove(registrationId) != null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/PartitionServiceProxy.java
@@ -31,10 +31,13 @@ import com.hazelcast.partition.Partition;
 import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.partition.PartitionService;
 
+import javax.annotation.Nonnull;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * @author mdogan 5/16/13
@@ -61,7 +64,8 @@ public final class PartitionServiceProxy implements PartitionService {
     }
 
     @Override
-    public Partition getPartition(Object key) {
+    public Partition getPartition(@Nonnull Object key) {
+        checkNotNull(key, "key cannot be null");
         final int partitionId = partitionService.getPartitionId(key);
         return partitionService.getPartition(partitionId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.core;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -49,7 +50,7 @@ public interface LifecycleService {
      * @param lifecycleListener the listener object
      * @return the listener ID
      */
-    UUID addLifecycleListener(LifecycleListener lifecycleListener);
+    @Nonnull UUID addLifecycleListener(@Nonnull LifecycleListener lifecycleListener);
 
     /**
      * Removes a lifecycle listener.
@@ -57,5 +58,5 @@ public interface LifecycleService {
      * @param registrationId the listener ID returned by {@link #addLifecycleListener(LifecycleListener)}
      * @return true if the listener is removed successfully, false otherwise
      */
-    boolean removeLifecycleListener(UUID registrationId);
+    boolean removeLifecycleListener(@Nonnull UUID registrationId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
@@ -16,19 +16,20 @@
 
 package com.hazelcast.cp;
 
-import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.collection.ISet;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
+import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
-import com.hazelcast.map.IMap;
-import com.hazelcast.collection.ISet;
 import com.hazelcast.cp.lock.FencedLock;
 import com.hazelcast.cp.session.CPSession;
 import com.hazelcast.cp.session.CPSessionManagementService;
+import com.hazelcast.map.IMap;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -386,7 +387,8 @@ public interface CPSubsystem {
      * @return {@link IAtomicLong} proxy for the given name
      * @throws HazelcastException if CP Subsystem is not enabled
      */
-    IAtomicLong getAtomicLong(String name);
+    @Nonnull
+    IAtomicLong getAtomicLong(@Nonnull String name);
 
     /**
      * Returns a proxy for an {@link IAtomicReference} instance created on
@@ -409,7 +411,8 @@ public interface CPSubsystem {
      * @return {@link IAtomicReference} proxy for the given name
      * @throws HazelcastException if CP Subsystem is not enabled
      */
-    <E> IAtomicReference<E> getAtomicReference(String name);
+    @Nonnull
+    <E> IAtomicReference<E> getAtomicReference(@Nonnull String name);
 
     /**
      * Returns a proxy for an {@link ICountDownLatch} instance created on
@@ -432,7 +435,7 @@ public interface CPSubsystem {
      * @return {@link ICountDownLatch} proxy for the given name
      * @throws HazelcastException if CP Subsystem is not enabled
      */
-    ICountDownLatch getCountDownLatch(String name);
+    @Nonnull ICountDownLatch getCountDownLatch(@Nonnull String name);
 
     /**
      * Returns a proxy for an {@link FencedLock} instance created on CP
@@ -450,13 +453,12 @@ public interface CPSubsystem {
      * <strong>Each call of this method performs a commit to the METADATA CP
      * group. Hence, callers should cache the returned proxy.</strong>
      *
-     * @see FencedLockConfig
-     *
      * @param name name of the {@link FencedLock} proxy
      * @return {@link FencedLock} proxy for the given name
      * @throws HazelcastException if CP Subsystem is not enabled
+     * @see FencedLockConfig
      */
-    FencedLock getLock(String name);
+    @Nonnull FencedLock getLock(@Nonnull String name);
 
     /**
      * Returns a proxy for an {@link ISemaphore} instance created on CP
@@ -474,13 +476,12 @@ public interface CPSubsystem {
      * <strong>Each call of this method performs a commit to the METADATA CP
      * group. Hence, callers should cache the returned proxy.</strong>
      *
-     * @see SemaphoreConfig
-     *
      * @param name name of the {@link ISemaphore} proxy
      * @return {@link ISemaphore} proxy for the given name
      * @throws HazelcastException if CP Subsystem is not enabled
+     * @see SemaphoreConfig
      */
-    ISemaphore getSemaphore(String name);
+    @Nonnull ISemaphore getSemaphore(@Nonnull String name);
 
     /**
      * Returns the local CP member if this Hazelcast member is part of

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
@@ -40,6 +40,7 @@ import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -68,32 +69,37 @@ public class CPSubsystemImpl implements CPSubsystem {
         }
     }
 
+    @Nonnull
     @Override
-    public IAtomicLong getAtomicLong(String name) {
+    public IAtomicLong getAtomicLong(@Nonnull String name) {
         checkNotNull(name, "Retrieving an atomic long instance with a null name is not allowed!");
         return createProxy(AtomicLongService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public <E> IAtomicReference<E> getAtomicReference(String name) {
+    public <E> IAtomicReference<E> getAtomicReference(@Nonnull String name) {
         checkNotNull(name, "Retrieving an atomic reference instance with a null name is not allowed!");
         return createProxy(AtomicRefService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public ICountDownLatch getCountDownLatch(String name) {
+    public ICountDownLatch getCountDownLatch(@Nonnull String name) {
         checkNotNull(name, "Retrieving a count down latch instance with a null name is not allowed!");
         return createProxy(CountDownLatchService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public FencedLock getLock(String name) {
+    public FencedLock getLock(@Nonnull String name) {
         checkNotNull(name, "Retrieving an fenced lock instance with a null name is not allowed!");
         return createProxy(LockService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
-    public ISemaphore getSemaphore(String name) {
+    public ISemaphore getSemaphore(@Nonnull String name) {
         checkNotNull(name, "Retrieving a semaphore instance with a null name is not allowed!");
         return createProxy(SemaphoreService.SERVICE_NAME, name);
     }
@@ -126,7 +132,7 @@ public class CPSubsystemImpl implements CPSubsystem {
         return getService(RaftSessionService.SERVICE_NAME);
     }
 
-    private <T> T getService(String serviceName) {
+    private <T> T getService(@Nonnull String serviceName) {
         return instance.node.getNodeEngine().getService(serviceName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -260,12 +260,14 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         return getDistributedObject(DistributedDurableExecutorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
     public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         checkNotNull(name, "Retrieving a Flake ID-generator instance with a null name is not allowed!");
         return getDistributedObject(FlakeIdGeneratorService.SERVICE_NAME, name);
     }
 
+    @Nonnull
     @Override
     public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         checkNotNull(name, "Retrieving a replicated map instance with a null name is not allowed!");

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -136,6 +136,7 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().getRingbuffer(name);
     }
 
+    @Nonnull
     @Override
     public IExecutorService getExecutorService(@Nonnull String name) {
         return getOriginal().getExecutorService(name);
@@ -168,11 +169,13 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().newTransactionContext(options);
     }
 
+    @Nonnull
     @Override
     public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         return getOriginal().getFlakeIdGenerator(name);
     }
 
+    @Nonnull
     @Override
     public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
         return getOriginal().getReplicatedMap(name);

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/LifecycleServiceImpl.java
@@ -21,21 +21,22 @@ import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.internal.jmx.ManagementService;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.internal.util.UuidUtil;
+import com.hazelcast.logging.ILogger;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 public class LifecycleServiceImpl implements LifecycleService {
 
     private final HazelcastInstanceImpl instance;
-    private final ConcurrentMap<UUID, LifecycleListener> lifecycleListeners
-            = new ConcurrentHashMap<UUID, LifecycleListener>();
+    private final ConcurrentMap<UUID, LifecycleListener> lifecycleListeners = new ConcurrentHashMap<>();
     private final Object lifecycleLock = new Object();
 
     public LifecycleServiceImpl(HazelcastInstanceImpl instance) {
@@ -46,15 +47,18 @@ public class LifecycleServiceImpl implements LifecycleService {
         return instance.node.getLogger(LifecycleService.class.getName());
     }
 
+    @Nonnull
     @Override
-    public UUID addLifecycleListener(LifecycleListener lifecycleListener) {
+    public UUID addLifecycleListener(@Nonnull LifecycleListener lifecycleListener) {
+        checkNotNull(lifecycleListener, "lifecycleListener must not be null");
         final UUID id = UuidUtil.newUnsecureUUID();
         lifecycleListeners.put(id, lifecycleListener);
         return id;
     }
 
     @Override
-    public boolean removeLifecycleListener(UUID registrationId) {
+    public boolean removeLifecycleListener(@Nonnull UUID registrationId) {
+        checkNotNull(registrationId, "registrationId must not be null");
         return lifecycleListeners.remove(registrationId) != null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/TerminatedLifecycleService.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/TerminatedLifecycleService.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 public final class TerminatedLifecycleService implements LifecycleService {
@@ -37,13 +38,14 @@ public final class TerminatedLifecycleService implements LifecycleService {
     public void terminate() {
     }
 
+    @Nonnull
     @Override
-    public UUID addLifecycleListener(LifecycleListener lifecycleListener) {
+    public UUID addLifecycleListener(@Nonnull LifecycleListener lifecycleListener) {
         throw new HazelcastInstanceNotActiveException();
     }
 
     @Override
-    public boolean removeLifecycleListener(UUID registrationId) {
+    public boolean removeLifecycleListener(@Nonnull UUID registrationId) {
         throw new HazelcastInstanceNotActiveException();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.internal.util.FutureUtil;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,6 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 public class PartitionServiceProxy implements PartitionService {
 
@@ -83,7 +85,8 @@ public class PartitionServiceProxy implements PartitionService {
     }
 
     @Override
-    public Partition getPartition(Object key) {
+    public Partition getPartition(@Nonnull Object key) {
+        checkNotNull(key, "key cannot be null");
         int partitionId = partitionService.getPartitionId(key);
         return partitionMap.get(partitionId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/logging/LogListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LogListener.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.logging;
 
+@FunctionalInterface
 public interface LogListener {
-
     void log(LogEvent logEvent);
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggingService.java
@@ -16,15 +16,16 @@
 
 package com.hazelcast.logging;
 
+import javax.annotation.Nonnull;
 import java.util.logging.Level;
 
 public interface LoggingService {
 
-    void addLogListener(Level level, LogListener logListener);
+    void addLogListener(@Nonnull Level level, @Nonnull LogListener logListener);
 
-    void removeLogListener(LogListener logListener);
+    void removeLogListener(@Nonnull LogListener logListener);
 
-    ILogger getLogger(String name);
+    @Nonnull ILogger getLogger(@Nonnull String name);
 
-    ILogger getLogger(Class type);
+    @Nonnull ILogger getLogger(@Nonnull Class type);
 }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -122,6 +122,7 @@ class HazelcastOSGiInstanceImpl
         return delegatedInstance.getMultiMap(name);
     }
 
+    @Nonnull
     @Override
     public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
         return delegatedInstance.getRingbuffer(name);
@@ -183,6 +184,7 @@ class HazelcastOSGiInstanceImpl
         return delegatedInstance.newTransactionContext(options);
     }
 
+    @Nonnull
     @Override
     public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
         return delegatedInstance.getFlakeIdGenerator(name);

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionService.java
@@ -18,6 +18,7 @@ package com.hazelcast.partition;
 
 import com.hazelcast.cluster.Member;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * PartitionService allows you to query {@link Partition}s and attach/detach {@link MigrationListener}s to listen to partition
  * migration events.
- *
+ * <p>
  * The methods on the PartitionService are thread-safe.
  *
  * @see Partition
@@ -47,8 +48,7 @@ public interface PartitionService {
      * @param key the given key
      * @return the partition that the given key belongs to
      */
-    // TODO: what about null.
-    Partition getPartition(Object key);
+    Partition getPartition(@Nonnull Object key);
 
     /**
      * Adds a MigrationListener.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
@@ -39,6 +39,7 @@ import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.wan.impl.WanReplicationService;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
@@ -266,7 +267,7 @@ public interface NodeEngine {
      * @param <T>         the type of the service
      * @return the found service, or HazelcastException in case of failure ({@code null} will never be returned)
      */
-    <T> T getService(String serviceName);
+    <T> T getService(@Nonnull String serviceName);
 
     /**
      * Gets the service for the given serviceName if it exists or null otherwise.
@@ -276,7 +277,7 @@ public interface NodeEngine {
      * @return the found service, or null if the service was not found
      * @throws NullPointerException if the serviceName is {@code null}
      */
-    <T> T getServiceOrNull(String serviceName);
+    <T> T getServiceOrNull(@Nonnull String serviceName);
 
     /**
      * Returns the codebase version of the node. For example, when running on hazelcast-3.8.jar, this would resolve

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -375,7 +375,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
-    public <T> T getService(String serviceName) {
+    public <T> T getService(@Nonnull String serviceName) {
         T service = serviceManager.getService(serviceName);
         if (service == null) {
             if (isRunning()) {
@@ -389,7 +389,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
-    public <T> T getServiceOrNull(String serviceName) {
+    public <T> T getServiceOrNull(@Nonnull String serviceName) {
         return serviceManager.getService(serviceName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.internal.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -41,7 +42,7 @@ public class Registration implements EventRegistration {
     public Registration() {
     }
 
-    public Registration(UUID id, String serviceName, String topic,
+    public Registration(@Nonnull UUID id, String serviceName, String topic,
                         EventFilter filter, Address subscriber, Object listener, boolean localOnly) {
         this.id = Preconditions.checkNotNull(id, "Registration ID cannot be null!");
         this.filter = filter;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceManager.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.servicemanager;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ public interface ServiceManager {
      * @param serviceName the name of the service.
      * @return the found ServiceInfo or null if nothing is found.
      */
-    ServiceInfo getServiceInfo(String serviceName);
+    ServiceInfo getServiceInfo(@Nonnull String serviceName);
 
     /**
      * Gets all the service info's for services that implement a given class/interface.
@@ -46,7 +47,7 @@ public interface ServiceManager {
      * @param <T>
      * @return the found service or null if nothing is found.
      */
-    <T> T getService(String serviceName);
+    <T> T getService(@Nonnull String serviceName);
 
     /**
      * Gets all services implementing a certain class/interface.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -63,6 +63,7 @@ import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.wan.impl.WanReplicationService;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Collections;
@@ -328,7 +329,7 @@ public final class ServiceManagerImpl implements ServiceManager {
     }
 
     @Override
-    public ServiceInfo getServiceInfo(String serviceName) {
+    public ServiceInfo getServiceInfo(@Nonnull String serviceName) {
         return services.get(serviceName);
     }
 
@@ -349,7 +350,7 @@ public final class ServiceManagerImpl implements ServiceManager {
     }
 
     @Override
-    public <T> T getService(String serviceName) {
+    public <T> T getService(@Nonnull String serviceName) {
         final ServiceInfo serviceInfo = getServiceInfo(serviceName);
         return serviceInfo != null ? (T) serviceInfo.getService() : null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/HazelcastXAResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/HazelcastXAResource.java
@@ -18,6 +18,7 @@ package com.hazelcast.transaction;
 
 import com.hazelcast.core.DistributedObject;
 
+import javax.annotation.Nonnull;
 import javax.transaction.xa.XAResource;
 
 /**
@@ -31,7 +32,7 @@ public interface HazelcastXAResource extends XAResource, DistributedObject {
      * @return TransactionContext associated with the current thread
      * @throws IllegalStateException if no context found
      */
-    TransactionContext getTransactionContext();
+    @Nonnull TransactionContext getTransactionContext();
 
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -39,6 +39,7 @@ import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOpe
 import com.hazelcast.transaction.impl.xa.operations.FinalizeRemoteTransactionOperation;
 import com.hazelcast.internal.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -295,6 +296,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
         return SERVICE_NAME;
     }
 
+    @Nonnull
     @Override
     public TransactionContext getTransactionContext() {
         long threadId = Thread.currentThread().getId();

--- a/hazelcast/src/test/java/com/hazelcast/AbstractLifecycleServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/AbstractLifecycleServiceNullTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractLifecycleServiceNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(s -> s.addLifecycleListener(null));
+        assertThrowsNPE(s -> s.removeLifecycleListener(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<LifecycleService> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<LifecycleService> method) {
+        try {
+            method.accept(getDriver().getLifecycleService());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/MemberLifecycleServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/MemberLifecycleServiceNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic lifecycle service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberLifecycleServiceNullTest extends AbstractLifecycleServiceNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/AbstractClientServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AbstractClientServiceNullTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractClientServiceNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(cs -> cs.addClientListener(null));
+        assertThrowsNPE(cs -> cs.removeClientListener(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<ClientService> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<ClientService> method) {
+        try {
+            method.accept(getDriver().getClientService());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientLifecycleServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientLifecycleServiceNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.AbstractLifecycleServiceNullTest;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Client implementation for basic lifecycle service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientLifecycleServiceNullTest extends AbstractLifecycleServiceNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/MemberClientServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/MemberClientServiceNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic client service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberClientServiceNullTest extends AbstractClientServiceNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/ClientCPSubsystemNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/ClientCPSubsystemNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cp;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.AbstractCPSubsystemNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Client implementation for basic CP subsystem methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientCPSubsystemNullTest extends AbstractCPSubsystemNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/logging/ClientLoggingServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/logging/ClientLoggingServiceNullTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.logging;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.AbstractLoggingServiceNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Client implementation for basic logging service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientLoggingServiceNullTest extends AbstractLoggingServiceNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected boolean isNotClient() {
+        return false;
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.partitionservice;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.partition.AbstractPartitionServiceNullTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Client implementation for basic partition service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientPartitionServiceNullTest extends AbstractPartitionServiceNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/AbstractCPSubsystemNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/AbstractCPSubsystemNullTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractCPSubsystemNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(cp -> cp.getAtomicLong(null));
+        assertThrowsNPE(cp -> cp.getAtomicReference(null));
+        assertThrowsNPE(cp -> cp.getCountDownLatch(null));
+        assertThrowsNPE(cp -> cp.getLock(null));
+        assertThrowsNPE(cp -> cp.getSemaphore(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<CPSubsystem> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<CPSubsystem> method) {
+        try {
+            method.accept(getDriver().getCPSubsystem());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/MemberCPSubsystemNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/MemberCPSubsystemNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic CP subsystem methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberCPSubsystemNullTest extends AbstractCPSubsystemNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggingServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggingServiceNullTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.logging;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+import java.util.logging.Level;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractLoggingServiceNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        LogListener dummyLogListener = logEvent -> {
+
+        };
+        if (isNotClient()) {
+            assertThrowsNPE(s -> s.addLogListener(null, dummyLogListener));
+            assertThrowsNPE(s -> s.addLogListener(Level.FINEST, null));
+            assertThrowsNPE(s -> s.removeLogListener(null));
+        }
+        assertThrowsNPE(s -> s.getLogger((String) null));
+        assertThrowsNPE(s -> s.getLogger((Class) null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<LoggingService> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<LoggingService> method) {
+        try {
+            method.accept(getDriver().getLoggingService());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract boolean isNotClient();
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/logging/MemberLoggingServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/MemberLoggingServiceNullTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.logging;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic logging service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberLoggingServiceNullTest extends AbstractLoggingServiceNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected boolean isNotClient() {
+        return true;
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/partition/AbstractPartitionServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/AbstractPartitionServiceNullTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractPartitionServiceNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        assertThrowsNPE(ps -> ps.getPartition(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<PartitionService> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<PartitionService> method) {
+        try {
+            method.accept(getDriver().getPartitionService());
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/partition/MemberPartitionServiceNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/MemberPartitionServiceNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic partition service methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberPartitionServiceNullTest extends AbstractPartitionServiceNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}


### PR DESCRIPTION
Adds Nonnull and Nullable annotations to CP subsystem, logging service,
lifecycle service, partition service and client service.
Aligned behaviour of client-side XAResourceProxy with the member-side
implementation when it comes to behaviour with null parameters.
Added FunctionalInterface to LogListener and cleaned up some JDK8
code.

I realise there's much more API that might be covered (including return values) but this is as far as I'm willing to go at the moment.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3268