### PR TITLE
Support for force-init and publish of uninitialized proxies

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -309,4 +309,17 @@ public final class ProxyRegistry {
             ((AbstractDistributedObject) distributedObject).invalidate();
         }
     }
+
+    /**
+     * Force-initializes and publishes all uninitialized proxies in this registry.
+     */
+    void initializeAndPublishProxies() {
+        for (Map.Entry<String, DistributedObjectFuture> entry : proxies.entrySet()) {
+            DistributedObjectFuture future = entry.getValue();
+            if (!future.isSetAndInitialized()) {
+                extractDistributedObject(future);
+                publish(new DistributedObjectEventPacket(CREATED, serviceName, entry.getKey()));
+            }
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -312,13 +312,32 @@ public final class ProxyRegistry {
 
     /**
      * Force-initializes and publishes all uninitialized proxies in this registry.
+     * <p>
+     * This method assumes that the uninitialized proxies originate from
+     * {@code doCreateProxy(publishEvent=false, initialize=false, ...)}. Since local
+     * events were already emitted for such proxies, only remote events are published
+     * by this method.
+     * <p>
+     * Calling this method concurrently with
+     * {@code doCreateProxy(publishEvent=true)} may result in publishing the remote
+     * events multiple times for some of the proxies.
      */
     void initializeAndPublishProxies() {
         for (Map.Entry<String, DistributedObjectFuture> entry : proxies.entrySet()) {
+            String name = entry.getKey();
             DistributedObjectFuture future = entry.getValue();
             if (!future.isSetAndInitialized()) {
-                extractDistributedObject(future);
-                publish(new DistributedObjectEventPacket(CREATED, serviceName, entry.getKey()));
+                try {
+                    future.get();
+                } catch (Throwable e) {
+                    // proxy initialization failed
+                    // deregister future to avoid infinite hang on future.get()
+                    proxyService.logger.warning("Error while initializing proxy: " + name, e);
+                    future.setError(e);
+                    proxies.remove(entry.getKey());
+                    throw rethrow(e);
+                }
+                publish(new DistributedObjectEventPacket(CREATED, serviceName, name));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -124,6 +124,12 @@ public class ProxyServiceImpl
         return count;
     }
 
+    public void initializeAndPublishProxies() {
+        for (ProxyRegistry registry : registries.values()) {
+            registry.initializeAndPublishProxies();
+        }
+    }
+
     @Override
     public void initializeDistributedObject(String serviceName, String name) {
         checkServiceNameNotNull(serviceName);


### PR DESCRIPTION
Added functionality to `ProxyServiceImpl` to force-initialize
and publish all uninitialized proxy objects.

Relates to https://github.com/hazelcast/hazelcast-enterprise/issues/3325
Required for https://github.com/hazelcast/hazelcast-enterprise/pull/3343 (EE)