### PR TITLE
Offload the Raft node step down process from partition threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -142,7 +142,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
 
     public static final String SERVICE_NAME = "hz:core:raft";
 
-    static final String CP_SUBSYSTEM_EXECUTOR = "hz:cpSubsystem";
+    public static final String CP_SUBSYSTEM_EXECUTOR = "hz:cpSubsystem";
     static final String CP_SUBSYSTEM_MANAGEMENT_EXECUTOR = "hz:cpSubsystemManagement";
 
     private static final long REMOVE_MISSING_MEMBER_TASK_PERIOD_SECONDS = 1;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftQueryOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftQueryOp.java
@@ -36,6 +36,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.io.IOException;
 import java.util.function.BiConsumer;
 
+import static com.hazelcast.cp.internal.RaftService.CP_SUBSYSTEM_EXECUTOR;
 import static com.hazelcast.internal.util.InvocationUtil.CALLER_RUNS_EXECUTOR;
 
 /**
@@ -76,8 +77,8 @@ public class RaftQueryOp extends Operation implements IndeterminateOperationStat
             }
             return;
         } else if (raftNode.getStatus() == RaftNodeStatus.STEPPED_DOWN) {
-            service.stepDownRaftNode(groupId);
             sendResponse(new NotLeaderException(groupId, service.getLocalCPEndpoint(), null));
+            getNodeEngine().getExecutionService().execute(CP_SUBSYSTEM_EXECUTOR, () -> service.stepDownRaftNode(groupId));
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 
-import static com.hazelcast.internal.util.InvocationUtil.CALLER_RUNS_EXECUTOR;
+import static com.hazelcast.cp.internal.RaftService.CP_SUBSYSTEM_EXECUTOR;
 
 /**
  * The base class that replicates the given {@link RaftOp}
@@ -70,8 +70,8 @@ public abstract class RaftReplicateOp extends Operation implements IdentifiedDat
             }
             return;
         } else if (raftNode.getStatus() == RaftNodeStatus.STEPPED_DOWN) {
-            service.stepDownRaftNode(groupId);
             sendResponse(new NotLeaderException(groupId, service.getLocalCPEndpoint(), null));
+            getNodeEngine().getExecutionService().execute(CP_SUBSYSTEM_EXECUTOR, () -> service.stepDownRaftNode(groupId));
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CompleteDestroyRaftGroupsOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CompleteDestroyRaftGroupsOp.java
@@ -77,7 +77,7 @@ public class CompleteDestroyRaftGroupsOp extends MetadataRaftGroupOp implements 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int count = in.readInt();
-        groupIds = new HashSet<CPGroupId>();
+        groupIds = new HashSet<>();
         for (int i = 0; i < count; i++) {
             CPGroupId groupId = in.readObject();
             groupIds.add(groupId);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CompleteRaftGroupMembershipChangesOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CompleteRaftGroupMembershipChangesOp.java
@@ -81,7 +81,7 @@ public class CompleteRaftGroupMembershipChangesOp extends MetadataRaftGroupOp im
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int count = in.readInt();
-        changedGroups = new HashMap<CPGroupId, BiTuple<Long, Long>>(count);
+        changedGroups = new HashMap<>(count);
         for (int i = 0; i < count; i++) {
             CPGroupId groupId = in.readObject();
             long currMembersCommitIndex = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftGroupOp.java
@@ -93,7 +93,7 @@ public class CreateRaftGroupOp extends MetadataRaftGroupOp implements Indetermin
     public void readData(ObjectDataInput in) throws IOException {
         groupName = in.readUTF();
         int len = in.readInt();
-        members = new ArrayList<RaftEndpoint>(len);
+        members = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             RaftEndpoint member = in.readObject();
             members.add(member);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftNodeOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftNodeOp.java
@@ -95,7 +95,7 @@ public class CreateRaftNodeOp extends Operation implements IdentifiedDataSeriali
         super.readInternal(in);
         groupId = in.readObject();
         int count = in.readInt();
-        initialMembers = new ArrayList<RaftEndpoint>(count);
+        initialMembers = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
             RaftEndpoint member = in.readObject();
             initialMembers.add(member);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/InitMetadataRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/InitMetadataRaftGroupOp.java
@@ -89,7 +89,7 @@ public class InitMetadataRaftGroupOp extends MetadataRaftGroupOp implements Inde
     public void readData(ObjectDataInput in) throws IOException {
         callerCPMember = in.readObject();
         int len = in.readInt();
-        discoveredCPMembers = new ArrayList<CPMemberInfo>(len);
+        discoveredCPMembers = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             CPMemberInfo member = in.readObject();
             discoveredCPMembers.add(member);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/PublishActiveCPMembersOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/PublishActiveCPMembersOp.java
@@ -96,7 +96,7 @@ public class PublishActiveCPMembersOp extends Operation implements IdentifiedDat
         metadataGroupId = in.readObject();
         membersCommitIndex = in.readLong();
         int len = in.readInt();
-        members = new ArrayList<CPMemberInfo>(len);
+        members = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             CPMemberInfo member = in.readObject();
             members.add(member);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/RemoveCPMemberOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/RemoveCPMemberOp.java
@@ -27,10 +27,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * When a CP member is shutting down gracefully, or a crashed CP member is
- * removed from CP Subsystem via {@link RaftService#removeCPMember(String)},
+ * removed from CP Subsystem via {@link RaftService#removeCPMember(UUID)},
  * this operation is committed to the Metadata Raft group.
  */
 public class RemoveCPMemberOp extends MetadataRaftGroupOp implements IndeterminateOperationStateAware,

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/TerminateRaftNodesOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/TerminateRaftNodesOp.java
@@ -91,7 +91,7 @@ public class TerminateRaftNodesOp extends Operation implements IdentifiedDataSer
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int count = in.readInt();
-        groupIds = new ArrayList<CPGroupId>();
+        groupIds = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             CPGroupId groupId = in.readObject();
             groupIds.add(groupId);


### PR DESCRIPTION
Since the Raft node termination and step down processes involve locking,
these tasks are not executed on partition threads. RaftQueryOp and
RaftReplicateOp run on partition threads and they must offload the Raft
node step down process.

Fixes #15771