### PR TITLE
CachingProvider no longer resolves URI as instance name

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
@@ -115,7 +116,7 @@ public final class HazelcastServerCachingProvider extends AbstractHazelcastCachi
     private Config getDefaultConfig() {
         Config config = new XmlConfigBuilder().build();
         if (namedDefaultHzInstance && isNullOrEmpty(config.getInstanceName())) {
-            config.setInstanceName(SHARED_JCACHE_INSTANCE_NAME);
+            config.setInstanceName(HazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME);
         }
         return config;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -623,4 +623,9 @@ public class ClientCacheProxy<K, V> extends ClientCacheProxySupport<K, V>
     public CacheStatistics getLocalCacheStatistics() {
         return statsHandler.getStatistics();
     }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "{name=" + name + ", nameWithPrefix=" + nameWithPrefix + '}';
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.cache.impl;
 
+import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.AbstractHazelcastCacheManager;
 import com.hazelcast.cache.impl.AbstractHazelcastCachingProvider;
 import com.hazelcast.client.HazelcastClient;
@@ -116,7 +117,7 @@ public final class HazelcastClientCachingProvider extends AbstractHazelcastCachi
     private ClientConfig getDefaultClientConfig() {
         ClientConfig clientConfig = new XmlClientConfigBuilder().build();
         if (namedDefaultHzInstance && isNullOrEmpty(clientConfig.getInstanceName())) {
-            clientConfig.setInstanceName(SHARED_JCACHE_INSTANCE_NAME);
+            clientConfig.setInstanceName(HazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME);
         }
         return clientConfig;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -75,7 +75,6 @@ public class CachingProviderTest extends HazelcastTestSupport {
         instance3 = instanceFactory.newHazelcastInstance(config);
     }
 
-
     protected String getConfigClasspathLocation() {
         return CONFIG_CLASSPATH_LOCATION;
     }
@@ -111,7 +110,7 @@ public class CachingProviderTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void whenDefaultURI_inexistentInstanceNameAsProperty_thenStartsOtherInstance() throws URISyntaxException {
+    public void whenDefaultURI_inexistentInstanceNameAsProperty_thenStartsOtherInstance() {
         cachingProvider.getCacheManager(null, null, propertiesByInstanceName("instance-does-not-exist"));
         assertInstanceStarted("instance-does-not-exist");
     }
@@ -126,19 +125,6 @@ public class CachingProviderTest extends HazelcastTestSupport {
     public void whenDefaultURI_noInstanceName_thenUseDefaultHazelcastInstance() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager();
         assertCacheManagerInstance(cacheManager, instance1);
-    }
-
-    @Test
-    public void whenInstanceNameAsUri_thenThatInstanceIsUsed() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI(INSTANCE_2_NAME), null);
-        assertCacheManagerInstance(cacheManager, instance2);
-    }
-
-    @Test
-    public void whenInexistentInstanceNameAsUri_thenOtherInstanceIsStarted() throws URISyntaxException {
-        cachingProvider.getCacheManager(new URI("does-not-exist"), null);
-        assertInstanceStarted("does-not-exist");
     }
 
     @Test
@@ -161,9 +147,6 @@ public class CachingProviderTest extends HazelcastTestSupport {
         cachingProvider.getCacheManager(new URI("classpath:this-config-does-not-exist"), null);
     }
 
-    // test that config location property has priority over attempting URI interpretation:
-    // CacheManager's URI points to invalid config location, however a valid config location is
-    // specified in properties
     @Test
     public void whenConfigLocationAsProperty_thenThatInstanceIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
@@ -197,13 +180,6 @@ public class CachingProviderTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void whenInstanceItselfAsProperty_andValidInstanceNameURI_thenInstanceItselfIsUsed() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("classpath:" + getConfigClasspathLocation()), null, propertiesByInstanceItself(instance2));
-        assertCacheManagerInstance(cacheManager, instance2);
-    }
-
-    @Test
     public void whenInstanceItselfAsProperty_andDefaultURI_thenInstanceItselfIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
                 null, null, propertiesByInstanceItself(instance3));
@@ -220,7 +196,7 @@ public class CachingProviderTest extends HazelcastTestSupport {
             CacheManager defaultCacheManager = defaultCachingProvider.getCacheManager();
             Collection<HazelcastInstance> instances = getStartedInstances();
             for (HazelcastInstance instance : instances) {
-                if (AbstractHazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME.equals(instance.getName())) {
+                if (HazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME.equals(instance.getName())) {
                     fail("The default named HazelcastInstance shouldn't have been started");
                 }
             }
@@ -240,7 +216,7 @@ public class CachingProviderTest extends HazelcastTestSupport {
             Collection<HazelcastInstance> instances = getStartedInstances();
             boolean sharedInstanceStarted = false;
             for (HazelcastInstance instance : instances) {
-                if (instance.getName().equals(AbstractHazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME)) {
+                if (instance.getName().equals(HazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME)) {
                     sharedInstanceStarted = true;
                 }
             }
@@ -251,7 +227,7 @@ public class CachingProviderTest extends HazelcastTestSupport {
         }
     }
 
-    protected void assertCacheManagerInstance(HazelcastCacheManager cacheManager, HazelcastInstance instance) {
+    private void assertCacheManagerInstance(HazelcastCacheManager cacheManager, HazelcastInstance instance) {
         assertEquals(instance, cacheManager.getHazelcastInstance());
     }
 


### PR DESCRIPTION
Reasoning: in this config mode, `URI` is used both as namespace for the
cache manager and as a means to locate a running HZ instance. With
moby naming auto generating instance names in 4.0 (when not explicitly
set in configuration), the following snippet when executed from 2
processes will result in creation of two separate `Cache` instances which
is probably not what a user would expect:

```
System.setProperty("hazelcast.jcache.provider.type", "server");
HazelcastInstance hz = Hazelcast.newHazelcastInstance();
CachingProvider provider = Caching.getCachingProvider();
Cache cache = provider.getCacheManager(new URI(hz.getName()), null)
  .createCache("test", new CacheConfig());
System.out.println(cache.get("a"));
cache.put("a", "b");
```

The ability to use an existing `HazelcastInstance` identified by instance
name is still available by using `Properties` via
`CachingProvider#getCacheManager(URI, ClassLoader, Properties)`. This way
to integrate with existing hazelcast instances is unambiguous and
explicit.