### PR TITLE
Remove check for upper threshold for statistics test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -367,12 +367,8 @@ public class ClientStatisticsTest extends ClientTestSupport {
         // it's seen during the tests that the collection time may be much larger (up to 9 seconds),
         // hence we will keep the upperThreshold a lot higher
         double lowerThreshold = STATS_PERIOD_MILLIS * 0.9;
-        double upperThreshold = STATS_PERIOD_MILLIS * 20.0;
         assertTrue("Time difference between two collections is " + timeDifferenceMillis
                         + " ms but, but it should be greater than " + lowerThreshold + " ms",
                 timeDifferenceMillis >= lowerThreshold);
-        assertTrue("Time difference between two collections is " + timeDifferenceMillis
-                        + " ms, but it should be less than " + upperThreshold + " ms",
-                timeDifferenceMillis <= upperThreshold);
     }
 }


### PR DESCRIPTION
Test will verify that we get next statistics eventually, but it will not check for if the period is longer than it needs to be. 
fixes https://github.com/hazelcast/hazelcast/issues/15965