### PR TITLE
Fix MapWanSyncAPITest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -197,7 +197,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             storage.put(key, record);
             mutationObserver.onPutRecord(key, record, null, true);
         } else {
-            updateRecord(key, record, null, value, now, true,
+            updateRecord(key, record, record.getValue(), value, now, true,
                     ttl, maxIdle, false, transactionId, true);
         }
 


### PR DESCRIPTION
The test was failing because of a NPE in the merkle tree update code
since we were sending null for the old value. Additionally, the old and
new value parameters were switched.

Changed the test assertions to not assert sync stats if sync was
performed twice. This is because the first sync might have actually
synced the map and set the stats to non-zero whilst the second sync
might not sync anything and set the stats to zero, causing the assertion
to fail.

Also, extended most WAN tests from HazelcastTestSupport so we get
reports about jitter on test failures.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/3145
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3329