### PR TITLE
Tweaks to MetricsDescriptorImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptor.java
@@ -124,11 +124,12 @@ public interface MetricDescriptor {
     MetricDescriptor withTag(String tag, String value);
 
     /**
-     * Returns the value associated with the given {@code tag}.
+     * Returns the value associated with the given {@code tag} or {@code null}
+     * if the given tag is not set for the descriptor. If tag is duplicated,
+     * returns the first occurrence.
      *
      * @param tag The tag
-     * @return the value of the tag or {@code null} if the given tag is
-     * not set for the descriptor
+     * @return the value of the tag or {@code null}
      */
     @Nullable
     String tagValue(String tag);
@@ -146,10 +147,10 @@ public interface MetricDescriptor {
      * Returns the name of the tag at the given index.
      *
      * @param index The index
-     * @return the name of the tag
      * @see #tagValue(int)
      * @see #tagCount()
      * @see #readTags(BiConsumer)
+     * @throws IndexOutOfBoundsException if index is out of bounds
      */
     @Nullable
     String tag(int index);
@@ -158,10 +159,10 @@ public interface MetricDescriptor {
      * Returns the value of the tag at the given index.
      *
      * @param index The index
-     * @return the value of the tag
      * @see #tag(int)
      * @see #tagCount()
      * @see #readTags(BiConsumer)
+     * @throws IndexOutOfBoundsException if index is out of bounds
      */
     @Nullable
     String tagValue(int index);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/HashUtil.java
@@ -328,7 +328,7 @@ public final class HashUtil {
      *
      * @param length the length of the array/list
      * @return the mod of the hash
-     * @throws IllegalArgumentException if mod smaller than 1.
+     * @throws IllegalArgumentException if length is smaller than 1.
      */
     public static int hashToIndex(int hash, int length) {
         checkPositive(length, "length must be larger than 0");

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
@@ -17,7 +17,7 @@
 package com.hazelcast.spi.exception;
 
 /**
- * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates operation is send to a
+ * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates operation was sent to a
  * machine that isn't member of the cluster.
  */
 public class TargetNotMemberException extends RetryableHazelcastException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricDescriptorImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricDescriptorImplTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
@@ -66,6 +67,22 @@ public class MetricDescriptorImplTest {
     @Test(expected = NullPointerException.class)
     public void testConstructorWithNullThrows() {
         new MetricDescriptorImpl(null);
+    }
+
+    @Test
+    public void testToString_emptyWithExcludedTargets() {
+        MetricDescriptorImpl descriptor = new MetricDescriptorImpl(supplier);
+
+        assertEquals("[excludedTargets={}]",
+                descriptor.toString());
+    }
+
+    @Test
+    public void testToString_emptyWithoutExcludedTargets() {
+        MetricDescriptorImpl descriptor = new MetricDescriptorImpl(supplier);
+
+        assertEquals("[]",
+                descriptor.metricString());
     }
 
     @Test
@@ -205,6 +222,15 @@ public class MetricDescriptorImplTest {
 
         assertEquals("[discriminatorTag=discriminatorValue,unit=ms,metric=prefix.metricValue,tag0=tag0Value,"
                         + "excludedTargets={MANAGEMENT_CENTER,JMX}]",
+                descriptor.toString());
+    }
+
+    @Test
+    public void testToString_includesEmptyExcludedTargets() {
+        MetricDescriptorImpl descriptor = new MetricDescriptorImpl(supplier)
+                .withTag("tag0", "tag0Value");
+
+        assertEquals("[tag0=tag0Value,excludedTargets={}]",
                 descriptor.toString());
     }
 
@@ -382,6 +408,25 @@ public class MetricDescriptorImplTest {
     }
 
     @Test
+    public void testEqualsDifferentTagOrder() {
+        MetricDescriptorImpl metricDescriptor1 = new MetricDescriptorImpl(mock(Supplier.class));
+        MetricDescriptorImpl metricDescriptor2 = new MetricDescriptorImpl(mock(Supplier.class));
+
+        metricDescriptor1
+                .withMetric("metricName")
+                .withTag("tag0", "tag0Value")
+                .withTag("tag1", "tag1Value");
+
+        metricDescriptor2
+                .withMetric("metricName")
+                .withTag("tag1", "tag1Value")
+                .withTag("tag0", "tag0Value");
+
+        assertEquals(metricDescriptor1, metricDescriptor2);
+        assertEquals(metricDescriptor1.hashCode(), metricDescriptor2.hashCode());
+    }
+
+    @Test
     public void testEqualsDifferentClass() {
         MetricDescriptorImpl descriptor = new MetricDescriptorImpl(mock(Supplier.class));
         assertNotEquals(descriptor, new Object());
@@ -542,17 +587,31 @@ public class MetricDescriptorImplTest {
     }
 
     @Test
-    public void testTagsWithNegativeIndexReturnsNull() {
+    public void testTagsWithNegativeIndexFails() {
         MetricDescriptorImpl descriptor = new MetricDescriptorImpl(mock(Supplier.class));
-        assertNull(descriptor.tag(-1));
-        assertNull(descriptor.tagValue(-1));
+        try {
+            assertNull(descriptor.tag(-1));
+            fail("should have failed");
+        } catch (IndexOutOfBoundsException expected) { }
+
+        try {
+            assertNull(descriptor.tagValue(-1));
+            fail("should have failed");
+        } catch (IndexOutOfBoundsException expected) { }
     }
 
     @Test
     public void testTagsWithTooHighIndexReturnsNull() {
         MetricDescriptorImpl descriptor = new MetricDescriptorImpl(mock(Supplier.class));
-        assertNull(descriptor.tag(MAX_VALUE));
-        assertNull(descriptor.tagValue(MAX_VALUE));
+        try {
+            assertNull(descriptor.tag(MAX_VALUE));
+            fail("should have failed");
+        } catch (IndexOutOfBoundsException expected) { }
+
+        try {
+            assertNull(descriptor.tagValue(MAX_VALUE));
+            fail("should have failed");
+        } catch (IndexOutOfBoundsException expected) { }
     }
 
     @Test


### PR DESCRIPTION
- reduce complexity in buildMetricString(): It's less branching to replace the
comma at the end than to check if we need to add a comma before each item.

- throw when index out of bounds instead of returning null

- more tests

- multiple trivial changes