### PR TITLE
Prevent concurrent migration finalization to cancel scheduled tasks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
@@ -30,8 +30,7 @@ public class DurableExecutorPartitionContainer {
     private final int partitionId;
     private final NodeEngineImpl nodeEngine;
 
-    private final Map<String, DurableExecutorContainer> executorContainerMap
-            = new HashMap<String, DurableExecutorContainer>();
+    private final Map<String, DurableExecutorContainer> executorContainerMap = new HashMap<>();
 
     public DurableExecutorPartitionContainer(NodeEngineImpl nodeEngine, int partitionId) {
         this.nodeEngine = nodeEngine;
@@ -54,7 +53,7 @@ public class DurableExecutorPartitionContainer {
     }
 
     public Operation prepareReplicationOperation(int replicaIndex) {
-        HashMap<String, DurableExecutorContainer> map = new HashMap<String, DurableExecutorContainer>();
+        HashMap<String, DurableExecutorContainer> map = new HashMap<>();
         for (DurableExecutorContainer executorContainer : executorContainerMap.values()) {
             if (replicaIndex > executorContainer.getDurability()) {
                 continue;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConstructorFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConstructorFunction.java
@@ -22,6 +22,7 @@ package com.hazelcast.internal.util;
  * @param <K> key type
  * @param <V> value type
  */
+@FunctionalInterface
 public interface ConstructorFunction<K, V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostListener.java
@@ -63,6 +63,7 @@ import java.util.EventListener;
  * @see PartitionService
  * @since 3.5
  */
+@FunctionalInterface
 public interface PartitionLostListener extends EventListener {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
@@ -33,8 +33,10 @@ public abstract class AbstractScheduledExecutorContainerHolder
 
     final NodeEngine nodeEngine;
 
-    final ConcurrentMap<String, ScheduledExecutorContainer> containers =
-            new ConcurrentHashMap<String, ScheduledExecutorContainer>();
+    /**
+     * Containers for scheduled tasks, grouped by scheduler name
+     */
+    final ConcurrentMap<String, ScheduledExecutorContainer> containers = new ConcurrentHashMap<>();
 
     public AbstractScheduledExecutorContainerHolder(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.scheduledexecutor.impl;
 
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.scheduledexecutor.DuplicateTaskException;
 import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
@@ -29,7 +30,6 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.ScheduledExecutorMergeTypes;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import java.util.Collection;
 import java.util.Map;
@@ -42,11 +42,11 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import static com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService.SERVICE_NAME;
-import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService.SERVICE_NAME;
+import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 import static java.lang.String.format;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
@@ -72,7 +72,7 @@ public class ScheduledExecutorContainer {
     private final int capacity;
 
     ScheduledExecutorContainer(String name, int partitionId, NodeEngine nodeEngine, int durability, int capacity) {
-        this(name, partitionId, nodeEngine, durability, capacity, new ConcurrentHashMap<String, ScheduledTaskDescriptor>());
+        this(name, partitionId, nodeEngine, durability, capacity, new ConcurrentHashMap<>());
     }
 
     ScheduledExecutorContainer(String name, int partitionId, NodeEngine nodeEngine, int durability, int capacity,
@@ -219,6 +219,11 @@ public class ScheduledExecutorContainer {
         return ScheduledTaskHandlerImpl.of(partitionId, getName(), taskName);
     }
 
+    /**
+     * Attempts to promote and schedule all suspended tasks on this partition.
+     * Exceptions throw during rescheduling will be rethrown and will prevent
+     * further suspended tasks from being scheduled.
+     */
     public void promoteSuspended() {
         for (ScheduledTaskDescriptor descriptor : tasks.values()) {
             try {
@@ -226,7 +231,6 @@ public class ScheduledExecutorContainer {
                 if (descriptor.shouldSchedule()) {
                     doSchedule(descriptor);
                 }
-
             } catch (Exception e) {
                 throw rethrow(e);
             }
@@ -296,33 +300,47 @@ public class ScheduledExecutorContainer {
         return descriptor.getScheduledFuture();
     }
 
-    Map<String, ScheduledTaskDescriptor> prepareForReplication(boolean migrationMode) {
-
+    /**
+     * Returns all task descriptors on this container, mapped by task name.
+     *
+     * @return a map of all tasks on this container
+     */
+    Map<String, ScheduledTaskDescriptor> prepareForReplication() {
         Map<String, ScheduledTaskDescriptor> replicas = createHashMap(tasks.size());
-
         for (ScheduledTaskDescriptor descriptor : tasks.values()) {
             try {
-                ScheduledTaskDescriptor replica = new ScheduledTaskDescriptor(descriptor.getDefinition(), descriptor.getState(),
-                        descriptor.getStatsSnapshot(), descriptor.getTaskResult());
+                ScheduledTaskDescriptor replica = new ScheduledTaskDescriptor(descriptor.getDefinition(),
+                        descriptor.getState(),
+                        descriptor.getStatsSnapshot(),
+                        descriptor.getTaskResult());
                 replicas.put(descriptor.getDefinition().getName(), replica);
             } catch (Exception ex) {
                 sneakyThrow(ex);
-            } finally {
-                if (migrationMode) {
-                    // Best effort to cancel & interrupt the task.
-                    // In the case of Runnable the DelegateAndSkipOnConcurrentExecutionDecorator is not exposing access
-                    // to the Executor's Future, hence, we have no access on the runner thread to interrupt. In this case
-                    // the line below is only cancelling future runs.
-                    try {
-                        descriptor.suspend();
-                    } catch (Exception ex) {
-                        throw rethrow(ex);
-                    }
-                }
             }
         }
-
         return replicas;
+    }
+
+    /**
+     * Attempts to cancel and interrupt all tasks on this container. Exceptions
+     * thrown during task cancellation will be rethrown and prevent further
+     * tasks from being cancelled.
+     */
+    void suspendTasks() {
+        for (ScheduledTaskDescriptor descriptor : tasks.values()) {
+            // Best effort to cancel & interrupt the task.
+            // In the case of Runnable the DelegateAndSkipOnConcurrentExecutionDecorator is not exposing access
+            // to the Executor's Future, hence, we have no access on the runner thread to interrupt. In this case
+            // the line below is only cancelling future runs.
+            try {
+                descriptor.suspend();
+                if (logger.isFinestEnabled()) {
+                    log(FINEST, descriptor.getDefinition().getName(), "Cancelled");
+                }
+            } catch (Exception ex) {
+                throw rethrow(ex);
+            }
+        }
     }
 
     void checkNotDuplicateTask(String taskName) {
@@ -385,20 +403,16 @@ public class ScheduledExecutorContainer {
         assert descriptor.getScheduledFuture() == null;
         TaskDefinition definition = descriptor.getDefinition();
 
-        if (logger.isFinestEnabled()) {
-            log(FINEST, definition.getName(), "Scheduled");
-        }
-
         ScheduledFuture future;
         TaskRunner<V> runner;
         switch (definition.getType()) {
             case SINGLE_RUN:
-                runner = new TaskRunner<V>(this, descriptor);
+                runner = new TaskRunner<>(this, descriptor);
                 future = new DelegatingScheduledFutureStripper<V>(executionService
                         .scheduleDurable(name, (Callable) runner, definition.getInitialDelay(), definition.getUnit()));
                 break;
             case AT_FIXED_RATE:
-                runner = new TaskRunner<V>(this, descriptor);
+                runner = new TaskRunner<>(this, descriptor);
                 future = executionService
                         .scheduleDurableWithRepetition(name, runner, definition.getInitialDelay(), definition.getPeriod(),
                                 definition.getUnit());
@@ -408,6 +422,10 @@ public class ScheduledExecutorContainer {
         }
 
         descriptor.setScheduledFuture(future);
+
+        if (logger.isFinestEnabled()) {
+            log(FINEST, definition.getName(), "Scheduled");
+        }
     }
 
     private void checkNotStaleTask(String taskName) {
@@ -415,5 +433,4 @@ public class ScheduledExecutorContainer {
             throw new StaleTaskException("Task with name " + taskName + " not found. ");
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
@@ -17,56 +17,56 @@
 package com.hazelcast.scheduledexecutor.impl;
 
 import com.hazelcast.config.ScheduledExecutorConfig;
+import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.scheduledexecutor.impl.operations.ReplicationOperation;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.internal.util.ConstructorFunction;
 
 import java.util.Iterator;
 import java.util.Map;
 
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
-public class ScheduledExecutorPartition
-        extends AbstractScheduledExecutorContainerHolder {
+public class ScheduledExecutorPartition extends AbstractScheduledExecutorContainerHolder {
 
     private final ILogger logger;
     private final int partitionId;
+    private final ConstructorFunction<String, ScheduledExecutorContainer> containerConstructorFunction;
 
-    private final ConstructorFunction<String, ScheduledExecutorContainer> containerConstructorFunction =
-            new ConstructorFunction<String, ScheduledExecutorContainer>() {
-                @Override
-                public ScheduledExecutorContainer createNew(String name) {
-                    if (logger.isFinestEnabled()) {
-                        logger.finest("[Partition:" + partitionId + "]Create new scheduled executor container with name:" + name);
-                    }
-
-                    ScheduledExecutorConfig config = nodeEngine.getConfig().findScheduledExecutorConfig(name);
-                    return new ScheduledExecutorContainer(name, partitionId, nodeEngine, config.getDurability(),
-                            config.getCapacity());
-                }
-            };
 
     ScheduledExecutorPartition(NodeEngine nodeEngine, int partitionId) {
         super(nodeEngine);
         this.logger = nodeEngine.getLogger(getClass());
         this.partitionId = partitionId;
+        this.containerConstructorFunction = name -> {
+            if (logger.isFinestEnabled()) {
+                logger.finest("[Partition:" + partitionId + "]Create new scheduled executor container with name:" + name);
+            }
+            ScheduledExecutorConfig config = nodeEngine.getConfig().findScheduledExecutorConfig(name);
+            return new ScheduledExecutorContainer(name, partitionId, nodeEngine, config.getDurability(),
+                    config.getCapacity());
+        };
     }
 
-    public Operation prepareReplicationOperation(int replicaIndex, boolean migrationMode) {
+    /**
+     * Collects all tasks for replication for all schedulers on this partition.
+     *
+     * @param replicaIndex the replica index of the member which will receive the returned operation
+     * @return the
+     */
+    public Operation prepareReplicationOperation(int replicaIndex) {
         Map<String, Map<String, ScheduledTaskDescriptor>> map = createHashMap(containers.size());
 
         if (logger.isFinestEnabled()) {
-            logger.finest("[Partition: " + partitionId + "] Prepare replication(migration: " + migrationMode + ") "
-                    + "for index: " + replicaIndex);
+            logger.finest("[Partition: " + partitionId + "] Preparing replication for index: " + replicaIndex);
         }
 
         for (ScheduledExecutorContainer container : containers.values()) {
             if (replicaIndex > container.getDurability()) {
                 continue;
             }
-            map.put(container.getName(), container.prepareForReplication(migrationMode));
+            map.put(container.getName(), container.prepareForReplication());
         }
 
         return new ReplicationOperation(map);
@@ -101,6 +101,11 @@ public class ScheduledExecutorPartition
         }
     }
 
+    /**
+     * Attempts to promote and schedule all suspended tasks on this partition.
+     * Exceptions throw during rescheduling will be rethrown and will prevent
+     * further suspended tasks from being scheduled.
+     */
     void promoteSuspended() {
         if (logger.isFinestEnabled()) {
             logger.finest("[Partition: " + partitionId + "] " + "Promote suspended");
@@ -108,6 +113,21 @@ public class ScheduledExecutorPartition
 
         for (ScheduledExecutorContainer container : containers.values()) {
             container.promoteSuspended();
+        }
+    }
+
+    /**
+     * Attempts to cancel and interrupt all tasks on all containers. Exceptions
+     * thrown during task cancellation will be rethrown and prevent further
+     * tasks from being cancelled.
+     */
+    void suspendTasks() {
+        if (logger.isFinestEnabled()) {
+            logger.finest("[Partition: " + partitionId + "] Suspending tasks");
+        }
+
+        for (ScheduledExecutorContainer container : containers.values()) {
+            container.suspendTasks();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cache/ClientCacheSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cache/ClientCacheSplitBrainProtectionReadTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.splitbrainprotection.cache;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.cache.CacheSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientCacheSplitBrainProtectionReadTest extends CacheSplitBrainProt
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cache/ClientCacheSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cache/ClientCacheSplitBrainProtectionWriteTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.splitbrainprotection.cache;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.cache.CacheSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientCacheSplitBrainProtectionWriteTest extends CacheSplitBrainPro
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cardinality/ClientCardinalityEstimatorSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cardinality/ClientCardinalityEstimatorSplitBrainProtectionReadTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.splitbrainprotection.cardinality;
 import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.cardinality.CardinalityEstimatorSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientCardinalityEstimatorSplitBrainProtectionReadTest extends Card
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cardinality/ClientCardinalityEstimatorSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/cardinality/ClientCardinalityEstimatorSplitBrainProtectionWriteTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.splitbrainprotection.cardinality;
 import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.cardinality.CardinalityEstimatorSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientCardinalityEstimatorSplitBrainProtectionWriteTest extends Car
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/durableexecutor/ClientDurableExecutorSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/durableexecutor/ClientDurableExecutorSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.durableexecutor;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.durableexecutor.DurableExecutorSplitBrainProtectionReadTest;
@@ -42,7 +41,7 @@ public class ClientDurableExecutorSplitBrainProtectionReadTest extends DurableEx
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/durableexecutor/ClientDurableExecutorSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/durableexecutor/ClientDurableExecutorSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.durableexecutor;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.durableexecutor.DurableExecutorSplitBrainProtectionWriteTest;
@@ -42,7 +41,7 @@ public class ClientDurableExecutorSplitBrainProtectionWriteTest extends DurableE
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/executor/ClientExecutorSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/executor/ClientExecutorSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.executor;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.executor.ExecutorSplitBrainProtectionReadTest;
@@ -42,7 +41,7 @@ public class ClientExecutorSplitBrainProtectionReadTest extends ExecutorSplitBra
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/executor/ClientExecutorSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/executor/ClientExecutorSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.executor;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.executor.ExecutorSplitBrainProtectionWriteTest;
@@ -43,7 +42,7 @@ public class ClientExecutorSplitBrainProtectionWriteTest extends ExecutorSplitBr
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientListSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientListSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.list;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IList;
 import com.hazelcast.splitbrainprotection.list.ListSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientListSplitBrainProtectionReadTest extends ListSplitBrainProtec
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientListSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientListSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.list;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IList;
 import com.hazelcast.splitbrainprotection.list.ListSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientListSplitBrainProtectionWriteTest extends ListSplitBrainProte
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientTransactionalListSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientTransactionalListSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.list;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.list.TransactionalListSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -42,7 +41,7 @@ public class ClientTransactionalListSplitBrainProtectionReadTest extends Transac
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientTransactionalListSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/list/ClientTransactionalListSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.list;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.list.TransactionalListSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalListSplitBrainProtectionWriteTest extends Transa
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientMapSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientMapSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.map;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.map.IMap;
 import com.hazelcast.splitbrainprotection.map.MapSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientMapSplitBrainProtectionReadTest extends MapSplitBrainProtecti
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientMapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientMapSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.map;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.map.IMap;
 import com.hazelcast.splitbrainprotection.map.MapSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientMapSplitBrainProtectionWriteTest extends MapSplitBrainProtect
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientTransactionalMapSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientTransactionalMapSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.map;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.map.TransactionalMapSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalMapSplitBrainProtectionReadTest extends Transact
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientTransactionalMapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/map/ClientTransactionalMapSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.map;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.map.TransactionalMapSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalMapSplitBrainProtectionWriteTest extends Transac
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientMultiMapSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientMultiMapSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.multimap;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.splitbrainprotection.multimap.MultiMapSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientMultiMapSplitBrainProtectionReadTest extends MultiMapSplitBra
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientMultiMapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientMultiMapSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.multimap;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.splitbrainprotection.multimap.MultiMapSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientMultiMapSplitBrainProtectionWriteTest extends MultiMapSplitBr
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientTransactionalMultiMapSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientTransactionalMultiMapSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.multimap;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.multimap.TransactionalMultiMapSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalMultiMapSplitBrainProtectionReadTest extends Tra
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientTransactionalMultiMapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/multimap/ClientTransactionalMultiMapSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.multimap;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.multimap.TransactionalMultiMapSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalMultiMapSplitBrainProtectionWriteTest extends Tr
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/pncounter/ClientPNCounterSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/pncounter/ClientPNCounterSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.pncounter;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.splitbrainprotection.pncounter.PNCounterSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientPNCounterSplitBrainProtectionReadTest extends PNCounterSplitB
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/pncounter/ClientPNCounterSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/pncounter/ClientPNCounterSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.pncounter;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.splitbrainprotection.pncounter.PNCounterSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientPNCounterSplitBrainProtectionWriteTest extends PNCounterSplit
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientQueueSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientQueueSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.queue;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.splitbrainprotection.queue.QueueSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientQueueSplitBrainProtectionReadTest extends QueueSplitBrainProt
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientQueueSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientQueueSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.queue;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.splitbrainprotection.queue.QueueSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientQueueSplitBrainProtectionWriteTest extends QueueSplitBrainPro
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientTransactionalQueueSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientTransactionalQueueSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.queue;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.queue.TransactionalQueueSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalQueueSplitBrainProtectionReadTest extends Transa
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientTransactionalQueueSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/queue/ClientTransactionalQueueSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.queue;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.queue.TransactionalQueueSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalQueueSplitBrainProtectionWriteTest extends Trans
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/replicatedmap/ClientReplicatedMapSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/replicatedmap/ClientReplicatedMapSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.replicatedmap;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.splitbrainprotection.replicatedmap.ReplicatedMapSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientReplicatedMapSplitBrainProtectionReadTest extends ReplicatedM
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/replicatedmap/ClientReplicatedMapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/replicatedmap/ClientReplicatedMapSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.replicatedmap;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.splitbrainprotection.replicatedmap.ReplicatedMapSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientReplicatedMapSplitBrainProtectionWriteTest extends Replicated
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/ringbuffer/ClientRingbufferSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/ringbuffer/ClientRingbufferSplitBrainProtectionReadTest.java
@@ -18,9 +18,8 @@ package com.hazelcast.client.splitbrainprotection.ringbuffer;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
-import com.hazelcast.splitbrainprotection.ringbuffer.RingbufferSplitBrainProtectionReadTest;
 import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.splitbrainprotection.ringbuffer.RingbufferSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,7 +40,7 @@ public class ClientRingbufferSplitBrainProtectionReadTest extends RingbufferSpli
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/ringbuffer/ClientRingbufferSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/ringbuffer/ClientRingbufferSplitBrainProtectionWriteTest.java
@@ -18,9 +18,8 @@ package com.hazelcast.client.splitbrainprotection.ringbuffer;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
-import com.hazelcast.splitbrainprotection.ringbuffer.RingbufferSplitBrainProtectionWriteTest;
 import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.splitbrainprotection.ringbuffer.RingbufferSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,7 +40,7 @@ public class ClientRingbufferSplitBrainProtectionWriteTest extends RingbufferSpl
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/scheduledexecutor/ClientScheduledExecutorSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/scheduledexecutor/ClientScheduledExecutorSplitBrainProtectionReadTest.java
@@ -18,10 +18,9 @@ package com.hazelcast.client.splitbrainprotection.scheduledexecutor;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.scheduledexecutor.ScheduledExecutorSplitBrainProtectionReadTest;
-import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -42,7 +41,7 @@ public class ClientScheduledExecutorSplitBrainProtectionReadTest extends Schedul
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/scheduledexecutor/ClientScheduledExecutorSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/scheduledexecutor/ClientScheduledExecutorSplitBrainProtectionWriteTest.java
@@ -18,10 +18,9 @@ package com.hazelcast.client.splitbrainprotection.scheduledexecutor;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.scheduledexecutor.ScheduledExecutorSplitBrainProtectionWriteTest;
-import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -42,7 +41,7 @@ public class ClientScheduledExecutorSplitBrainProtectionWriteTest extends Schedu
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientSetSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientSetSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.set;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.splitbrainprotection.set.SetSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientSetSplitBrainProtectionReadTest extends SetSplitBrainProtecti
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientSetSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientSetSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.set;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.splitbrainprotection.set.SetSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -41,7 +40,7 @@ public class ClientSetSplitBrainProtectionWriteTest extends SetSplitBrainProtect
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientTransactionalSetSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientTransactionalSetSplitBrainProtectionReadTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.set;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.set.TransactionalSetSplitBrainProtectionReadTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalSetSplitBrainProtectionReadTest extends Transact
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientTransactionalSetSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/splitbrainprotection/set/ClientTransactionalSetSplitBrainProtectionWriteTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.splitbrainprotection.set;
 
 import com.hazelcast.client.splitbrainprotection.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.splitbrainprotection.set.TransactionalSetSplitBrainProtectionWriteTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -41,7 +40,7 @@ public class ClientTransactionalSetSplitBrainProtectionWriteTest extends Transac
     @BeforeClass
     public static void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
-        initTestEnvironment(new Config(), factory);
+        initTestEnvironment(smallInstanceConfig(), factory);
         clients = new PartitionedClusterClients(cluster, factory);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/AbstractSplitBrainProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/AbstractSplitBrainProtectionTest.java
@@ -45,15 +45,13 @@ import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-
-import java.io.Serializable;
 
 import static com.hazelcast.splitbrainprotection.PartitionedCluster.SPLIT_BRAIN_PROTECTION_ID;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ_WRITE;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.WRITE;
-import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static java.util.Arrays.asList;
 
 /**
@@ -67,24 +65,21 @@ import static java.util.Arrays.asList;
  * </ul>
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class AbstractSplitBrainProtectionTest {
+public abstract class AbstractSplitBrainProtectionTest extends HazelcastTestSupport {
 
-    protected static final String REFERENCE_NAME = "reference" + "splitBrainProtection" + randomString();
-    protected static final String LONG_NAME = "long" + "splitBrainProtection" + randomString();
-    protected static final String CACHE_NAME = "splitBrainProtection" + randomString();
-    protected static final String ESTIMATOR_NAME = "splitBrainProtection" + randomString();
-    protected static final String DURABLE_EXEC_NAME = "splitBrainProtection" + randomString();
-    protected static final String EXEC_NAME = "splitBrainProtection" + randomString();
-    protected static final String LIST_NAME = "splitBrainProtection" + randomString();
-    protected static final String LOCK_NAME = "splitBrainProtection" + randomString();
-    protected static final String MAP_NAME = "splitBrainProtection" + randomString();
-    protected static final String MULTI_MAP_NAME = "splitBrainProtection" + randomString();
-    protected static final String QUEUE_NAME = "splitBrainProtection" + randomString();
-    protected static final String REPLICATED_MAP_NAME = "splitBrainProtection" + randomString();
-    protected static final String RINGBUFFER_NAME = "splitBrainProtection" + randomString();
-    protected static final String SCHEDULED_EXEC_NAME = "splitBrainProtection" + randomString();
-    protected static final String SET_NAME = "splitBrainProtection" + randomString();
-    protected static final String PN_COUNTER_NAME = "splitBrainProtection" + randomString();
+    protected static final String CACHE_NAME = "splitBrainProtection-cache-" + randomString();
+    protected static final String ESTIMATOR_NAME = "splitBrainProtection-estimator-" + randomString();
+    protected static final String DURABLE_EXEC_NAME = "splitBrainProtection-durable-exec-" + randomString();
+    protected static final String EXEC_NAME = "splitBrainProtection-exec-" + randomString();
+    protected static final String LIST_NAME = "splitBrainProtection-list-" + randomString();
+    protected static final String MAP_NAME = "splitBrainProtection-map-" + randomString();
+    protected static final String MULTI_MAP_NAME = "splitBrainProtection-multimap-" + randomString();
+    protected static final String QUEUE_NAME = "splitBrainProtection-queue-" + randomString();
+    protected static final String REPLICATED_MAP_NAME = "splitBrainProtection-replicated-map-" + randomString();
+    protected static final String RINGBUFFER_NAME = "splitBrainProtection-ringbuffer-" + randomString();
+    protected static final String SCHEDULED_EXEC_NAME = "splitBrainProtection-scheduled-exec-" + randomString();
+    protected static final String SET_NAME = "splitBrainProtection-set-" + randomString();
+    protected static final String PN_COUNTER_NAME = "splitBrainProtection-pn-counter-" + randomString();
 
     protected static PartitionedCluster cluster;
     protected static TestHazelcastInstanceFactory factory;
@@ -304,18 +299,7 @@ public abstract class AbstractSplitBrainProtectionTest {
     }
 
     protected static IFunction function() {
-        return new IFunction<Object, Object>() {
-            @Override
-            public Object apply(Object input) {
-                return input;
-            }
-        };
+        return (IFunction<Object, Object>) input -> input;
     }
 
-    public static class SplitBrainProtectionTestClass implements Serializable {
-
-        public static SplitBrainProtectionTestClass object() {
-            return new SplitBrainProtectionTestClass();
-        }
-    }
 }


### PR DESCRIPTION
A FinalizeMigrationOperation can be invoked concurrently to other
partition migrations. As such, the operation may invoke beforeMigration
and commitMigration/rollbackMigration methods while there is a
concurrent invocation to prepareReplicationOperation for another
partition.
This may cause the scheduled executor service to mistakenly think it is
preparing a replication operation for a migration while in fact there
was is no migration.

Also, did some JDK8 cleanups and made all quorum tests to use small
test instances.

Fixes:
https://github.com/hazelcast/hazelcast/issues/15904
https://github.com/hazelcast/hazelcast/issues/12197