### PR TITLE
catch exception when method can't be make accessible

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OperatingSystemMXBeanSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OperatingSystemMXBeanSupport.java
@@ -45,7 +45,11 @@ public final class OperatingSystemMXBeanSupport {
             String methodName = "get" + attributeName;
             OperatingSystemMXBean systemMXBean = OPERATING_SYSTEM_MX_BEAN;
             Method method = systemMXBean.getClass().getMethod(methodName);
-            method.setAccessible(true);
+            try {
+                method.setAccessible(true);
+            } catch (Exception e) {
+                return defaultValue;
+            }
 
             Object value = method.invoke(systemMXBean);
             if (value == null) {


### PR DESCRIPTION
This PR is the fix for #15884 

Catching `Exception` however it throws [`InaccessibleObjectException`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/InaccessibleObjectException.html)

@blazember could you please take a look?