### PR TITLE
Improve MetadataRaftGroupTest assertions

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -59,7 +59,6 @@ import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGro
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getSnapshotEntry;
-import static com.hazelcast.cp.internal.raft.impl.RaftUtil.waitUntilLeaderElected;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.FINALIZE_JOIN;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsToAddresses;
@@ -492,7 +491,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
                 assertTrueEventually(() -> {
                     RaftNodeImpl raftNode = getRaftNode(instance, groupId);
                     assertNotNull(raftNode);
-                    waitUntilLeaderElected(raftNode);
+                    assertNotNull("Leader is null on " + raftNode, getLeaderMember(raftNode));
                 });
             }
         }
@@ -514,7 +513,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
                 }
                 RaftNodeImpl raftNode = getRaftNode(instance, getMetadataGroupId(instance));
                 assertNotNull(raftNode);
-                waitUntilLeaderElected(raftNode);
+                assertNotNull("Leader is null on " + raftNode, getLeaderMember(raftNode));
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/RaftUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/RaftUtil.java
@@ -125,7 +125,7 @@ public class RaftUtil {
     }
 
     public static void waitUntilLeaderElected(RaftNodeImpl node) {
-        assertTrueEventually(() -> assertNotNull(getLeaderMember(node)));
+        assertTrueEventually(() -> assertNotNull("Leader is null on " + node, getLeaderMember(node)));
     }
 
     private static <T> T readRaftState(RaftNodeImpl node, Callable<T> task) {


### PR DESCRIPTION
Improved leader election assertions in tests. Tests should not timeout anymore and fail with failing assertion if they ever fail again.

Closes #15464