### PR TITLE
Collect tcp.connection metrics only once

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpUnifiedEndpointManager.java
@@ -18,9 +18,6 @@ package com.hazelcast.internal.nio.tcp;
 
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.ProtocolType;
-import com.hazelcast.internal.metrics.MetricTagger;
-import com.hazelcast.internal.metrics.MetricTaggerSupplier;
-import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.nio.IOService;
@@ -108,13 +105,5 @@ class TcpIpUnifiedEndpointManager
     @Probe(name = "textCount", level = MANDATORY)
     public int getCurrentTextConnections() {
         return getTextConnections().size();
-    }
-
-    @Override
-    public void provideDynamicMetrics(MetricTaggerSupplier taggerSupplier, MetricsCollectionContext context) {
-        super.provideDynamicMetrics(taggerSupplier, context);
-
-        MetricTagger tagger = taggerSupplier.getMetricTagger("tcp.connection");
-        context.collect(tagger, this);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManagerMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManagerMetricsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nio.tcp;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static com.hazelcast.test.TestEnvironment.HAZELCAST_TEST_USE_NETWORK;
+import static java.util.Collections.emptySet;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TcpIpEndpointManagerMetricsTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = set(HAZELCAST_TEST_USE_NETWORK, "true");
+
+    @Test
+    public void testUnifiedEndpointManagerMetricsCollectedOnce() {
+        MetricsCollector collectorMock = mock(MetricsCollector.class);
+        HazelcastInstance instance = createHazelcastInstance();
+
+        getNodeEngineImpl(instance).getMetricsRegistry().collect(collectorMock);
+
+        // defined by TcpIpEndpointManager
+        verifyCollectedOnce(collectorMock, "tcp.connection.count");
+        // defined by TcpIpUnifiedEndpointManager
+        verifyCollectedOnce(collectorMock, "tcp.connection.clientCount");
+        verifyCollectedOnce(collectorMock, "tcp.connection.textCount");
+    }
+
+    private void verifyCollectedOnce(MetricsCollector collectorMock, String metric) {
+        verify(collectorMock).collectLong(matches(".*" + metric + ".*"), anyLong(), eq(emptySet()));
+    }
+}


### PR DESCRIPTION
Both `TcpIpUnifiedEndpointManager` and `TcpIpEndpointManager` provided
dynamic metrics while the first extends the latter. This results in
double metrics collection. This issue is solved by making
`TcpIpUnifiedEndpointManager` not providing dynamic metrics since those
are already provided by its parent.

Fixes #15883