### PR TITLE
Improved MembershipUpdateTest.connectionsToRemovedMember_shouldBeClosed (#15710)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -852,7 +852,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
     @Test
     public void connectionsToRemovedMember_shouldBeClosed() {
         Config config = new Config()
-            .setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "10")
+            .setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "20")
             .setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);


### PR DESCRIPTION
Increased `MAX_NO_HEARTBEAT_SECONDS` from 10s to 20s to make the test less sensitive to hiccups.

Fixes https://github.com/hazelcast/hazelcast/issues/15710