### PR TITLE
Fixed missing EventService registrations after cluster members startup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.config.SecurityConfig;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.management.operation.UpdatePermissionConfigOperation;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -27,6 +30,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
+import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 
@@ -84,6 +88,18 @@ public class OnJoinOp
                     runDirect(op);
                 } catch (Exception e) {
                     getLogger().warning("Error while running post-join operation: " + op, e);
+                }
+            }
+
+            final ClusterService clusterService = getService();
+            // if executed on master, broadcast to all other members except sender (joining member)
+            if (clusterService.isMaster()) {
+                final OperationService operationService = getNodeEngine().getOperationService();
+                for (Member member : clusterService.getMembers()) {
+                    if (!member.localMember() && !member.getUuid().equals(getCallerUuid())) {
+                        OnJoinOp operation = new OnJoinOp(operations);
+                        operationService.invokeOnTarget(ClusterServiceImpl.SERVICE_NAME, operation, member.getAddress());
+                    }
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.impl.eventservice.EventRegistration;
+import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static java.util.Collections.synchronizedList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class EventRegistrationTest extends HazelcastTestSupport {
+
+    private final ILogger logger = Logger.getLogger(getClass());
+
+    @After
+    public void tearDown() throws InterruptedException {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void test_eventRegistrations_OnStartup() {
+        assertEventRegistrations(3, startInstances(3));
+    }
+
+    private HazelcastInstance[] startInstances(int nodeCount) {
+        final List<HazelcastInstance> instancesList = synchronizedList(new ArrayList<HazelcastInstance>());
+        final CountDownLatch latch = new CountDownLatch(nodeCount);
+        final TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(3);
+
+        for (int i = 0; i < nodeCount; ++i) {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Address address = instanceFactory.nextAddress();
+                        HazelcastInstance instance = instanceFactory.newHazelcastInstance(address, new Config());
+                        instancesList.add(instance);
+                    } catch (Throwable e) {
+                        logger.severe(e);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            }, "Start thread for node " + i).start();
+        }
+
+        assertOpenEventually(latch);
+
+        return instancesList.toArray(new HazelcastInstance[0]);
+    }
+
+    private static void assertEventRegistrations(final int expected, final HazelcastInstance... instances) {
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                for (HazelcastInstance instance : instances) {
+                    Collection<EventRegistration> regs = getNodeEngineImpl(instance).getEventService().getRegistrations(
+                            ProxyServiceImpl.SERVICE_NAME, ProxyServiceImpl.SERVICE_NAME);
+                    assertEquals(instance + ": " + regs, expected, regs.size());
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fixed a race condition between new cluster member join and post join
operations executed as part of concurrent member join.

Send post operations directly to master from joining member and it in
turn broadcasts them to all other members of the cluster. This way
master guarantees that all post join operations are executed on all
members of the cluster.

Fixes: https://github.com/hazelcast/hazelcast/issues/15950