### PR TITLE
Removed the isolated operation thread flag

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -41,7 +41,6 @@ import com.hazelcast.spi.impl.operationservice.OperationService;
 import java.util.Map;
 import java.util.function.Function;
 
-import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -59,75 +58,15 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.partition.count", 271);
 
     /**
-     * For more detail see {@link #PARTITION_OPERATION_THREAD_COUNT}.
-     *
-     * If this property is set to false, Hazelcast will default to 3.x style
-     * operation thread configuration whereby the sum of the number of partition
-     * threads and IO threads exceeds the number of cores.
-     *
-     * If this property is set to true (default) Hazelcast will subtract the
-     * number of IO threads from the number of available processors and that will
-     * be the number of partition threads.
-     *
-     * If explicit number of partition threads is configured, this property is
-     * irrelevant.
-     *
-     * This property favors the typical get/set type of application. Application
-     * that are number crunching or query heavy, will get a performance hit
-     * because not all cores will be busy with processing operations since there
-     * are less operation threads than processors. So for such applications it
-     * is best to explicitly disable this property.
-     */
-    public static final HazelcastProperty PARTITION_OPERATION_THREAD_ISOLATED
-            = new HazelcastProperty("hazelcast.operation.thread.isolated", new Function<HazelcastProperties, Boolean>() {
-        @Override
-        public Boolean apply(HazelcastProperties properties) {
-            int availableProcessors = RuntimeAvailableProcessors.get();
-            if (availableProcessors < 20) {
-                return false;
-            }
-
-            int ioThreads = properties.getInteger(IO_INPUT_THREAD_COUNT) + properties.getInteger(IO_OUTPUT_THREAD_COUNT);
-            if (ioThreads > 8) {
-                return false;
-            }
-
-            return true;
-        }
-    });
-
-    /**
      * The number of partition operation handler threads per member.
      * <p>
      * If this is less than the number of partitions on a member, partition operations
      * will queue behind other operations of different partitions.
      *
-     * If the JVM detects 20 or more cores, and 'hazelcast.operation.thread.isolated' is set to true,
-     * it will prevent creating more threads than available cores by
-     * determining the number of operation threads as corecount-iothreadcount.
-     * This will prevent that IO threads and partition threads will contend for cores and this leads to
-     * increases throughput and less jitter.
-     *
-     * If explicit number of partition threads is configured, than the magic where we try to determine optimal
-     * number of partition threads is bypassed.
      */
     public static final HazelcastProperty PARTITION_OPERATION_THREAD_COUNT
-            = new HazelcastProperty("hazelcast.operation.thread.count", new Function<HazelcastProperties, Integer>() {
-        @Override
-        public Integer apply(HazelcastProperties properties) {
-            int availableProcessors = RuntimeAvailableProcessors.get();
-            boolean isolated = properties.getBoolean(PARTITION_OPERATION_THREAD_ISOLATED);
-
-            if (isolated) {
-                int ioThreads = properties.getInteger(IO_INPUT_THREAD_COUNT) + properties.getInteger(IO_OUTPUT_THREAD_COUNT);
-                int partitionThreadCount = availableProcessors - ioThreads;
-                return checkPositive(partitionThreadCount, "partitionThreadCount must be positive,"
-                        + " but was " + partitionThreadCount);
-            } else {
-                return max(2, availableProcessors);
-            }
-        }
-    });
+            = new HazelcastProperty("hazelcast.operation.thread.count",
+            (Function<HazelcastProperties, Integer>) properties -> max(2, RuntimeAvailableProcessors.get()));
 
     /**
      * The number of generic operation handler threads per member.


### PR DESCRIPTION
If you want to have less operation threads than cores, use the
operation threadcount directly.