### PR TITLE
Adds test and fixes for ClientDelegatingFuture

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientInterceptingDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientInterceptingDelegatingFuture.java
@@ -50,7 +50,7 @@ public class ClientInterceptingDelegatingFuture<V> extends ClientDelegatingFutur
         Throwable throwable = null;
         ClientMessage response = null;
         try {
-            response = future.get();
+            response = (ClientMessage) future.get();
         } catch (Throwable t) {
             originalThrowable = t;
             throwable = (t instanceof ExecutionException) ? t.getCause() : t;
@@ -65,7 +65,7 @@ public class ClientInterceptingDelegatingFuture<V> extends ClientDelegatingFutur
         Throwable throwable = null;
         ClientMessage response = null;
         try {
-            response = future.get(timeout, unit);
+            response = (ClientMessage) future.get(timeout, unit);
         } catch (Throwable t) {
             originalThrowable = t;
             throwable = (t instanceof ExecutionException) ? t.getCause() : t;
@@ -79,7 +79,7 @@ public class ClientInterceptingDelegatingFuture<V> extends ClientDelegatingFutur
         Throwable throwable = null;
         ClientMessage response = null;
         try {
-            response = future.join();
+            response = (ClientMessage) future.join();
         } catch (Throwable t) {
             originalThrowable = t;
             throwable = (t instanceof CompletionException) ? t.getCause() : t;
@@ -92,7 +92,7 @@ public class ClientInterceptingDelegatingFuture<V> extends ClientDelegatingFutur
         Throwable throwable = null;
         ClientMessage response = null;
         try {
-            response = future.joinInternal();
+            response = ((ClientInvocationFuture) future).joinInternal();
         } catch (Throwable t) {
             throwable = t;
         }
@@ -104,7 +104,7 @@ public class ClientInterceptingDelegatingFuture<V> extends ClientDelegatingFutur
             interceptor.accept(null, throwable);
             throw ExceptionUtil.sneakyThrow(originalThrowable);
         } else {
-            final V value = resolveResponse(response, deserializeResponse);
+            final V value = resolve(response);
             interceptor.accept(value, null);
             return value;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -17,21 +17,21 @@
 package com.hazelcast.client.impl.spi.impl;
 
 import com.hazelcast.client.HazelcastClientNotActiveException;
-import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
-import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.connection.nio.ClusterConnectorService;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.ClientClusterService;
 import com.hazelcast.client.impl.spi.ClientExecutionService;
 import com.hazelcast.client.impl.spi.EventHandler;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -388,5 +388,14 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
                 + ", objectName = " + objectName
                 + ", target = " + target
                 + ", sendConnection = " + sendConnection + '}';
+    }
+
+    // package private methods for tests
+    CallIdSequence getCallIdSequence() {
+        return callIdSequence;
+    }
+
+    ClientInvocationFuture getClientInvocationFuture() {
+        return clientInvocationFuture;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -79,7 +79,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     // new Throwable(String message)
     private static final MethodType MT_INIT_STRING = MethodType.methodType(void.class, String.class);
 
-    private static final AtomicReferenceFieldUpdater<AbstractInvocationFuture, Object> STATE =
+    private static final AtomicReferenceFieldUpdater<AbstractInvocationFuture, Object> STATE_UPDATER =
             newUpdater(AbstractInvocationFuture.class, Object.class, "state");
 
     // Default executor for async callbacks: ForkJoinPool.commonPool() or a thread-per-task executor when
@@ -470,14 +470,17 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         return future;
     }
 
+    @Override
     public InternalCompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
         return runAfterEitherAsync(other, action, CALLER_RUNS);
     }
 
+    @Override
     public InternalCompletableFuture<Void> runAfterEitherAsync(@Nonnull CompletionStage<?> other, @Nonnull Runnable action) {
         return runAfterEitherAsync(other, action, defaultExecutor());
     }
 
+    @Override
     public InternalCompletableFuture<Void> runAfterEitherAsync(@Nonnull CompletionStage<?> other,
                                                        @Nonnull Runnable action,
                                                        @Nonnull Executor executor) {
@@ -510,7 +513,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     boolean compareAndSetState(Object oldState, Object newState) {
-        return STATE.compareAndSet(this, oldState, newState);
+        return STATE_UPDATER.compareAndSet(this, oldState, newState);
     }
 
     protected final Object getState() {
@@ -1843,7 +1846,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
      * {@code exceptionFromParent}. Otherwise, the dependent future is completed exceptionally with
      * the exception thrown from user action ({@code exceptionFromAction}).
      */
-    private static void completeDependentExceptionally(CompletableFuture future, Throwable exceptionFromParent,
+    public static void completeDependentExceptionally(CompletableFuture future, Throwable exceptionFromParent,
                                                        Throwable exceptionFromAction) {
         assert (exceptionFromParent != null || exceptionFromAction != null);
         if (exceptionFromParent == null) {
@@ -1858,7 +1861,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
      * {@code CompletionException}, if {@code throwable} is not {@code null}, or with the given
      * {@code value}.
      */
-    private static <V> void completeDependent(CompletableFuture<V> future, V value, Throwable throwable) {
+    public static <V> void completeDependent(CompletableFuture<V> future, V value, Throwable throwable) {
         if (throwable == null) {
             future.complete(value);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
@@ -62,10 +62,10 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
         }
     };
 
-    private final CompletableFuture future;
-    private final InternalSerializationService serializationService;
-    private final Object result;
-    private volatile Object deserializedValue = VOID;
+    protected final CompletableFuture future;
+    protected final InternalSerializationService serializationService;
+    protected final Object result;
+    protected volatile Object deserializedValue = VOID;
 
     public DelegatingCompletableFuture(@Nonnull SerializationService serializationService,
                                        @Nonnull CompletableFuture future) {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientDelegatingFutureTest_CompletionStageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientDelegatingFutureTest_CompletionStageTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.spi.impl;
+
+import com.hazelcast.client.impl.ClientDelegatingFuture;
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapGetCodec;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.CompletableFutureAbstractTest;
+import com.hazelcast.test.ExpectedRuntimeException;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastMillis;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+
+public class ClientDelegatingFutureTest_CompletionStageTest extends CompletableFutureAbstractTest {
+    /*
+     * This test sets up a member & client, as required for
+     * construction of ClientInvocation. However invocations are not
+     * sent to the member, as we need to complete invocations normally or
+     * exceptionally depending on test case.
+     */
+
+    private TestHazelcastFactory factory;
+    private HazelcastClientInstanceImpl client;
+    private ClientMessage request;
+    private ClientMessage response;
+    private SerializationService serializationService;
+    private Data key;
+    private Data value;
+    private ClientInvocation invocation;
+
+    @Before
+    public void setup() {
+        factory = new TestHazelcastFactory();
+        factory.newHazelcastInstance(getConfig());
+        client = getHazelcastClientInstanceImpl(factory.newHazelcastClient());
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        key = serializationService.toData("key");
+        value = serializationService.toData(returnValue);
+        request = MapGetCodec.encodeRequest("test", key, 1L);
+        response = MapGetCodec.encodeResponse(value);
+        invocation = new ClientInvocation(client, request, "test");
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    protected Config getConfig() {
+        Config config = smallInstanceConfig();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        return config;
+    }
+
+    @Override
+    protected CompletableFuture<Object> newCompletableFuture(boolean exceptional, long completeAfterMillis) {
+        invocation.getCallIdSequence().next();
+        ClientInvocationFuture cf = invocation.getClientInvocationFuture();
+
+        ClientDelegatingFuture<Object> future =
+                new ClientDelegatingFuture<>(cf, serializationService, message -> MapGetCodec.decodeResponse(message).response);
+
+        Executor completionExecutor;
+        if (completeAfterMillis <= 0) {
+            completionExecutor = CALLER_RUNS;
+        } else {
+            completionExecutor = command -> new Thread(() -> {
+                sleepAtLeastMillis(completeAfterMillis);
+                command.run();
+            }, "test-completion-thread").start();
+        }
+        if (exceptional) {
+            completionExecutor.execute(() -> invocation.completeExceptionally(new ExpectedRuntimeException()));
+        } else {
+            completionExecutor.execute(completeNormally(invocation));
+        }
+        return future;
+    }
+
+    private Runnable completeNormally(ClientInvocation future) {
+        return () -> future.complete(response);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_CompletionStageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_CompletionStageTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.impl.CompletableFutureAbstractTest;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.CompletableFutureTestUtil.CountingExecutor;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -50,7 +49,6 @@ public class InvocationFuture_CompletionStageTest extends CompletableFutureAbstr
     public void setup() {
         factory = new TestHazelcastInstanceFactory();
         local = factory.newHazelcastInstance(getConfig());
-        countingExecutor = new CountingExecutor();
     }
 
     @After


### PR DESCRIPTION
Test coverage was missing for `ClientDelegatingFuture`;
additionally delegating implementations of `whenComplete`
and `exceptionally` could result in unexpected exception
wrapping. This is fixed by implementing both methods
via callback adapters for respective `handle` methods, avoiding
a wrapper completable future.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3188