### PR TITLE
EntryLoader: ignore entries with calculated TTL equal to 0

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -351,7 +351,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (mapDataStore.isWithExpirationTime()) {
             MetadataAwareValue loaderEntry = (MetadataAwareValue) value;
             long proposedTtl = expirationTimeToTtl(loaderEntry.getExpirationTime());
-            if (proposedTtl < 0) {
+            if (proposedTtl <= 0) {
                 return null;
             }
             value = loaderEntry.getValue();
@@ -375,7 +375,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         return record;
     }
 
-    private long expirationTimeToTtl(long definedExpirationTime) {
+    protected long expirationTimeToTtl(long definedExpirationTime) {
         return definedExpirationTime - System.currentTimeMillis();
     }
 
@@ -645,7 +645,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             if (mapDataStore.isWithExpirationTime()) {
                 MetadataAwareValue loaderEntry = (MetadataAwareValue) value;
 
-                if (expirationTimeToTtl(loaderEntry.getExpirationTime()) >= 0) {
+                if (expirationTimeToTtl(loaderEntry.getExpirationTime()) > 0) {
                     resultMap.put(key, loaderEntry.getValue());
                 }
                 putFromLoad(key, loaderEntry.getValue(), loaderEntry.getExpirationTime(), callerAddress);
@@ -937,7 +937,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             return putFromLoad(key, value, callerAddress);
         }
         long ttl = expirationTimeToTtl(expirationTime);
-        if (ttl < 0) {
+        if (ttl <= 0) {
             return null;
         }
         return putFromLoadInternal(key, value, ttl, UNSET, false, callerAddress);
@@ -954,7 +954,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             return putFromLoadBackup(key, value);
         }
         long ttl = expirationTimeToTtl(expirationTime);
-        if (ttl < 0) {
+        if (ttl <= 0) {
             return null;
         }
         return putFromLoadInternal(key, value, ttl, UNSET, true, null);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -211,6 +211,18 @@ public interface RecordStore<R extends Record> {
      */
     Object putFromLoad(Data key, Object value, Address callerAddress);
 
+    /**
+     * Puts key-value pair (with expiration time) to map which is the result of a load from
+     * map store operation.
+     *
+     * @param key            key to put.
+     * @param value          to put.
+     * @param expirationTime the expiration time of the key-value pair {@link Long#MAX_VALUE
+     *                       if the key-value pair should not expire}.
+     * @return the previous value associated with <tt>key</tt>, or
+     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
+     * @see com.hazelcast.map.impl.operation.PutFromLoadAllOperation
+     */
     Object putFromLoad(Data key, Object value, long expirationTime, Address callerAddress);
 
     /**
@@ -224,6 +236,18 @@ public interface RecordStore<R extends Record> {
      */
     Object putFromLoadBackup(Data key, Object value);
 
+    /**
+     * Puts key-value pair (with expiration time) to map which is the result of a load from
+     * map store operation on backup.
+     *
+     * @param key            key to put.
+     * @param value          to put.
+     * @param expirationTime the expiration time of the key-value pair {@link Long#MAX_VALUE
+     *                       if the key-value pair should not expire}.
+     * @return the previous value associated with <tt>key</tt>, or
+     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
+     * @see com.hazelcast.map.impl.operation.PutFromLoadAllBackupOperation
+     */
     Object putFromLoadBackup(Data key, Object value, long expirationTime);
 
     boolean merge(MapMergeTypes mergingEntry,


### PR DESCRIPTION
When a MetadataAwareValue was loaded (for instance in
DefaultRecordStore.loadRecordOrNull()) exactly (in millis)
at its expiration time, the entry would be marked as
non-expirable. This was because we convert the expiration
time to TTL (expiration time - current time) and if the TTL
was 0, we treated the record as non-expirable.

Changed the above TTL comparison code from greater/less-than
to greater/less-than-or-equal.

Also added missing (internal) javadoc to
RecordStore.putFromLoad[Backup].

Fixes https://github.com/hazelcast/hazelcast/issues/15991