### PR TITLE
Removes public static factory method of HazelcastClientCachingProvider

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -54,15 +54,6 @@ public final class HazelcastClientCachingProvider extends AbstractHazelcastCachi
         this.hazelcastInstance = instance;
     }
 
-    /**
-     * Helper method for creating caching provider for testing etc.
-     */
-    public static HazelcastClientCachingProvider createCachingProvider(HazelcastInstance hazelcastInstance) {
-        HazelcastClientCachingProvider cachingProvider = new HazelcastClientCachingProvider();
-        cachingProvider.hazelcastInstance = hazelcastInstance;
-        return cachingProvider;
-    }
-
     @Override
     public String toString() {
         return "HazelcastClientCachingProvider{hazelcastInstance=" + hazelcastInstance + '}';


### PR DESCRIPTION
This method should have been removed with previous cleanup #15890 (as was already done for server-side counterpart).

Tests & code samples have already been adapted to this change and need no further update.