### PR TITLE
Public Javadoc fixes/improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -64,7 +64,7 @@ import java.util.concurrent.ForkJoinPool;
  * In a reactive way:
  * <pre>
  *   CompletionStage&lt;Value&gt; stage = unwrappedCache.getAsync( &quot;key-1&quot; ) ;
- *   stage.thenAcceptAsync(value -> {
+ *   stage.thenAcceptAsync(value -&gt; {
  *         System.out.println(value);
  *     });
  * </pre>
@@ -76,20 +76,18 @@ import java.util.concurrent.ForkJoinPool;
  * </pre>
  *
  * <p>
- *     Dependent actions can be registered on the returned {@link CompletionStage}.
- *     Their execution follows {@link java.util.concurrent.CompletableFuture}
- *     execution conventions:
- *     <ul>
- *         <li>dependent actions registered by <em>non-async</em> methods may
- *        be executed by the thread that completes the current CompletableFuture or by any other
- *        caller of a completion method.</li>
- *        <li>dependent actions registered by default <em>async</em> methods without an explicit
- *        {@code Executor} argument are executed by {@link ForkJoinPool#commonPool()} unless
- *        its parallelism level is less than 2, in which case a new {@code Thread} is created to
- *        run each action</li>
- *     </ul>
- *
- * </p>
+ * Dependent actions can be registered on the returned {@link CompletionStage}.
+ * Their execution follows {@link java.util.concurrent.CompletableFuture}
+ * execution conventions:
+ * <ul>
+ *     <li>dependent actions registered by <em>non-async</em> methods may
+ *     be executed by the thread that completes the current CompletableFuture or by any other
+ *     caller of a completion method.</li>
+ *     <li>dependent actions registered by default <em>async</em> methods without an explicit
+ *     {@code Executor} argument are executed by {@link ForkJoinPool#commonPool()} unless
+ *     its parallelism level is less than 2, in which case a new {@code Thread} is created to
+ *     run each action</li>
+ * </ul>
  *
  * <b>Custom ExpiryPolicy:</b><br>
  * For most of the typical operations, Hazelcast provides overloaded versions with an additional

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
@@ -77,7 +77,7 @@ public interface CardinalityEstimator extends DistributedObject {
      * </pre>
      * <pre>
      *     CompletionStage&lt;Void&gt; stage = estimator.addAsync();
-     *     stage.whenCompleteAsync((response, throwable) -> {
+     *     stage.whenCompleteAsync((response, throwable) -&gt; {
      *          if (throwable == null) {
      *              // do something
      *          } else {
@@ -108,7 +108,7 @@ public interface CardinalityEstimator extends DistributedObject {
      * </pre>
      * <pre>
      *     CompletionStage&lt;Long&gt; stage = estimator.estimateAsync();
-     *     stage.whenCompleteAsync((response, throwable) -> {
+     *     stage.whenCompleteAsync((response, throwable) -&gt; {
      *          if (throwable == null) {
      *              // do something with the result
      *          } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.r
  * The HazelcastClient is comparable to the {@link com.hazelcast.core.Hazelcast} class and provides the ability
  * the create and manage Hazelcast clients. Hazelcast clients are {@link HazelcastInstance} implementations, so
  * in most cases most of the code is unaware of talking to a cluster member or a client.
- * <p/>
+ * <p>
  * <h1>Smart vs unisocket clients</h1>
  * Hazelcast Client enables you to do all Hazelcast operations without being a member of the cluster. Clients can be:
  * <ol>
@@ -56,7 +56,7 @@ import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.r
  * </li>
  * </ol>
  * For more information see {@link com.hazelcast.client.config.ClientNetworkConfig#setSmartRouting(boolean)}.
- * <p/>
+ * <p>
  * <h1>High availability</h1>
  * When the connected cluster member dies, client will automatically switch to another live member.
  */
@@ -76,7 +76,7 @@ public final class HazelcastClient {
      * Creates a new HazelcastInstance (a new client in a cluster).
      * This method allows you to create and run multiple instances
      * of Hazelcast clients on the same JVM.
-     * <p/>
+     * <p>
      * To shutdown all running HazelcastInstances (all clients on this JVM)
      * call {@link #shutdownAll()}.
      *
@@ -118,7 +118,7 @@ public final class HazelcastClient {
      * Creates a new HazelcastInstance (a new client in a cluster).
      * This method allows you to create and run multiple instances
      * of Hazelcast clients on the same JVM.
-     * <p/>
+     * <p>
      * To shutdown all running HazelcastInstances (all clients on this JVM)
      * call {@link #shutdownAll()}.
      *
@@ -219,11 +219,11 @@ public final class HazelcastClient {
 
     /**
      * Gets an immutable collection of all client HazelcastInstances created in this JVM.
-     * <p/>
+     * <p>
      * In managed environments such as Java EE or OSGi Hazelcast can be loaded by multiple classloaders. Typically you will get
      * at least one classloader per every application deployed. In these cases only the client HazelcastInstances created
      * by the same application will be seen, and instances created by different applications are invisible.
-     * <p/>
+     * <p>
      * The returned collection is a snapshot of the client HazelcastInstances. So changes to the client HazelcastInstances
      * will not be visible in this collection.
      *
@@ -236,10 +236,10 @@ public final class HazelcastClient {
 
     /**
      * Shuts down all the client HazelcastInstance created in this JVM.
-     * <p/>
+     * <p>
      * To be more precise it shuts down the HazelcastInstances loaded using the same classloader this HazelcastClient has been
      * loaded with.
-     * <p/>
+     * <p>
      * This method is mostly used for testing purposes.
      *
      * @see #getAllHazelcastClients()
@@ -313,13 +313,11 @@ public final class HazelcastClient {
     /**
      * Sets <tt>OutOfMemoryHandler</tt> to be used when an <tt>OutOfMemoryError</tt>
      * is caught by Hazelcast Client threads.
-     * <p/>
      * <p>
      * <b>Warning: </b> <tt>OutOfMemoryHandler</tt> may not be called although JVM throws
      * <tt>OutOfMemoryError</tt>.
      * Because error may be thrown from an external (user thread) thread
      * and Hazelcast may not be informed about <tt>OutOfMemoryError</tt>.
-     * </p>
      *
      * @param outOfMemoryHandler set when an <tt>OutOfMemoryError</tt> is caught by HazelcastClient threads
      * @see OutOfMemoryError

--- a/hazelcast/src/main/java/com/hazelcast/client/LoadBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/LoadBalancer.java
@@ -24,11 +24,11 @@ import com.hazelcast.cluster.Member;
 /**
  * {@link LoadBalancer} allows you to send operations to one of a number of endpoints(Members).
  * It is up to the implementation to use different load balancing policies.
- * <p/>
+ * <p>
  * If Client is configured with {@link ClientNetworkConfig#isSmartRouting()},
  * only the operations that are not key based will be router to the endpoint returned by the LoadBalancer. If it is
  * not {@link ClientNetworkConfig#isSmartRouting()}, {@link LoadBalancer} will not be used.
- * <p/>
+ * <p>
  *
  * For configuration see  {@link com.hazelcast.client.config.ClientConfig#setLoadBalancer(LoadBalancer)}
  */

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -587,7 +587,7 @@ public class ClientConfig {
     /**
      * Sets the classLoader which is used by serialization and listener configuration
      *
-     * @param classLoader
+     * @param classLoader the classLoader
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
      */
     public ClientConfig setClassLoader(ClassLoader classLoader) {
@@ -768,7 +768,7 @@ public class ClientConfig {
     /**
      * Set User Code Deployment configuration
      *
-     * @param userCodeDeploymentConfig
+     * @param userCodeDeploymentConfig the configuration of User Code Deployment
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
      * @since 3.9
      */

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConnectionStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConnectionStrategyConfig.java
@@ -92,7 +92,7 @@ public class ClientConnectionStrategyConfig {
      * custom implementations may ignore it if configured.
      * default value is {@link ReconnectMode#ON}
      *
-     * @param reconnectMode
+     * @param reconnectMode the reconnect mode
      * @return the updated ClientConnectionStrategyConfig
      */
     public ClientConnectionStrategyConfig setReconnectMode(ReconnectMode reconnectMode) {
@@ -114,7 +114,7 @@ public class ClientConnectionStrategyConfig {
      * Connection Retry Config is controls the period among the retries and when should a client gave up
      * retrying. Exponential behaviour can be chosen or jitter can be added to wait periods.
      *
-     * @param connectionRetryConfig
+     * @param connectionRetryConfig the connection retry config
      * @return the updated ClientConnectionStrategyConfig
      */
     public ClientConnectionStrategyConfig setConnectionRetryConfig(ConnectionRetryConfig connectionRetryConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -226,7 +226,7 @@ public class ClientNetworkConfig {
      * This can be because of network, or simply because the member died. However it is not clear whether the
      * application is performed or not. For idempotent operations this is harmless, but for non idempotent ones
      * retrying can cause to undesirable effects. Note that the redo can perform on any member.
-     * <p/>
+     * <p>
      * If false, the operation will throw {@link RuntimeException} that is wrapping {@link java.io.IOException}.
      * TODO clear what is the exception here
      *

--- a/hazelcast/src/main/java/com/hazelcast/client/config/SocketOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/SocketOptions.java
@@ -71,7 +71,7 @@ public class SocketOptions {
      * Enable/disable TCP_NODELAY socket option.
      *
      * @param tcpNoDelay
-     * @return
+     * @return SocketOptions configured
      */
     public SocketOptions setTcpNoDelay(boolean tcpNoDelay) {
         this.tcpNoDelay = tcpNoDelay;

--- a/hazelcast/src/main/java/com/hazelcast/client/config/SocketOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/SocketOptions.java
@@ -70,7 +70,7 @@ public class SocketOptions {
     /**
      * Enable/disable TCP_NODELAY socket option.
      *
-     * @param tcpNoDelay
+     * @param tcpNoDelay the TCP_NODELAY socket option
      * @return SocketOptions configured
      */
     public SocketOptions setTcpNoDelay(boolean tcpNoDelay) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -91,11 +91,11 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
     /**
      * Constructs a {@link XmlClientConfigBuilder} that loads the configuration
      * with the provided {@link XmlClientConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link XmlClientConfigLocator} is {@code null}, a new
      * instance is created and the config is located in every possible
      * places. For these places, please see {@link XmlClientConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link XmlClientConfigLocator} is not {@code null}, it
      * is expected that it already located the configuration XML to load
      * from. No further attempt to locate the configuration XML is made

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
@@ -92,11 +92,11 @@ public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
     /**
      * Constructs a {@link XmlClientFailoverConfigBuilder} that loads the configuration
      * with the provided {@link XmlClientFailoverConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link XmlClientFailoverConfigLocator} is {@code null}, a new
      * instance is created and the config is located in every possible
      * places. For these places, please see {@link XmlClientFailoverConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link XmlClientFailoverConfigLocator} is not {@code null}, it
      * is expected that it already located the configuration XML to load
      * from. No further attempt to locate the configuration XML is made

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
@@ -88,11 +88,11 @@ public class YamlClientConfigBuilder extends AbstractYamlConfigBuilder {
     /**
      * Constructs a {@link YamlClientConfigBuilder} that loads the configuration
      * with the provided {@link YamlClientConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link YamlClientConfigLocator} is {@code null}, a new
      * instance is created and the config is located in every possible
      * places. For these places, please see {@link YamlClientConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link YamlClientConfigLocator} is not {@code null}, it
      * is expected that it already located the configuration YAML to load
      * from. No further attempt to locate the configuration YAML is made

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
@@ -90,11 +90,11 @@ public class YamlClientFailoverConfigBuilder extends AbstractYamlConfigBuilder {
     /**
      * Constructs a {@link YamlClientFailoverConfigBuilder} that loads the configuration
      * with the provided {@link YamlClientFailoverConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link YamlClientFailoverConfigLocator} is {@code null}, a new
      * instance is created and the config is located in every possible
      * places. For these places, please see {@link YamlClientFailoverConfigLocator}.
-     * <p/>
+     * <p>
      * If the provided {@link YamlClientFailoverConfigLocator} is not {@code null}, it
      * is expected that it already located the configuration YAML to load
      * from. No further attempt to locate the configuration YAML is made

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -84,11 +84,11 @@ public final class ClientProperty {
 
     /**
      * The maximum number of concurrent invocations allowed.
-     * <p/>
+     * <p>
      * To prevent the system from overloading, user can apply a constraint on the number of concurrent invocations.
      * If the maximum number of concurrent invocations has been exceeded and a new invocation comes in,
      * then hazelcast will throw HazelcastOverloadException
-     * <p/>
+     * <p>
      * By default it is configured as Integer.MaxValue.
      */
     public static final HazelcastProperty MAX_CONCURRENT_INVOCATIONS
@@ -96,14 +96,12 @@ public final class ClientProperty {
 
     /**
      * Control the maximum timeout in millis to wait for an invocation space to be available.
-     * <p/>
+     * <p>
      * If an invocation can't be made because there are too many pending invocations, then an exponential backoff is done
      * to give the system time to deal with the backlog of invocations. This property controls how long an invocation is
      * allowed to wait before getting a {@link com.hazelcast.core.HazelcastOverloadException}.
-     * <p/>
      * <p>
      * When set to -1 then <code>HazelcastOverloadException</code> is thrown immediately without any waiting.
-     * </p>
      */
     public static final HazelcastProperty BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS
             = new HazelcastProperty("hazelcast.client.invocation.backoff.timeout.millis", -1, MILLISECONDS);
@@ -141,10 +139,10 @@ public final class ClientProperty {
     /**
      * The interval in seconds between {@link com.hazelcast.internal.networking.nio.iobalancer.IOBalancer IOBalancer}
      * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
-     * <p/>
+     * <p>
      * Please see the documentation of {@link com.hazelcast.internal.networking.nio.iobalancer.IOBalancer IOBalancer}
      * for a detailed explanation of the problem.
-     * <p/>
+     * <p>
      * The default is 20 seconds. A value smaller than 1 disables the balancer.
      */
     public static final HazelcastProperty IO_BALANCER_INTERVAL_SECONDS

--- a/hazelcast/src/main/java/com/hazelcast/cluster/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Member.java
@@ -85,7 +85,7 @@ public interface Member extends DataSerializable, Endpoint {
     UUID getUuid();
 
     /**
-     * Returns configured attributes for this member.<br/>
+     * Returns configured attributes for this member.<br>
      * <b>This method might not be available on all native clients.</b>
      *
      * @return configured attributes for this member.
@@ -112,7 +112,7 @@ public interface Member extends DataSerializable, Endpoint {
 
     /**
      * Removes a key-value pair attribute for this member if given key was
-     * previously assigned as an attribute.<br/>
+     * previously assigned as an attribute.<br>
      * If key wasn't assigned to a value this method does nothing.
      *
      * @param key The key to be deleted from the member attributes

--- a/hazelcast/src/main/java/com/hazelcast/collection/BaseQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/BaseQueue.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  * @see java.util.concurrent.BlockingQueue
  * @see IQueue
  * @see TransactionalQueue
- * @param <E>
+ * @param <E> queue item type
  */
 public interface BaseQueue<E> extends DistributedObject {
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/IList.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/IList.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p>Supports split brain protection {@link SplitBrainProtectionConfig} since 3.10
  * in cluster versions 3.10 and higher.
  *
- * @param <E>
+ * @param <E> the type of elements maintained by this list
  * @see List
  */
 public interface IList<E> extends List<E>, ICollection<E> {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -715,6 +715,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> implements Spli
      *                 or will be resolved to loaded classes and the actual {@code keyType} and {@code valueType} will be copied.
      *                 Otherwise, this configuration's {@code keyClassName} and {@code valueClassName} will be copied to the
      *                 target config, to be resolved at a later time.
+     * @param <T>      the target object type
      * @return the target config
      */
     public <T extends CacheConfig<K, V>> T copy(T target, boolean resolved) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheDeserializedValues.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheDeserializedValues.java
@@ -56,7 +56,7 @@ public enum CacheDeserializedValues {
     /**
      * Create instance from String
      *
-     * @param string
+     * @param string the string value to parse
      * @return instance of {@link CacheDeserializedValues}
      * @throws IllegalArgumentException when unknown value is passed
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -549,7 +549,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider,
      * Sets the metadata policy. See {@link MetadataPolicy} for more
      * information.
      *
-     * @param metadataPolicy
+     * @param metadataPolicy the metadata policy
      */
     public MapConfig setMetadataPolicy(MetadataPolicy metadataPolicy) {
         this.metadataPolicy = metadataPolicy;

--- a/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
@@ -42,7 +42,8 @@ public final class SSLConfig {
     /**
      * Returns the name of the implementation class.
      * <p>
-     * Class can either be an  {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     * Class can either be an {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@code com.hazelcast.nio.ssl.SSLEngineFactory}
+     * (Enterprise edition).
      *
      * @return the name implementation class
      */
@@ -53,7 +54,8 @@ public final class SSLConfig {
     /**
      * Sets the name for the implementation class.
      * <p>
-     * Class can either be an  {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     * Class can either be an {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@code com.hazelcast.nio.ssl.SSLEngineFactory}
+     * (Enterprise edition).
      *
      * @param factoryClassName the name implementation class
      */
@@ -85,7 +87,7 @@ public final class SSLConfig {
      * Sets the implementation object.
      * <p>
      * Object must be instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory} or
-     * {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     * {@code com.hazelcast.nio.ssl.SSLEngineFactory} (Enterprise edition).
      *
      * @param factoryImplementation the implementation object
      * @return this SSLConfig instance
@@ -98,7 +100,8 @@ public final class SSLConfig {
     /**
      * Returns the factory implementation object.
      * <p>
-     * Object is instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     * Object is instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@code com.hazelcast.nio.ssl.SSLEngineFactory}
+     * (Enterprise edition).
      *
      * @return the factory implementation object
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/SecureStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecureStoreConfig.java
@@ -18,7 +18,7 @@ package com.hazelcast.config;
 
 /**
  * Abstract Secure Store configuration class.
- * <p/>
+ * <p>
  * A Secure Store represents an abstraction for interacting
  * with systems that manage symmetric encryption keys. Different
  * types of Secure Stores are configured by means of corresponding

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
@@ -119,7 +119,8 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
      *
      * @param secretStr sensitive string to be protected by encryption
      * @param iterations iteration count
-     * @return Encrypted value.
+     * @return the encrypted value.
+     * @throws Exception in case of any exceptional case
      */
     protected String encrypt(String secretStr, int iterations) throws Exception {
         SecureRandom secureRandom = new SecureRandom();
@@ -133,8 +134,9 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
     /**
      * Decrypts given encrypted variable.
      *
-     * @param encryptedStr
-     * @return
+     * @param encryptedStr the encrypted value
+     * @return the decrypted value
+     * @throws Exception in case of any exceptional case
      */
     protected String decrypt(String encryptedStr) throws Exception {
         String[] split = encryptedStr.split(":");

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -1549,6 +1549,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
      * Starts the test application.
      * <p>
      * Loads the config from classpath hazelcast.xml, if it fails to load, will use default config.
+     * @throws Exception in case of any exceptional case
      */
     public static void main(String[] args) throws Exception {
         Config config;

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
@@ -32,7 +32,7 @@ import com.hazelcast.map.listener.MapEvictedListener;
  * of operations carried out via the {@link IMap}
  * interface.  Events will not fire, for example, for an entry
  * that comes into the Map via the {@link MapLoader} lifecycle.
- * <p/>
+ * <p>
  * This interface is here for backward compatibility reasons.
  * For a most appropriate alternative please use/check
  * {@link com.hazelcast.map.listener.MapListener} interface.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -78,6 +78,7 @@ public interface HazelcastInstance {
      * Creates or returns the distributed queue instance with the specified name.
      *
      * @param name name of the distributed queue
+     * @param <E> queue item type
      * @return distributed queue instance with the specified name
      */
     @Nonnull
@@ -87,6 +88,7 @@ public interface HazelcastInstance {
      * Creates or returns the distributed topic instance with the specified name.
      *
      * @param name name of the distributed topic
+     * @param <E> the type of the topic message
      * @return distributed topic instance with the specified name
      */
     @Nonnull
@@ -96,6 +98,7 @@ public interface HazelcastInstance {
      * Creates or returns the distributed set instance with the specified name.
      *
      * @param name name of the distributed set
+     * @param <E> the type of elements maintained by the set
      * @return distributed set instance with the specified name
      */
     @Nonnull
@@ -106,6 +109,7 @@ public interface HazelcastInstance {
      * Index based operations on the list are not supported.
      *
      * @param name name of the distributed list
+     * @param <E> the type of elements maintained by the list
      * @return distributed list instance with the specified name
      */
     @Nonnull
@@ -115,6 +119,8 @@ public interface HazelcastInstance {
      * Creates or returns the distributed map instance with the specified name.
      *
      * @param name name of the distributed map
+     * @param <K> key type
+     * @param <V> value type
      * @return distributed map instance with the specified name
      */
     @Nonnull
@@ -124,6 +130,8 @@ public interface HazelcastInstance {
      * Creates or returns the replicated map instance with the specified name.
      *
      * @param name name of the distributed map
+     * @param <K> the type of keys maintained by the replicated map
+     * @param <V> the type of mapped values
      * @return replicated map instance with specified name
      * @throws ReplicatedMapCantBeCreatedOnLiteMemberException if it is called on a lite member
      * @since 3.2
@@ -135,6 +143,8 @@ public interface HazelcastInstance {
      * Creates or returns the distributed multimap instance with the specified name.
      *
      * @param name name of the distributed multimap
+     * @param <K> type of the multimap key
+     * @param <V> type of the multimap value
      * @return distributed multimap instance with the specified name
      */
     @Nonnull
@@ -144,6 +154,7 @@ public interface HazelcastInstance {
      * Creates or returns the distributed Ringbuffer instance with the specified name.
      *
      * @param name name of the distributed Ringbuffer
+     * @param <E> the type of the elements that the Ringbuffer contains
      * @return distributed RingBuffer instance with the specified name
      */
     @Nonnull
@@ -153,6 +164,7 @@ public interface HazelcastInstance {
      * Creates or returns the reliable topic instance with the specified name.
      *
      * @param name name of the reliable topic
+     * @param <E> the type of the topic message
      * @return the reliable topic
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/core/ICacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICacheManager.java
@@ -50,6 +50,8 @@ public interface ICacheManager {
      * Classloader prefix is generated as a string representation of the specified classloader: ({@code cl.toString()})
      *
      * @param name the prefixed name of the cache
+     * @param <K> the type of key
+     * @param <V> the type of value
      * @return the cache instance with the specified prefixed name
      *
      * @throws com.hazelcast.cache.CacheNotExistsException  if there is no configured or created cache

--- a/hazelcast/src/main/java/com/hazelcast/core/Pipelining.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Pipelining.java
@@ -75,7 +75,7 @@ import static com.hazelcast.internal.util.Preconditions.checkPositive;
  * evolve. But there is no problem using it in production. We use similar techniques
  * to achieve high performance.
  *
- * @param <E>
+ * @param <E> the result type of the Pipelining
  */
 @Beta
 public class Pipelining<E> {

--- a/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
@@ -88,7 +88,7 @@ import java.util.UUID;
  * configuration does not have to be same with the CP member count. Namely,
  * number of CP members in CP Subsystem can be larger than the configured
  * CP group size. CP groups usually consist of an odd number of CP members
- * between 3 and 7. Operations are committed & executed only after they are
+ * between 3 and 7. Operations are committed &amp; executed only after they are
  * successfully replicated to the majority of CP members in a CP group.
  * An odd number of CP members is more advantageous to an even number because
  * of the quorum or majority calculations. For a CP group of N members,
@@ -408,6 +408,7 @@ public interface CPSubsystem {
      * group. Hence, callers should cache the returned proxy.</strong>
      *
      * @param name name of the {@link IAtomicReference} proxy
+     * @param <E> the type of object referred to by the reference
      * @return {@link IAtomicReference} proxy for the given name
      * @throws HazelcastException if CP Subsystem is not enabled
      */

--- a/hazelcast/src/main/java/com/hazelcast/cp/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/IAtomicLong.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletionStage;
  * from which the operation's result can be obtained in a blocking manner. For example:
  * <pre>
  * CompletionStage&lt;Long&gt; stage = atomicLong.addAndGetAsync(13);
- * stage.whenCompleteAsync((response, t) -> {
+ * stage.whenCompleteAsync((response, t) -&gt; {
  *     if (t == null) {
  *         // do something with the result
  *     } else {
@@ -170,6 +170,7 @@ public interface IAtomicLong extends DistributedObject {
      * Applies a function on the value, the actual stored value will not change.
      *
      * @param function the function applied to the value, the value is not changed
+     * @param <R> the result type of the function
      * @return the result of the function application
      * @throws IllegalArgumentException if function is {@code null}
      * @since 3.2
@@ -194,7 +195,7 @@ public interface IAtomicLong extends DistributedObject {
      * </pre>
      * <pre>
      * CompletionStage&lt;Long&gt; stage = atomicLong.addAndGetAsync(13);
-     * stage.whenCompleteAsync((response, t) -> {
+     * stage.whenCompleteAsync((response, t) -&gt; {
      *     if (t == null) {
      *         // do something with the result
      *     } else {
@@ -358,7 +359,7 @@ public interface IAtomicLong extends DistributedObject {
      * }
      *
      * CompletionStage&lt;Boolean&gt; stage = atomicLong.applyAsync(new IsOneFunction());
-     * stage.whenCompleteAsync((response, t) -> {
+     * stage.whenCompleteAsync((response, t) -&gt; {
      *    if (t == null) {
      *        // do something with the response
      *    } else {
@@ -368,6 +369,7 @@ public interface IAtomicLong extends DistributedObject {
      * </pre>
      *
      * @param function the function
+     * @param <R> the result type of the function
      * @return a {@link CompletionStage} with the result of the function application
      * @throws IllegalArgumentException if function is {@code null}
      * @since 3.7

--- a/hazelcast/src/main/java/com/hazelcast/cp/IAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/IAtomicReference.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletionStage;
  * registering a callback to be executed upon completion. For example:
  * <pre>
  * CompletionStage&lt;E&gt; future = atomicRef.getAsync();
- * future.whenCompleteAsync((v, throwable) -> {
+ * future.whenCompleteAsync((v, throwable) -&gt; {
  *     if (throwable == null) {
  *         // do something with the old value returned by put operation
  *     } else {
@@ -146,6 +146,7 @@ public interface IAtomicReference<E> extends DistributedObject {
      * change.
      *
      * @param function the function applied on the value, the stored value does not change
+     * @param <R> the result type of the function
      * @return the result of the function application
      * @throws IllegalArgumentException if function is {@code null}
      */
@@ -237,6 +238,7 @@ public interface IAtomicReference<E> extends DistributedObject {
      * change.
      *
      * @param function the function
+     * @param <R> the result type of the function
      * @return the result of the function application
      * @throws IllegalArgumentException if function is {@code null}
      */

--- a/hazelcast/src/main/java/com/hazelcast/cp/lock/FencedLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/lock/FencedLock.java
@@ -601,7 +601,7 @@ public interface FencedLock extends Lock, DistributedObject {
      * May the force be the one who dares to implement
      * a linearizable distributed {@link Condition} :)
      *
-     * @throws UnsupportedOperationException
+     * @throws UnsupportedOperationException for now
      */
     Condition newCondition();
 }

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorService.java
@@ -132,6 +132,7 @@ public interface DurableExecutorService extends ExecutorService, DistributedObje
      *
      * @param task task submitted to the owner of the specified key
      * @param key  the specified key
+     * @param <T>  the return type of the task
      * @return a Future representing pending completion of the task
      */
     <T> DurableExecutorServiceFuture<T> submitToKeyOwner(@Nonnull Callable<T> task,

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorServiceFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorServiceFuture.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 /**
  * A Future where one can obtain the task ID for tracking the response.
  *
- * @param <V>
+ * @param <V> The result type returned by this Future's {@code get} method
  */
 public interface DurableExecutorServiceFuture<V> extends CompletionStage<V>, Future<V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/function/BiConsumerEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/BiConsumerEx.java
@@ -37,6 +37,7 @@ public interface BiConsumerEx<T, U> extends BiConsumer<T, U>, Serializable {
 
     /**
      * Exception-declaring version of {@link BiConsumer#accept}.
+     * @throws Exception in case of any exceptional case
      */
     void acceptEx(T t, U u) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/function/BiFunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/BiFunctionEx.java
@@ -38,6 +38,7 @@ public interface BiFunctionEx<T, U, R> extends BiFunction<T, U, R>, Serializable
 
     /**
      * Exception-declaring version of {@link BiFunction#apply}.
+     * @throws Exception in case of any exceptional case
      */
     R applyEx(T t, U u) throws Exception;
 
@@ -54,6 +55,8 @@ public interface BiFunctionEx<T, U, R> extends BiFunction<T, U, R>, Serializable
      * {@code Serializable} variant of {@link
      * BiFunction#andThen(java.util.function.Function)
      * java.util.function.BiFunction#andThen(Function)}.
+     * @param <V> the type of output of the {@code after} function, and of the
+     *           composed function
      */
     default <V> BiFunctionEx<T, U, V> andThen(FunctionEx<? super R, ? extends V> after) {
         checkNotNull(after, "after");

--- a/hazelcast/src/main/java/com/hazelcast/function/BiPredicateEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/BiPredicateEx.java
@@ -37,6 +37,7 @@ public interface BiPredicateEx<T, U> extends BiPredicate<T, U>, Serializable {
 
     /**
      * Exception-declaring version of {@link BiPredicate#test}.
+     * @throws Exception in case of any exceptional case
      */
     boolean testEx(T t, U u) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/function/BinaryOperatorEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/BinaryOperatorEx.java
@@ -37,6 +37,7 @@ public interface BinaryOperatorEx<T> extends BinaryOperator<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link BinaryOperator#apply}.
+     * @throws Exception in case of any exceptional case
      */
     T applyEx(T t1, T t2) throws Exception;
 
@@ -52,6 +53,7 @@ public interface BinaryOperatorEx<T> extends BinaryOperator<T>, Serializable {
     /**
      * {@code Serializable} variant of {@link
      * BinaryOperator#minBy(Comparator) java.util.function.BinaryOperator#minBy(Comparator)}.
+     * @param <T> the type of the input arguments of the comparator
      */
     static <T> BinaryOperatorEx<T> minBy(Comparator<? super T> comparator) {
         checkNotNull(comparator, "comparator");
@@ -61,6 +63,7 @@ public interface BinaryOperatorEx<T> extends BinaryOperator<T>, Serializable {
     /**
      * {@code Serializable} variant of {@link
      * BinaryOperator#maxBy(Comparator) java.util.function.BinaryOperator#maxBy(Comparator)}.
+     * @param <T> the type of the input arguments of the comparator
      */
     static <T> BinaryOperatorEx<T> maxBy(Comparator<? super T> comparator) {
         checkNotNull(comparator, "comparator");

--- a/hazelcast/src/main/java/com/hazelcast/function/ComparatorEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ComparatorEx.java
@@ -43,6 +43,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link Comparator#compare}.
+     * @throws Exception in case of any exceptional case
      */
     int compareEx(T o1, T o2) throws Exception;
 
@@ -59,6 +60,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#naturalOrder()
      * java.util.Comparator#naturalOrder()}.
+     * @param  <T> the {@link Comparable} type of element to be compared
      */
     @SuppressWarnings("unchecked")
     static <T extends Comparable<? super T>> ComparatorEx<T> naturalOrder() {
@@ -69,6 +71,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#reverseOrder()
      * java.util.Comparator#reverseOrder()}.
+     * @param  <T> the {@link Comparable} type of element to be compared
      */
     @SuppressWarnings("unchecked")
     static <T extends Comparable<? super T>> ComparatorEx<T> reverseOrder() {
@@ -79,6 +82,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#nullsFirst(Comparator)
      * java.util.Comparator#nullsFirst(Comparator)}.
+     * @param  <T> the type of the elements to be compared
      */
     static <T> ComparatorEx<T> nullsFirst(Comparator<? super T> comparator) {
         checkSerializable(comparator, "comparator");
@@ -90,6 +94,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#nullsFirst(Comparator)
      * java.util.Comparator#nullsFirst(Comparator)}.
+     * @param  <T> the type of the elements to be compared
      */
     static <T> ComparatorEx<T> nullsFirst(ComparatorEx<? super T> comparator) {
         return nullsFirst((Comparator<? super T>) comparator);
@@ -99,6 +104,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#nullsLast(Comparator)
      * java.util.Comparator#nullsLast(Comparator)}.
+     * @param  <T> the type of the elements to be compared
      */
     static <T> ComparatorEx<T> nullsLast(Comparator<? super T> comparator) {
         checkSerializable(comparator, "comparator");
@@ -110,6 +116,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#nullsLast(Comparator)
      * java.util.Comparator#nullsLast(Comparator)}.
+     * @param  <T> the type of the elements to be compared
      */
     static <T> ComparatorEx<T> nullsLast(ComparatorEx<? super T> comparator) {
         return nullsLast((Comparator<? super T>) comparator);
@@ -119,6 +126,8 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparing(Function, Comparator)
      * java.util.Comparator#comparing(Function, Comparator)}.
+     * @param  <T> the type of element to be compared
+     * @param  <U> the type of the sort key
      */
     static <T, U> ComparatorEx<T> comparing(
             Function<? super T, ? extends U> toKeyFn,
@@ -136,6 +145,8 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparing(Function, Comparator)
      * java.util.Comparator#comparing(Function, Comparator)}.
+     * @param  <T> the type of element to be compared
+     * @param  <U> the type of the sort key
      */
     static <T, U> ComparatorEx<T> comparing(
             FunctionEx<? super T, ? extends U> toKeyFn,
@@ -147,6 +158,8 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparing(Function)
      * java.util.Comparator#comparing(Function)}.
+     * @param  <T> the type of element to be compared
+     * @param  <U> the type of the {@code Comparable} sort key
      */
     static <T, U extends Comparable<? super U>> ComparatorEx<T> comparing(
             Function<? super T, ? extends U> toKeyFn
@@ -160,6 +173,8 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparing(Function)
      * java.util.Comparator#comparing(Function)}.
+     * @param  <T> the type of element to be compared
+     * @param  <U> the type of the {@code Comparable} sort key
      */
     static <T, U extends Comparable<? super U>> ComparatorEx<T> comparing(
             FunctionEx<? super T, ? extends U> toKeyFn
@@ -171,6 +186,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparingInt(ToIntFunction)
      * java.util.Comparator#comparingInt(ToIntFunction)}.
+     * @param  <T> the type of element to be compared
      */
     static <T> ComparatorEx<T> comparingInt(ToIntFunction<? super T> toKeyFn) {
         checkNotNull(toKeyFn, "toKeyFn");
@@ -182,6 +198,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparingInt(ToIntFunction)
      * java.util.Comparator#comparingInt(ToIntFunction)}.
+     * @param  <T> the type of element to be compared
      */
     static <T> ComparatorEx<T> comparingInt(ToIntFunctionEx<? super T> toKeyFn) {
         return comparingInt((ToIntFunction<? super T>) toKeyFn);
@@ -191,6 +208,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparingLong(ToLongFunction)
      * java.util.Comparator#comparingLong(ToLongFunction)}.
+     * @param  <T> the type of element to be compared
      */
     static <T> ComparatorEx<T> comparingLong(ToLongFunction<? super T> toKeyFn) {
         checkNotNull(toKeyFn, "toKeyFn");
@@ -202,6 +220,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparingLong(ToLongFunction)
      * java.util.Comparator#comparingLong(ToLongFunction)}.
+     * @param  <T> the type of element to be compared
      */
     static <T> ComparatorEx<T> comparingLong(ToLongFunctionEx<? super T> toKeyFn) {
         return comparingLong((ToLongFunction<? super T>) toKeyFn);
@@ -211,6 +230,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparingDouble(ToDoubleFunction)
      * java.util.Comparator#comparingDouble(ToDoubleFunction)}.
+     * @param  <T> the type of element to be compared
      */
     static <T> ComparatorEx<T> comparingDouble(ToDoubleFunction<? super T> toKeyFn) {
         checkNotNull(toKeyFn, "toKeyFn");
@@ -222,6 +242,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#comparingDouble(ToDoubleFunction)
      * java.util.Comparator#comparingDouble(ToDoubleFunction)}.
+     * @param  <T> the type of element to be compared
      */
     static <T> ComparatorEx<T> comparingDouble(ToDoubleFunctionEx<? super T> toKeyFn) {
         return comparingDouble((ToDoubleFunction<? super T>) toKeyFn);
@@ -255,6 +276,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#thenComparing(Function, Comparator)
      * java.util.Comparator#thenComparing(Function, Comparator)}.
+     * @param  <U>  the type of the sort key
      */
     @Override
     default <U> ComparatorEx<T> thenComparing(
@@ -269,6 +291,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#thenComparing(Function, Comparator)
      * java.util.Comparator#thenComparing(Function, Comparator)}.
+     * @param  <U>  the type of the sort key
      */
     default <U> ComparatorEx<T> thenComparing(
             FunctionEx<? super T, ? extends U> toKeyFn,
@@ -280,6 +303,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#thenComparing(Function)
      * java.util.Comparator#thenComparing(Function)}.
+     * @param  <U>  the type of the {@link Comparable} sort key
      */
     @Override
     default <U extends Comparable<? super U>> ComparatorEx<T> thenComparing(
@@ -293,6 +317,7 @@ public interface ComparatorEx<T> extends Comparator<T>, Serializable {
      * {@code Serializable} variant of {@link
      * Comparator#thenComparing(Function)
      * java.util.Comparator#thenComparing(Function)}.
+     * @param  <U>  the type of the {@link Comparable} sort key
      */
     default <U extends Comparable<? super U>> ComparatorEx<T> thenComparing(
             FunctionEx<? super T, ? extends U> toKeyFn) {

--- a/hazelcast/src/main/java/com/hazelcast/function/ConsumerEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ConsumerEx.java
@@ -36,6 +36,7 @@ public interface ConsumerEx<T> extends Consumer<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link Consumer#accept}
+     * @throws Exception in case of any exceptional case
      */
     void acceptEx(T t) throws Exception;
 
@@ -62,6 +63,7 @@ public interface ConsumerEx<T> extends Consumer<T>, Serializable {
 
     /**
      * Returns a consumer that does nothing.
+     * @param <T> the consumer input type
      */
     static <T> ConsumerEx<T> noop() {
         return x -> {

--- a/hazelcast/src/main/java/com/hazelcast/function/FunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/FunctionEx.java
@@ -37,6 +37,7 @@ public interface FunctionEx<T, R> extends Function<T, R>, Serializable {
 
     /**
      * Exception-declaring version of {@link Function#apply}.
+     * @throws Exception in case of any exceptional case
      */
     R applyEx(T t) throws Exception;
 
@@ -52,6 +53,7 @@ public interface FunctionEx<T, R> extends Function<T, R>, Serializable {
     /**
      * {@code Serializable} variant of {@link Function#identity()
      * java.util.function.Function#identity()}.
+     * @param <T> the type of the input and output objects to the function
      */
     static <T> FunctionEx<T, T> identity() {
         return t -> t;
@@ -60,6 +62,8 @@ public interface FunctionEx<T, R> extends Function<T, R>, Serializable {
     /**
      * {@code Serializable} variant of {@link Function#compose(Function)
      * java.util.function.Function#compose(Function)}.
+     * @param <V> the type of input to the {@code before} function, and to the
+     *           composed function
      */
     default <V> FunctionEx<V, R> compose(FunctionEx<? super V, ? extends T> before) {
         checkNotNull(before, "before");
@@ -69,6 +73,8 @@ public interface FunctionEx<T, R> extends Function<T, R>, Serializable {
     /**
      * {@code Serializable} variant of {@link Function#andThen(Function)
      * java.util.function.Function#andThen(Function)}.
+     * @param <V> the type of output of the {@code after} function, and of the
+     *           composed function
      */
     default <V> FunctionEx<T, V> andThen(FunctionEx<? super R, ? extends V> after) {
         checkNotNull(after, "after");

--- a/hazelcast/src/main/java/com/hazelcast/function/Functions.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/Functions.java
@@ -32,6 +32,7 @@ public final class Functions {
     /**
      * Synonym for {@link FunctionEx#identity}, to be used as a
      * projection function (e.g., key extractor).
+     * @param <T> the type of the input and output objects to the function
      */
     @Nonnull
     public static <T> FunctionEx<T, T> wholeItem() {

--- a/hazelcast/src/main/java/com/hazelcast/function/PredicateEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/PredicateEx.java
@@ -38,6 +38,7 @@ public interface PredicateEx<T> extends Predicate<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link Predicate#test}.
+     * @throws Exception in case of any exceptional case
      */
     boolean testEx(T t) throws Exception;
 
@@ -52,6 +53,7 @@ public interface PredicateEx<T> extends Predicate<T>, Serializable {
 
     /**
      * Returns a predicate that always evaluates to {@code true}.
+     * @param <T> the type of the input to the predicate
      */
     @Nonnull
     static <T> PredicateEx<T> alwaysTrue() {
@@ -60,6 +62,7 @@ public interface PredicateEx<T> extends Predicate<T>, Serializable {
 
     /**
      * Returns a predicate that always evaluates to {@code false}.
+     * @param <T> the type of the input to the predicate
      */
     @Nonnull
     static <T> PredicateEx<T> alwaysFalse() {
@@ -68,6 +71,7 @@ public interface PredicateEx<T> extends Predicate<T>, Serializable {
 
     /**
      * {@code Serializable} variant of
+     * @param <T> the type of the input to the predicate
      * {@link Predicate#isEqual(Object) java.util.function.Predicate#isEqual(Object)}.
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/function/SupplierEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/SupplierEx.java
@@ -34,6 +34,7 @@ public interface SupplierEx<T> extends Supplier<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link Supplier#get}.
+     * @throws Exception in case of any exceptional case
      */
     T getEx() throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/function/ToDoubleFunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ToDoubleFunctionEx.java
@@ -34,6 +34,7 @@ public interface ToDoubleFunctionEx<T> extends ToDoubleFunction<T>, Serializable
 
     /**
      * Exception-declaring version of {@link ToDoubleFunction#applyAsDouble}.
+     * @throws Exception in case of any exceptional case
      */
     double applyAsDoubleEx(T value) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/function/ToIntFunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ToIntFunctionEx.java
@@ -34,6 +34,7 @@ public interface ToIntFunctionEx<T> extends ToIntFunction<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link ToIntFunction#applyAsInt}.
+     * @throws Exception in case of any exceptional case
      */
     int applyAsIntEx(T value) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/function/ToLongFunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ToLongFunctionEx.java
@@ -34,6 +34,7 @@ public interface ToLongFunctionEx<T> extends ToLongFunction<T>, Serializable {
 
     /**
      * Exception-declaring version of {@link ToLongFunction#applyAsLong}.
+     * @throws Exception in case of any exceptional case
      */
     long applyAsLongEx(T value) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DomConfigProcessor.java
@@ -32,7 +32,7 @@ public interface DomConfigProcessor {
      * Traverses the DOM and fills the config
      *
      * @param rootNode the root node
-     * @throws Exception
+     * @throws Exception in case of any exceptional case
      */
     void buildConfig(Node rootNode) throws Exception;
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
@@ -56,7 +56,7 @@ public interface IPartitionService extends CoreService {
      *
      * @param partitionId the partitionId
      * @return owner of partition
-     * @throws InterruptedException
+     * @throws InterruptedException if interrupted while waiting
      * @throws NoDataMemberInClusterException if all nodes are lite members and partitions can't be assigned
      */
     Address getPartitionOwnerOrWait(int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryLoader.java
@@ -70,7 +70,7 @@ public interface EntryLoader<K, V> extends MapLoader<K, EntryLoader.MetadataAwar
 
         /**
          * Returns the value
-         * @return
+         * @return the value
          */
         public V getValue() {
             return value;

--- a/hazelcast/src/main/java/com/hazelcast/map/EventLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EventLostEvent.java
@@ -58,10 +58,8 @@ public class EventLostEvent implements IMapEvent {
 
     /**
      * Intentionally returns {@code null}.
-     * Used in {@link com.hazelcast.map.impl.querycache.subscriber.InternalQueryCacheListenerAdapter}.
      *
      * @return {@code null}
-     * @see com.hazelcast.map.impl.querycache.subscriber.InternalQueryCacheListenerAdapter
      */
     @Override
     public EntryEventType getEventType() {

--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -926,7 +926,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * methods:
      * <pre>
      *   CompletionStage&lt;Void&gt; future = map.setAsync("a", "b", 5, TimeUnit.MINUTES);
-     *   future.thenRunAsync(() -> System.out.println("done"));
+     *   future.thenRunAsync(() -&gt; System.out.println("done"));
      * </pre>
      * <p>
      * <b>Warning 1:</b>
@@ -1000,7 +1000,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * methods:
      * <pre>
      *   CompletionStage&lt;Void&gt; future = map.setAsync("a", "b", 5, TimeUnit.MINUTES);
-     *   future.thenRunAsync(() -> System.out.println("Done"));
+     *   future.thenRunAsync(() -&gt; System.out.println("Done"));
      * </pre>
      * <p>
      * <b>Warning 1:</b>
@@ -1817,6 +1817,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * @return {@code true} if the lock was acquired, {@code false} if the waiting time
      * elapsed before the lock was acquired
      * @throws NullPointerException if the specified key is {@code null}
+     * @throws InterruptedException if interrupted while trying to acquire the lock
      */
     boolean tryLock(@Nonnull K key, long time, @Nullable TimeUnit timeunit) throws InterruptedException;
 
@@ -1847,6 +1848,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * @return {@code true} if the lock was acquired, {@code false} if the waiting time
      * elapsed before the lock was acquired
      * @throws NullPointerException if the specified key is {@code null}
+     * @throws InterruptedException if interrupted while trying to acquire the lock
      */
     boolean tryLock(@Nonnull K key,
                     long time, @Nullable TimeUnit timeunit,
@@ -2473,6 +2475,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * if the write-behind queue has reached its per-node maximum
      * capacity.
      *
+     * @param <R> the entry processor return type
      * @return result of {@link EntryProcessor#process(Entry)}
      * @throws NullPointerException if the specified key is {@code null}
      * @see Offloadable
@@ -2531,6 +2534,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      *
      * @param keys The keys to execute the entry processor on. Can be empty, in
      *             that case it's a local no-op
+     * @param <R>  the entry processor return type
      * @return results of {@link EntryProcessor#process(Entry)}
      * @throws NullPointerException if there's null element in {@code keys}
      */

--- a/hazelcast/src/main/java/com/hazelcast/multimap/BaseMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/BaseMultiMap.java
@@ -26,8 +26,8 @@ import java.util.Collection;
  *
  * @see MultiMap
  * @see TransactionalMultiMap
- * @param <K>
- * @param <V>
+ * @param <K> type of the multimap key
+ * @param <V> type of the multimap value
  */
 public interface BaseMultiMap<K, V> extends DistributedObject {
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -403,6 +403,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param timeunit the time unit of the {@code time} argument
      * @return {@code true} if the lock was acquired, {@code false} if the
      * waiting time elapsed before the lock was acquired
+     * @throws InterruptedException if interrupted while trying to acquire the lock
      */
     boolean tryLock(@Nonnull K key,
                     long time, @Nullable TimeUnit timeunit) throws InterruptedException;
@@ -432,6 +433,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @return {@code true} if the lock was acquired and {@code false} if the
      * waiting time elapsed before the lock was acquired
      * @throws NullPointerException if the specified key is {@code null}
+     * @throws InterruptedException if interrupted while trying to acquire the lock
      */
     boolean tryLock(@Nonnull K key,
                     long time, @Nullable TimeUnit timeunit,

--- a/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
@@ -34,7 +34,7 @@ public interface MemberSocketInterceptor extends SocketInterceptor {
      * meaning security requirements and clusters are matching.
      *
      * @param acceptedSocket accepted socket
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void onAccept(Socket acceptedSocket) throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -27,61 +27,61 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
 
     /**
      * @param bytes byte array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeByteArray(byte[] bytes) throws IOException;
 
     /**
      * @param booleans boolean array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeBooleanArray(boolean[] booleans) throws IOException;
 
     /**
      * @param chars char array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeCharArray(char[] chars) throws IOException;
 
     /**
      * @param ints int array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeIntArray(int[] ints) throws IOException;
 
     /**
      * @param longs long array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeLongArray(long[] longs) throws IOException;
 
     /**
      * @param values double array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeDoubleArray(double[] values) throws IOException;
 
     /**
      * @param values float array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeFloatArray(float[] values) throws IOException;
 
     /**
      * @param values short array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeShortArray(short[] values) throws IOException;
 
     /**
      * @param values String array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeUTFArray(String[] values) throws IOException;
 
     /**
      * @param object object to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeObject(Object object) throws IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
@@ -46,7 +46,7 @@ public interface SocketInterceptor {
      * Called when a connection is established.
      *
      * @param connectedSocket related socket
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void onConnect(Socket connectedSocket) throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArraySerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArraySerializer.java
@@ -33,7 +33,7 @@ public interface ByteArraySerializer<T> extends Serializer {
      *
      * @param object that will be serialized
      * @return byte array that object is serialized into
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     byte[] write(T object) throws IOException;
 
@@ -42,7 +42,7 @@ public interface ByteArraySerializer<T> extends Serializer {
      *
      * @param buffer that object will be read from
      * @return deserialized object
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     T read(byte[] buffer) throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Portable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Portable.java
@@ -59,7 +59,7 @@ public interface Portable {
      * Serialize this portable object using PortableWriter
      *
      * @param writer PortableWriter
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writePortable(PortableWriter writer) throws IOException;
 
@@ -67,7 +67,7 @@ public interface Portable {
      * Read portable fields using PortableReader
      *
      * @param reader PortableReader
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void readPortable(PortableReader reader) throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -60,140 +60,141 @@ public interface PortableReader {
     /**
      * @param fieldName name of the field
      * @return the int value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     int readInt(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the long value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     long readLong(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the utf string value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     String readUTF(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the boolean value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     boolean readBoolean(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the byte value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     byte readByte(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the char value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     char readChar(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the double value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     double readDouble(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the float value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     float readFloat(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the short value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     short readShort(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
+     * @param <P> the type of the portable read
      * @return the portable value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     <P extends Portable> P readPortable(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the byte array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     byte[] readByteArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the boolean array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     boolean[] readBooleanArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the char array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     char[] readCharArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the int array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     int[] readIntArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the long array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     long[] readLongArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the double array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     double[] readDoubleArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the float array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     float[] readFloatArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the short array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     short[] readShortArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the String array value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     String[] readUTFArray(String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the portable value read
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     Portable[] readPortableArray(String fieldName) throws IOException;
 
@@ -204,7 +205,7 @@ public interface PortableReader {
      * IOException will be thrown.
      *
      * @return rawDataInput
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     ObjectDataInput getRawDataInput() throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
@@ -31,7 +31,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeInt(String fieldName, int value) throws IOException;
 
@@ -40,7 +40,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     long value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeLong(String fieldName, long value) throws IOException;
 
@@ -49,7 +49,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     utf string value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeUTF(String fieldName, String value) throws IOException;
 
@@ -58,7 +58,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeBoolean(String fieldName, boolean value) throws IOException;
 
@@ -67,7 +67,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeByte(String fieldName, byte value) throws IOException;
 
@@ -76,7 +76,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeChar(String fieldName, int value) throws IOException;
 
@@ -85,7 +85,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeDouble(String fieldName, double value) throws IOException;
 
@@ -94,7 +94,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeFloat(String fieldName, float value) throws IOException;
 
@@ -103,7 +103,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param value     int value to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeShort(String fieldName, short value) throws IOException;
 
@@ -112,7 +112,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param portable  Portable to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writePortable(String fieldName, Portable portable) throws IOException;
 
@@ -122,7 +122,7 @@ public interface PortableWriter {
      * @param fieldName name of the field
      * @param factoryId factory ID of related portable class
      * @param classId   class ID of related portable class
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeNullPortable(String fieldName, int factoryId, int classId) throws IOException;
 
@@ -131,7 +131,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param bytes     byte array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeByteArray(String fieldName, byte[] bytes) throws IOException;
 
@@ -140,7 +140,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param booleans     boolean array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeBooleanArray(String fieldName, boolean[] booleans) throws IOException;
 
@@ -149,7 +149,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param chars     char array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeCharArray(String fieldName, char[] chars) throws IOException;
 
@@ -158,7 +158,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param ints      int array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeIntArray(String fieldName, int[] ints) throws IOException;
 
@@ -167,7 +167,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param longs     long array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeLongArray(String fieldName, long[] longs) throws IOException;
 
@@ -176,7 +176,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param values    double array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeDoubleArray(String fieldName, double[] values) throws IOException;
 
@@ -185,7 +185,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param values    float array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeFloatArray(String fieldName, float[] values) throws IOException;
 
@@ -194,7 +194,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param values    short array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeShortArray(String fieldName, short[] values) throws IOException;
 
@@ -203,7 +203,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param values    String array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writeUTFArray(String fieldName, String[] values) throws IOException;
 
@@ -212,7 +212,7 @@ public interface PortableWriter {
      *
      * @param fieldName name of the field
      * @param portables portable array to be written
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     void writePortableArray(String fieldName, Portable[] portables) throws IOException;
 
@@ -222,7 +222,7 @@ public interface PortableWriter {
      * in IOException
      *
      * @return ObjectDataOutput
-     * @throws IOException
+     * @throws IOException in case of any exceptional case
      */
     ObjectDataOutput getRawDataOutput() throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionAwareKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionAwareKey.java
@@ -29,8 +29,8 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
  * A {@link PartitionAware} key. This is useful in combination with a Map where you want to control the
  * partition of a key.
  *
- * @param <K>
- * @param <P>
+ * @param <K> the key type
+ * @param <P> the partitionKey type
  */
 @BinaryInterface
 public final class PartitionAwareKey<K, P> implements PartitionAware<Object>, DataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
@@ -193,6 +193,8 @@ public final class Predicates {
 
     /**
      * Creates an <b>always true</b> predicate that will pass all items.
+     * @param <K> the type of keys the predicate operates on.
+     * @param <V> the type of values the predicate operates on.
      */
     public static <K, V> Predicate<K, V> alwaysTrue() {
         return TruePredicate.INSTANCE;
@@ -200,6 +202,8 @@ public final class Predicates {
 
     /**
      * Creates an <b>always false</b> predicate that will filter out all items.
+     * @param <K> the type of keys the predicate operates on.
+     * @param <V> the type of values the predicate operates on.
      */
     public static <K, V> Predicate<K, V> alwaysFalse() {
         return FalsePredicate.INSTANCE;
@@ -210,6 +214,8 @@ public final class Predicates {
      * the value class is an {@code instanceof} the given {@code klass}.
      *
      * @param klass the class the created predicate will check for.
+     * @param <K>   the type of keys the predicate operates on.
+     * @param <V>   the type of values the predicate operates on.
      * @return the created <b>instance of</b> predicate.
      */
     public static <K, V> Predicate<K, V> instanceOf(final Class klass) {
@@ -223,6 +229,8 @@ public final class Predicates {
      * and will pass any item.
      *
      * @param predicates the child predicates to form the resulting <b>and</b> predicate from.
+     * @param <K>        the type of keys the predicate operates on.
+     * @param <V>        the type of values the predicate operates on.
      * @return the created <b>and</b> predicate instance.
      */
     public static <K, V> Predicate<K, V> and(Predicate... predicates) {
@@ -233,6 +241,8 @@ public final class Predicates {
      * Creates a <b>not</b> predicate that will negate the result of the given {@code predicate}.
      *
      * @param predicate the predicate to negate the value of.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>not</b> predicate instance.
      */
     public static <K, V> Predicate<K, V> not(Predicate predicate) {
@@ -246,6 +256,8 @@ public final class Predicates {
      * and will never pass any items.
      *
      * @param predicates the child predicates to form the resulting <b>or</b> predicate from.
+     * @param <K>        the type of keys the predicate operates on.
+     * @param <V>        the type of values the predicate operates on.
      * @return the created <b>or</b> predicate instance.
      */
     public static <K, V> Predicate<K, V> or(Predicate... predicates) {
@@ -261,6 +273,8 @@ public final class Predicates {
      *
      * @param attribute the attribute to fetch the value for comparison from.
      * @param value     the value to compare the attribute value against. Can be {@code null}.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>not equal</b> predicate instance.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -277,6 +291,8 @@ public final class Predicates {
      *
      * @param attribute the attribute to fetch the value for comparison from.
      * @param value     the value to compare the attribute value against. Can be {@code null}.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>equal</b> predicate instance.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -297,6 +313,8 @@ public final class Predicates {
      *                  match the percentage sign or the underscore character itself, escape it with the backslash,
      *                  for example {@code "\\%"} string will match the percentage sign. Can be {@code null}.
      * @return the created <b>like</b> predicate instance.
+     * @param <K> the type of keys the predicate operates on.
+     * @param <V> the type of values the predicate operates on.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      * @see #ilike(String, String)
      * @see #regex(String, String)
@@ -317,6 +335,8 @@ public final class Predicates {
      *                  multiple characters, the _ (underscore) is a placeholder for a single character. If you need to
      *                  match the percentage sign or the underscore character itself, escape it with the backslash,
      *                  for example {@code "\\%"} string will match the percentage sign. Can be {@code null}.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>case-insensitive like</b> predicate instance.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      * @see #like(String, String)
@@ -336,6 +356,8 @@ public final class Predicates {
      * @param attribute the attribute to fetch the value for matching from.
      * @param pattern   the pattern to match the attribute value against. The pattern interpreted exactly the same as
      *                  described in {@link java.util.regex.Pattern}. Can be {@code null}.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>regex</b> predicate instance.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      * @see #like(String, String)
@@ -354,6 +376,8 @@ public final class Predicates {
      *
      * @param attribute the left-hand side attribute to fetch the value for comparison from.
      * @param value     the right-hand side value to compare the attribute value against.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>greater than</b> predicate.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -370,6 +394,8 @@ public final class Predicates {
      *
      * @param attribute the left-hand side attribute to fetch the value for comparison from.
      * @param value     the right-hand side value to compare the attribute value against.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>greater than or equal to</b> predicate.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -386,6 +412,8 @@ public final class Predicates {
      *
      * @param attribute the left-hand side attribute to fetch the value for comparison from.
      * @param value     the right-hand side value to compare the attribute value against.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>less than</b> predicate.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -402,6 +430,8 @@ public final class Predicates {
      *
      * @param attribute the left-hand side attribute to fetch the value for comparison from.
      * @param value     the right-hand side value to compare the attribute value against.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>less than or equal to</b> predicate.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -420,6 +450,8 @@ public final class Predicates {
      * @param attribute the attribute to fetch the value to check from.
      * @param from      the inclusive lower bound of the range to check.
      * @param to        the inclusive upper bound of the range to check.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>between</b> predicate.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -436,6 +468,8 @@ public final class Predicates {
      *
      * @param attribute the attribute to fetch the value to test from.
      * @param values    the values set to test the membership in. Individual values can be {@code null}.
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
      * @return the created <b>in</b> predicate.
      * @throws IllegalArgumentException if the {@code attribute} does not exist.
      */
@@ -455,6 +489,8 @@ public final class Predicates {
      * <i>Implicit Type Conversion</i> sections of {@link Predicates}.
      *
      * @param expression the 'where' expression.
+     * @param <K>        the type of keys the predicate operates on.
+     * @param <V>        the type of values the predicate operates on.
      * @return the created <b>sql</b> predicate instance.
      * @throws IllegalArgumentException if the SQL expression is invalid.
      */
@@ -466,7 +502,9 @@ public final class Predicates {
      * Creates a paging predicate with a page size. Results will not be filtered and will be returned in natural order.
      *
      * @param pageSize page size
-     * @throws {@link IllegalArgumentException} if pageSize is not greater than 0
+     * @param <K>      the type of keys the predicate operates on.
+     * @param <V>      the type of values the predicate operates on.
+     * @throws IllegalArgumentException if pageSize is not greater than 0
      */
     public static <K, V> PagingPredicate<K, V> pagingPredicate(int pageSize) {
         return new PagingPredicateImpl<>(pageSize);
@@ -478,8 +516,10 @@ public final class Predicates {
      *
      * @param predicate the inner predicate through which results will be filtered
      * @param pageSize  the page size
-     * @throws {@link IllegalArgumentException} if pageSize is not greater than 0
-     * @throws {@link IllegalArgumentException} if inner predicate is also a paging predicate
+     * @param <K>       the type of keys the predicate operates on.
+     * @param <V>       the type of values the predicate operates on.
+     * @throws IllegalArgumentException if pageSize is not greater than 0
+     * @throws IllegalArgumentException if inner predicate is also a paging predicate
      */
     public static <K, V> PagingPredicate<K, V> pagingPredicate(Predicate predicate, int pageSize) {
         return new PagingPredicateImpl<>(predicate, pageSize);
@@ -491,7 +531,9 @@ public final class Predicates {
      *
      * @param comparator the comparator through which results will be ordered
      * @param pageSize   the page size
-     * @throws {@link IllegalArgumentException} if pageSize is not greater than 0
+     * @param <K>        the type of keys the predicate operates on.
+     * @param <V>        the type of values the predicate operates on.
+     * @throws IllegalArgumentException if pageSize is not greater than 0
      */
     public static <K, V> PagingPredicate<K, V> pagingPredicate(Comparator<Map.Entry<K, V>> comparator, int pageSize) {
         return new PagingPredicateImpl<>(comparator, pageSize);
@@ -504,8 +546,10 @@ public final class Predicates {
      * @param predicate  the inner predicate through which results will be filtered
      * @param comparator the comparator through which results will be ordered
      * @param pageSize   the page size
-     * @throws {@link IllegalArgumentException} if pageSize is not greater than 0
-     * @throws {@link IllegalArgumentException} if inner predicate is also a {@link PagingPredicate}
+     * @param <K>        the type of keys the predicate operates on.
+     * @param <V>        the type of values the predicate operates on.
+     * @throws IllegalArgumentException if pageSize is not greater than 0
+     * @throws IllegalArgumentException if inner predicate is also a {@link PagingPredicate}
      */
     public static <K, V> PagingPredicate<K, V> pagingPredicate(Predicate<K, V> predicate, Comparator<Map.Entry<K, V>> comparator,
                                                                int pageSize) {
@@ -517,6 +561,8 @@ public final class Predicates {
      *
      * @param partitionKey the partition key
      * @param target       the target {@link Predicate}
+     * @param <K>          the type of keys the predicate operates on.
+     * @param <V>          the type of values the predicate operates on.
      * @throws NullPointerException     if partition key or target predicate is {@code null}
      */
     public static <K, V> PartitionPredicate<K, V> partitionPredicate(Object partitionKey, Predicate<K, V> target) {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledExecutorService.java
@@ -89,6 +89,7 @@ public interface IScheduledExecutorService
      * @param command the task to execute
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -104,6 +105,7 @@ public interface IScheduledExecutorService
      * @param command the task to execute
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the return type of callable tasks
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -128,6 +130,7 @@ public interface IScheduledExecutorService
      * @param initialDelay the time to delay first execution
      * @param period       the period between successive executions
      * @param unit         the time unit of the initialDelay and period parameters
+     * @param <V>          the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task, and whose
      * {@code get()} method will throw an exception upon cancellation
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -145,6 +148,7 @@ public interface IScheduledExecutorService
      * @param member  the member to execute the task
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -163,6 +167,7 @@ public interface IScheduledExecutorService
      * @param member  the member to execute the task
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the return type of callable tasks
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -190,6 +195,7 @@ public interface IScheduledExecutorService
      * @param initialDelay the time to delay first execution
      * @param period       the period between successive executions
      * @param unit         the time unit of the initialDelay and period parameters
+     * @param <V>          the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task, and whose
      * {@code get()} method will throw an exception upon cancellation
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -208,6 +214,7 @@ public interface IScheduledExecutorService
      * @param key     the key to identify the partition owner, which will execute the task
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -226,6 +233,7 @@ public interface IScheduledExecutorService
      * @param key     the key to identify the partition owner, which will execute the task
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the return type of callable tasks
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -253,6 +261,7 @@ public interface IScheduledExecutorService
      * @param initialDelay the time to delay first execution
      * @param period       the period between successive executions
      * @param unit         the time unit of the initialDelay and period parameters
+     * @param <V>          the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task, and whose
      * {@code get()} method will throw an exception upon cancellation
      * @throws RejectedExecutionException if the task cannot be  scheduled for execution
@@ -275,6 +284,7 @@ public interface IScheduledExecutorService
      * @param command the task to execute
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -296,6 +306,7 @@ public interface IScheduledExecutorService
      * @param command the task to execute
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the return type of callable tasks
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -326,6 +337,7 @@ public interface IScheduledExecutorService
      * @param initialDelay the time to delay first execution
      * @param period       the period between successive executions
      * @param unit         the time unit of the initialDelay and period parameters
+     * @param <V>          the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task, and whose
      * {@code get()} method will throw an exception upon cancellation
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -347,6 +359,7 @@ public interface IScheduledExecutorService
      * @param members the collections of members - where to execute the task
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -369,6 +382,7 @@ public interface IScheduledExecutorService
      * @param members the collections of members - where to execute the task
      * @param delay   the time from now to delay execution
      * @param unit    the time unit of the delay parameter
+     * @param <V>     the return type of callable tasks
      * @return a ScheduledFuture representing pending completion of the task and whose
      * {@code get()} method will return {@code null} upon completion
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -399,6 +413,7 @@ public interface IScheduledExecutorService
      * @param initialDelay the time to delay first execution
      * @param period       the period between successive executions
      * @param unit         the time unit of the initialDelay and period parameters
+     * @param <V>          the result type of the returned ScheduledFuture
      * @return a ScheduledFuture representing pending completion of the task, and whose
      * {@code get()} method will throw an exception upon cancellation
      * @throws RejectedExecutionException if the task cannot be scheduled for execution
@@ -417,7 +432,7 @@ public interface IScheduledExecutorService
      * <code>ScheduledFuture</code> again.
      *
      * @param handler The handler of the task as found from {@link IScheduledFuture#getHandler()}
-     * @param <V>     The return type of callable tasks
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return A new {@link IScheduledFuture} from the given handler.
      */
     @Nonnull
@@ -428,6 +443,7 @@ public interface IScheduledExecutorService
      * members in the cluster. If a member has no running tasks for this
      * scheduler, it wont be included in the returned {@link Map}.
      *
+     * @param <V>     the result type of the returned ScheduledFuture
      * @return A {@link Map} with {@link Member} keys and a List of {@link IScheduledFuture}
      * found for this scheduler.
      */

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/TaskUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/TaskUtils.java
@@ -44,6 +44,7 @@ public final class TaskUtils {
      *
      * @param name     The name that the task will have
      * @param callable The callable task to be named
+     * @param <V>      The return type of callable task
      * @return A new Callable implementing the {@link NamedTask} interface
      */
     public static <V> Callable<V> named(final String name, final Callable<V> callable) {

--- a/hazelcast/src/main/java/com/hazelcast/security/IPermissionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/IPermissionPolicy.java
@@ -35,7 +35,7 @@ public interface IPermissionPolicy {
      * Configures {@link IPermissionPolicy}.
      *
      * @param config Hazelcast {@link Config}
-     * @param properties
+     * @param properties additional properties used to configure the IPermissionPolicy
      */
     void configure(Config config, Properties properties);
 

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
@@ -41,7 +41,7 @@ public interface SecurityContext {
      * @param connection member connection
      *
      * @return {@link LoginContext}
-     * @throws LoginException
+     * @throws LoginException in case of any exceptional case
      */
     LoginContext createMemberLoginContext(String clusterName, Credentials credentials, Connection connection)
             throws LoginException;
@@ -53,7 +53,7 @@ public interface SecurityContext {
      * @param credentials client credentials
      * @param connection client connection
      * @return {@link LoginContext}
-     * @throws LoginException
+     * @throws LoginException in case of any exceptional case
      */
     LoginContext createClientLoginContext(String clusterName, Credentials credentials, Connection connection)
             throws LoginException;
@@ -70,7 +70,7 @@ public interface SecurityContext {
      *
      * @param subject the current subject
      * @param permission the specified permission for the subject
-     * @throws AccessControlException
+     * @throws AccessControlException if the specified permission has not been granted to the subject
      */
     void checkPermission(Subject subject, Permission permission) throws AccessControlException;
 
@@ -83,7 +83,7 @@ public interface SecurityContext {
      * @param objectName
      * @param methodName
      * @param parameters
-     * @throws AccessControlException
+     * @throws AccessControlException if access is denied
      */
     void interceptBefore(Credentials credentials, String serviceName, String objectName,
                          String methodName, Object[] parameters) throws AccessControlException;

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptor.java
@@ -30,7 +30,7 @@ public interface SecurityInterceptor {
      * @param objectName
      * @param methodName
      * @param parameters
-     * @throws AccessControlException
+     * @throws AccessControlException if access is denied
      */
     void before(Credentials credentials, String objectType, String objectName, String methodName,
                 Parameters parameters) throws AccessControlException;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -209,9 +209,9 @@ public final class ActionConstants {
     /**
      * Creates a permission
      *
-     * @param name
-     * @param serviceName
-     * @param actions
+     * @param name the permission name
+     * @param serviceName the service name
+     * @param actions the actions
      * @return the created Permission
      * @throws java.lang.IllegalArgumentException if there is no service found with the given serviceName.
      */

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAddressProvider.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.EndpointQualifier;
 
 import java.net.InetSocketAddress;
@@ -26,7 +27,7 @@ import java.util.List;
  * <b>IMPORTANT</b>
  * This interface is not intended to provide addresses of other cluster members with
  * which the hazelcast instance will form a cluster. This is an SPI for advanced use in
- * cases where the {@link com.hazelcast.instance.DefaultAddressPicker} does not
+ * cases where the {@link AddressPicker} implementation does not
  * pick suitable addresses to bind to and publish to other cluster members.
  * For instance, this could allow easier deployment in some cases when running on
  * Docker, AWS or other cloud environments.
@@ -41,7 +42,6 @@ import java.util.List;
  * <p>
  * This is practical in some cloud environments where the default strategy is not yielding good results.
  *
- * @see com.hazelcast.instance.DefaultAddressPicker
  * @see com.hazelcast.config.NetworkConfig#setMemberAddressProviderConfig(com.hazelcast.config.MemberAddressProviderConfig)
  */
 public interface MemberAddressProvider {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -333,13 +333,13 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.map.load.chunk.size", 1000);
 
     /**
-     * The delay until the first run of the {@link com.hazelcast.internal.cluster.impl.SplitBrainHandler}
+     * The delay until the first run of the split-brain handler.
      */
     public static final HazelcastProperty MERGE_FIRST_RUN_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.merge.first.run.delay.seconds", 300, SECONDS);
 
     /**
-     * The interval between invocations of the {@link com.hazelcast.internal.cluster.impl.SplitBrainHandler}
+     * The interval between invocations of the split-brain handler.
      */
     public static final HazelcastProperty MERGE_NEXT_RUN_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.merge.next.run.delay.seconds", 120, SECONDS);
@@ -655,7 +655,8 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.enterprise.license.key");
 
     /**
-     * Setting this capacity is valid if you set {@link com.hazelcast.config.MapStoreConfig#writeCoalescing} to {@code false}.
+     * Setting this capacity is valid if you set {@code writeCoalescing} to {@code false}
+     * (see {@link com.hazelcast.config.MapStoreConfig#setWriteCoalescing(boolean)}).
      * Otherwise its value will not be taken into account.
      * <p>
      * The per node maximum write-behind queue capacity is the total of all write-behind queue sizes in a node, including backups.
@@ -976,11 +977,11 @@ public final class ClusterProperty {
 
     /**
      * Defines whether Moby Names should be used for instance name generating when it is not provided by user.
-     * </p>
+     * <p>
      * Moby Name is a short human-readable name consisting of randomly chosen adjective and the surname of a famous person.
-     * </p>
+     * <p>
      * If set to true, Moby Name will be chosen, otherwise a name that is concatenation of static prefix, number and cluster name.
-     * </p>
+     * <p>
      * By default is true.
      */
     public static final HazelcastProperty MOBY_NAMING_ENABLED

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -294,6 +294,7 @@ public class HazelcastProperties {
      * The case of the enum is ignored.
      *
      * @param property the {@link ClusterProperty} to get the value from
+     * @param <E> the enum type
      * @return the enum
      * @throws IllegalArgumentException if the enum value can't be found
      */

--- a/hazelcast/src/main/java/com/hazelcast/spi/tenantcontrol/DestroyEventContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/tenantcontrol/DestroyEventContext.java
@@ -40,13 +40,13 @@ public interface DestroyEventContext<T> {
 
     /**
      *
-     * @return
+     * @return the name of the distributed object
      */
     String getDistributedObjectName();
 
     /**
      *
-     * @return
+     * @return the service name
      */
     String getServiceName();
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalTaskContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalTaskContext.java
@@ -25,6 +25,8 @@ public interface TransactionalTaskContext {
      * Returns the transactional distributed map instance with the specified name.
      *
      * @param name name of the distributed transactional map
+     * @param <K> type of the map key
+     * @param <V> type of the map value
      * @return transactional distributed map instance with the specified name
      */
     <K, V> TransactionalMap<K, V> getMap(String name);
@@ -33,6 +35,7 @@ public interface TransactionalTaskContext {
      * Returns the transactional queue instance with the specified name.
      *
      * @param name name of the transactional queue
+     * @param <E> the type of elements held in the queue
      * @return transactional queue instance with the specified name
      */
     <E> TransactionalQueue<E> getQueue(String name);
@@ -41,6 +44,8 @@ public interface TransactionalTaskContext {
      * Returns the transactional multimap instance with the specified name.
      *
      * @param name name of the transactional multimap
+     * @param <K> type of the multimap key
+     * @param <V> type of the multimap value
      * @return transactional multimap instance with the specified name
      */
     <K, V> TransactionalMultiMap<K, V> getMultiMap(String name);
@@ -49,6 +54,7 @@ public interface TransactionalTaskContext {
      * Returns the transactional list instance with the specified name.
      *
      * @param name name of the transactional list
+     * @param <E> the type of elements held in the list
      * @return transactional list instance with the specified name
      */
     <E> TransactionalList<E> getList(String name);
@@ -57,6 +63,7 @@ public interface TransactionalTaskContext {
      * Returns the transactional set instance with the specified name.
      *
      * @param name name of the transactional set
+     * @param <E> the type of elements held in the set
      * @return transactional set instance with the specified name
      */
     <E> TransactionalSet<E> getSet(String name);
@@ -67,6 +74,7 @@ public interface TransactionalTaskContext {
      *
      * @param serviceName service name for the transactional object instance
      * @param name name of the transactional object instance
+     * @param <T> the type of the transactional object
      * @return transactional object instance with the specified name
      */
     <T extends TransactionalObject> T getTransactionalObject(String serviceName, String name);

--- a/hazelcast/src/main/java/com/hazelcast/version/Version.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/Version.java
@@ -231,8 +231,8 @@ public final class Version implements IdentifiedDataSerializable, Comparable<Ver
     /**
      * Checks if the version is between specified version (both ends inclusive)
      *
-     * @param from
-     * @param to
+     * @param from the lower bound version
+     * @param to the upper bound version
      * @return true if the version is between from and to (both ends inclusive)
      */
     public boolean isBetween(Version from, Version to) {


### PR DESCRIPTION
Fixed malformed markup, added missing `@throws` and generic type parameters.

What is left: missing/incomplete `@param` and `@return`. Will address those over the winter time.