### PR TITLE
IO threadcount for smart client only when enough cpu's

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -123,7 +123,7 @@ public final class ClientProperty {
     /**
      * Controls the number of IO input threads. Defaults to -1, so the system will decide.
      *
-     * If client is a smart client, it will default to 3 otherwise it will default to 1.
+     * If client is a smart client and processor count larger than 8, it will default to 3 otherwise it will default to 1.
      */
     public static final HazelcastProperty IO_INPUT_THREAD_COUNT
             = new HazelcastProperty("hazelcast.client.io.input.thread.count", -1);
@@ -131,7 +131,7 @@ public final class ClientProperty {
     /**
      * Controls the number of IO output threads. Defaults to -1, so the system will decide.
      *
-     * If client is a smart client, it will default to 3 otherwise it will default to 1.
+     * If client is a smart client and processor count larger than 8 , it will default to 3 otherwise it will default to 1.
      */
     public static final HazelcastProperty IO_OUTPUT_THREAD_COUNT
             = new HazelcastProperty("hazelcast.client.io.output.thread.count", -1);


### PR DESCRIPTION
Only when more than 8 cpu's are detected a smart client will
get 3+3 io threads. This will prevent performance regressions
on smaller boxes.