### PR TITLE
Allow checking security realm name presence

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -166,6 +166,16 @@ public class SecurityConfig {
     }
 
     /**
+     * Returns if the given name is a valid realm name.
+     *
+     * @param name realm name to be checked
+     * @return {@code true} if realm with given name exists, {@code false} otherwise.
+     */
+    public boolean isRealm(String name) {
+        return name != null && realmConfigs.containsKey(name);
+    }
+
+    /**
      * @return a boolean flag indicating whether actions, submitted as tasks in an Executor from clients
      * and have no permission mappings, are blocked or allowed.
      * <p>

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -188,10 +188,14 @@ public class DynamicSecurityConfig extends SecurityConfig {
         return staticSecurityConfig.getRealmLoginModuleConfigs(realmName);
     }
 
-
     @Override
     public SecurityConfig setClientRealmConfig(String realmName, RealmConfig realmConfig) {
         throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public boolean isRealm(String name) {
+        return staticSecurityConfig.isRealm(name);
     }
 
     @Override


### PR DESCRIPTION
This is the OS part of fail-fast approach for missing security realms.