### PR TITLE
Remove preCandidateState when prevote timeouts or new leader is elected

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/RaftState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/RaftState.java
@@ -327,6 +327,10 @@ public final class RaftState {
      */
     public void leader(RaftEndpoint endpoint) {
         leader = endpoint;
+        if (endpoint != null) {
+            // Since we have a new leader, preCandidateState becomes obsolete.
+            preCandidateState = null;
+        }
     }
 
     /**
@@ -460,6 +464,13 @@ public final class RaftState {
     public void initPreCandidateState() {
         preCandidateState = new CandidateState(majority());
         preCandidateState.grantVote(localEndpoint);
+    }
+
+    /**
+     * Removes pre-candidate state
+     */
+    public void removePreCandidateState() {
+        preCandidateState = null;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/PreVoteTimeoutTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/PreVoteTimeoutTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cp.internal.raft.impl.task;
 
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
+import com.hazelcast.cp.internal.raft.impl.state.RaftState;
 
 import static com.hazelcast.cp.internal.raft.impl.RaftRole.FOLLOWER;
 
@@ -36,10 +37,17 @@ public class PreVoteTimeoutTask extends RaftNodeStatusAwareTask implements Runna
 
     @Override
     protected void innerRun() {
-        if (raftNode.state().role() != FOLLOWER) {
+        RaftState state = raftNode.state();
+        // Remove previously set preCandidateState.
+        // Since it's now obsolete,
+        // either a new pre-vote round will begin
+        // or pre-vote phase will cease.
+        state.removePreCandidateState();
+
+        if (state.role() != FOLLOWER) {
             return;
         }
-        logger.fine("Pre-vote for term: " + raftNode.state().term() + " has timed out!");
+        logger.fine("Pre-vote for term: " + state.term() + " has timed out!");
         new PreVoteTask(raftNode, term).run();
     }
 }


### PR DESCRIPTION
Otherwise when two nodes execute pre-vote concurrently
and one of them starts real election and wins,
`preCandidateState` can leak on other node.
That node may not start election anymore.

Fixes hazelcast/hazelcast-enterprise#3321