### PR TITLE
Disallow null message on topic.publish

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientTopicProxy.java
@@ -23,20 +23,17 @@ import com.hazelcast.client.impl.protocol.codec.TopicRemoveMessageListenerCodec;
 import com.hazelcast.client.impl.spi.ClientContext;
 import com.hazelcast.client.impl.spi.EventHandler;
 import com.hazelcast.client.impl.spi.impl.ListenerMessageCodec;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.topic.LocalTopicStats;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.topic.impl.DataAwareMessage;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import java.util.UUID;
 
-import static com.hazelcast.client.impl.proxy.ClientMapProxy.NULL_LISTENER_IS_NOT_ALLOWED;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -46,12 +43,16 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  */
 public class ClientTopicProxy<E> extends PartitionSpecificClientProxy implements ITopic<E> {
 
+    private static final String NULL_MESSAGE_IS_NOT_ALLOWED = "Null message is not allowed!";
+    private static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
+
     public ClientTopicProxy(String serviceName, String objectId, ClientContext context) {
         super(serviceName, objectId, context);
     }
 
     @Override
-    public void publish(@Nullable E message) {
+    public void publish(@Nonnull E message) {
+        checkNotNull(message, NULL_MESSAGE_IS_NOT_ALLOWED);
         Data data = toData(message);
         ClientMessage request = TopicPublishCodec.encodeRequest(name, data);
         invokeOnPartition(request);

--- a/hazelcast/src/main/java/com/hazelcast/topic/ITopic.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/ITopic.java
@@ -19,7 +19,6 @@ package com.hazelcast.topic;
 import com.hazelcast.core.DistributedObject;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.UUID;
 
 /**
@@ -62,7 +61,7 @@ public interface ITopic<E> extends DistributedObject {
      * @throws TopicOverloadException if the consumer is too slow
      *                                (only works in combination with reliable topic)
      */
-    void publish(@Nullable E message);
+    void publish(@Nonnull E message);
 
     /**
      * Subscribes to this topic. When a message is published, the

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.topic.impl;
 
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.topic.MessageListener;
-import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.LocalTopicStats;
+import com.hazelcast.topic.MessageListener;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import java.util.UUID;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -36,14 +34,16 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  */
 public class TopicProxy<E> extends TopicProxySupport implements ITopic<E> {
 
-    private static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
+    protected static final String NULL_MESSAGE_IS_NOT_ALLOWED = "Null message is not allowed!";
+    protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
 
     public TopicProxy(String name, NodeEngine nodeEngine, TopicService service) {
         super(name, nodeEngine, service);
     }
 
     @Override
-    public void publish(@Nullable E message) {
+    public void publish(@Nonnull E message) {
+        checkNotNull(message, NULL_MESSAGE_IS_NOT_ALLOWED);
         publishInternal(message);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -95,7 +95,7 @@ public abstract class TopicProxySupport extends AbstractDistributedObject<TopicS
      *
      * @param message the message to be published
      */
-    public void publishInternal(Object message) {
+    public void publishInternal(@Nonnull Object message) {
         topicStats.incrementPublishes();
         topicService.publishMessage(name, message, multithreaded);
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -20,7 +20,9 @@ import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * Topic proxy used when global ordering is enabled (all nodes listening to
@@ -38,7 +40,8 @@ public class TotalOrderedTopicProxy<E> extends TopicProxy<E> {
     }
 
     @Override
-    public void publish(@Nullable E message) {
+    public void publish(@Nonnull  E message) {
+        checkNotNull(message, NULL_MESSAGE_IS_NOT_ALLOWED);
         Operation operation = new PublishOperation(getName(), toData(message))
                 .setPartitionId(partitionId);
         InternalCompletableFuture f = invokeOnPartition(operation);

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicNullTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.topic.AbstractTopicNullTest;
+import com.hazelcast.topic.impl.reliable.AbstractReliableTopicNullTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientTopicNullTest extends AbstractTopicNullTest {
+public class ClientReliableTopicNullTest extends AbstractReliableTopicNullTest {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     private HazelcastInstance client;

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
@@ -82,12 +82,6 @@ public class ClientReliableTopicTest extends HazelcastTestSupport {
 
     // ============== addMessageListener ==============================
 
-    @Test(expected = NullPointerException.class)
-    public void addMessageListener_whenNull() {
-        ITopic topic = client.getReliableTopic(randomString());
-        topic.addMessageListener(null);
-    }
-
     @Test
     public void addMessageListener() {
         ITopic topic = client.getReliableTopic(randomString());
@@ -96,12 +90,6 @@ public class ClientReliableTopicTest extends HazelcastTestSupport {
     }
 
     // ============== removeMessageListener ==============================
-
-    @Test(expected = NullPointerException.class)
-    public void removeMessageListener_whenNull() {
-        ITopic topic = client.getReliableTopic(randomString());
-        topic.removeMessageListener(null);
-    }
 
     @Test
     public void removeMessageListener_whenExisting() {
@@ -165,21 +153,6 @@ public class ClientReliableTopicTest extends HazelcastTestSupport {
             @Override
             public void run() throws Exception {
                 assertContains(listener.objects, msg);
-            }
-        });
-    }
-
-    @Test
-    public void publishNull() throws InterruptedException {
-        ITopic topic = client.getReliableTopic(randomString());
-        final ReliableMessageListenerMock listener = new ReliableMessageListenerMock();
-        topic.addMessageListener(listener);
-        topic.publish(null);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertContains(listener.objects, null);
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/topic/AbstractTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/AbstractTopicNullTest.java
@@ -32,6 +32,7 @@ public abstract class AbstractTopicNullTest extends HazelcastTestSupport {
     public void testNullability() {
         assertThrowsNPE(t -> t.addMessageListener(null));
         assertThrowsNPE(t -> t.removeMessageListener(null));
+        assertThrowsNPE(t -> t.publish(null));
     }
 
     private void assertThrowsNPE(ConsumerEx<ITopic<Object>> method) {

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/AbstractReliableTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/AbstractReliableTopicNullTest.java
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-package com.hazelcast.topic;
+package com.hazelcast.topic.impl.reliable;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.topic.ITopic;
 import org.junit.Test;
 
-public abstract class AbstractTopicNullTest extends HazelcastTestSupport {
+public abstract class AbstractReliableTopicNullTest extends HazelcastTestSupport {
 
     @Test(expected = NullPointerException.class)
     public void testAddNullMessageListener() {
-        ITopic<Object> topic = getDriver().getTopic(randomName());
+        ITopic<Object> topic = getDriver().getReliableTopic(randomName());
         topic.addMessageListener(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testRemoveMessageListenerWithNullId() {
-        ITopic<Object> topic = getDriver().getTopic(randomName());
+        ITopic<Object> topic = getDriver().getReliableTopic(randomName());
         topic.removeMessageListener(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testPublishNullMessage() {
-        ITopic<Object> topic = getDriver().getTopic(randomName());
+        ITopic<Object> topic = getDriver().getReliableTopic(randomName());
         topic.publish(null);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/MemberReliableTopicNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/MemberReliableTopicNullTest.java
@@ -14,42 +14,34 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.topic;
+package com.hazelcast.topic.impl.reliable;
 
-import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.topic.AbstractTopicNullTest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
- * Member implementation for basic queue methods nullability tests
+ * Member implementation for basic map methods nullability tests
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientTopicNullTest extends AbstractTopicNullTest {
+public class MemberReliableTopicNullTest extends AbstractReliableTopicNullTest {
 
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-    private HazelcastInstance client;
+    private HazelcastInstance instance;
 
     @Before
     public void setup() {
-        hazelcastFactory.newHazelcastInstance();
-        client = hazelcastFactory.newHazelcastClient();
-    }
-
-    @After
-    public void tearDown() {
-        hazelcastFactory.terminateAll();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
     }
 
     @Override
     protected HazelcastInstance getDriver() {
-        return client;
+        return instance;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
@@ -72,11 +72,6 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
 
     // ============== addMessageListener ==============================
 
-    @Test(expected = NullPointerException.class)
-    public void addMessageListener_whenNull() {
-        topic.addMessageListener(null);
-    }
-
     @Test
     public void addMessageListener() {
         UUID id = topic.addMessageListener(new ReliableMessageListenerMock());
@@ -85,11 +80,6 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
     }
 
     // ============== removeMessageListener ==============================
-
-    @Test(expected = NullPointerException.class)
-    public void removeMessageListener_whenNull() {
-        topic.removeMessageListener(null);
-    }
 
     @Test
     public void removeMessageListener_whenExisting() {
@@ -149,20 +139,6 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
             @Override
             public void run() throws Exception {
                 assertContains(listener.objects, msg);
-            }
-        });
-    }
-
-    @Test
-    public void publishNull() throws InterruptedException {
-        final ReliableMessageListenerMock listener = new ReliableMessageListenerMock();
-        topic.addMessageListener(listener);
-        topic.publish(null);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertContains(listener.objects, null);
             }
         });
     }


### PR DESCRIPTION
To allow client and member behaviour, we disallow publishing
`null` message on topic
fixes https://github.com/hazelcast/hazelcast/issues/15338