### PR TITLE
Fixes handling of cache statistics

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.internal.monitor.LocalCacheStats;
 import com.hazelcast.internal.monitor.impl.MemberStateImpl;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -35,8 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -116,28 +113,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testAllCachesWithStatsEnabled_arePresent() {
-        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
-        // create 100 caches with stats enabled
-        for (int i = 0; i < 100; i++) {
-            hz.getCacheManager().getCache(CACHE_WITH_STATS_PREFIX + i);
-        }
-        // create 50 caches with stats disabled
-        for (int i = 0; i < 50; i++) {
-            hz.getCacheManager().getCache(CACHE_WITHOUT_STATS_PREFIX + i);
-        }
-
-        CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
-        Map<String, LocalCacheStats> stats = cacheService.getStats();
-        for (String cacheNameWithPrefix : stats.keySet()) {
-            assertContains(cacheNameWithPrefix, CACHE_WITH_STATS_PREFIX);
-        }
-    }
-
-    @Test
     public void testOnlyCachesWithStatsEnabled_areReportedInTimedMemberState() {
-        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
-
         // create 100 caches with stats enabled
         for (int i = 0; i < 100; i++) {
             hz.getCacheManager().getCache(CACHE_WITH_STATS_PREFIX + i);

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
@@ -17,11 +17,14 @@
 package com.hazelcast.internal.management;
 
 import com.hazelcast.cache.CacheUtil;
+import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.monitor.LocalCacheStats;
+import com.hazelcast.internal.monitor.impl.MemberStateImpl;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -33,15 +36,22 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class TimedMemberStateTest extends HazelcastTestSupport {
 
+    private static final String CACHE_WITH_STATS_PREFIX = "cache-with-stats-";
+    private static final String CACHE_WITHOUT_STATS_PREFIX = "other-cache-";
+
+    private TimedMemberStateFactory timedMemberStateFactory;
     private TimedMemberState timedMemberState;
     private HazelcastInstance hz;
 
@@ -49,17 +59,13 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
     public void setUp() {
         Config config = smallInstanceConfig();
         config.addCacheConfig(new CacheSimpleConfig()
-                                  .setName("test-cache")
+                                  .setName(CACHE_WITH_STATS_PREFIX + "*")
                                   .setStatisticsEnabled(true));
+        config.addCacheConfig(new CacheSimpleConfig()
+                                  .setName(CACHE_WITHOUT_STATS_PREFIX + "*"));
         hz = createHazelcastInstance(config);
-        TimedMemberStateFactory timedMemberStateFactory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
-
-        timedMemberState = timedMemberStateFactory.createTimedMemberState();
-        timedMemberState.setClusterName("ClusterName");
-        timedMemberState.setTime(1827731);
-        timedMemberState.setSslEnabled(true);
-        timedMemberState.setLite(true);
-        timedMemberState.setScriptingEnabled(false);
+        timedMemberStateFactory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
+        timedMemberState = createState();
     }
 
     @Test
@@ -103,9 +109,60 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
     @Test
     public void testCacheGetStats() {
         NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
-        hz.getCacheManager().getCache("test-cache");
+        hz.getCacheManager().getCache(CACHE_WITH_STATS_PREFIX + "1");
         CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
         assertNotNull(cacheService.getStats()
-                          .get(CacheUtil.getDistributedObjectName("test-cache")));
+                          .get(CacheUtil.getDistributedObjectName(CACHE_WITH_STATS_PREFIX + "1")));
+    }
+
+    @Test
+    public void testAllCachesWithStatsEnabled_arePresent() {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        // create 100 caches with stats enabled
+        for (int i = 0; i < 100; i++) {
+            hz.getCacheManager().getCache(CACHE_WITH_STATS_PREFIX + i);
+        }
+        // create 50 caches with stats disabled
+        for (int i = 0; i < 50; i++) {
+            hz.getCacheManager().getCache(CACHE_WITHOUT_STATS_PREFIX + i);
+        }
+
+        CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
+        Map<String, LocalCacheStats> stats = cacheService.getStats();
+        for (String cacheNameWithPrefix : stats.keySet()) {
+            assertContains(cacheNameWithPrefix, CACHE_WITH_STATS_PREFIX);
+        }
+    }
+
+    @Test
+    public void testOnlyCachesWithStatsEnabled_areReportedInTimedMemberState() {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+
+        // create 100 caches with stats enabled
+        for (int i = 0; i < 100; i++) {
+            hz.getCacheManager().getCache(CACHE_WITH_STATS_PREFIX + i);
+        }
+        // create 50 caches with stats disabled
+        for (int i = 0; i < 50; i++) {
+            ICache cacheWithoutStats = hz.getCacheManager().getCache(CACHE_WITHOUT_STATS_PREFIX + i);
+            // explicitly request local stats -> this registers an empty stats object in CacheService
+            cacheWithoutStats.getLocalCacheStatistics();
+        }
+
+        MemberStateImpl memberState = createState().getMemberState();
+        for (int i = 0; i < 100; i++) {
+            assertNotNull(memberState.getLocalCacheStats(CacheUtil.getDistributedObjectName(CACHE_WITH_STATS_PREFIX + i)));
+            assertNull(memberState.getLocalCacheStats(CacheUtil.getDistributedObjectName(CACHE_WITHOUT_STATS_PREFIX + i)));
+        }
+    }
+
+    private TimedMemberState createState() {
+        TimedMemberState state = timedMemberStateFactory.createTimedMemberState();
+        state.setClusterName("ClusterName");
+        state.setTime(1827731);
+        state.setSslEnabled(true);
+        state.setLite(true);
+        state.setScriptingEnabled(false);
+        return state;
     }
 }


### PR DESCRIPTION
Previously used `Config.findCacheConfig` can only lookup
cache configs added statically or dynamically via `Config.addCacheConfig`
but misses configuration of dynamically created caches via
`CacheManager.createCache`, so it is wrong to use it to filter stats.
Instead, we retrieve cache configs from `CacheService.getCacheConfigs`
which includes configuration of all caches known at runtime.

Fixes missing cache statistics from MC