### PR TITLE
Use smallInstanceConfig() for unit test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListAbstractTest.java
@@ -46,7 +46,7 @@ public abstract class ListAbstractTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        Config config = new Config();
+        Config config = smallInstanceConfig();
         config.addListConfig(new ListConfig("testAdd_whenCapacityReached_thenItemNotAdded*").setMaxSize(10));
 
         instances = newInstances(config);


### PR DESCRIPTION
Minimize consumed resources by the unit test optimizing member's Config.

Closes https://github.com/hazelcast/hazelcast/issues/15700