### PR TITLE
[3.x] Make gathering multimap stats not to break last access merge policy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -61,9 +61,20 @@ public class MultiMapPartitionContainer {
         return container;
     }
 
-    public MultiMapContainer getMultiMapContainer(String name) {
+    /**
+     * Returns the {@link MultiMapContainer} with the given {@code name}
+     * if exists or {@code null otherwise}. Depending on the {@code isAccess}
+     * parameter this call updates the {@code lastAccessTime} field of the
+     * container.
+     *
+     * @param name     The name of the container to retrieve
+     * @param isAccess Indicates whether or not this call should be treated
+     *                 as an access
+     * @return the container or {@code null} if doesn't exist
+     */
+    public MultiMapContainer getMultiMapContainer(String name, boolean isAccess) {
         MultiMapContainer container = containerMap.get(name);
-        if (container != null) {
+        if (container != null && isAccess) {
             container.access();
         }
         return container;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -212,12 +212,14 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         Set<Data> keySet = new HashSet<Data>();
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
             IPartition partition = nodeEngine.getPartitionService().getPartition(i);
+            boolean isLocalPartition = partition.isLocal();
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
-            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name);
+            // we should not treat retrieving the container on backups an access
+            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name, isLocalPartition);
             if (multiMapContainer == null) {
                 continue;
             }
-            if (partition.isLocal()) {
+            if (isLocalPartition) {
                 keySet.addAll(multiMapContainer.keySet());
             }
         }
@@ -394,7 +396,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         for (int partitionId = 0; partitionId < nodeEngine.getPartitionService().getPartitionCount(); partitionId++) {
             IPartition partition = nodeEngine.getPartitionService().getPartition(partitionId, false);
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(partitionId);
-            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name);
+            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name, false);
             if (multiMapContainer == null) {
                 continue;
             }

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -45,6 +45,10 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import java.util.Collection;
 import java.util.Map;
 
+import static com.hazelcast.internal.diagnostics.Diagnostics.ENABLED;
+import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_DISTRIBUTED_DATASTRUCTURES;
+import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_LEVEL;
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.multimap.MultiMapTestUtil.getBackupMultiMap;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertFalse;
@@ -128,6 +132,11 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
                 .setStatisticsEnabled(true)
                 .setBackupCount(1)
                 .setAsyncBackupCount(0);
+
+        config.getProperties().setProperty(ENABLED.getName(), "true");
+        config.getProperties().setProperty(METRICS_DISTRIBUTED_DATASTRUCTURES.getName(), "true");
+        config.getProperties().setProperty(METRICS_LEVEL.getName(), INFO.name());
+
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestUtil.java
@@ -63,7 +63,7 @@ public final class MultiMapTestUtil {
                     continue;
                 }
                 MultiMapPartitionContainer partitionContainer = mapService.getPartitionContainer(partitionId);
-                MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(multiMapName);
+                MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(multiMapName, false);
                 if (multiMapContainer == null) {
                     continue;
                 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
@@ -423,7 +423,7 @@ public class AnswerTest extends HazelcastTestSupport {
         multiMap.put(key, "value2");
 
         MultiMapPartitionContainer partitionContainer = multiMapService.getPartitionContainer(partitionId);
-        MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer("myMultiMap");
+        MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer("myMultiMap", false);
 
         ConcurrentMap<Data, MultiMapValue> multiMapValues = multiMapContainer.getMultiMapValues();
         for (Map.Entry<Data, MultiMapValue> entry : multiMapValues.entrySet()) {


### PR DESCRIPTION
Gathering multimap statistics calls `MultiMapPartitionContainer#getMultiMapContainer()` that updates the `lastAccessTime` of the returned container, which in the end breaks the last access merge policy. This is fixed by making gathering statistics not to count access. Also, retrieving the container on backups for the given partition made not to be considered access.

Fixes #16001

`4.0` PR: #16004