### PR TITLE
Fix multiplier config to be set as double from xml

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
@@ -191,7 +191,7 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             } else if (maxBackoffMillis.equals(nodeName)) {
                 connectionRetryConfig.setMaxBackoffMillis(getIntegerValue(maxBackoffMillis, value));
             } else if (multiplier.equals(nodeName)) {
-                connectionRetryConfig.setMultiplier(getIntegerValue(multiplier, value));
+                connectionRetryConfig.setMultiplier(getDoubleValue(multiplier, value));
             } else if ("fail-on-max-backoff".equals(nodeName)) {
                 connectionRetryConfig.setFailOnMaxBackoff(getBooleanValue(value));
             } else if (jitter.equals(nodeName)) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -280,7 +280,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
         assertEquals(0.5, exponentialRetryConfig.getJitter(), 0);
         assertEquals(2000, exponentialRetryConfig.getInitialBackoffMillis());
         assertEquals(60000, exponentialRetryConfig.getMaxBackoffMillis());
-        assertEquals(3, exponentialRetryConfig.getMultiplier(), 0);
+        assertEquals(3.1, exponentialRetryConfig.getMultiplier(), 0);
     }
 
     @Test

--- a/hazelcast-client/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-full.xml
@@ -285,7 +285,7 @@
         <connection-retry enabled="true">
             <initial-backoff-millis>2000</initial-backoff-millis>
             <max-backoff-millis>60000</max-backoff-millis>
-            <multiplier>3</multiplier>
+            <multiplier>3.1</multiplier>
             <fail-on-max-backoff>true</fail-on-max-backoff>
             <jitter>0.5</jitter>
         </connection-retry>

--- a/hazelcast-client/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-full.yaml
@@ -274,7 +274,7 @@ hazelcast-client:
       enabled: true
       initial-backoff-millis: 2000
       max-backoff-millis: 60000
-      multiplier: 3
+      multiplier: 3.1
       fail-on-max-backoff: true
       jitter: 0.5
 


### PR DESCRIPTION
Backports the fix done here
https://github.com/hazelcast/hazelcast/pull/15821/files#diff-8e281ab46ab63892f2b6de961ba839e7R194