### PR TITLE
Metrics fixes and improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptor.java
@@ -137,8 +137,34 @@ public interface MetricDescriptor {
      * Calls the given {@code tagReader} with all tags in this descriptor.
      *
      * @param tagReader The reader to call
+     * @see #tag(int)
+     * @see #tagValue(int)
      */
     void readTags(BiConsumer<String, String> tagReader);
+
+    /**
+     * Returns the name of the tag at the given index.
+     *
+     * @param index The index
+     * @return the name of the tag
+     * @see #tagValue(int)
+     * @see #tagCount()
+     * @see #readTags(BiConsumer)
+     */
+    @Nullable
+    String tag(int index);
+
+    /**
+     * Returns the value of the tag at the given index.
+     *
+     * @param index The index
+     * @return the value of the tag
+     * @see #tag(int)
+     * @see #tagCount()
+     * @see #readTags(BiConsumer)
+     */
+    @Nullable
+    String tagValue(int index);
 
     /**
      * Returns the number of tags in this descriptor.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricDescriptorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricDescriptorImpl.java
@@ -36,6 +36,7 @@ import static java.util.Objects.requireNonNull;
  * Default implementation of {@link MetricDescriptor} and
  * {@link MetricDescriptor}.
  */
+@SuppressWarnings("checkstyle:MethodCount")
 public final class MetricDescriptorImpl implements MetricDescriptor {
     private static final int INITIAL_TAG_CAPACITY = 4;
     private static final double GROW_FACTOR = 1.2D;
@@ -186,6 +187,26 @@ public final class MetricDescriptorImpl implements MetricDescriptor {
             String tagValue = tags[i + 1];
             tagReader.accept(tag, tagValue);
         }
+    }
+
+    @Override
+    public String tag(int index) {
+        index = index << 1;
+        if (index < 0 || index >= tags.length) {
+            return null;
+        }
+
+        return tags[index];
+    }
+
+    @Override
+    public String tagValue(int index) {
+        index = (index << 1) + 1;
+        if (index < 0 || index >= tags.length) {
+            return null;
+        }
+
+        return tags[index];
     }
 
     @Override
@@ -465,5 +486,4 @@ public final class MetricDescriptorImpl implements MetricDescriptor {
             return metricName();
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -171,7 +171,8 @@ public class JmxPublisher implements MetricsPublisher {
         /**
          * See {@link MetricsConfig#setJmxEnabled(boolean)}.
          */
-        @SuppressWarnings({"checkstyle:ExecutableStatementCount", "checkstyle:NPathComplexity"})
+        @SuppressWarnings({"checkstyle:ExecutableStatementCount", "checkstyle:NPathComplexity",
+                           "checkstyle:CyclomaticComplexity"})
         MetricData(MetricDescriptor descriptor, String instanceNameEscaped, String domainPrefix) {
             StringBuilder mBeanTags = new StringBuilder();
             StringBuilder moduleBuilder = new StringBuilder();
@@ -201,6 +202,9 @@ public class JmxPublisher implements MetricsPublisher {
             String discriminator = descriptor.discriminator();
             String discriminatorValue = descriptor.discriminatorValue();
             if (discriminator != null && discriminatorValue != null) {
+                if (mBeanTags.length() > 0) {
+                    mBeanTags.append(',');
+                }
                 int newTagIdx = tagCnt.getAndInc();
                 mBeanTags.append("tag").append(newTagIdx).append("=")
                          .append(escapeObjectNameValue(discriminator + "=" + discriminatorValue));

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -180,7 +180,10 @@ public class JmxPublisher implements MetricsPublisher {
             ProbeUnit descriptorUnit = descriptor.unit();
             unit = descriptorUnit != null ? descriptorUnit.name() : "unknown";
             MutableInteger tagCnt = new MutableInteger();
-            descriptor.readTags((tag, tagValue) -> {
+            for (int i = 0; i < descriptor.tagCount(); i++) {
+                String tag = descriptor.tag(i);
+                String tagValue = descriptor.tagValue(i);
+
                 if ("module".equals(tag)) {
                     moduleBuilder.append(tagValue);
                 } else {
@@ -191,16 +194,16 @@ public class JmxPublisher implements MetricsPublisher {
                     mBeanTags.append("tag").append(newTagIdx).append('=')
                              .append(escapeObjectNameValue(tag + "=" + tagValue));
                 }
-            });
+            }
             if (moduleBuilder.length() > 0) {
                 module = moduleBuilder.toString();
             }
             String discriminator = descriptor.discriminator();
             String discriminatorValue = descriptor.discriminatorValue();
             if (discriminator != null && discriminatorValue != null) {
-                mBeanTags.append(escapeObjectNameValue(discriminator))
-                         .append('=')
-                         .append(escapeObjectNameValue(discriminatorValue));
+                int newTagIdx = tagCnt.getAndInc();
+                mBeanTags.append("tag").append(newTagIdx).append("=")
+                         .append(escapeObjectNameValue(discriminator + "=" + discriminatorValue));
             }
 
             assert metric != null : "metric == null";

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -101,7 +101,21 @@ public class JmxPublisherTest {
     }
 
     @Test
-    public void when_singleMetricNewFormatWithModule() throws Exception {
+    public void when_singleMetricWithPrefixAndDiscriminator() throws Exception {
+        MetricDescriptor descriptor = newDescriptor()
+                .withPrefix("d")
+                .withMetric("c")
+                .withDiscriminator("name", "itsName")
+                .withTag("tag1", "a")
+                .withTag("tag2", "b");
+        jmxPublisher.publishLong(descriptor, 1L);
+        assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,prefix=d,tag0=\"tag1=a\",tag1=\"tag2=b\",tag2=\"name=itsName\"",
+                        singletonList(entry("c", 1L)))));
+    }
+
+    @Test
+    public void when_singleMetricWithModule() throws Exception {
         MetricDescriptor descriptor = newDescriptor()
                 .withMetric("c")
                 .withTag("tag1", "a")
@@ -113,7 +127,7 @@ public class JmxPublisherTest {
     }
 
     @Test
-    public void when_moreMetricsNewFormat() throws Exception {
+    public void when_moreMetrics() throws Exception {
         jmxPublisher.publishLong(newDescriptor()
                 .withMetric("c")
                 .withTag("tag1", "a")


### PR DESCRIPTION
- Add `tag(index)` and `tagValue(index)` to prevent allocation with
`readTags(BiConsumer)` in some cases
- Fix JmxPublisher to render discriminator tag correctly