### PR TITLE
Catch and log exceptions from dynamic metrics providers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpNetworkingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpNetworkingService.java
@@ -390,7 +390,9 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
                 }
             }
 
-            unifiedEndpointManager.provideDynamicMetrics(taggerSupplier, context);
+            if (unifiedEndpointManager != null) {
+                unifiedEndpointManager.provideDynamicMetrics(taggerSupplier, context);
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DynamicMetricsCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DynamicMetricsCollectionTest.java
@@ -133,6 +133,19 @@ public class DynamicMetricsCollectionTest extends HazelcastTestSupport {
         verify(collectorMock, never()).collectDouble("[unit=bytes,metric=test.someMetric]", 42.42D, emptySet());
     }
 
+    @Test
+    public void testDynamicProviderExceptionsAreNotPropagated() {
+        MetricsCollector collectorMock = mock(MetricsCollector.class);
+        MetricsRegistry metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), MANDATORY);
+        metricsRegistry.registerDynamicMetricsProvider((taggerSupplier, context) -> {
+            throw new RuntimeException("Intentionally failing metrics collection");
+
+        });
+
+        metricsRegistry.collect(collectorMock);
+        // we just expect there is no exception
+    }
+
     private static class SourceObject {
         @Probe
         private long longField;


### PR DESCRIPTION
If the dynamic metrics collection encounters an exception it bubbles the
exception up to the caller triggered the periodic task that triggered
the collection. It is fixed by catching and logging the exception
without bubbling it up.

Throwing an NPE from
`TcpIpNetworkingService.MetricsProvider#provideDynamicMetrics` in
advanced networking mode is fixed by adding a null check around
`unifiedEndpointManager`.

Fixes #15932