### PR TITLE
[BACKPORT] EntryProcessor with Predicate should not touch non-matching entries

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -117,6 +117,11 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         return isRecordStoreExpirable();
     }
 
+    @Override
+    public Object get(Data dataKey, boolean backup, Address callerAddress) {
+        return get(dataKey, backup, callerAddress, true);
+    }
+
     /**
      * Intended to put an upper bound to iterations. Used in evictions.
      *
@@ -343,7 +348,8 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         clearExpiredRecordsTask.tryToSendBackupExpiryOp(this, true);
     }
 
-    protected void accessRecord(Record record, long now) {
+    @Override
+    public void accessRecord(Record record, long now) {
         record.onAccess(now);
         updateStatsOnGet(now);
         setExpirationTime(record);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -508,14 +508,14 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Object get(Data key, boolean backup, Address callerAddress) {
+    public Object get(Data key, boolean backup, Address callerAddress, boolean touch) {
         checkIfLoaded();
         long now = getNow();
 
         Record record = getRecordOrNull(key, now, backup);
         if (record == null) {
             record = loadRecordOrNull(key, backup, callerAddress);
-        } else {
+        } else if (touch) {
             accessRecord(record, now);
         }
         Object value = record == null ? null : record.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -59,6 +59,17 @@ public interface RecordStore<R extends Record> {
 
     LocalRecordStoreStats getLocalRecordStoreStats();
 
+    /**
+     * Touches the given record, updating its last access time to {@code now} and
+     * maintaining statistics.
+     * <p>
+     * An implementation is not supposed to be thread safe.
+     *
+     * @param record the accessed record
+     * @param now    the current time
+     */
+    void accessRecord(Record record, long now);
+
     String getName();
 
     /**
@@ -129,8 +140,16 @@ public interface RecordStore<R extends Record> {
      * Loads missing keys from map store.
      *
      * @param dataKey key.
-     * @param backup  <code>true</code> if a backup partition, otherwise <code>false</code>.
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
+     * @param touch   when {@code true}, if an existing record was found for the given key,
+     *                then its last access time is updated.
      * @return value of an entry in {@link RecordStore}
+     */
+    Object get(Data dataKey, boolean backup, Address callerAddress, boolean touch);
+
+    /**
+     * Same as {@link #get(Data, boolean, Address, boolean)} with parameter {@code touch}
+     * set {@code true}.
      */
     Object get(Data dataKey, boolean backup, Address callerAddress);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
@@ -132,6 +132,21 @@ public class MapRemoveAllTest extends HazelcastTestSupport {
         assertEquals(100, totalBackupEntryCount);
     }
 
+    // see https://github.com/hazelcast/hazelcast/issues/15515
+    @Test
+    public void removeAll_doesNotTouchNonMatchingEntries() {
+        String mapName = "test";
+        IMap<Integer, Integer> map = member.getMap(mapName);
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i);
+        }
+        long expirationTime = map.getEntryView(1).getExpirationTime();
+
+        map.removeAll(new SqlPredicate("__key >= 100"));
+        assertEquals("Expiration time of non-matching key 1 should be same as original",
+                expirationTime, map.getEntryView(1).getExpirationTime());
+    }
+
     private static final class OddFinderPredicate implements Predicate<Integer, Integer> {
         @Override
         public boolean apply(Map.Entry<Integer, Integer> mapEntry) {


### PR DESCRIPTION
When an EntryProcessor is executed on entries filtered by a Predicate,
then non-matching entries are not accessed by the EntryProcessor.
Therefore their last access time should not be updated.

Fixes #15515 in `maintenance-3.x` branch