### PR TITLE
Adapts configuration exceptions as required by JSR-107 spec

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorEvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorEvictionConfigTest.java
@@ -45,7 +45,7 @@ public class ConfigValidatorEvictionConfigTest extends HazelcastTestSupport {
         checkCacheEvictionConfig(getEvictionConfig(false, false));
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void checkEvictionConfig_forCache_when_wrong_max_size_policy() {
         EvictionConfig evictionConfig = getEvictionConfig(false, false);
         evictionConfig.setMaxSizePolicy(MaxSizePolicy.PER_PARTITION);
@@ -235,7 +235,7 @@ public class ConfigValidatorEvictionConfigTest extends HazelcastTestSupport {
         checkCacheMaxSizePolicy(evictionConfig.getMaxSizePolicy(), InMemoryFormat.BINARY);
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void checkEvictionConfig_withEntryCountMaxSizePolicy_NATIVE() {
         EvictionConfig evictionConfig = new EvictionConfig()
                 .setMaxSizePolicy(MaxSizePolicy.ENTRY_COUNT);

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -107,7 +107,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
         checkCacheConfig(cacheSimpleConfig, splitBrainMergePolicyProvider);
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void checkCacheConfig_withEntryCountMaxSizePolicy_NATIVE() {
         EvictionConfig evictionConfig = new EvictionConfig()
                 .setMaxSizePolicy(MaxSizePolicy.ENTRY_COUNT);

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorCacheIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorCacheIntegrationTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.config.mergepolicies.ComplexCustomMergePolicy;
@@ -101,7 +100,7 @@ public class MergePolicyValidatorCacheIntegrationTest extends AbstractMergePolic
     public void testCache_withComplexCustomMergePolicy() {
         HazelcastInstance hz = getHazelcastInstance("complexCustom", complexCustomMergePolicy);
 
-        expectedException.expect(InvalidConfigurationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(containsString(complexCustomMergePolicy.getPolicy()));
         expectedException.expectMessage(containsString(MergingCosts.class.getName()));
         hz.getCacheManager().getCache("complexCustom");
@@ -118,7 +117,7 @@ public class MergePolicyValidatorCacheIntegrationTest extends AbstractMergePolic
     public void testCache_withCustomMapMergePolicyNoTypeVariable() {
         HazelcastInstance hz = getHazelcastInstance("customMapNoTypeVariable", customMapMergePolicyNoTypeVariable);
 
-        expectedException.expect(InvalidConfigurationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(containsString(customMapMergePolicyNoTypeVariable.getPolicy()));
         expectedException.expectMessage(containsString(MapMergeTypes.class.getName()));
         hz.getCacheManager().getCache("customMapNoTypeVariable");
@@ -135,9 +134,21 @@ public class MergePolicyValidatorCacheIntegrationTest extends AbstractMergePolic
     public void testCache_withCustomMapMergePolicy() {
         HazelcastInstance hz = getHazelcastInstance("customMap", customMapMergePolicy);
 
-        expectedException.expect(InvalidConfigurationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(containsString(customMapMergePolicy.getPolicy()));
         expectedException.expectMessage(containsString(MapMergeTypes.class.getName()));
         hz.getCacheManager().getCache("customMap");
+    }
+
+    @Override
+    void expectCardinalityEstimatorException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("CardinalityEstimator"));
+    }
+
+    @Override
+    void expectedInvalidMergePolicyException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString(invalidMergePolicyConfig.getPolicy()));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorCachingProviderIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorCachingProviderIntegrationTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.jsr.JsrTestUtil;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.config.mergepolicies.ComplexCustomMergePolicy;
@@ -114,7 +113,7 @@ public class MergePolicyValidatorCachingProviderIntegrationTest
      */
     @Test
     public void testCache_withComplexCustomMergePolicy() {
-        expectedException.expect(InvalidConfigurationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(containsString(complexCustomMergePolicy.getPolicy()));
         expectedException.expectMessage(containsString(MergingCosts.class.getName()));
         getCache("complexCustom", complexCustomMergePolicy);
@@ -129,7 +128,7 @@ public class MergePolicyValidatorCachingProviderIntegrationTest
      */
     @Test
     public void testCache_withCustomMapMergePolicyNoTypeVariable() {
-        expectedException.expect(InvalidConfigurationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(containsString(customMapMergePolicyNoTypeVariable.getPolicy()));
         expectedException.expectMessage(containsString(MapMergeTypes.class.getName()));
         getCache("customMapNoTypeVariable", customMapMergePolicyNoTypeVariable);
@@ -144,7 +143,7 @@ public class MergePolicyValidatorCachingProviderIntegrationTest
      */
     @Test
     public void testCache_withCustomMapMergePolicy() {
-        expectedException.expect(InvalidConfigurationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(containsString(customMapMergePolicy.getPolicy()));
         expectedException.expectMessage(containsString(MapMergeTypes.class.getName()));
         getCache("customMap", customMapMergePolicy);
@@ -156,5 +155,17 @@ public class MergePolicyValidatorCachingProviderIntegrationTest
                 .setPolicy(PutIfAbsentMergePolicy.class.getName());
 
         getCache("legacyPutIfAbsent", legacyMergePolicyConfig);
+    }
+
+    @Override
+    void expectCardinalityEstimatorException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("CardinalityEstimator"));
+    }
+
+    @Override
+    void expectedInvalidMergePolicyException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString(invalidMergePolicyConfig.getPolicy()));
     }
 }


### PR DESCRIPTION
As specified in [`CacheManager#createCache` javadoc](https://static.javadoc.io/javax.cache/cache-api/1.1.1/javax/cache/CacheManager.html#createCache-java.lang.String-C-), in case an invalid
configuration is supplied, an `IllegalArgumentException` should be thrown.
This change applies also to validation in the context of
`CacheManager#getCache` and `HazelcastInstance#getCacheManager#getCache`
methods, so that a uniform approach across all get-or-create cache
methods is applied.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3229#issuecomment-550228766