### PR TITLE
Handle destroyed Raft group on Raft node init task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -1357,7 +1357,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
                 } else {
                     if (throwable instanceof CPGroupDestroyedException) {
                         CPGroupId destroyedGroupId = ((CPGroupDestroyedException) throwable).getGroupId();
-                        destroyedGroupIds.add(destroyedGroupId);
+                        terminateRaftNode(destroyedGroupId, true);
                     }
 
                     if (logger.isFineEnabled()) {


### PR DESCRIPTION
When a queried Raft node is not existing on local member, the local
member asks the METADATA CP group to get the CP group info and create
the Raft node if needed. If the CP group is already destroyed, the local
member must process this information using the Raft node termination
logic by calling `RaftService.terminateRaftNode()`.

OSS side of https://github.com/hazelcast/hazelcast-enterprise/pull/3301