### PR TITLE
Make CacheConfig IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -71,6 +71,7 @@ import com.hazelcast.cache.impl.record.CacheObjectRecord;
 import com.hazelcast.cache.impl.tenantcontrol.CacheDestroyEventContext;
 import com.hazelcast.client.impl.protocol.task.cache.CacheAssignAndGetUuidsOperation;
 import com.hazelcast.client.impl.protocol.task.cache.CacheAssignAndGetUuidsOperationFactory;
+import com.hazelcast.config.CacheConfig;
 import com.hazelcast.internal.management.request.GetCacheEntryRequest;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
@@ -160,8 +161,9 @@ public final class CacheDataSerializerHook
     public static final int SET_EXPIRY_POLICY_BACKUP = 64;
     public static final int EXPIRE_BATCH_BACKUP = 65;
     public static final int CACHE_DESTROY_EVENT_CONTEXT = 66;
+    public static final int CACHE_CONFIG = 67;
 
-    private static final int LEN = CACHE_DESTROY_EVENT_CONTEXT + 1;
+    private static final int LEN = CACHE_CONFIG + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -235,6 +237,7 @@ public final class CacheDataSerializerHook
         constructors[SET_EXPIRY_POLICY_BACKUP] = arg -> new CacheSetExpiryPolicyBackupOperation();
         constructors[EXPIRE_BATCH_BACKUP] = arg -> new CacheExpireBatchBackupOperation();
         constructors[CACHE_DESTROY_EVENT_CONTEXT] = arg -> new CacheDestroyEventContext();
+        constructors[CACHE_CONFIG] = arg -> new CacheConfig<>();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -19,10 +19,9 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.config.AbstractCacheConfig;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheConfigAccessor;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.spi.tenantcontrol.TenantControl;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -40,7 +39,7 @@ import java.io.IOException;
  * @param <V> the value type
  * @since 3.9
  */
-public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements IdentifiedDataSerializable {
+public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> {
     public PreJoinCacheConfig() {
         super();
     }
@@ -118,11 +117,6 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements Ident
     }
 
     @Override
-    public int getFactoryId() {
-        return CacheDataSerializerHook.F_ID;
-    }
-
-    @Override
     public int getClassId() {
         return CacheDataSerializerHook.PRE_JOIN_CACHE_CONFIG;
     }
@@ -141,11 +135,7 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements Ident
             return false;
         }
 
-        if (!this.getValueClassName().equals(that.getValueClassName())) {
-            return false;
-        }
-
-        return true;
+        return this.getValueClassName().equals(that.getValueClassName());
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.impl.protocol;
 import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.serialization.BinaryInterface;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -97,7 +96,6 @@ import java.util.Objects;
  * ;UUID                    = int64 int64
  */
 @SuppressWarnings("checkstyle:MagicNumber")
-@BinaryInterface
 public final class ClientMessage implements OutboundFrame {
 
     // All offsets here are offset of frame.content byte[]

--- a/hazelcast/src/main/java/com/hazelcast/cluster/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Address.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cluster;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -34,7 +33,6 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 /**
  * Represents an address of a member in the cluster.
  */
-@BinaryInterface
 public final class Address implements IdentifiedDataSerializable {
 
     private static final byte IPV4 = 4;

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.DeferredValue;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.serialization.BinaryInterface;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -43,9 +43,8 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  * @param <K> the key type
  * @param <V> the value type
  */
-@BinaryInterface
 @SuppressWarnings("checkstyle:methodcount")
-public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, DataSerializable {
+public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, IdentifiedDataSerializable {
 
     private static final String DEFAULT_KEY_VALUE_TYPE = "java.lang.Object";
 
@@ -424,6 +423,11 @@ public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K,
     public CacheConfiguration<K, V> setStoreByValue(boolean storeByValue) {
         this.isStoreByValue = storeByValue;
         return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
     }
 
     protected Set<DeferredValue<CacheEntryListenerConfiguration<K, V>>> createConcurrentSet() {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.DeferredValue;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.merge.SplitBrainMergeTypeProvider;
@@ -65,7 +65,6 @@ import static com.hazelcast.spi.tenantcontrol.TenantControl.NOOP_TENANT_CONTROL;
  * @param <K> the key type
  * @param <V> the value type
  */
-@BinaryInterface
 public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> implements SplitBrainMergeTypeProvider {
 
     private String name;
@@ -543,6 +542,11 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> implements Spli
         for (CachePartitionLostListenerConfig partitionLostListenerConfig : partitionLostListenerConfigs) {
             out.writeObject(partitionLostListenerConfig);
         }
+    }
+
+    @Override
+    public int getClassId() {
+        return CacheDataSerializerHook.CACHE_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
@@ -18,7 +18,6 @@ package com.hazelcast.config;
 
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
-import com.hazelcast.internal.serialization.BinaryInterface;
 
 import java.io.Serializable;
 
@@ -27,7 +26,6 @@ import java.io.Serializable;
  *
  * @see CachePartitionLostListener
  */
-@BinaryInterface
 public class CachePartitionLostListenerConfig extends ListenerConfig implements Serializable {
 
     public CachePartitionLostListenerConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.internal.eviction.EvictionConfiguration;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
 import com.hazelcast.internal.eviction.EvictionStrategyType;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -46,9 +46,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  *      for all other data structures and configurations</li>
  * </ul>
  */
-@BinaryInterface
-public class EvictionConfig implements EvictionConfiguration,
-        DataSerializable, Serializable {
+public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSerializable, Serializable {
 
     /**
      * Default maximum entry count.
@@ -228,6 +226,16 @@ public class EvictionConfig implements EvictionConfiguration,
         this.comparator = checkNotNull(comparator,
                 "Eviction policy comparator cannot be null!");
         return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ConfigDataSerializerHook.EVICTION_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -34,8 +34,7 @@ import java.util.List;
  *
  * @see WanReplicationConfig
  */
-@BinaryInterface
-public class WanReplicationRef implements DataSerializable, Serializable {
+public class WanReplicationRef implements IdentifiedDataSerializable, Serializable {
 
     private boolean republishingEnabled = true;
     private String name;
@@ -153,6 +152,16 @@ public class WanReplicationRef implements DataSerializable, Serializable {
     public WanReplicationRef setRepublishingEnabled(boolean republishEnabled) {
         this.republishingEnabled = republishEnabled;
         return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ConfigDataSerializerHook.WAN_REPLICATION_REF;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/CacheConfigReadOnly.java
@@ -25,7 +25,6 @@ import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.WanReplicationRef;
-import com.hazelcast.internal.serialization.BinaryInterface;
 
 import javax.annotation.Nonnull;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -43,7 +42,6 @@ import java.util.Set;
  * @param <K> type of the key
  * @param <V> type of the value
  */
-@BinaryInterface
 @SuppressWarnings("checkstyle:methodcount")
 public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/CachePartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/CachePartitionLostListenerConfigReadOnly.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.config;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.ListenerConfig;
-import com.hazelcast.internal.serialization.BinaryInterface;
 
 import java.util.EventListener;
 
@@ -28,7 +27,6 @@ import java.util.EventListener;
  *
  * @see CachePartitionLostListener
  */
-@BinaryInterface
 public class CachePartitionLostListenerConfigReadOnly
         extends CachePartitionLostListenerConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigDataSerializerHook.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EurekaConfig;
 import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GcpConfig;
@@ -65,6 +66,7 @@ import com.hazelcast.config.TopicConfig;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
 import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.dynamicconfig.AddDynamicConfigOperation;
 import com.hazelcast.internal.dynamicconfig.DynamicConfigPreJoinOperation;
@@ -148,8 +150,10 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int AWS_CONFIG = 56;
     public static final int DISCOVERY_CONFIG = 57;
     public static final int DISCOVERY_STRATEGY_CONFIG = 58;
+    public static final int WAN_REPLICATION_REF = 59;
+    public static final int EVICTION_CONFIG = 60;
 
-    private static final int LEN = DISCOVERY_STRATEGY_CONFIG + 1;
+    private static final int LEN = EVICTION_CONFIG + 1;
 
     @Override
     public int getFactoryId() {
@@ -223,6 +227,8 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
         constructors[AWS_CONFIG] = arg -> new AwsConfig();
         constructors[DISCOVERY_CONFIG] = arg -> new DiscoveryConfig();
         constructors[DISCOVERY_STRATEGY_CONFIG] = arg -> new DiscoveryStrategyConfig();
+        constructors[WAN_REPLICATION_REF] = arg -> new WanReplicationRef();
+        constructors[EVICTION_CONFIG] = arg -> new EvictionConfig();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/EvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/EvictionConfigReadOnly.java
@@ -20,12 +20,10 @@ import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.internal.serialization.BinaryInterface;
 
 /**
  * Read only version of {@link com.hazelcast.config.EvictionConfig}.
  */
-@BinaryInterface
 public class EvictionConfigReadOnly extends EvictionConfig {
 
     public EvictionConfigReadOnly(EvictionConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/WanReplicationRefReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/WanReplicationRefReadOnly.java
@@ -17,14 +17,12 @@
 package com.hazelcast.internal.config;
 
 import com.hazelcast.config.WanReplicationRef;
-import com.hazelcast.internal.serialization.BinaryInterface;
 
 import java.util.List;
 
 /**
  * Configuration for Wan target replication reference(read only)
  */
-@BinaryInterface
 public class WanReplicationRefReadOnly extends WanReplicationRef {
 
     public WanReplicationRefReadOnly(WanReplicationRef ref) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -170,8 +170,8 @@ public class DataSerializableConventionsTest {
      */
     @Test
     public void test_identifiedDataSerializables_haveUniqueFactoryAndTypeId() throws Exception {
-        Set<String> classesWithInstantiationProblems = new TreeSet<String>();
-        Set<String> classesThrowingUnsupportedOperationException = new TreeSet<String>();
+        Set<String> classesWithInstantiationProblems = new TreeSet<>();
+        Set<String> classesThrowingUnsupportedOperationException = new TreeSet<>();
 
         Multimap<Integer, Integer> factoryToTypeId = HashMultimap.create();
 
@@ -273,7 +273,8 @@ public class DataSerializableConventionsTest {
 
     private boolean isReadOnlyConfig(Class<? extends IdentifiedDataSerializable> klass) {
         String className = klass.getName();
-        return className.endsWith("ReadOnly") && className.contains("Config");
+        return className.endsWith("ReadOnly")
+                && (className.contains("Config") || className.contains("WanReplicationRef"));
     }
 
     /**


### PR DESCRIPTION
Codec is now used for `CacheConfig` in client protocol, so `CacheConfig`
and referenced classes:
- can use `IdentifiedDataSerializable` serialization for member-to-member
communication and evolve independently of client protocol
- need no longer be marked as `@BinaryInterface`

Also removed `@BinaryInterface` annotation from `Address` class which
is serialized using client protocol codec.

Fixes #15967 