### PR TITLE
Client metrics configuration

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -1516,6 +1516,7 @@
                     <xs:element name="user-code-deployment" type="user-code-deployment-client" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="flake-id-generator" type="client-flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="reliable-topic" type="client-reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="metrics" type="client-metrics" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:choice>
                 <xs:attribute name="executor-pool-size" type="xs:int" use="optional"/>
             </xs:extension>
@@ -3454,6 +3455,32 @@
             <xs:simpleType>
                 <xs:restriction base="xs:string"/>
             </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="client-metrics">
+        <xs:all>
+            <xs:element name="jmx" type="metrics-jmx" minOccurs="0"/>
+            <xs:element name="collection-frequency-seconds" type="xs:unsignedInt" default="5" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the metrics collection frequency in seconds.
+                        By default, metrics are collected every 5 seconds.
+                        May be overridden by 'hazelcast.metrics.collection.frequency'
+                        system property.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Master-switch for the metrics system. Controls whether
+                    the metrics are collected and publishers are enabled.
+                    May be overridden by 'hazelcast.metrics.enabled'
+                    system property.
+                </xs:documentation>
+            </xs:annotation>
         </xs:attribute>
     </xs:complexType>
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -24,6 +24,7 @@ import com.hazelcast.client.config.ClientConnectionStrategyConfig;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode;
 import com.hazelcast.client.config.ClientFlakeIdGeneratorConfig;
 import com.hazelcast.client.config.ClientIcmpPingConfig;
+import com.hazelcast.client.config.ClientMetricsConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.ClientReliableTopicConfig;
 import com.hazelcast.client.config.ClientUserCodeDeploymentConfig;
@@ -31,6 +32,9 @@ import com.hazelcast.client.config.ConnectionRetryConfig;
 import com.hazelcast.client.config.ProxyFactoryConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.util.RoundRobinLB;
+import com.hazelcast.collection.IList;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.ISet;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EvictionPolicy;
@@ -48,15 +52,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.cp.ICountDownLatch;
-import com.hazelcast.collection.IList;
-import com.hazelcast.map.IMap;
-import com.hazelcast.collection.IQueue;
 import com.hazelcast.cp.ISemaphore;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.collection.ISet;
+import com.hazelcast.map.IMap;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -134,6 +135,9 @@ public class TestClientApplicationContext {
 
     @Resource(name = "client17-backupAckToClient")
     private HazelcastClientProxy backupAckToClient;
+
+    @Resource(name = "client18-metrics")
+    private HazelcastClientProxy metricsClient;
 
     @Resource(name = "instance")
     private HazelcastInstance instance;
@@ -487,5 +491,14 @@ public class TestClientApplicationContext {
     @Test
     public void testBackupAckToClient() {
         assertFalse(backupAckToClient.getClientConfig().isBackupAckToClientEnabled());
+    }
+
+    @Test
+    public void testMetrics() {
+        ClientMetricsConfig metricsConfig = metricsClient.getClientConfig().getMetricsConfig();
+
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+        assertEquals(42, metricsConfig.getCollectionFrequencySeconds());
     }
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -379,6 +379,18 @@
         <hz:backup-ack-to-client-enabled>false</hz:backup-ack-to-client-enabled>
     </hz:client>
 
+    <hz:client id="client18-metrics">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
+        <hz:network>
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+        </hz:network>
+        <hz:metrics enabled="false">
+            <hz:jmx enabled="false"/>
+            <hz:collection-frequency-seconds>42</hz:collection-frequency-seconds>
+        </hz:metrics>
+    </hz:client>
+
     <bean id="credentials" class="com.hazelcast.security.UsernamePasswordCredentials">
         <property name="name" value="spring-cluster"/>
         <property name="password" value="spring-cluster-pass"/>

--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -18,11 +18,11 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientFailoverConfig;
-import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.client.impl.clientside.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.clientside.DefaultClientConnectionManagerFactory;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -16,11 +16,25 @@
 
 package com.hazelcast.client.config;
 
-import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
-import static com.hazelcast.internal.util.Preconditions.checkFalse;
-import static com.hazelcast.internal.util.Preconditions.isNotNull;
-import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
+import com.hazelcast.client.Client;
+import com.hazelcast.client.LoadBalancer;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigPatternMatcher;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.NativeMemoryConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
+import com.hazelcast.core.ManagedContext;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.internal.config.ConfigUtils;
+import com.hazelcast.internal.util.Preconditions;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.security.Credentials;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -33,26 +47,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import javax.annotation.Nonnull;
-
-import com.hazelcast.client.Client;
-import com.hazelcast.client.LoadBalancer;
-import com.hazelcast.config.Config;
-import com.hazelcast.config.ConfigPatternMatcher;
-import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.ListenerConfig;
-import com.hazelcast.config.MetricsConfig;
-import com.hazelcast.config.NativeMemoryConfig;
-import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.config.QueryCacheConfig;
-import com.hazelcast.config.SerializationConfig;
-import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
-import com.hazelcast.core.ManagedContext;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
-import com.hazelcast.internal.config.ConfigUtils;
-import com.hazelcast.internal.util.Preconditions;
-import com.hazelcast.partition.strategy.StringPartitioningStrategy;
-import com.hazelcast.security.Credentials;
+import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
+import static com.hazelcast.internal.util.Preconditions.checkFalse;
+import static com.hazelcast.internal.util.Preconditions.isNotNull;
+import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
 /**
  * Main configuration to setup a Hazelcast Client
@@ -109,7 +107,7 @@ public class ClientConfig {
     private final Map<String, ClientFlakeIdGeneratorConfig> flakeIdGeneratorConfigMap;
     private final Set<String> labels;
     private final ConcurrentMap<String, Object> userContext;
-    private MetricsConfig metricsConfig = new MetricsConfig();
+    private ClientMetricsConfig metricsConfig = new ClientMetricsConfig();
 
     public ClientConfig() {
         listenerConfigs = new LinkedList<>();
@@ -172,7 +170,7 @@ public class ClientConfig {
         }
         labels = new HashSet<>(config.labels);
         userContext = new ConcurrentHashMap<>(config.userContext);
-        metricsConfig = new MetricsConfig(config.metricsConfig);
+        metricsConfig = new ClientMetricsConfig(config.metricsConfig);
     }
 
     /**
@@ -893,7 +891,7 @@ public class ClientConfig {
      * Returns the metrics collection config.
      */
     @Nonnull
-    public MetricsConfig getMetricsConfig() {
+    public ClientMetricsConfig getMetricsConfig() {
         return metricsConfig;
     }
 
@@ -901,7 +899,7 @@ public class ClientConfig {
      * Sets the metrics collection config.
      */
     @Nonnull
-    public ClientConfig setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
+    public ClientConfig setMetricsConfig(@Nonnull ClientMetricsConfig metricsConfig) {
         Preconditions.checkNotNull(metricsConfig, "metricsConfig");
         this.metricsConfig = metricsConfig;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.AliasedDiscoveryConfig;
-import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.config.ConfigXmlGenerator.XmlGenerator;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.DiscoveryConfig;
@@ -40,6 +39,7 @@ import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
+import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -60,8 +60,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
-import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
 /**
  * The ClientConfigXmlGenerator is responsible for transforming a
@@ -136,6 +136,8 @@ public final class ClientConfigXmlGenerator {
         userCodeDeployment(gen, clientConfig.getUserCodeDeploymentConfig());
         //FlakeIdGenerator
         flakeIdGenerator(gen, clientConfig.getFlakeIdGeneratorConfigMap());
+        //Metrics
+        metrics(gen, clientConfig.getMetricsConfig());
 
         //close HazelcastClient
         gen.close();
@@ -585,5 +587,13 @@ public final class ClientConfigXmlGenerator {
         return !isNullOrEmpty(className) ? className
                 : impl != null ? impl.getClass().getName()
                 : null;
+    }
+
+    private static void metrics(XmlGenerator gen, ClientMetricsConfig metricsConfig) {
+        gen.open("metrics", "enabled", metricsConfig.isEnabled())
+           .open("jmx", "enabled", metricsConfig.getJmxConfig().isEnabled())
+           .close()
+           .node("collection-frequency-seconds", metricsConfig.getCollectionFrequencySeconds())
+           .close();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientMetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientMetricsConfig.java
@@ -14,40 +14,24 @@
  * limitations under the License.
  */
 
-package com.hazelcast.config;
+package com.hazelcast.client.config;
 
-import javax.annotation.Nonnull;
+import com.hazelcast.config.BaseMetricsConfig;
+
 import java.util.Objects;
 
-import static java.util.Objects.requireNonNull;
-
 /**
- * Member-side metrics collection configuration.
+ * Client-side metrics collection configuration.
  *
  * @since 4.0
  */
-public class MetricsConfig extends BaseMetricsConfig<MetricsConfig> {
-
-    private MetricsManagementCenterConfig managementCenterConfig = new MetricsManagementCenterConfig();
-
-    public MetricsConfig() {
+public class ClientMetricsConfig extends BaseMetricsConfig<ClientMetricsConfig> {
+    public ClientMetricsConfig() {
         super();
     }
 
-    public MetricsConfig(MetricsConfig metricsConfig) {
+    public ClientMetricsConfig(ClientMetricsConfig metricsConfig) {
         super(metricsConfig);
-        this.managementCenterConfig = new MetricsManagementCenterConfig(metricsConfig.managementCenterConfig);
-    }
-
-    @Nonnull
-    public MetricsConfig setManagementCenterConfig(MetricsManagementCenterConfig managementCenterConfig) {
-        this.managementCenterConfig = requireNonNull(managementCenterConfig, "Management Center config must not be null");
-        return this;
-    }
-
-    @Nonnull
-    public MetricsManagementCenterConfig getManagementCenterConfig() {
-        return managementCenterConfig;
     }
 
     @Override
@@ -56,11 +40,11 @@ public class MetricsConfig extends BaseMetricsConfig<MetricsConfig> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof MetricsConfig)) {
+        if (!(o instanceof ClientMetricsConfig)) {
             return false;
         }
 
-        MetricsConfig that = (MetricsConfig) o;
+        ClientMetricsConfig that = (ClientMetricsConfig) o;
 
         if (enabled != that.enabled) {
             return false;
@@ -68,16 +52,12 @@ public class MetricsConfig extends BaseMetricsConfig<MetricsConfig> {
         if (collectionFrequencySeconds != that.collectionFrequencySeconds) {
             return false;
         }
-        if (!Objects.equals(managementCenterConfig, that.managementCenterConfig)) {
-            return false;
-        }
         return Objects.equals(jmxConfig, that.jmxConfig);
     }
 
     @Override
     public final int hashCode() {
-        int result = Boolean.hashCode(enabled);
-        result = 31 * result + (managementCenterConfig != null ? managementCenterConfig.hashCode() : 0);
+        int result = (enabled ? 1 : 0);
         result = 31 * result + (jmxConfig != null ? jmxConfig.hashCode() : 0);
         result = 31 * result + collectionFrequencySeconds;
         return result;
@@ -85,11 +65,11 @@ public class MetricsConfig extends BaseMetricsConfig<MetricsConfig> {
 
     @Override
     public String toString() {
-        return "MetricsConfig{"
+        return "ClientMetricsConfig{"
                 + "enabled=" + enabled
-                + ", managementCenterConfig=" + managementCenterConfig
                 + ", jmxConfig=" + jmxConfig
                 + ", collectionFrequencySeconds=" + collectionFrequencySeconds
                 + '}';
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientConfigSections.java
@@ -37,8 +37,12 @@ public enum ClientConfigSections {
     BACKUP_ACK_TO_CLIENT("backup-ack-to-client-enabled", false),
     INSTANCE_NAME("instance-name", false),
     CONNECTION_STRATEGY("connection-strategy", false),
-    USER_CODE_DEPLOYMENT("user-code-deployment", false), FLAKE_ID_GENERATOR("flake-id-generator", true), RELIABLE_TOPIC(
-            "reliable-topic", true), LABELS("client-labels", false);
+    USER_CODE_DEPLOYMENT("user-code-deployment", false),
+    FLAKE_ID_GENERATOR("flake-id-generator", true),
+    RELIABLE_TOPIC("reliable-topic", true),
+    LABELS("client-labels", false),
+    CLUSTER_NAME("cluster-name", false),
+    METRICS("metrics", false);
 
     final boolean multipleOccurrence;
     private final String name;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -204,12 +204,16 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                                        AddressProvider externalAddressProvider) {
         assert clientConfig != null || clientFailoverConfig != null : "At most one type of config can be provided";
         assert clientConfig == null || clientFailoverConfig == null : "At least one config should be provided ";
-        MetricsConfigHelper.overrideClientMetricsConfig(clientConfig);
         if (clientConfig != null) {
+            MetricsConfigHelper.overrideClientMetricsConfig(clientConfig);
             this.config = clientConfig;
         } else {
+            for (ClientConfig failoverClientConfig : clientFailoverConfig.getClientConfigs()) {
+                MetricsConfigHelper.overrideClientMetricsConfig(failoverClientConfig);
+            }
             this.config = clientFailoverConfig.getClientConfigs().get(0);
         }
+        MetricsConfigHelper.overrideClientMetricsConfig(this.config);
         this.clientFailoverConfig = clientFailoverConfig;
         if (config.getInstanceName() != null) {
             instanceName = config.getInstanceName();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -213,7 +213,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             }
             this.config = clientFailoverConfig.getClientConfigs().get(0);
         }
-        MetricsConfigHelper.overrideClientMetricsConfig(this.config);
         this.clientFailoverConfig = clientFailoverConfig;
         if (config.getInstanceName() != null) {
             instanceName = config.getInstanceName();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -94,6 +94,7 @@ import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
 import com.hazelcast.internal.diagnostics.SystemPropertiesPlugin;
+import com.hazelcast.internal.metrics.impl.MetricsConfigHelper;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.internal.metrics.metricsets.ClassLoadingMetricSet;
 import com.hazelcast.internal.metrics.metricsets.FileMetricSet;
@@ -203,6 +204,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                                        AddressProvider externalAddressProvider) {
         assert clientConfig != null || clientFailoverConfig != null : "At most one type of config can be provided";
         assert clientConfig == null || clientFailoverConfig == null : "At least one config should be provided ";
+        MetricsConfigHelper.overrideClientMetricsConfig(clientConfig);
         if (clientConfig != null) {
             this.config = clientConfig;
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.properties;
 
+import com.hazelcast.client.config.ClientMetricsConfig;
+import com.hazelcast.config.MetricsJmxConfig;
 import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
@@ -240,11 +242,57 @@ public final class ClientProperty {
             "hazelcast.client.statistics.period.seconds", 3, SECONDS);
 
     /**
+     * Enables/disables metrics collection altogether. This is a master
+     * switch for all metrics related functionality.
+     * <p/>
+     * NOTE: This property overrides {@link ClientMetricsConfig#isEnabled()}.
+     * <p/>
+     * Using {@link ClientMetricsConfig#setEnabled(boolean)} and the declarative
+     * counterparts are preferred over using this property. The main purpose
+     * of making metrics collection configurable from properties too is
+     * allowing operators to configure the metrics subsystem from the outside
+     * during investigation without touching or copying the configuration
+     * potentially embedded into a signed artifact.
+     */
+    public static final HazelcastProperty METRICS_ENABLED
+            = new HazelcastProperty("hazelcast.client.metrics.enabled");
+
+    /**
+     * Enables/disables exposing metrics on JMX.
+     * <p/>
+     * NOTE: This property overrides {@link MetricsJmxConfig#isEnabled()}.
+     * <p/>
+     * Using {@link MetricsJmxConfig#setEnabled(boolean)} and the declarative
+     * counterparts are preferred over using this property. The main purpose
+     * of making metrics collection configurable from properties too is
+     * allowing operators to configure the metrics subsystem from the outside
+     * during investigation without touching or copying the configuration
+     * potentially embedded into a signed artifact.
+     */
+    public static final HazelcastProperty METRICS_JMX_ENABLED
+            = new HazelcastProperty("hazelcast.client.metrics.jmx.enabled");
+
+    /**
      * Enables collecting debug metrics. Debug metrics are sent to the
      * diagnostics only.
      */
     public static final HazelcastProperty METRICS_DEBUG
             = new HazelcastProperty("hazelcast.client.metrics.debug.enabled");
+
+    /**
+     * Sets the metrics collection frequency in seconds.
+     * <p/>
+     * NOTE: This property overrides {@link ClientMetricsConfig#getCollectionFrequencySeconds()}.
+     * <p/>
+     * Using {@link ClientMetricsConfig#setCollectionFrequencySeconds(int)} and the declarative
+     * counterparts are preferred over using this property. The main purpose
+     * of making metrics collection configurable from properties too is
+     * allowing operators to configure the metrics subsystem from the outside
+     * during investigation without touching or copying the configuration
+     * potentially embedded into a signed artifact.
+     */
+    public static final HazelcastProperty METRICS_COLLECTION_FREQUENCY
+            = new HazelcastProperty("hazelcast.client.metrics.collection.frequency");
 
 
     private ClientProperty() {

--- a/hazelcast/src/main/java/com/hazelcast/config/BaseMetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/BaseMetricsConfig.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.util.Preconditions;
+import com.hazelcast.spi.properties.GroupProperty;
+
+import javax.annotation.Nonnull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class of configuration options specific to metrics collection.
+ *
+ * @param <T> The type of the concrete configuration class extending this
+ *            base class.
+ * @since 4.0
+ */
+public abstract class BaseMetricsConfig<T extends BaseMetricsConfig> {
+    /**
+     * Default collection interval for metrics
+     */
+    private static final int DEFAULT_METRICS_COLLECTION_SECONDS = 5;
+    protected boolean enabled = true;
+    protected MetricsJmxConfig jmxConfig = new MetricsJmxConfig();
+    protected int collectionFrequencySeconds = DEFAULT_METRICS_COLLECTION_SECONDS;
+
+    protected BaseMetricsConfig() {
+    }
+
+    protected BaseMetricsConfig(BaseMetricsConfig metricsConfig) {
+        this.enabled = metricsConfig.enabled;
+        this.jmxConfig = new MetricsJmxConfig(metricsConfig.jmxConfig);
+        this.collectionFrequencySeconds = metricsConfig.collectionFrequencySeconds;
+    }
+
+    /**
+     * Sets whether metrics collection should be enabled for the node. If
+     * enabled, Hazelcast Management Center will be able to connect to this
+     * member. It's enabled by default.
+     * <p/>
+     * May be overridden by {@link GroupProperty#METRICS_ENABLED}
+     * system property.
+     */
+    @Nonnull
+    public T setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return (T) this;
+    }
+
+    /**
+     * Returns if metrics collection is enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Nonnull
+    public T setJmxConfig(MetricsJmxConfig jmxConfig) {
+        this.jmxConfig = requireNonNull(jmxConfig, "JMX config must not be null");
+        return (T) this;
+    }
+
+    @Nonnull
+    public MetricsJmxConfig getJmxConfig() {
+        return jmxConfig;
+    }
+
+    /**
+     * Sets the metrics collection frequency in seconds. The same interval is
+     * used for collection for Management Center and for JMX publisher. By default,
+     * metrics are collected every 5 seconds.
+     * <p/>
+     * May be overridden by {@link GroupProperty#METRICS_COLLECTION_FREQUENCY}
+     * system property.
+     */
+    @Nonnull
+    public T setCollectionFrequencySeconds(int intervalSeconds) {
+        Preconditions.checkPositive(intervalSeconds, "collectionFrequencySeconds must be positive");
+        this.collectionFrequencySeconds = intervalSeconds;
+        return (T) this;
+    }
+
+    /**
+     * Returns the metrics collection frequency in seconds.
+     */
+    public int getCollectionFrequencySeconds() {
+        return this.collectionFrequencySeconds;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -197,7 +197,7 @@ public class Node {
     @SuppressWarnings({"checkstyle:executablestatementcount", "checkstyle:methodlength"})
     public Node(HazelcastInstanceImpl hazelcastInstance, Config staticConfig, NodeContext nodeContext) {
         this.properties = new HazelcastProperties(staticConfig);
-        MetricsConfigHelper.overrideMetricsConfig(staticConfig);
+        MetricsConfigHelper.overrideMemberMetricsConfig(staticConfig);
         DynamicConfigurationAwareConfig config = new DynamicConfigurationAwareConfig(staticConfig, this.properties);
         this.hazelcastInstance = hazelcastInstance;
         this.config = config;

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -49,6 +49,7 @@
                             maxOccurs="unbounded"/>
                 <xs:element name="reliable-topic" type="reliable-topic" minOccurs="0"
                             maxOccurs="unbounded"/>
+                <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -836,4 +837,46 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
+
+    <xs:complexType name="metrics">
+        <xs:all>
+            <xs:element name="jmx" type="metrics-jmx" minOccurs="0"/>
+            <xs:element name="collection-frequency-seconds" type="xs:unsignedInt" default="5" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the metrics collection frequency in seconds.
+                        By default, metrics are collected every 5 seconds.
+                        May be overridden by 'hazelcast.metrics.collection.frequency'
+                        system property.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Master-switch for the metrics system. Controls whether
+                    the metrics are collected and publishers are enabled.
+                    May be overridden by 'hazelcast.metrics.enabled'
+                    system property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="metrics-jmx">
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls whether the metrics collected are exposed to
+                    through JMX. It is enabled by default.
+                    In order to expose the metrics, the metrics system need
+                    to be enabled via the enabled master-switch attribute.
+                    May be overridden by 'hazelcast.metrics.jmx.enabled'
+                    system property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -864,4 +864,30 @@
         </classNames>
     </user-code-deployment>
 
+    <!--
+        ===== HAZELCAST METRICS CONFIGURATION =====
+
+        Configuration element's name is <metrics>.
+
+        It has the following sub-elements:
+        * <jmx>:
+            Defines the JMX related metrics configuration.
+
+            It has the following attributes:
+            * "enabled":
+                Controls whether the metrics collected are exposed to
+                through JMX. It is enabled by default.
+                In order to expose the metrics, the metrics system need
+                to be enabled via the enabled master-switch attribute.
+
+        * <collection-frequency-seconds>:
+            Sets the metrics collection frequency in seconds.
+            By default, metrics are collected every 5 seconds.
+
+    -->
+    <metrics enabled="false">
+        <jmx enabled="false"/>
+        <collection-frequency-seconds>42</collection-frequency-seconds>
+    </metrics>
+
 </hazelcast-client>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -869,6 +869,12 @@
 
         Configuration element's name is <metrics>.
 
+        It has the following attributes:
+        - enabled:
+            The master-switch for the metrics collection. If this is set
+            to false no metrics collection is done, regardless of the other
+            settings. Its default value is true.
+
         It has the following sub-elements:
         * <jmx>:
             Defines the JMX related metrics configuration.

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -834,6 +834,12 @@ hazelcast-client:
   # Configuration element's name is "metrics".
   #
   # It has the following sub-elements:
+  #     * "enabled":
+  #         The master-switch for the metrics collection. If this is set
+  #         to false no metrics collection is done, regardless of the other
+  #         settings. Its default value is true.
+  #
+  # It has the following sub-elements:
   # * "jmx":
   #     Defines the JMX related metrics configuration.
   #

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -827,3 +827,30 @@ hazelcast-client:
       - file://User/test/sample.jar
     classNames:
       - test.sampleClassName
+
+  #
+  # ===== HAZELCAST METRICS CONFIGURATION =====
+  #
+  # Configuration element's name is "metrics".
+  #
+  # It has the following sub-elements:
+  # * "jmx":
+  #     Defines the JMX related metrics configuration.
+  #
+  #       It has the following attributes:
+  #     * "enabled":
+  #         Controls whether the metrics collected are exposed to
+  #         through JMX. It is enabled by default.
+  #         In order to expose the metrics, the metrics system need
+  #         to be enabled via the enabled master-switch attribute.
+  #
+  # * "collection-frequency-seconds":
+  #     Sets the metrics collection frequency in seconds.
+  #     By default, metrics are collected every 5 seconds.
+  #
+  #
+  metrics:
+    enabled: false
+    jmx:
+      enabled: false
+    collection-frequency-seconds: 42

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -457,4 +457,14 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
 
     @Test
     public abstract void testTokenIdentityConfig();
+
+    @Test
+    public abstract void testMetricsConfig();
+
+    @Test
+    public abstract void testMetricsConfigMasterSwitchDisabled();
+
+    @Test
+    public abstract void testMetricsConfigJmxDisabled();
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -63,10 +63,10 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 
-import static com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
 import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.ASYNC;
-import static com.hazelcast.config.MaxSizePolicy.USED_NATIVE_MEMORY_SIZE;
+import static com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
 import static com.hazelcast.config.EvictionPolicy.LFU;
+import static com.hazelcast.config.MaxSizePolicy.USED_NATIVE_MEMORY_SIZE;
 import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -478,6 +478,22 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
 
         Map<String, ClientFlakeIdGeneratorConfig> actual = newConfigViaGenerator().getFlakeIdGeneratorConfigMap();
         assertMap(clientConfig.getFlakeIdGeneratorConfigMap(), actual);
+    }
+
+    @Test
+    public void testMetricsConfig() {
+        clientConfig.getMetricsConfig()
+                    .setEnabled(false)
+                    .setCollectionFrequencySeconds(10);
+
+        clientConfig.getMetricsConfig().getJmxConfig()
+                    .setEnabled(false);
+
+        ClientMetricsConfig originalConfig = clientConfig.getMetricsConfig();
+        ClientMetricsConfig generatedConfig = newConfigViaGenerator().getMetricsConfig();
+        assertEquals(originalConfig.isEnabled(), generatedConfig.isEnabled());
+        assertEquals(originalConfig.getJmxConfig().isEnabled(), generatedConfig.getJmxConfig().isEnabled());
+        assertEquals(originalConfig.getCollectionFrequencySeconds(), generatedConfig.getCollectionFrequencySeconds());
     }
 
     private ClientConfig newConfigViaGenerator() {

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientMetricsConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientMetricsConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientMetricsConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
+        EqualsVerifier.forClass(ClientMetricsConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+
+    @Test
+    public void testCloneEquals() {
+        // create MetricsConfig with non-defaults
+        ClientMetricsConfig original = new ClientMetricsConfig()
+                .setEnabled(false)
+                .setCollectionFrequencySeconds(1);
+
+        original.getJmxConfig()
+                .setEnabled(false);
+
+        ClientMetricsConfig clone = new ClientMetricsConfig(original);
+
+        assertEquals(original.hashCode(), clone.hashCode());
+        assertEquals(original, clone);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -331,6 +331,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     }
 
     @Override
+    @Test
     public void testLoadBalancerRandom() {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "<load-balancer type=\"random\" />"
@@ -342,6 +343,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     }
 
     @Override
+    @Test
     public void testLoadBalancerRoundRobin() {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "<load-balancer type=\"round-robin\" />"
@@ -353,6 +355,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     }
 
     @Override
+    @Test
     public void testWhitespaceInNonSpaceStrings() {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "<load-balancer type=' \n random \n'/>"
@@ -361,6 +364,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     }
 
     @Override
+    @Test
     public void testTokenIdentityConfig() {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "<security>"
@@ -373,6 +377,49 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         assertArrayEquals("Hazelcast".getBytes(StandardCharsets.US_ASCII), tokenIdentityConfig.getToken());
         assertEquals("SGF6ZWxjYXN0", tokenIdentityConfig.getTokenEncoded());
     }
+
+    @Override
+    @Test
+    public void testMetricsConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<metrics enabled=\"false\">"
+                + "  <jmx enabled=\"false\" />"
+                + "  <collection-frequency-seconds>10</collection-frequency-seconds>\n"
+                + "</metrics>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig config = buildConfig(xml);
+        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+        assertEquals(10, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigMasterSwitchDisabled() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<metrics enabled=\"false\"/>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig config = buildConfig(xml);
+        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertTrue(metricsConfig.getJmxConfig().isEnabled());
+    }
+
+    @Override
+    @Test
+    public void testMetricsConfigJmxDisabled() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<metrics>"
+                + "  <jmx enabled=\"false\" />"
+                + "</metrics>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig config = buildConfig(xml);
+        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
+        assertTrue(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+    }
+
 
     static ClientConfig buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
@@ -47,7 +47,7 @@ public class XmlYamlClientConfigBuilderEqualsTest {
     }
 
     @Test
-    public void testFullClientConfig() throws IOException {
+    public void testFullExampleClientConfig() throws IOException {
         String fullExampleXml = readResourceToString("hazelcast-client-full-example.xml");
         String fullExampleYaml = readResourceToString("hazelcast-client-full-example.yaml");
 
@@ -59,6 +59,26 @@ public class XmlYamlClientConfigBuilderEqualsTest {
 
         ClientConfig xmlConfig = buildConfigFromXml(fullExampleXml);
         ClientConfig yamlConfig = buildConfigFromYaml(fullExampleYaml);
+
+        String xmlConfigFromXml = ClientConfigXmlGenerator.generate(xmlConfig, 4);
+        String xmlConfigFromYaml = ClientConfigXmlGenerator.generate(yamlConfig, 4);
+
+        assertEquals(xmlConfigFromXml, xmlConfigFromYaml);
+    }
+
+    @Test
+    public void testFullClientConfig() throws IOException {
+        String fullConfigXml = readResourceToString("hazelcast-client-full.xml");
+        String fullConfigYaml = readResourceToString("hazelcast-client-full.yaml");
+
+        // remove imports to prevent the test from failing with importing non-existing files
+        fullConfigXml = fullConfigXml.replace("<import resource=\"your-client-configuration-XML-file\"/>", "");
+        fullConfigYaml = fullConfigYaml
+                .replace("\r", "")
+                .replace("import:\n    - your-client-configuration-YAML-file", "");
+
+        ClientConfig xmlConfig = buildConfigFromXml(fullConfigXml);
+        ClientConfig yamlConfig = buildConfigFromYaml(fullConfigYaml);
 
         String xmlConfigFromXml = ClientConfigXmlGenerator.generate(xmlConfig, 4);
         String xmlConfigFromYaml = ClientConfigXmlGenerator.generate(yamlConfig, 4);

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.internal.metrics;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientMetricsConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.client.properties.ClientProperty;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.MetricsConfig;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
+    private TestHazelcastFactory factory;
+
+    @Before
+    public void before() {
+        factory = new TestHazelcastFactory();
+        factory.newHazelcastInstance(smallInstanceConfig());
+    }
+
+    @After
+    public void after() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testSystemPropertiesOverrideConfig() {
+        // setting non-defaults
+        System.setProperty(ClientProperty.METRICS_ENABLED.getName(), "false");
+        System.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "false");
+        System.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "24");
+
+        HazelcastClientProxy client = createClient();
+        ClientConfig clientConfig = client.getClientConfig();
+
+        ClientMetricsConfig metricsConfig = clientConfig.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+        assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
+
+        // verify that the overridden config is used
+        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+    }
+
+    @Test
+    public void testInvalidSystemPropertiesIgnored() {
+        // setting non-defaults
+        System.setProperty(ClientProperty.METRICS_ENABLED.getName(), "invalid");
+        System.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "invalid");
+        System.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "invalid");
+
+        HazelcastClientProxy client = createClient();
+        ClientConfig config = client.getClientConfig();
+
+        ClientMetricsConfig defaultConfig = new ClientMetricsConfig();
+
+        // booleans result in false values even though they're "invalid"
+        // therefore, all boolean config fields are set to false
+        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+        assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
+
+        // verify that the overridden config is used
+        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+    }
+
+    @Test
+    public void testConfigPropertiesOverrideConfig() {
+        ClientConfig config = new ClientConfig();
+        // setting non-defaults
+        config.setProperty(ClientProperty.METRICS_ENABLED.getName(), "false");
+        config.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "false");
+        config.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "24");
+        factory.newHazelcastClient(config);
+
+        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+        assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
+
+        // verify that the overridden config is used
+        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+    }
+
+    @Test
+    public void testInvalidConfigPropertiesIgnored() {
+        ClientConfig config = new ClientConfig();
+        // setting non-defaults
+        config.setProperty(ClientProperty.METRICS_ENABLED.getName(), "invalid");
+        config.setProperty(ClientProperty.METRICS_JMX_ENABLED.getName(), "invalid");
+        config.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "invalid");
+
+        factory.newHazelcastClient(config);
+
+        MetricsConfig defaultConfig = new MetricsConfig();
+
+        // booleans result in false values even though they're "invalid"
+        // therefore, all boolean config fields are set to false
+        ClientMetricsConfig metricsConfig = config.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertFalse(metricsConfig.getJmxConfig().isEnabled());
+        assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
+
+        // verify that the overridden config is used
+        // TODO verify in a subsequent change that the override is actually effective; see MetricsPropertiesTest
+    }
+
+    @Test
+    public void testDebugMetricsSysPropNotSet() {
+        MetricsRegistry metricsRegistry = createClient().client.getMetricsRegistry();
+
+        assertEquals(INFO, metricsRegistry.minimumLevel());
+    }
+
+    @Test
+    public void testDebugMetricsSysPropDisabled() {
+        System.setProperty(ClientProperty.METRICS_DEBUG.getName(), "false");
+        MetricsRegistry metricsRegistry = createClient().client.getMetricsRegistry();
+
+        assertEquals(INFO, metricsRegistry.minimumLevel());
+    }
+
+    @Test
+    public void testDebugMetricsSysPropEnabled() {
+        System.setProperty(ClientProperty.METRICS_DEBUG.getName(), "true");
+        MetricsRegistry metricsRegistry = createClient().client.getMetricsRegistry();
+
+        assertEquals(DEBUG, metricsRegistry.minimumLevel());
+    }
+
+    private HazelcastClientProxy createClient() {
+        return (HazelcastClientProxy) factory.newHazelcastClient();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsPropertiesTest.java
@@ -22,9 +22,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,8 +37,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class MetricsPropertiesTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -306,4 +306,9 @@
         </classNames>
     </user-code-deployment>
 
+    <metrics enabled="false">
+        <jmx enabled="false"/>
+        <collection-frequency-seconds>42</collection-frequency-seconds>
+    </metrics>
+
 </hazelcast-client>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -286,7 +286,13 @@ hazelcast-client:
     enabled: true
     jarPaths:
       - /User/test/sample.jar
-      - https://hazelcast.com
+      - https://hazelcast.com/
       - file://User/test/sample.jar
     classNames:
       - test.sampleClassName
+
+  metrics:
+    enabled: false
+    jmx:
+      enabled: false
+    collection-frequency-seconds: 42

--- a/hazelcast/src/test/resources/test-hazelcast-client.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.xml
@@ -18,7 +18,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd">
 
     <cluster-name>foobar-xml</cluster-name>
     <network>


### PR DESCRIPTION
Completes client metrics configuration by adding metrics configuration,
comments and the respective config handling logic for the following places:
- `hazelcast-client-config-4.0.xsd`
- Spring XML client configuration
- `hazelcast-client-full-example.[xml|yaml]`
- `hazelcast-client-full.[xml|yaml]`

The client XML configuration looks like the one below with the
programmatic, YAML and Spring configurations following the same
structure.
```
<metrics enabled="true">
    <jmx enabled="true"/>
    <collection-frequency-seconds>5</collection-frequency-seconds>
</metrics>
```

The missing equality check test case for `hazelcast-client-full.xml` and `hazelcast-client-full.yaml` is also added.

Depends on: https://github.com/hazelcast/hazelcast/pull/15818