### PR TITLE
Update & persist active CP members on each metadata init commit

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/CPMetadataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/persistence/CPMetadataStore.java
@@ -54,8 +54,8 @@ public interface CPMetadataStore {
 
     /**
      * Reads {@link CPMember} identity of this member from storage.
-     * If {@code null} is returned, it means that AP/CP identity of the member
-     * is not not known yet CP member discovery will run.
+     * If {@code null} is returned, it means that either local member is AP
+     * or AP/CP identity of it is not known yet.
      */
     CPMember readLocalCPMember() throws IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/InitMetadataRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/InitMetadataRaftGroupOp.java
@@ -60,10 +60,6 @@ public class InitMetadataRaftGroupOp extends MetadataRaftGroupOp implements Inde
         return PostponedResponse.INSTANCE;
     }
 
-    public List<CPMemberInfo> getDiscoveredCPMembers() {
-        return discoveredCPMembers;
-    }
-
     @Override
     public boolean isRetryableOnIndeterminateOperationState() {
         return true;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocationContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocationContext.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,6 +76,7 @@ public class RaftInvocationContext {
             CPMembersContainer currentContainer = membersContainer.get();
             if (newContainer.version.compareTo(currentContainer.version) > 0) {
                 if (membersContainer.compareAndSet(currentContainer, newContainer)) {
+                    logger.info("Replaced " + currentContainer + " with " + newContainer);
                     return true;
                 }
             } else {
@@ -109,7 +111,7 @@ public class RaftInvocationContext {
 
             CPMembersContainer newContainer = new CPMembersContainer(currentContainer.version, newMembers);
             if (membersContainer.compareAndSet(currentContainer, newContainer)) {
-                logger.info("Replaced " + existingMember + " -> " + member);
+                logger.info("Replaced " + existingMember + " with " + member);
                 return;
             }
         }
@@ -200,6 +202,11 @@ public class RaftInvocationContext {
             this.members = members.values().toArray(new CPMember[0]);
             this.membersMap = members;
         }
+
+        @Override
+        public String toString() {
+            return "CPMembersContainer{" + "version=" + version + ", members=" + Arrays.toString(members) + '}';
+        }
     }
 
     @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
@@ -222,6 +229,11 @@ public class RaftInvocationContext {
             }
 
             return Long.compare(version, other.version);
+        }
+
+        @Override
+        public String toString() {
+            return "CPMembersVersion{" + "groupIdSeed=" + groupIdSeed + ", version=" + version + '}';
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
@@ -540,7 +540,7 @@ public class MigrationCommitServiceTest extends HazelcastTestSupport {
         OperationServiceImpl operationService = getOperationService(instances[0]);
         for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
             assertNotNull(operationService.invokeOnPartition(null, new TestGetOperation(), partitionId)
-                    .get(10, TimeUnit.SECONDS));
+                    .get(1, TimeUnit.MINUTES));
         }
     }
 


### PR DESCRIPTION
`InitMetadataRaftGroupOp` is submitted by each CP member during member discovery.
It's expected that each of these ops are the same, otherwise operation fails.
We were skipping to update of active CP members in `MetadataRaftGroupManager`
if it's already set by a previous `InitMetadataRaftGroupOp`.

Normally this is not an issue but... when IP addresses of CP members
change during restore from persistence, then problem appears.

CP members are persisted to a separate file, with the commitIndex
of the Raft log entry. If it's only persisted by the first `InitMetadataRaftGroupOp`,
then while applying subsequent `InitMetadataRaftGroupOp`s during restore,
IP address information in `RaftInvocationContext` can be overwritten
by former IP addresses. Because subsequent `InitMetadataRaftGroupOp`s will
have greater commit indexes.

That's why we have to persist active CP members for each `InitMetadataRaftGroupOp`
execution with the latest commitIndex.

Fixes hazelcast/hazelcast-enterprise#3279