### PR TITLE
Send client metrics to the member and merge them

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.client.Client;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.transaction.TransactionContext;
@@ -101,6 +102,13 @@ public interface ClientEndpoint extends Client {
      * @param stats the latest statistics retrieved from the client
      */
     void setClientStatistics(ClientStatistics stats);
+
+    /**
+     * Returns the latest client statistics.
+     *
+     * @return the client statistics
+     */
+    ClientStatistics getClientStatistics();
 
     /**
      * @return client attributes string for the client

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
-import static java.util.Arrays.asList;
 
 /**
  * The {@link com.hazelcast.client.impl.ClientEndpoint} and {@link Client} implementation.
@@ -277,7 +276,7 @@ public final class ClientEndpointImpl
                     return descriptor
                         // we exclude all metric targets here besides MANAGEMENT_CENTER
                         // since we want to send the client-side metrics only to MC
-                        .withExcludedTargets(asList(MetricTarget.values()))
+                        .withExcludedTargets(MetricTarget.VALUES_LIST)
                         .withIncludedTarget(MANAGEMENT_CENTER)
                         // we add "client" and "timestamp" tags for MC
                         .withTag(METRICS_TAG_CLIENT, getUuid().toString())

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -19,14 +19,15 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.Client;
 import com.hazelcast.client.impl.protocol.ClientExceptions;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.nio.ConnectionType;
+import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.proxyservice.ProxyService;
-import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.transaction.TransactionManagerService;
 
 import javax.annotation.Nonnull;
@@ -97,71 +98,11 @@ public interface ClientEngine extends Consumer<ClientMessage> {
     Map<String, Integer> getConnectedClientStats();
 
     /**
-     * The statistics is a String that is composed of key=value pairs separated by ',' . The following characters are escaped in
-     * IMap and ICache names by the escape character '\' : '=' '.' ',' '\'
+     * Returns the latest client statistics mapped to the client UUIDs.
      *
-     * The statistics key identify the category and name of the statistics. It is formatted as:
-     * mainCategory.subCategory.statisticName
-     *
-     * An e.g. Operating system committedVirtualMemorySize path would be: os.committedVirtualMemorySize
-     *
-     * The statistics key names can be one of the following (Used IMap named {@code &lt;example.fastmap&gt;} and ICache Named
-     * {@code &lt;StatTestCacheName&gt;} and assuming that the Near Cache is configured):
-     * <pre>
-     * clientType
-     * clusterConnectionTimestamp
-     * credentials.principal
-     * clientAddress
-     * clusterName
-     * enterprise
-     * lastStatisticsCollectionTime
-     * nearcache.&lt;example\.fastmap&gt;.creationTime
-     * nearcache.&lt;example\.fastmap&gt;.evictions
-     * nearcache.&lt;example\.fastmap&gt;.expirations
-     * nearcache.&lt;example\.fastmap&gt;.hits
-     * nearcache.&lt;example\.fastmap&gt;.lastPersistenceDuration
-     * nearcache.&lt;example\.fastmap&gt;.lastPersistenceFailure
-     * nearcache.&lt;example\.fastmap&gt;.lastPersistenceKeyCount
-     * nearcache.&lt;example\.fastmap&gt;.lastPersistenceTime
-     * nearcache.&lt;example\.fastmap&gt;.lastPersistenceWrittenBytes
-     * nearcache.&lt;example\.fastmap&gt;.misses
-     * nearcache.&lt;example\.fastmap&gt;.ownedEntryCount
-     * nearcache.&lt;example\.fastmap&gt;.ownedEntryMemoryCost
-     * nearcache.hz/&lt;StatTestCacheName&gt;.creationTime
-     * nearcache.hz/&lt;StatTestCacheName&gt;.evictions
-     * nearcache.hz/&lt;StatTestCacheName&gt;.expirations
-     * nearcache.hz/&lt;StatTestCacheName&gt;.hits
-     * nearcache.hz/&lt;StatTestCacheName&gt;.lastPersistenceDuration
-     * nearcache.hz/&lt;StatTestCacheName&gt;.lastPersistenceFailure
-     * nearcache.hz/&lt;StatTestCacheName&gt;.lastPersistenceKeyCount
-     * nearcache.hz/&lt;StatTestCacheName&gt;.lastPersistenceTime
-     * nearcache.hz/&lt;StatTestCacheName&gt;.lastPersistenceWrittenBytes
-     * nearcache.hz/&lt;StatTestCacheName&gt;.misses
-     * nearcache.hz/&lt;StatTestCacheName&gt;.ownedEntryCount
-     * nearcache.hz/&lt;StatTestCacheName&gt;.ownedEntryMemoryCost
-     * os.committedVirtualMemorySize
-     * os.freePhysicalMemorySize
-     * os.freeSwapSpaceSize
-     * os.maxFileDescriptorCount
-     * os.openFileDescriptorCount
-     * os.processCpuTime
-     * os.systemLoadAverage
-     * os.totalPhysicalMemorySize
-     * os.totalSwapSpaceSize
-     * runtime.availableProcessors
-     * runtime.freeMemory
-     * runtime.maxMemory
-     * runtime.totalMemory
-     * runtime.uptime
-     * runtime.usedMemory
-     * userExecutor.queueSize
-     * </pre>
-     * Not: Please observe that the name for the ICache appears to be the hazelcast instance name "hz" followed by "/" and
-     * followed by the cache name provided which is StatTestCacheName.
-     *
-     * @return Map of [client UUID UUID, client statistics String]
+     * @return map of the client statistics
      */
-    Map<UUID, String> getClientStatistics();
+    Map<UUID, ClientStatistics> getClientStatistics();
 
     /**
      * @param client to check if allowed through current ClientSelector.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -30,6 +30,7 @@ import com.hazelcast.client.impl.protocol.task.MessageTask;
 import com.hazelcast.client.impl.protocol.task.TransactionalMessageTask;
 import com.hazelcast.client.impl.protocol.task.UrgentMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.AbstractMapQueryMessageTask;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.EndpointQualifier;
@@ -79,6 +80,7 @@ import java.util.function.Consumer;
 
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadPoolName;
 
@@ -495,11 +497,11 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     }
 
     @Override
-    public Map<UUID, String> getClientStatistics() {
+    public Map<UUID, ClientStatistics> getClientStatistics() {
         Collection<ClientEndpoint> clientEndpoints = endpointManager.getEndpoints();
-        Map<UUID, String> statsMap = new HashMap<>(clientEndpoints.size());
+        Map<UUID, ClientStatistics> statsMap = createHashMap(clientEndpoints.size());
         for (ClientEndpoint e : clientEndpoints) {
-            String statistics = e.getClientAttributes();
+            ClientStatistics statistics = e.getClientStatistics();
             if (null != statistics) {
                 statsMap.put(e.getUuid(), statistics);
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -16,17 +16,18 @@
 
 package com.hazelcast.client.impl;
 
+import com.hazelcast.client.Client;
 import com.hazelcast.client.impl.protocol.ClientExceptions;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.Client;
-import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.logging.ILogger;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityContext;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.proxyservice.ProxyService;
-import com.hazelcast.spi.exception.TargetNotMemberException;
-import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.transaction.TransactionManagerService;
 
 import javax.annotation.Nonnull;
@@ -117,7 +118,7 @@ public class NoOpClientEngine implements ClientEngine {
     }
 
     @Override
-    public Map<UUID, String> getClientStatistics() {
+    public Map<UUID, ClientStatistics> getClientStatistics() {
         return emptyMap();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -807,4 +807,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         proxyManager.createDistributedObjectsOnCluster();
         queryCacheContext.recreateAllCaches();
     }
+
+    // visible for testing
+    public Statistics getStatistics() {
+        return statistics;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -55,7 +55,7 @@ import com.hazelcast.client.impl.spi.impl.ClientUserCodeDeploymentService;
 import com.hazelcast.client.impl.spi.impl.NonSmartClientInvocationService;
 import com.hazelcast.client.impl.spi.impl.SmartClientInvocationService;
 import com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl;
-import com.hazelcast.client.impl.statistics.Statistics;
+import com.hazelcast.client.impl.statistics.ClientStatisticsService;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.collection.IList;
@@ -174,7 +174,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ClientExtension clientExtension;
     private final LoggingService loggingService;
     private final MetricsRegistryImpl metricsRegistry;
-    private final Statistics statistics;
+    private final ClientStatisticsService clientStatisticsService;
     private final Diagnostics diagnostics;
     private final InternalSerializationService serializationService;
     private final ClientICacheManager hazelcastCacheManager;
@@ -237,7 +237,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         lockReferenceIdGenerator = new ClientLockReferenceIdGenerator();
         nearCacheManager = clientExtension.createNearCacheManager();
         clientExceptionFactory = initClientExceptionFactory();
-        statistics = new Statistics(this);
+        clientStatisticsService = new ClientStatisticsService(this);
         userCodeDeploymentService = new ClientUserCodeDeploymentService(config.getUserCodeDeploymentConfig(), classLoader);
         proxySessionManager = new ClientProxySessionManager(this);
         cpSubsystem = new CPSubsystemImpl(this);
@@ -377,7 +377,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             clusterService.start();
             connectionManager.tryOpenConnectionToAllMembers();
             loadBalancer.init(getCluster(), config);
-            statistics.start();
+            clientStatisticsService.start();
             clientExtension.afterStart(this);
             cpSubsystem.init(clientContext);
             sendStateToCluster();
@@ -809,7 +809,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     // visible for testing
-    public Statistics getStatistics() {
-        return statistics;
+    public ClientStatisticsService getClientStatisticsService() {
+        return clientStatisticsService;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ClientStatisticsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ClientStatisticsMessageTask.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.client.impl.protocol.task;
 
+import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientStatisticsCodec;
-import com.hazelcast.client.impl.ClientStatistics;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatistics.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.impl;
+package com.hazelcast.client.impl.statistics;
 
+import com.hazelcast.client.impl.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.task.ClientStatisticsMessageTask;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -39,15 +40,16 @@ public final class ClientStatistics {
         this.metricsBlob = metricsBlob;
     }
 
-    long timestamp() {
+    public long timestamp() {
         return timestamp;
     }
 
-    String clientAttributes() {
+    public String clientAttributes() {
         return clientAttributes;
     }
 
-    byte[] getMetricsBlob() {
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public byte[] metricsBlob() {
         return metricsBlob;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClusterConnectionMetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClusterConnectionMetricsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.statistics;
+
+import com.hazelcast.client.impl.connection.ClientConnectionManager;
+import com.hazelcast.client.impl.connection.nio.ClientConnection;
+import com.hazelcast.internal.metrics.DynamicMetricsProvider;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsCollectionContext;
+
+class ClusterConnectionMetricsProvider implements DynamicMetricsProvider {
+    private final ClientConnectionManager clientConnectionManager;
+
+    ClusterConnectionMetricsProvider(ClientConnectionManager clientConnectionManager) {
+        this.clientConnectionManager = clientConnectionManager;
+    }
+
+    @Override
+    public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
+        for (ClientConnection connection : clientConnectionManager.getActiveConnections()) {
+            context.collect(descriptor
+                    .withPrefix("cluster.connection")
+                    .withDiscriminator("endpoint", connection.getEndPoint().toString()),
+                connection);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/NearCacheMetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/NearCacheMetricsProvider.java
@@ -33,7 +33,7 @@ class NearCacheMetricsProvider implements DynamicMetricsProvider {
     @Override
     public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
 
-        descriptor.withPrefix("nearCache");
+        descriptor.withPrefix("nearcache");
         for (NearCache nearCache : nearCacheManager.listAllNearCaches()) {
             String nearCacheName = nearCache.getName();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/NearCacheMetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/NearCacheMetricsProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.statistics;
+
+import com.hazelcast.internal.metrics.DynamicMetricsProvider;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsCollectionContext;
+import com.hazelcast.internal.monitor.impl.NearCacheStatsImpl;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+
+class NearCacheMetricsProvider implements DynamicMetricsProvider {
+    private final NearCacheManager nearCacheManager;
+
+    NearCacheMetricsProvider(NearCacheManager nearCacheManager) {
+        this.nearCacheManager = nearCacheManager;
+    }
+
+    @Override
+    public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
+
+        descriptor.withPrefix("nearCache");
+        for (NearCache nearCache : nearCacheManager.listAllNearCaches()) {
+            String nearCacheName = nearCache.getName();
+
+            NearCacheStatsImpl nearCacheStats = (NearCacheStatsImpl) nearCache.getNearCacheStats();
+            context.collect(descriptor.copy().withDiscriminator("name", nearCacheName), nearCacheStats);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -16,23 +16,28 @@
 
 package com.hazelcast.client.impl.statistics;
 
+import com.hazelcast.client.config.ClientMetricsConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientStatisticsCodec;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
-import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.metrics.Gauge;
+import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.internal.metrics.impl.CompositeMetricsCollector;
+import com.hazelcast.internal.metrics.impl.MetricsCompressor;
+import com.hazelcast.internal.metrics.impl.PublisherMetricsCollector;
+import com.hazelcast.internal.metrics.jmx.JmxPublisher;
 import com.hazelcast.internal.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nio.ConnectionType;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.security.Credentials;
-import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,18 +57,18 @@ public class Statistics {
 
     private final MetricsRegistry metricsRegistry;
     private final boolean enabled;
-    private final HazelcastProperties properties;
     private final ILogger logger = Logger.getLogger(this.getClass());
 
     private final HazelcastClientInstanceImpl client;
 
     private final boolean enterprise;
+    private final ClientMetricsConfig metricsConfig;
 
     private PeriodicStatistics periodicStats;
 
     public Statistics(final HazelcastClientInstanceImpl clientInstance) {
-        this.properties = clientInstance.getProperties();
-        this.enabled = properties.getBoolean(ClientProperty.STATISTICS_ENABLED);
+        this.metricsConfig = clientInstance.getClientConfig().getMetricsConfig();
+        this.enabled = metricsConfig.isEnabled();
         this.client = clientInstance;
         this.enterprise = BuildInfoProvider.getBuildInfo().isEnterprise();
         this.metricsRegistry = clientInstance.getMetricsRegistry();
@@ -77,22 +82,23 @@ public class Statistics {
             return;
         }
 
-        long periodSeconds = properties.getSeconds(ClientProperty.STATISTICS_PERIOD_SECONDS);
-        if (periodSeconds <= 0) {
-            long defaultValue = Long.parseLong(ClientProperty.STATISTICS_PERIOD_SECONDS.getDefaultValue());
-            logger.warning("Provided client statistics " + ClientProperty.STATISTICS_PERIOD_SECONDS.getName()
-                    + " cannot be less than or equal to 0. You provided " + periodSeconds
-                    + " seconds as the configuration. Client will use the default value of " + defaultValue + " instead.");
-            periodSeconds = defaultValue;
-        }
+        metricsRegistry.registerDynamicMetricsProvider(new NearCacheMetricsProvider(client.getNearCacheManager()));
+        metricsRegistry.registerDynamicMetricsProvider(new ClusterConnectionMetricsProvider(client.getConnectionManager()));
+
+        long periodSeconds = metricsConfig.getCollectionFrequencySeconds();
 
         // Note that the OperatingSystemMetricSet and RuntimeMetricSet are already registered during client start,
         // hence we do not re-register
         periodicStats = new PeriodicStatistics();
 
-        schedulePeriodicStatisticsSendTask(periodSeconds);
+        schedulePeriodicStatisticsSendTask(metricsConfig.getCollectionFrequencySeconds());
 
         logger.info("Client statistics is enabled with period " + periodSeconds + " seconds.");
+    }
+
+    // visible for testing
+    public ClientMetricsConfig getMetricsConfig() {
+        return metricsConfig;
     }
 
     /**
@@ -106,25 +112,33 @@ public class Statistics {
      * @param periodSeconds the interval at which the statistics collection and send is being run
      */
     private void schedulePeriodicStatisticsSendTask(long periodSeconds) {
-        client.getClientExecutionService().scheduleWithRepetition(new Runnable() {
-            @Override
-            public void run() {
-                long collectionTimestamp = System.currentTimeMillis();
+        PublisherMetricsCollector publisherMetricsCollector = new PublisherMetricsCollector();
 
-                ClientConnection connection = getConnection();
-                if (connection == null) {
-                    logger.finest("Cannot send client statistics to the server. No connection found.");
-                    return;
-                }
+        if (metricsConfig.isEnabled() && metricsConfig.getJmxConfig().isEnabled()) {
+            publisherMetricsCollector.addPublisher(new JmxPublisher(client.getName(), "com.hazelcast"));
+        }
 
-                final StringBuilder stats = new StringBuilder();
+        ClientMetricCollector clientMetricCollector = new ClientMetricCollector();
+        CompositeMetricsCollector compositeMetricsCollector = new CompositeMetricsCollector(clientMetricCollector,
+            publisherMetricsCollector);
 
-                periodicStats.fillMetrics(collectionTimestamp, stats, connection);
+        client.getClientExecutionService().scheduleWithRepetition(() -> {
+            long collectionTimestamp = System.currentTimeMillis();
+            metricsRegistry.collect(compositeMetricsCollector);
+            publisherMetricsCollector.publishCollectedMetrics();
 
-                addNearCacheStats(stats);
-
-                sendStats(collectionTimestamp, stats.toString(), connection);
+            ClientConnection mainConnection = getConnection();
+            if (mainConnection == null) {
+                logger.finest("Cannot send client statistics to the server. No owner connection.");
+                return;
             }
+
+            final StringBuilder clientAttributes = new StringBuilder();
+            periodicStats.fillMetrics(collectionTimestamp, clientAttributes, mainConnection);
+            addNearCacheStats(clientAttributes);
+
+            byte[] metricsBlob = clientMetricCollector.getBlob();
+            sendStats(collectionTimestamp, clientAttributes.toString(), metricsBlob, mainConnection);
         }, 0, periodSeconds, SECONDS);
     }
 
@@ -261,7 +275,7 @@ public class Statistics {
             return null;
         }
 
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         int strStart = start;
         int index = start;
         // just initialize to a non-special character
@@ -286,8 +300,8 @@ public class Statistics {
         return result;
     }
 
-    private void sendStats(long collectionTimestamp, String newStats, ClientConnection ownerConnection) {
-        ClientMessage request = ClientStatisticsCodec.encodeRequest(collectionTimestamp, newStats, new byte[]{});
+    private void sendStats(long collectionTimestamp, String newStats, byte[] metricsBlob, ClientConnection ownerConnection) {
+        ClientMessage request = ClientStatisticsCodec.encodeRequest(collectionTimestamp, newStats, metricsBlob);
         try {
             new ClientInvocation(client, request, null, ownerConnection).invoke();
         } catch (Exception e) {
@@ -300,23 +314,23 @@ public class Statistics {
 
     class PeriodicStatistics {
         private final Gauge[] allGauges = {
-                metricsRegistry.newLongGauge("os.committedVirtualMemorySize"),
-                metricsRegistry.newLongGauge("os.freePhysicalMemorySize"),
-                metricsRegistry.newLongGauge("os.freeSwapSpaceSize"),
-                metricsRegistry.newLongGauge("os.maxFileDescriptorCount"),
-                metricsRegistry.newLongGauge("os.openFileDescriptorCount"),
-                metricsRegistry.newLongGauge("os.processCpuTime"),
-                metricsRegistry.newDoubleGauge("os.systemLoadAverage"),
-                metricsRegistry.newLongGauge("os.totalPhysicalMemorySize"),
-                metricsRegistry.newLongGauge("os.totalSwapSpaceSize"),
-                metricsRegistry.newLongGauge("runtime.availableProcessors"),
-                metricsRegistry.newLongGauge("runtime.freeMemory"),
-                metricsRegistry.newLongGauge("runtime.maxMemory"),
-                metricsRegistry.newLongGauge("runtime.totalMemory"),
-                metricsRegistry.newLongGauge("runtime.uptime"),
-                metricsRegistry.newLongGauge("runtime.usedMemory"),
-                metricsRegistry.newLongGauge("executionService.userExecutorQueueSize"),
-        };
+            metricsRegistry.newLongGauge("os.committedVirtualMemorySize"),
+            metricsRegistry.newLongGauge("os.freePhysicalMemorySize"),
+            metricsRegistry.newLongGauge("os.freeSwapSpaceSize"),
+            metricsRegistry.newLongGauge("os.maxFileDescriptorCount"),
+            metricsRegistry.newLongGauge("os.openFileDescriptorCount"),
+            metricsRegistry.newLongGauge("os.processCpuTime"),
+            metricsRegistry.newDoubleGauge("os.systemLoadAverage"),
+            metricsRegistry.newLongGauge("os.totalPhysicalMemorySize"),
+            metricsRegistry.newLongGauge("os.totalSwapSpaceSize"),
+            metricsRegistry.newLongGauge("runtime.availableProcessors"),
+            metricsRegistry.newLongGauge("runtime.freeMemory"),
+            metricsRegistry.newLongGauge("runtime.maxMemory"),
+            metricsRegistry.newLongGauge("runtime.totalMemory"),
+            metricsRegistry.newLongGauge("runtime.uptime"),
+            metricsRegistry.newLongGauge("runtime.usedMemory"),
+            metricsRegistry.newLongGauge("executionService.userExecutorQueueSize"),
+            };
 
         void fillMetrics(long collectionTimestamp, final StringBuilder stats, final ClientConnection mainConnection) {
             stats.append("lastStatisticsCollectionTime").append(KEY_VALUE_SEPARATOR).append(collectionTimestamp);
@@ -326,7 +340,7 @@ public class Statistics {
             addStat(stats, "clusterConnectionTimestamp", mainConnection.getStartTime());
 
             stats.append(STAT_SEPARATOR).append("clientAddress").append(KEY_VALUE_SEPARATOR)
-                    .append(mainConnection.getLocalSocketAddress().getAddress().getHostAddress());
+                 .append(mainConnection.getLocalSocketAddress().getAddress().getHostAddress());
 
             addStat(stats, "clientName", client.getName());
 
@@ -340,6 +354,36 @@ public class Statistics {
                 stats.append(STAT_SEPARATOR).append(gauge.getName()).append(KEY_VALUE_SEPARATOR);
                 gauge.render(stats);
             }
+        }
+    }
+
+    private class ClientMetricCollector
+        implements MetricsCollector {
+
+        private final MetricsCompressor compressor = new MetricsCompressor();
+
+        @Override
+        public void collectLong(MetricDescriptor descriptor, long value) {
+            compressor.addLong(descriptor, value);
+        }
+
+        @Override
+        public void collectDouble(MetricDescriptor descriptor, double value) {
+            compressor.addDouble(descriptor, value);
+        }
+
+        @Override
+        public void collectException(MetricDescriptor descriptor, Exception e) {
+            logger.warning("Error when collecting '" + descriptor.toString() + '\'', e);
+        }
+
+        @Override
+        public void collectNoValue(MetricDescriptor descriptor) {
+            // nop
+        }
+
+        private byte[] getBlob() {
+            return compressor.getBlobAndReset();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -18,8 +18,11 @@ package com.hazelcast.internal.management;
 
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.Client;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.collection.LocalQueueStats;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
@@ -27,6 +30,7 @@ import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.cp.CPMember;
+import com.hazelcast.executor.LocalExecutorStats;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.hotrestart.HotRestartService;
@@ -39,21 +43,10 @@ import com.hazelcast.internal.management.dto.AdvancedNetworkStatsDTO;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.monitor.LocalCacheStats;
-import com.hazelcast.internal.networking.NetworkStats;
-import com.hazelcast.internal.nio.AggregateEndpointManager;
-import com.hazelcast.internal.partition.InternalPartitionService;
-import com.hazelcast.internal.services.StatisticsAwareService;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.executor.LocalExecutorStats;
 import com.hazelcast.internal.monitor.LocalFlakeIdGeneratorStats;
-import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.internal.monitor.LocalMemoryStats;
-import com.hazelcast.multimap.LocalMultiMapStats;
 import com.hazelcast.internal.monitor.LocalOperationStats;
 import com.hazelcast.internal.monitor.LocalPNCounterStats;
-import com.hazelcast.collection.LocalQueueStats;
-import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
-import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.internal.monitor.LocalWanStats;
 import com.hazelcast.internal.monitor.WanSyncState;
 import com.hazelcast.internal.monitor.impl.HotRestartStateImpl;
@@ -62,10 +55,18 @@ import com.hazelcast.internal.monitor.impl.LocalOperationStatsImpl;
 import com.hazelcast.internal.monitor.impl.MemberPartitionStateImpl;
 import com.hazelcast.internal.monitor.impl.MemberStateImpl;
 import com.hazelcast.internal.monitor.impl.NodeStateImpl;
-import com.hazelcast.multimap.impl.MultiMapService;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
+import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.nio.AggregateEndpointManager;
 import com.hazelcast.internal.partition.IPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.services.StatisticsAwareService;
+import com.hazelcast.map.LocalMapStats;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.multimap.LocalMultiMapStats;
+import com.hazelcast.multimap.impl.MultiMapService;
+import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
+import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
+import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.wan.impl.WanReplicationService;
@@ -75,12 +76,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToLongFunction;
 
 import javax.annotation.Nonnull;
 
 import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
+import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
 
 /**
@@ -198,13 +201,25 @@ public class TimedMemberStateFactory {
         createClusterHotRestartStatus(memberState);
         createWanSyncState(memberState);
 
-        memberState.setClientStats(node.clientEngine.getClientStatistics());
+        memberState.setClientStats(getClientAttributes(node.getClientEngine().getClientStatistics()));
 
         AggregateEndpointManager aggregateEndpointManager = node.getNetworkingService().getAggregateEndpointManager();
         memberState.setInboundNetworkStats(createAdvancedNetworkStats(aggregateEndpointManager.getNetworkStats(),
                 NetworkStats::getBytesReceived));
         memberState.setOutboundNetworkStats(createAdvancedNetworkStats(aggregateEndpointManager.getNetworkStats(),
                 NetworkStats::getBytesSent));
+    }
+
+    private Map<UUID, String> getClientAttributes(Map<UUID, ClientStatistics> allClientStatistics) {
+        Map<UUID, String> statsMap = createHashMap(allClientStatistics.size());
+        for (Map.Entry<UUID, ClientStatistics> entry : allClientStatistics.entrySet()) {
+            UUID uuid = entry.getKey();
+            ClientStatistics statistics = entry.getValue();
+            if (statistics != null) {
+                statsMap.put(uuid, statistics.clientAttributes());
+            }
+        }
+        return statsMap;
     }
 
     private void createHotRestartState(MemberStateImpl memberState) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -21,9 +21,12 @@ import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Enum representing the target platforms of the metrics collection.
@@ -36,6 +39,8 @@ public enum MetricTarget {
     JMX,
     DIAGNOSTICS,
     JET_JOB;
+
+    public static final List<MetricTarget> VALUES_LIST = unmodifiableList(asList(values()));
 
     static final Int2ObjectHashMap<Set<MetricTarget>> BITSET_TO_SET_CACHE = new Int2ObjectHashMap<>();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsCollectionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsCollectionContext.java
@@ -52,4 +52,21 @@ public interface MetricsCollectionContext {
      */
     void collect(MetricDescriptor descriptor, String name, ProbeLevel level, ProbeUnit unit, double value);
 
+    /**
+     * Collects the given metric.
+     *
+     * @param descriptor The {@link MetricDescriptor} used to describe
+     *                   the metrics extracted from the {@code source} object
+     * @param value      The value of the collected metric
+     */
+    void collect(MetricDescriptor descriptor, long value);
+
+    /**
+     * Collects the given metric.
+     *
+     * @param descriptor The {@link MetricDescriptor} used to describe
+     *                   the metrics extracted from the {@code source} object
+     * @param value      The value of the collected metric
+     */
+    void collect(MetricDescriptor descriptor, double value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/CompositeMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/CompositeMetricsCollector.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class CompositeMetricsCollector implements MetricsCollector {
+
+    private final List<MetricsCollector> collectors;
+
+    public CompositeMetricsCollector(MetricsCollector... collectors) {
+        this.collectors = new ArrayList<>(asList(collectors));
+    }
+
+    @Override
+    public void collectLong(MetricDescriptor descriptor, long value) {
+        for (MetricsCollector collector : collectors) {
+            collector.collectLong(descriptor, value);
+        }
+    }
+
+    @Override
+    public void collectDouble(MetricDescriptor descriptor, double value) {
+        for (MetricsCollector collector : collectors) {
+            collector.collectDouble(descriptor, value);
+        }
+    }
+
+    @Override
+    public void collectException(MetricDescriptor descriptor, Exception e) {
+        for (MetricsCollector collector : collectors) {
+            collector.collectException(descriptor, e);
+        }
+    }
+
+    @Override
+    public void collectNoValue(MetricDescriptor descriptor) {
+        for (MetricsCollector collector : collectors) {
+            collector.collectNoValue(descriptor);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/CompositeMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/CompositeMetricsCollector.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.metrics.impl;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -29,7 +28,7 @@ public class CompositeMetricsCollector implements MetricsCollector {
     private final List<MetricsCollector> collectors;
 
     public CompositeMetricsCollector(MetricsCollector... collectors) {
-        this.collectors = new ArrayList<>(asList(collectors));
+        this.collectors = asList(collectors);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -19,10 +19,10 @@ package com.hazelcast.internal.metrics.impl;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricTarget;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.ProbeUnit;
@@ -203,7 +203,6 @@ class MetricsCollectionCycle {
             }
         }
 
-
         @Override
         public void collect(MetricDescriptor descriptor, String name, ProbeLevel level, ProbeUnit unit, double value) {
             if (level.isEnabled(minimumLevel)) {
@@ -215,6 +214,18 @@ class MetricsCollectionCycle {
                 lookupMetricValueCatcher(descriptorCopy).catchMetricValue(collectionId, value);
                 metricsCollector.collectDouble(descriptorCopy, value);
             }
+        }
+
+        @Override
+        public void collect(MetricDescriptor descriptor, long value) {
+            lookupMetricValueCatcher(descriptor).catchMetricValue(collectionId, value);
+            metricsCollector.collectLong(descriptor, value);
+        }
+
+        @Override
+        public void collect(MetricDescriptor descriptor, double value) {
+            lookupMetricValueCatcher(descriptor).catchMetricValue(collectionId, value);
+            metricsCollector.collectDouble(descriptor, value);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -476,7 +476,7 @@ public class MetricsCompressor {
                         consumer.consumeLong(descriptor, dis.readLong());
                         break;
                     case DOUBLE:
-                            consumer.consumeDouble(descriptor, dis.readDouble());
+                        consumer.consumeDouble(descriptor, dis.readDouble());
                         break;
                     default:
                         throw new IllegalStateException("Unexpected metric value type: " + type + " with ordinal " + typeOrdinal);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/PublisherMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/PublisherMetricsCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * {@link MetricsCollector} implementation delegating to the configured
+ * publishers.
+ */
+public class PublisherMetricsCollector implements MetricsCollector {
+    private final ILogger logger = Logger.getLogger(PublisherMetricsCollector.class);
+
+    private final List<MetricsPublisher> publishers = new CopyOnWriteArrayList<>();
+
+    public void addPublisher(MetricsPublisher publisher) {
+        publishers.add(publisher);
+    }
+
+    public boolean hasPublishers() {
+        return !publishers.isEmpty();
+    }
+
+    public List<MetricsPublisher> getPublishers() {
+        return unmodifiableList(publishers);
+    }
+
+    public void publishCollectedMetrics() {
+        for (MetricsPublisher publisher : publishers) {
+            try {
+                publisher.whenComplete();
+            } catch (Exception e) {
+                logger.severe("Error completing publication for publisher " + publisher, e);
+            }
+        }
+    }
+
+    public void shutdown() {
+        for (MetricsPublisher publisher : publishers) {
+            try {
+                publisher.shutdown();
+            } catch (Exception e) {
+                logger.warning("Error shutting down metrics publisher " + publisher.name(), e);
+            }
+        }
+    }
+
+    @Override
+    public void collectLong(MetricDescriptor descriptor, long value) {
+        for (MetricsPublisher publisher : publishers) {
+            try {
+                publisher.publishLong(descriptor, value);
+            } catch (Exception e) {
+                logError(descriptor, value, publisher, e);
+            }
+        }
+    }
+
+    @Override
+    public void collectDouble(MetricDescriptor descriptor, double value) {
+        for (MetricsPublisher publisher : publishers) {
+            try {
+                publisher.publishDouble(descriptor, value);
+            } catch (Exception e) {
+                logError(descriptor, value, publisher, e);
+            }
+        }
+    }
+
+    @Override
+    public void collectException(MetricDescriptor descriptor, Exception e) {
+        logger.warning("Error when collecting '" + descriptor.toString() + '\'', e);
+    }
+
+    @Override
+    public void collectNoValue(MetricDescriptor descriptor) {
+        // noop
+    }
+
+    private void logError(MetricDescriptor descriptor, Object value, MetricsPublisher publisher, Exception e) {
+        logger.fine("Error publishing metric to: " + publisher.name() + ", metric=" + descriptor.toString()
+                + ", value=" + value, e);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
@@ -36,14 +36,19 @@ import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
     private TestHazelcastFactory factory;
+    private ClientConfig clientConfig;
+    private ClientMetricsConfig originalMetricsConfig;
 
     @Before
     public void before() {
+        clientConfig = new ClientConfig();
+        originalMetricsConfig = clientConfig.getMetricsConfig();
         factory = new TestHazelcastFactory();
         factory.newHazelcastInstance(smallInstanceConfig());
     }
@@ -69,7 +74,8 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
     @Test
@@ -92,48 +98,47 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
     @Test
     public void testConfigPropertiesOverrideConfig() {
-        ClientConfig config = new ClientConfig();
         // setting non-defaults
-        config.setProperty(ClientProperty.METRICS_ENABLED.getName(), "false");
-        config.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "false");
-        config.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "24");
-        factory.newHazelcastClient(config);
+        clientConfig.setProperty(ClientProperty.METRICS_ENABLED.getName(), "false");
+        clientConfig.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "false");
+        clientConfig.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "24");
+        HazelcastClientProxy client = createClient();
 
-        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
-        assertFalse(metricsConfig.isEnabled());
-        assertFalse(metricsConfig.getJmxConfig().isEnabled());
-        assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
+        assertFalse(originalMetricsConfig.isEnabled());
+        assertFalse(originalMetricsConfig.getJmxConfig().isEnabled());
+        assertEquals(24, originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
     @Test
     public void testInvalidConfigPropertiesIgnored() {
-        ClientConfig config = new ClientConfig();
         // setting non-defaults
-        config.setProperty(ClientProperty.METRICS_ENABLED.getName(), "invalid");
-        config.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "invalid");
-        config.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "invalid");
+        clientConfig.setProperty(ClientProperty.METRICS_ENABLED.getName(), "invalid");
+        clientConfig.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "invalid");
+        clientConfig.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "invalid");
 
-        factory.newHazelcastClient(config);
+        HazelcastClientProxy client = createClient();
 
         MetricsConfig defaultConfig = new MetricsConfig();
 
         // booleans result in false values even though they're "invalid"
         // therefore, all boolean config fields are set to false
-        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
-        assertFalse(metricsConfig.isEnabled());
-        assertFalse(metricsConfig.getJmxConfig().isEnabled());
-        assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
+        assertFalse(originalMetricsConfig.isEnabled());
+        assertFalse(originalMetricsConfig.getJmxConfig().isEnabled());
+        assertEquals(defaultConfig.getCollectionFrequencySeconds(), originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
     @Test
@@ -160,7 +165,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
     }
 
     private HazelcastClientProxy createClient() {
-        return (HazelcastClientProxy) factory.newHazelcastClient();
+        return (HazelcastClientProxy) factory.newHazelcastClient(clientConfig);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
@@ -74,7 +74,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -98,7 +98,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -115,7 +115,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -137,7 +137,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getStatistics().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.internal.metrics;
+
+import com.hazelcast.client.Client;
+import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricTarget;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeUnit;
+import com.hazelcast.internal.metrics.impl.CapturingCollector;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
+import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
+import static com.hazelcast.internal.metrics.impl.DefaultMetricDescriptorSupplier.DEFAULT_DESCRIPTOR_SUPPLIER;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientMetricsTest extends HazelcastTestSupport {
+
+    private TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testLongClientMetricIsMergedIntoMemberMetrics() {
+        HazelcastInstance memberInstance = givenMemberWithTwoClients();
+        MetricsRegistry metricsRegistry = getNodeEngineImpl(memberInstance).getMetricsRegistry();
+
+        // randomly chosen long client metric, we just check that
+        // we have client-side metrics merged into the member metrics
+        assertClientMetricsObservedEventually(memberInstance, metricsRegistry, "gc", "minorCount", COUNT);
+    }
+
+    @Test
+    public void testDoubleClientMetricIsMergedIntoMemberMetrics() {
+        HazelcastInstance memberInstance = givenMemberWithTwoClients();
+        MetricsRegistry metricsRegistry = getNodeEngineImpl(memberInstance).getMetricsRegistry();
+
+        // randomly chosen double client metric, we just check that
+        // we have client-side metrics merged into the member metrics
+        assertClientMetricsObservedEventually(memberInstance, metricsRegistry, "os", "systemLoadAverage", null);
+    }
+
+    private HazelcastInstance givenMemberWithTwoClients() {
+        Config conf = getConfig();
+        conf.getMetricsConfig()
+            .setEnabled(true)
+            .setCollectionFrequencySeconds(1);
+
+        HazelcastInstance memberInstance = hazelcastFactory.newHazelcastInstance(conf);
+        hazelcastFactory.newHazelcastClient();
+        hazelcastFactory.newHazelcastClient();
+        return memberInstance;
+    }
+
+    private void assertClientMetricsObservedEventually(HazelcastInstance memberInstance, MetricsRegistry metricsRegistry,
+                                                       String prefix, String metric, ProbeUnit unit) {
+        assertTrueEventually(() -> {
+            CapturingCollector collector = new CapturingCollector();
+            metricsRegistry.collect(collector);
+
+            ClientEngine clientEngine = getNode(memberInstance).getClientEngine();
+            Collection<Client> clients = clientEngine.getClients();
+
+            assertEquals(2, clients.size());
+
+            for (Client client : clients) {
+                UUID clientUuid = client.getUuid();
+                ClientStatistics clientStatistics = clientEngine.getClientStatistics().get(clientUuid);
+                assertNotNull(clientStatistics);
+                long timestamp = clientStatistics.timestamp();
+
+                MetricDescriptor expectedDescriptor = DEFAULT_DESCRIPTOR_SUPPLIER
+                        .get()
+                        .withPrefix(prefix)
+                        .withMetric(metric)
+                        .withUnit(unit)
+                        .withTag("client", clientUuid.toString())
+                        .withTag("timestamp", Long.toString(timestamp))
+                        .withExcludedTargets(asList(MetricTarget.values()))
+                        .withIncludedTarget(MANAGEMENT_CENTER);
+
+                assertContains(collector.captures().keySet(), expectedDescriptor);
+            }
+        });
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -21,8 +21,8 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.nio.ClientConnection;
+import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.client.impl.statistics.Statistics;
-import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -31,10 +31,8 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICacheManager;
 import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -129,35 +127,29 @@ public class ClientStatisticsTest extends ClientTestSupport {
         // wait enough time for statistics collection
         waitForNextStatsCollection(client, clientEngine, lastStatisticsCollectionTimeString);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                Map<String, String> stats = getStats(client, clientEngine);
-                String mapHits = stats.get(MAP_HITS_KEY);
-                assertNotNull(format("%s should not be null (%s)", MAP_HITS_KEY, stats), mapHits);
-                assertEquals(format("Expected 0 map hits (%s)", stats), "0", mapHits);
-                String cacheHits = stats.get(CACHE_HITS_KEY);
-                assertNull(format("%s should be null (%s)", CACHE_HITS_KEY, stats), cacheHits);
+        assertTrueEventually(() -> {
+            Map<String, String> stats12 = getStats(client, clientEngine);
+            String mapHits12 = stats12.get(MAP_HITS_KEY);
+            assertNotNull(format("%s should not be null (%s)", MAP_HITS_KEY, stats12), mapHits12);
+            assertEquals(format("Expected 0 map hits (%s)", stats12), "0", mapHits12);
+            String cacheHits12 = stats12.get(CACHE_HITS_KEY);
+            assertNull(format("%s should be null (%s)", CACHE_HITS_KEY, stats12), cacheHits12);
 
-                // verify that collection is periodic
-                verifyThatCollectionIsPeriodic(stats, lastCollectionTime);
-            }
+            // verify that collection is periodic
+            verifyThatCollectionIsPeriodic(stats12, lastCollectionTime);
         });
 
         // produce map and cache stat
         produceSomeStats(hazelcastInstance, client);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                Map<String, String> stats = getStats(client, clientEngine);
-                String mapHits = stats.get(MAP_HITS_KEY);
-                assertNotNull(format("%s should not be null (%s)", MAP_HITS_KEY, stats), mapHits);
-                assertEquals(format("Expected 1 map hits (%s)", stats), "1", mapHits);
-                String cacheHits = stats.get(CACHE_HITS_KEY);
-                assertNotNull(format("%s should not be null (%s)", CACHE_HITS_KEY, stats), cacheHits);
-                assertEquals(format("Expected 1 cache hits (%s)", stats), "1", cacheHits);
-            }
+        assertTrueEventually(() -> {
+            Map<String, String> stats1 = getStats(client, clientEngine);
+            String mapHits1 = stats1.get(MAP_HITS_KEY);
+            assertNotNull(format("%s should not be null (%s)", MAP_HITS_KEY, stats1), mapHits1);
+            assertEquals(format("Expected 1 map hits (%s)", stats1), "1", mapHits1);
+            String cacheHits1 = stats1.get(CACHE_HITS_KEY);
+            assertNotNull(format("%s should not be null (%s)", CACHE_HITS_KEY, stats1), cacheHits1);
+            assertEquals(format("Expected 1 cache hits (%s)", stats1), "1", cacheHits1);
         });
     }
 
@@ -183,19 +175,16 @@ public class ClientStatisticsTest extends ClientTestSupport {
     }
 
     @Test
-    public void testStatisticsClusterReconnect() throws InterruptedException {
+    public void testStatisticsClusterReconnect() {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
         HazelcastClientInstanceImpl client = createHazelcastClient();
 
         hazelcastInstance.getLifecycleService().terminate();
 
         final CountDownLatch latch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
-                    latch.countDown();
-                }
+        client.getLifecycleService().addLifecycleListener(event -> {
+            if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
+                latch.countDown();
             }
         });
 
@@ -217,20 +206,17 @@ public class ClientStatisticsTest extends ClientTestSupport {
         final HazelcastClientInstanceImpl client2 = createHazelcastClient();
         final ClientEngineImpl clientEngine = getClientEngineImpl(hazelcastInstance);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                Map<UUID, String> clientStatistics = clientEngine.getClientStatistics();
-                assertNotNull(clientStatistics);
-                assertEquals(2, clientStatistics.size());
-                List<UUID> expectedUUIDs = new ArrayList<>(2);
-                expectedUUIDs.add(client1.getClientClusterService().getLocalClient().getUuid());
-                expectedUUIDs.add(client2.getClientClusterService().getLocalClient().getUuid());
-                for (Map.Entry<UUID, String> clientEntry : clientStatistics.entrySet()) {
-                    assertTrue(expectedUUIDs.contains(clientEntry.getKey()));
-                    String stats = clientEntry.getValue();
-                    assertNotNull(stats);
-                }
+        assertTrueEventually(() -> {
+            Map<UUID, ClientStatistics> clientStatistics = clientEngine.getClientStatistics();
+            assertNotNull(clientStatistics);
+            assertEquals(2, clientStatistics.size());
+            List<UUID> expectedUUIDs = new ArrayList<>(2);
+            expectedUUIDs.add(client1.getClientClusterService().getLocalClient().getUuid());
+            expectedUUIDs.add(client2.getClientClusterService().getLocalClient().getUuid());
+            for (Map.Entry<UUID, ClientStatistics> clientEntry : clientStatistics.entrySet()) {
+                assertTrue(expectedUUIDs.contains(clientEntry.getKey()));
+                String clientAttributes = clientEntry.getValue().clientAttributes();
+                assertNotNull(clientAttributes);
             }
         });
 
@@ -242,17 +228,15 @@ public class ClientStatisticsTest extends ClientTestSupport {
         final ClientEngineImpl clientEngine = getClientEngineImpl(hazelcastInstance);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "false");
-        clientConfig.setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS));
+        clientConfig.getMetricsConfig()
+                    .setEnabled(false)
+                    .setCollectionFrequencySeconds(STATS_PERIOD_SECONDS);
 
         hazelcastFactory.newHazelcastClient(clientConfig);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() {
-                Map<UUID, String> statistics = clientEngine.getClientStatistics();
-                assertEquals(0, statistics.size());
-            }
+        assertTrueAllTheTime(() -> {
+            Map<UUID, ClientStatistics> statistics = clientEngine.getClientStatistics();
+            assertEquals(0, statistics.size());
         }, STATS_PERIOD_SECONDS * 3);
     }
 
@@ -276,13 +260,13 @@ public class ClientStatisticsTest extends ClientTestSupport {
 
     private HazelcastClientInstanceImpl createHazelcastClient() {
         ClientConfig clientConfig = new ClientConfig()
-                .setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "true")
-                .setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS))
                 // add IMap and ICache with Near Cache config
                 .addNearCacheConfig(new NearCacheConfig(MAP_NAME))
                 .addNearCacheConfig(new NearCacheConfig(CACHE_NAME));
 
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
+        clientConfig.getMetricsConfig()
+                    .setCollectionFrequencySeconds(STATS_PERIOD_SECONDS);
 
         HazelcastInstance clientInstance = hazelcastFactory.newHazelcastClient(clientConfig);
         return getHazelcastClientInstanceImpl(clientInstance);
@@ -319,17 +303,17 @@ public class ClientStatisticsTest extends ClientTestSupport {
     }
 
     private static Map<String, String> getStats(HazelcastClientInstanceImpl client, ClientEngineImpl clientEngine) {
-        Map<UUID, String> clientStatistics = clientEngine.getClientStatistics();
+        Map<UUID, ClientStatistics> clientStatistics = clientEngine.getClientStatistics();
         assertNotNull("clientStatistics should not be null", clientStatistics);
         assertEquals("clientStatistics.size() should be 1", 1, clientStatistics.size());
-        Set<Map.Entry<UUID, String>> entries = clientStatistics.entrySet();
-        Map.Entry<UUID, String> statEntry = entries.iterator().next();
+        Set<Map.Entry<UUID, ClientStatistics>> entries = clientStatistics.entrySet();
+        Map.Entry<UUID, ClientStatistics> statEntry = entries.iterator().next();
         assertEquals(client.getClientClusterService().getLocalClient().getUuid(), statEntry.getKey());
-        return parseStatValue(statEntry.getValue());
+        return parseClientAttributeValue(statEntry.getValue().clientAttributes());
     }
 
-    private static Map<String, String> parseStatValue(String value) {
-        Map<String, String> result = new HashMap<String, String>();
+    private static Map<String, String> parseClientAttributeValue(String value) {
+        Map<String, String> result = new HashMap<>();
         for (String stat : split(value)) {
             List<String> keyValue = split(stat, 0, '=');
             assertNotNull(format("keyValue should not be null (%s)", stat), keyValue);
@@ -340,22 +324,14 @@ public class ClientStatisticsTest extends ClientTestSupport {
 
     private static void waitForFirstStatisticsCollection(final HazelcastClientInstanceImpl client,
                                                          final ClientEngineImpl clientEngine) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                getStats(client, clientEngine);
-            }
-        });
+        assertTrueEventually(() -> getStats(client, clientEngine));
     }
 
     private static void waitForNextStatsCollection(final HazelcastClientInstanceImpl client, final ClientEngineImpl clientEngine,
                                                    final String lastStatisticsCollectionTime) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                Map<String, String> stats = getStats(client, clientEngine);
-                assertNotEquals(lastStatisticsCollectionTime, stats.get("lastStatisticsCollectionTime"));
-            }
+        assertTrueEventually(() -> {
+            Map<String, String> stats = getStats(client, clientEngine);
+            assertNotEquals(lastStatisticsCollectionTime, stats.get("lastStatisticsCollectionTime"));
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.statistics.ClientStatistics;
-import com.hazelcast.client.impl.statistics.Statistics;
+import com.hazelcast.client.impl.statistics.ClientStatisticsService;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -53,8 +53,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
-import static com.hazelcast.client.impl.statistics.Statistics.split;
-import static com.hazelcast.client.impl.statistics.Statistics.unescapeSpecialCharacters;
+import static com.hazelcast.client.impl.statistics.ClientStatisticsService.split;
+import static com.hazelcast.client.impl.statistics.ClientStatisticsService.unescapeSpecialCharacters;
 import static java.lang.String.format;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -245,7 +245,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
         String originalString = "stat1=value1.lastName,stat2=value2\\hello==";
         String escapedString = "stat1\\=value1\\.lastName\\,stat2\\=value2\\\\hello\\=\\=";
         StringBuilder buffer = new StringBuilder(originalString);
-        Statistics.escapeSpecialCharacters(buffer);
+        ClientStatisticsService.escapeSpecialCharacters(buffer);
         assertEquals(escapedString, buffer.toString());
         assertEquals(originalString, unescapeSpecialCharacters(escapedString));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/CompositeMetricsCollectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/CompositeMetricsCollectorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static com.hazelcast.internal.metrics.impl.DefaultMetricDescriptorSupplier.DEFAULT_DESCRIPTOR_SUPPLIER;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CompositeMetricsCollectorTest {
+
+    @Mock
+    private MetricsCollector collectorMock1;
+
+    @Mock
+    private MetricsCollector collectorMock2;
+
+    private MetricDescriptor metricsDescriptor;
+
+    private CompositeMetricsCollector compositeCollector;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        compositeCollector = new CompositeMetricsCollector(collectorMock1, collectorMock2);
+
+        metricsDescriptor = DEFAULT_DESCRIPTOR_SUPPLIER
+                .get()
+                .withPrefix("test")
+                .withMetric("metric");
+    }
+
+    @Test
+    public void testCollectLong() {
+        compositeCollector.collectLong(metricsDescriptor, 42);
+
+        verify(collectorMock1).collectLong(metricsDescriptor, 42);
+        verify(collectorMock2).collectLong(metricsDescriptor, 42);
+    }
+
+    @Test
+    public void testCollectDouble() {
+        compositeCollector.collectDouble(metricsDescriptor, 42.42D);
+
+        verify(collectorMock1).collectDouble(metricsDescriptor, 42.42D);
+        verify(collectorMock2).collectDouble(metricsDescriptor, 42.42D);
+    }
+
+    @Test
+    public void testCollectException() {
+        Exception ex = new Exception();
+        compositeCollector.collectException(metricsDescriptor, ex);
+
+        verify(collectorMock1).collectException(metricsDescriptor, ex);
+        verify(collectorMock2).collectException(metricsDescriptor, ex);
+    }
+
+    @Test
+    public void testCollectNoValue() {
+        compositeCollector.collectNoValue(metricsDescriptor);
+
+        verify(collectorMock1).collectNoValue(metricsDescriptor);
+        verify(collectorMock2).collectNoValue(metricsDescriptor);
+    }
+}


### PR DESCRIPTION
The metrics collected on the client side are sent to the member to
include them in the metrics blob collected on the member side. The
metrics are sent from the client to the member using the same
metrics compression that the member-side is using.

If enabled in the metrics configuration, the client exposes the collected
client-side metrics automatically on JMX under
`com.hazelcast/Metrics/$clientName`.

Adds two client-side dynamic metric providers:
- `NearCacheMetricsProvider`
- `ClusterConnectionMetricsProvider`