### PR TITLE
initialize new proxies locally on getDistributedObjects

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -632,7 +632,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                     ClientGetDistributedObjectsCodec.decodeResponse(response);
 
             Collection<? extends DistributedObject> distributedObjects = proxyManager.getDistributedObjects();
-            Set<DistributedObjectInfo> localDistributedObjects = new HashSet<DistributedObjectInfo>();
+            Set<DistributedObjectInfo> localDistributedObjects = new HashSet<>();
             for (DistributedObject localInfo : distributedObjects) {
                 localDistributedObjects.add(new DistributedObjectInfo(localInfo.getServiceName(), localInfo.getName()));
             }
@@ -640,7 +640,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             Collection<DistributedObjectInfo> newDistributedObjectInfo = resultParameters.response;
             for (DistributedObjectInfo distributedObjectInfo : newDistributedObjectInfo) {
                 localDistributedObjects.remove(distributedObjectInfo);
-                getDistributedObject(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
+                getDistributedObject(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName(), false);
             }
 
             for (DistributedObjectInfo distributedObjectInfo : localDistributedObjects) {
@@ -699,6 +699,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
                                                                 @Nonnull String name) {
         return (T) proxyManager.getOrCreateProxy(serviceName, name);
+    }
+
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
+                                                                @Nonnull String name, boolean remote) {
+        return (T) proxyManager.getOrCreateProxy(serviceName, name, remote);
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -698,11 +698,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     @Override
     public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
                                                                 @Nonnull String name) {
-        return (T) proxyManager.getOrCreateProxy(serviceName, name);
+        return getDistributedObject(serviceName, name, true);
     }
 
-    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
-                                                                @Nonnull String name, boolean remote) {
+    private <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
+                                                                 @Nonnull String name, boolean remote) {
         return (T) proxyManager.getOrCreateProxy(serviceName, name, remote);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -703,7 +703,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName,
                                                                  @Nonnull String name, boolean remote) {
-        return (T) proxyManager.getOrCreateProxy(serviceName, name, remote);
+        if (remote) {
+            return (T) proxyManager.getOrCreateProxy(serviceName, name);
+        }
+        return (T) proxyManager.getOrCreateLocalProxy(serviceName, name);
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -269,6 +269,11 @@ public final class ProxyManager {
 
     public ClientProxy getOrCreateProxy(@Nonnull String service,
                                         @Nonnull String id) {
+        return getOrCreateProxy(service, id, true);
+    }
+
+    public ClientProxy getOrCreateProxy(@Nonnull String service,
+                                        @Nonnull String id, boolean remote) {
         checkNotNull(service, "Service name is required!");
         checkNotNull(id, "Object name is required!");
 
@@ -289,7 +294,11 @@ public final class ProxyManager {
 
         try {
             ClientProxy clientProxy = createClientProxy(id, factory);
-            initializeWithRetry(clientProxy);
+            if (remote) {
+                initializeWithRetry(clientProxy);
+            } else {
+                clientProxy.onInitialize();
+            }
             proxyFuture.set(clientProxy);
             return clientProxy;
         } catch (Throwable e) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -268,11 +268,6 @@ public final class ProxyManager {
     }
 
     public ClientProxy getOrCreateProxy(@Nonnull String service,
-                                        @Nonnull String id) {
-        return getOrCreateProxy(service, id, true);
-    }
-
-    public ClientProxy getOrCreateProxy(@Nonnull String service,
                                         @Nonnull String id, boolean remote) {
         checkNotNull(service, "Service name is required!");
         checkNotNull(id, "Object name is required!");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -268,7 +268,17 @@ public final class ProxyManager {
     }
 
     public ClientProxy getOrCreateProxy(@Nonnull String service,
-                                        @Nonnull String id, boolean remote) {
+                                        @Nonnull String id) {
+        return getOrCreateProxyInternal(service, id, true);
+    }
+
+    public ClientProxy getOrCreateLocalProxy(@Nonnull String service,
+                                             @Nonnull String id) {
+        return getOrCreateProxyInternal(service, id, false);
+    }
+
+    private ClientProxy getOrCreateProxyInternal(@Nonnull String service,
+                                                 @Nonnull String id, boolean remote) {
         checkNotNull(service, "Service name is required!");
         checkNotNull(id, "Object name is required!");
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/LazyDistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/LazyDistributedObjectEvent.java
@@ -44,7 +44,7 @@ public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
     public DistributedObject getDistributedObject() {
         distributedObject = super.getDistributedObject();
         if (distributedObject == null) {
-            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName());
+            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName(), true);
         }
         return distributedObject;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/LazyDistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/LazyDistributedObjectEvent.java
@@ -44,7 +44,7 @@ public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
     public DistributedObject getDistributedObject() {
         distributedObject = super.getDistributedObject();
         if (distributedObject == null) {
-            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName(), true);
+            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName());
         }
         return distributedObject;
     }


### PR DESCRIPTION
When the `getDistributedObjects` is called, client tries to create proxies that are unknown to it. However, formerly client was trying to do that by a remote call. This is unnecessary since the newly received proxies are already created on member. Also, if the proxy is destroyed after sending the proxy list to client on member side, old behaviour was causing deleted proxies to recreated again as described in #14571 

With this PR, newly received proxies are only initialized locally.

fixes #14571 