### PR TITLE
Fix issues in local Raft nodes cleanup task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -121,7 +121,7 @@ class RaftGroupMembershipManager {
     private class CheckLocalRaftNodesTask implements Runnable {
 
         public void run() {
-            if (skipRunningTask()) {
+            if (!(raftService.isDiscoveryCompleted() && raftService.isStartCompleted())) {
                 return;
             }
 
@@ -139,7 +139,7 @@ class RaftGroupMembershipManager {
                     continue;
                 }
 
-                CompletableFuture<CPGroupInfo> f = queryMetadata(new GetRaftGroupOp(groupId));
+                CompletableFuture<CPGroupSummary> f = queryMetadata(new GetRaftGroupOp(groupId));
 
                 f.whenCompleteAsync((group, t) -> {
                     if (t == null) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/persistence/RestoredRaftState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/persistence/RestoredRaftState.java
@@ -43,7 +43,7 @@ public class RestoredRaftState {
             @Nonnull RaftEndpoint localEndpoint,
             @Nonnull Collection<RaftEndpoint> initialMembers,
             int term,
-            @Nonnull RaftEndpoint votedFor,
+            @Nullable RaftEndpoint votedFor,
             @Nullable SnapshotEntry snapshot,
             @Nonnull LogEntry[] entries
     ) {
@@ -69,7 +69,7 @@ public class RestoredRaftState {
         return term;
     }
 
-    @Nonnull
+    @Nullable
     public RaftEndpoint votedFor() {
         return votedFor;
     }


### PR DESCRIPTION
`CheckLocalRaftNodesTask` is a periodic task and responsible for
handling terminated or stepped-down nodes.

- It should run on every CP member, not just on METADATA leader.
- `GetRaftGroupOp` returns `CPGroupSummary`, not `CPGroupInfo`.