### PR TITLE
use the correct method to get client connection count on NetworkingServiceMBean

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/NetworkingServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/NetworkingServiceMBean.java
@@ -59,7 +59,7 @@ public class NetworkingServiceMBean
             return -1;
         }
 
-        return cem.getConnections().size();
+        return cem.getActiveConnections().size();
     }
 
     @ManagedAnnotation("activeConnectionCount")


### PR DESCRIPTION
Formerly, `NetworkingServiceMBean#getCurrentClientConnections` was using the wrong method to get active client connection count. This was causing the problem described in #15681.

fixes #15681 