### PR TITLE
EntryProcessor with Predicate should not touch non-matching entries

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
@@ -86,6 +87,7 @@ public final class EntryOperator {
     private Object newValue;
     private EntryEventType eventType;
     private Data result;
+    private boolean didMatchPredicate;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     private EntryOperator(MapOperation mapOperation, Object processor, Predicate predicate, boolean collectWanEvents) {
@@ -141,6 +143,7 @@ public final class EntryOperator {
         this.newValue = newValue;
         this.eventType = eventType;
         this.result = result;
+        this.didMatchPredicate = true;
         return this;
     }
 
@@ -151,7 +154,7 @@ public final class EntryOperator {
             return this;
         }
 
-        oldValue = recordStore.get(dataKey, backup, callerAddress);
+        oldValue = recordStore.get(dataKey, backup, callerAddress, false);
         // predicated entry processors can only be applied to existing entries
         // so if we have a predicate and somehow(due to expiration or split-brain healing)
         // we found value null, we should skip that entry.
@@ -173,6 +176,7 @@ public final class EntryOperator {
 
         Entry entry = createMapEntry(dataKey, oldValue, locked);
         if (outOfPredicateScope(entry)) {
+            this.didMatchPredicate = false;
             return this;
         }
 
@@ -207,13 +211,20 @@ public final class EntryOperator {
     }
 
     public EntryOperator doPostOperateOps() {
+        if (!didMatchPredicate) {
+            return this;
+        }
         if (eventType == null) {
             // when event type is null, it means this is a read-only entry processor and not modified entry.
+            onTouched();
             return this;
         }
         switch (eventType) {
-            case ADDED:
             case UPDATED:
+                onTouched();
+                onAddedOrUpdated();
+                break;
+            case ADDED:
                 onAddedOrUpdated();
                 break;
             case REMOVED:
@@ -277,6 +288,14 @@ public final class EntryOperator {
         }
 
         eventType = oldValue == null ? ADDED : UPDATED;
+    }
+
+    private void onTouched() {
+        // updates access time if record exists
+        Record record = recordStore.getRecord(dataKey);
+        if (record != null) {
+            recordStore.accessRecord(record, Clock.currentTimeMillis());
+        }
     }
 
     private void onAddedOrUpdated() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -567,7 +567,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Object get(Data key, boolean backup, Address callerAddress) {
+    public Object get(Data key, boolean backup, Address callerAddress, boolean touch) {
         checkIfLoaded();
         long now = getNow();
 
@@ -575,7 +575,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             record = loadRecordOrNull(key, backup, callerAddress);
             record = getOrNullIfExpired(record, now, backup);
-        } else {
+        } else if (touch) {
             accessRecord(record, now);
         }
         Object value = record == null ? null : record.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -144,10 +144,20 @@ public interface RecordStore<R extends Record> {
      * Loads missing keys from map store.
      *
      * @param dataKey key.
-     * @param backup  <code>true</code> if a backup partition, otherwise <code>false</code>.
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
+     * @param touch   when {@code true}, if an existing record was found for the given key,
+     *                then its last access time is updated.
      * @return value of an entry in {@link RecordStore}
      */
-    Object get(Data dataKey, boolean backup, Address callerAddress);
+    Object get(Data dataKey, boolean backup, Address callerAddress, boolean touch);
+
+    /**
+     * Same as {@link #get(Data, boolean, Address, boolean)} with parameter {@code touch}
+     * set {@code true}.
+     */
+    default Object get(Data dataKey, boolean backup, Address callerAddress) {
+        return get(dataKey, backup, callerAddress, true);
+    }
 
     /**
      * Called when {@link com.hazelcast.config.MapConfig#isReadBackupData} is <code>true</code> from

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
@@ -1628,6 +1629,42 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         for (Object response : partitionResponses.values()) {
             assertEquals(0, ((MapEntries) response).size());
         }
+    }
+
+    // when executing EntryProcessor with predicate via partition scan
+    // entries not matching the predicate should not be touched
+    // see https://github.com/hazelcast/hazelcast/issues/15515
+    @Test
+    public void testEntryProcessorWithPredicate_doesNotTouchNonMatchingEntries() {
+        testEntryProcessorWithPredicate_updatesLastAccessTime(false);
+    }
+
+    @Test
+    public void testEntryProcessorWithPredicate_touchesMatchingEntries() {
+        testEntryProcessorWithPredicate_updatesLastAccessTime(true);
+    }
+
+    private void testEntryProcessorWithPredicate_updatesLastAccessTime(boolean accessExpected) {
+        Config config = withoutNetworkJoin(smallInstanceConfig());
+        config.getMapConfig(MAP_NAME)
+              .setTimeToLiveSeconds(60)
+              .setMaxIdleSeconds(30);
+
+        HazelcastInstance member = createHazelcastInstance(config);
+        IMap<String, String> map = member.getMap(MAP_NAME);
+        map.put("testKey", "testValue");
+        EntryView evStart = map.getEntryView("testKey");
+        sleepAtLeastSeconds(2);
+        map.executeOnEntries(entry -> null, entry -> accessExpected);
+        EntryView evEnd = map.getEntryView("testKey");
+
+        if (accessExpected) {
+            assertTrue("Expiration time should be greater than original one",
+                    evEnd.getExpirationTime() > evStart.getExpirationTime());
+        } else {
+            assertEquals("Expiration time should be the same", evStart.getExpirationTime(), evEnd.getExpirationTime());
+        }
+
     }
 
     private static class MyData implements Serializable {

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
@@ -57,7 +57,7 @@ public class MapRemoveAllTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void throws_exception_whenPredicateNull() throws Exception {
+    public void throws_exception_whenPredicateNull() {
         expectedException.expect(NullPointerException.class);
         expectedException.expectMessage("predicate cannot be null");
 
@@ -66,7 +66,7 @@ public class MapRemoveAllTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void removes_all_entries_whenPredicateTrue() throws Exception {
+    public void removes_all_entries_whenPredicateTrue() {
         IMap<Integer, Integer> map = member.getMap("test");
         for (int i = 0; i < MAP_SIZE; i++) {
             map.put(i, i);
@@ -78,7 +78,7 @@ public class MapRemoveAllTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void removes_no_entries_whenPredicateFalse() throws Exception {
+    public void removes_no_entries_whenPredicateFalse() {
         IMap<Integer, Integer> map = member.getMap("test");
         for (int i = 0; i < MAP_SIZE; i++) {
             map.put(i, i);
@@ -90,7 +90,7 @@ public class MapRemoveAllTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void removes_odd_keys_whenPredicateOdd() throws Exception {
+    public void removes_odd_keys_whenPredicateOdd() {
         IMap<Integer, Integer> map = member.getMap("test");
         for (int i = 0; i < MAP_SIZE; i++) {
             map.put(i, i);
@@ -127,6 +127,21 @@ public class MapRemoveAllTest extends HazelcastTestSupport {
 
         assertEquals(100, totalOwnedEntryCount);
         assertEquals(100, totalBackupEntryCount);
+    }
+
+    // see https://github.com/hazelcast/hazelcast/issues/15515
+    @Test
+    public void removeAll_doesNotTouchNonMatchingEntries() {
+        String mapName = "test";
+        IMap<Integer, Integer> map = member.getMap(mapName);
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i);
+        }
+        long expirationTime = map.getEntryView(1).getExpirationTime();
+
+        map.removeAll(Predicates.sql("__key >= 100"));
+        assertEquals("Expiration time of non-matching key 1 should be same as original",
+                expirationTime, map.getEntryView(1).getExpirationTime());
     }
 
     private static final class OddFinderPredicate implements Predicate<Integer, Integer> {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -185,6 +185,13 @@ public abstract class HazelcastTestSupport {
         return new Config();
     }
 
+    // disables multicast/tcp-ip network discovery on the given config and returns the same
+    public static Config withoutNetworkJoin(Config config) {
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        return config;
+    }
+
     protected Config getConfig() {
         return regularInstanceConfig();
     }


### PR DESCRIPTION
When an `EntryProcessor` is executed on entries filtered by a `Predicate`,
then non-matching entries are not accessed by the `EntryProcessor`.
Therefore their last access time should not be updated.

Fixes #15515 on `master`