### PR TITLE
Fix WAN queue migration for structures with backupCount>1

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -76,7 +76,7 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
         Data dataKey = mergingEntry.getKey();
 
         CacheRecord backupRecord = recordStore.merge(mergingEntry, mergePolicy, NOT_WAN);
-        if (backupRecord != null) {
+        if (backupRecords != null && backupRecord != null) {
             backupRecords.put(dataKey, backupRecord);
         }
         if (recordStore.isWanReplicationEnabled()) {
@@ -90,7 +90,7 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
 
     @Override
     public Object getResponse() {
-        return !backupRecords.isEmpty();
+        return hasBackups && !backupRecords.isEmpty();
     }
 
     @Override
@@ -117,7 +117,7 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int size = in.readInt();
-        mergingEntries = new ArrayList<CacheMergeTypes>(size);
+        mergingEntries = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             CacheMergeTypes mergingEntry = in.readObject();
             mergingEntries.add(mergingEntry);

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -71,7 +71,7 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
 
     /**
      * Returns the fully qualified class name of the class implementing
-     * WanReplicationConsumer.
+     * {@link com.hazelcast.wan.WanReplicationConsumer}.
      *
      * @return fully qualified class name
      */
@@ -81,7 +81,7 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
 
     /**
      * Sets the fully qualified class name of the class implementing
-     * WanReplicationConsumer.
+     * {@link com.hazelcast.wan.WanReplicationConsumer}.
      * The class name may be {@code null} in which case the implementation or
      * the default processing logic for incoming WAN events will be used.
      *
@@ -95,7 +95,8 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Returns the implementation implementing WanReplicationConsumer.
+     * Returns the implementation implementing
+     * {@link com.hazelcast.wan.WanReplicationConsumer}.
      *
      * @return the implementation for this WAN consumer
      */
@@ -105,11 +106,11 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
 
     /**
      * Sets the implementation for this WAN consumer. The object must implement
-     * WanReplicationConsumer.
+     * {@link com.hazelcast.wan.WanReplicationConsumer}.
      * The implementation may be {@code null} in which case the class name or
      * the default processing logic for incoming WAN events will be used.
      *
-     * @param implementation the object implementing WanReplicationConsumer
+     * @param implementation the object implementing {@link com.hazelcast.wan.WanReplicationConsumer}
      * @return this config
      * @see #setClassName(String)
      */

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationConsumer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.wan;
 
 import com.hazelcast.config.WanConsumerConfig;

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationConsumer.java
@@ -1,0 +1,43 @@
+package com.hazelcast.wan;
+
+import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.instance.impl.Node;
+
+/**
+ * Interface to be implemented by custom WAN event consumers. Wan replication
+ * consumers are typically used in conjunction with a custom
+ * {@link WanReplicationPublisher}. The publisher will then publish events
+ * in a custom fashion which the consumer expects and processes accordingly.
+ * This way, you can provide custom publication and consumption mechanisms
+ * and protocols for WAN replication. The default implementation of the WAN
+ * publisher ignores any configured custom consumers and the WAN events will
+ * be processed as if there was no custom consumer implementation.
+ * Can be registered by programmatically or by XML using {@link WanConsumerConfig}.
+ *
+ * @see WanReplicationPublisher
+ */
+public interface WanReplicationConsumer {
+
+    /**
+     * Initialize the WAN consumer. The method is invoked once the node has
+     * started.
+     * The WAN consumer is responsible for registering itself for WAN event
+     * consumption. Typically this means that you would either use the
+     * {@link com.hazelcast.spi.impl.executionservice.ExecutionService}
+     * to schedule the consumer to run periodically or continually by having an
+     * implementation which uses blocking or spinning locks to check for new
+     * events. The implementation is free however to choose another approach.
+     *
+     * @param node               this node
+     * @param wanReplicationName the name of the {@link WanReplicationConfig}
+     * @param config             the WAN consumer config
+     */
+    void init(Node node, String wanReplicationName, WanConsumerConfig config);
+
+    /**
+     * Callback method to shutdown the WAN replication consumer. This is called
+     * on node shutdown.
+     */
+    void shutdown();
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
@@ -219,18 +219,4 @@ public interface WanReplicationPublisher<T> {
     default int removeWanEvents() {
         return 0;
     }
-
-    /**
-     * Removes all WAN events awaiting replication and belonging to the provided
-     * service and partition.
-     * If the publisher does not store WAN events, this method is a no-op.
-     * Invoked when migrating WAN replication data between members in a cluster.
-     * NOTE: used only in Hazelcast Enterprise.
-     *
-     * @param serviceName the service name of the WAN events should be removed
-     * @param partitionId the partition ID of the WAN events should be removed
-     */
-    default int removeWanEvents(int partitionId, String serviceName) {
-        return 0;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisherMigrationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisherMigrationListener.java
@@ -1,0 +1,37 @@
+package com.hazelcast.wan;
+
+import com.hazelcast.spi.partition.PartitionMigrationEvent;
+
+/**
+ * Interface for WAN publisher migration related events. Can be implemented
+ * by WAN publishers to listen to migration events, for example to maintain
+ * the WAN event counters.
+ * <p>
+ * None of the methods of this interface is expected to block or fail.
+ * NOTE: used only in Hazelcast Enterprise.
+ *
+ * @see PartitionMigrationEvent
+ * @see com.hazelcast.spi.partition.MigrationAwareService
+ */
+public interface WanReplicationPublisherMigrationListener {
+    /**
+     * Indicates that migration started for a given partition
+     *
+     * @param event the migration event
+     */
+    void onMigrationStart(PartitionMigrationEvent event);
+
+    /**
+     * Indicates that migration is committing for a given partition
+     *
+     * @param event the migration event
+     */
+    void onMigrationCommit(PartitionMigrationEvent event);
+
+    /**
+     * Indicates that migration is rolling back for a given partition
+     *
+     * @param event the migration event
+     */
+    void onMigrationRollback(PartitionMigrationEvent event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisherMigrationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisherMigrationListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.wan;
 
 import com.hazelcast.spi.partition.PartitionMigrationEvent;


### PR DESCRIPTION
Currently, on migration commit/rollback, we were clearing all partition
queues if the new replica index was greater than 1. This is fine if the
backup count for a map/cache is 1 but if the backup count is higher, we
clear the queues even though we shouldn't.
We now clear queues depending on the new replica index and the queue
backup count, exactly how map service does it.
As a side-effect, we simplify the WAN publisher SPI since we can now
remove two methods from the SPI - one which was even a leaking
abstraction mentioning "queues".

Also, fixed NPE issues in CacheMergeOperation when backupCount is 0 and
renamed "WanEventQueueMigrationListener" which is part of the publisher
SPI to remove mentioning of "queues".

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2091
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3283