### PR TITLE
Fix HazelcastRaftTestSupport.getLeaderInstance() NPE

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/HazelcastRaftTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/HazelcastRaftTestSupport.java
@@ -157,6 +157,7 @@ public abstract class HazelcastRaftTestSupport extends HazelcastTestSupport {
         RaftNodeImpl raftNode = raftNodeRef[0];
         waitUntilLeaderElected(raftNode);
         RaftEndpoint leaderEndpoint = getLeaderMember(raftNode);
+        assertNotNull(leaderEndpoint);
 
         for (HazelcastInstance instance : instances) {
             CPMember cpMember = instance.getCPSubsystem().getLocalCPMember();
@@ -184,6 +185,7 @@ public abstract class HazelcastRaftTestSupport extends HazelcastTestSupport {
         RaftNodeImpl raftNode = raftNodeRef[0];
         waitUntilLeaderElected(raftNode);
         RaftEndpoint leaderEndpoint = getLeaderMember(raftNode);
+        assertNotNull(leaderEndpoint);
 
         for (HazelcastInstance instance : instances) {
             CPMember cpMember = instance.getCPSubsystem().getLocalCPMember();


### PR DESCRIPTION
Fixes hazelcast/hazelcast-enterprise#3306