### PR TITLE
Enhance Counters so that they can be reused in Jet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/Counter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/Counter.java
@@ -34,6 +34,11 @@ public interface Counter {
     long get();
 
     /**
+     * Sets the current value of the counter.
+     */
+    void set(long value);
+
+    /**
      * Increments the counter by one.
      * @return the new counter state
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/MwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/MwCounter.java
@@ -39,6 +39,11 @@ public final class MwCounter implements Counter {
     }
 
     @Override
+    public void set(long newValue) {
+        COUNTER.set(this, newValue);
+    }
+
+    @Override
     public long get() {
         return value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
@@ -92,7 +92,7 @@ public abstract class SwCounter implements Counter {
         private long localValue;
         private volatile long value;
 
-        protected UnsafeSwCounter(long initialValue) {
+        UnsafeSwCounter(long initialValue) {
             this.value = initialValue;
         }
 
@@ -118,6 +118,12 @@ public abstract class SwCounter implements Counter {
         }
 
         @Override
+        public void set(long newValue) {
+            localValue = newValue;
+            MEM.putOrderedLong(this, OFFSET, newValue);
+        }
+
+        @Override
         public String toString() {
             return "Counter{value=" + value + '}';
         }
@@ -132,7 +138,7 @@ public abstract class SwCounter implements Counter {
 
         private volatile long value;
 
-        protected SafeSwCounter(long initialValue) {
+        SafeSwCounter(long initialValue) {
             this.value = initialValue;
         }
 
@@ -153,6 +159,11 @@ public abstract class SwCounter implements Counter {
         @Override
         public long get() {
             return value;
+        }
+
+        @Override
+        public void set(long newValue) {
+            COUNTER.lazySet(this, newValue);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/MwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/MwCounterTest.java
@@ -52,6 +52,12 @@ public class MwCounterTest {
     }
 
     @Test
+    public void set() {
+        counter.set(100_000);
+        assertEquals(100_000, counter.get());
+    }
+
+    @Test
     public void test_toString() {
         String s = counter.toString();
         assertEquals("Counter{value=0}", s);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SafeSwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SafeSwCounterTest.java
@@ -51,6 +51,12 @@ public class SafeSwCounterTest {
     }
 
     @Test
+    public void set() {
+        counter.set(100_000);
+        assertEquals(100_000, counter.get());
+    }
+
+    @Test
     public void test_toString() {
         String s = counter.toString();
         assertEquals("Counter{value=0}", s);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SwCounterTest.java
@@ -54,6 +54,12 @@ public class SwCounterTest {
     }
 
     @Test
+    public void set() {
+        counter.set(100_000);
+        assertEquals(100_000, counter.get());
+    }
+
+    @Test
     public void test_toString() {
         String s = counter.toString();
         assertEquals("Counter{value=0}", s);


### PR DESCRIPTION
We found ourselves re-implementing these counters in Jet and we would prefer to just use them. For that we need them to also have a `set` method. This PR adds that.