### PR TITLE
[WIP] IMap.putIfAbsent ignores locked key

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -591,6 +591,15 @@ public class ClientMapProxy<K, V> extends ClientProxy
         return putIfAbsentInternal(ttl, timeunit, null, null, key, value);
     }
 
+    //no-op for read policy
+    @Override
+    public V putIfAbsent(@Nonnull K key, @Nonnull V value, @Nonnull ReadPolicy readPolicy) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
+
+        return putIfAbsentInternal(UNSET, MILLISECONDS, null, null, key, value);
+    }
+
     @Override
     public V putIfAbsent(@Nonnull K key, @Nonnull V value,
                          long ttl, @Nonnull TimeUnit ttlUnit,

--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -230,6 +230,10 @@ import java.util.concurrent.TimeUnit;
  * @see java.util.concurrent.ConcurrentMap
  */
 public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
+    enum ReadPolicy {
+        LATEST_WRITE,
+        WEAK
+    }
 
     /**
      * {@inheritDoc}
@@ -1430,6 +1434,8 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      *                              is {@code null}
      */
     V putIfAbsent(@Nonnull K key, @Nonnull V value, long ttl, @Nonnull TimeUnit ttlUnit);
+
+    V putIfAbsent(@Nonnull K key, @Nonnull V value, @Nonnull ReadPolicy readPolicy);
 
     /**
      * Puts an entry into this map with a given TTL (time to live) value and

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -74,7 +74,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
     private final AtomicLong sequence = new AtomicLong(0);
 
     /**
-     * @see {@link com.hazelcast.config.MapStoreConfig#setWriteCoalescing(boolean)}
+     * @see com.hazelcast.config.MapStoreConfig#setWriteCoalescing(boolean)
      */
     private final boolean coalesce;
     private final int partitionId;
@@ -245,7 +245,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
         // This may be a value with expirationTime. So we need
         // to return an ExtendedValue
         if (isWithExpirationTime() && delayedEntry.getValue() != null) {
-            return new MetadataAwareValue(toObject(delayedEntry.getValue()), delayedEntry.getExpirationTime());
+            return new MetadataAwareValue<>(toObject(delayedEntry.getValue()), delayedEntry.getExpirationTime());
         }
         return toObject(delayedEntry.getValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryOperation;
@@ -79,11 +80,12 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value,
+                                                   long ttl, long maxIdle, IMap.ReadPolicy readPolicy) {
         if (hasNoExpiry(ttl, maxIdle)) {
-            return new PutIfAbsentOperation(name, key, value);
+            return new PutIfAbsentOperation(name, key, value, readPolicy);
         } else {
-            return new PutIfAbsentWithExpiryOperation(name, key, value, ttl, maxIdle);
+            return new PutIfAbsentWithExpiryOperation(name, key, value, ttl, maxIdle, readPolicy);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -43,7 +43,8 @@ public interface MapOperationProvider {
 
     MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle);
 
-    MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle);
+    MapOperation createPutIfAbsentOperation(String name, Data key, Data value,
+                                            long ttl, long maxIdle, IMap.ReadPolicy readPolicy);
 
     MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl, long maxIdle);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentWithExpiryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentWithExpiryOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -28,8 +29,8 @@ public class PutIfAbsentWithExpiryOperation extends PutIfAbsentOperation {
     private long ttl;
     private long maxIdle;
 
-    public PutIfAbsentWithExpiryOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
-        super(name, dataKey, value);
+    public PutIfAbsentWithExpiryOperation(String name, Data dataKey, Data value, long ttl, long maxIdle, IMap.ReadPolicy readPolicy) {
+        super(name, dataKey, value, readPolicy);
         this.ttl = ttl;
         this.maxIdle = maxIdle;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -160,7 +160,18 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(timeunit, NULL_TIMEUNIT_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit, UNSET, TimeUnit.MILLISECONDS);
+        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit, UNSET, TimeUnit.MILLISECONDS, ReadPolicy.LATEST_WRITE);
+        return toObject(result);
+    }
+
+    @Override
+    public V putIfAbsent(@Nonnull K key, @Nonnull V value, @Nonnull ReadPolicy readPolicy) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
+        checkNotNull(readPolicy, "Null readPolicy is not allowed!");
+
+        Data valueData = toData(value);
+        Data result = putIfAbsentInternal(key, valueData, UNSET, TimeUnit.MILLISECONDS, UNSET, TimeUnit.MILLISECONDS, readPolicy);
         return toObject(result);
     }
 
@@ -174,7 +185,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(maxIdleUnit, NULL_MAX_IDLE_UNIT_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit, maxIdle, maxIdleUnit);
+        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit, maxIdle, maxIdleUnit, ReadPolicy.LATEST_WRITE);
         return toObject(result);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -425,19 +425,18 @@ abstract class MapProxySupport<K, V>
 
     protected Data putIfAbsentInternal(Object key, Data value,
                                        long ttl, TimeUnit ttlUnit,
-                                       long maxIdle, TimeUnit maxIdleUnit) {
-
+                                       long maxIdle, TimeUnit maxIdleUnit, ReadPolicy readPolicy) {
         Data keyData = toDataWithStrategy(key);
-        MapOperation operation = newPutIfAbsentOperation(keyData, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
+        MapOperation operation = newPutIfAbsentOperation(keyData, value, ttl, ttlUnit, maxIdle, maxIdleUnit, readPolicy);
         return (Data) invokeOperation(keyData, operation);
     }
 
     private MapOperation newPutIfAbsentOperation(Data keyData, Data valueData,
                                                  long ttl, TimeUnit timeunit,
-                                                 long maxIdle, TimeUnit maxIdleUnit) {
+                                                 long maxIdle, TimeUnit maxIdleUnit, ReadPolicy readPolicy) {
         return operationProvider.createPutIfAbsentOperation(name, keyData, valueData,
                 timeInMsOrOneIfResultIsZero(ttl, timeunit),
-                timeInMsOrOneIfResultIsZero(maxIdle, maxIdleUnit));
+                timeInMsOrOneIfResultIsZero(maxIdle, maxIdleUnit), readPolicy);
     }
 
     protected void putTransientInternal(Object key, Data value,

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.nearcache.impl.invalidation.BatchNearCacheInvalida
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidation;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.InterceptorRegistry;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
@@ -182,10 +183,11 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit ttlUnit,
+                                       long maxIdle, TimeUnit maxIdleUnit, IMap.ReadPolicy readPolicy) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putIfAbsentInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
+            return super.putIfAbsentInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit, readPolicy);
         } finally {
             invalidateNearCache(key);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -217,7 +217,6 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         return isTtlDefined(ttl) || isMaxIdleDefined(maxIdle);
     }
 
-
     @Override
     public Record getOrNullIfExpired(Record record, long now, boolean backup) {
         if (!isRecordStoreExpirable()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.monitor.impl.LocalRecordStoreStatsImpl;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.comparators.ValueComparator;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.JsonMetadataInitializer;
 import com.hazelcast.map.impl.MapContainer;
@@ -204,6 +205,15 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         Record record = createRecord(key, newValue, ttlMillis, maxIdleMillis, now);
         putIntoMapStore(record, key, newValue, now, transactionId);
         storage.put(key, record);
+        mutationObserver.onPutRecord(key, record, oldValue, false);
+        return record;
+    }
+
+    protected Record putNewRecord(Data key, Object oldValue, Object newValue, long ttlMillis,
+                                  long maxIdleMillis, long now, UUID transactionId, IMap.ReadPolicy readPolicy) {
+        Record record = createRecord(key, newValue, ttlMillis, maxIdleMillis, now);
+        putIntoMapStore(record, key, newValue, now, transactionId);
+        storage.put(key, record, readPolicy);
         mutationObserver.onPutRecord(key, record, oldValue, false);
         return record;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -68,7 +68,7 @@ public interface RecordStore<R extends Record> {
      */
     Object put(Data dataKey, Object dataValue, long ttl, long maxIdle);
 
-    Object putIfAbsent(Data dataKey, Object value, long ttl, long maxIdle, Address callerAddress);
+    Object putIfAbsent(Data dataKey, Object value, long ttl, long maxIdle, Address callerAddress, IMap.ReadPolicy readPolicy);
 
     /**
      * @param key        the key

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.core.EntryView;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
@@ -36,6 +37,8 @@ import java.util.Iterator;
 public interface Storage<K, R> {
 
     void put(K key, R record);
+
+    void put(K key, R record, IMap.ReadPolicy readPolicy);
 
     void updateRecordValue(K key, R record, Object value);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.recordstore;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
@@ -80,6 +81,21 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
         record.setKey(key);
 
         R previousRecord = records.put(key, record);
+
+        if (previousRecord == null) {
+            updateCostEstimate(entryCostEstimator.calculateEntryCost(key, record));
+        } else {
+            updateCostEstimate(-entryCostEstimator.calculateValueCost(previousRecord));
+            updateCostEstimate(entryCostEstimator.calculateValueCost(record));
+        }
+    }
+
+    @Override
+    public void put(Data key, R record, IMap.ReadPolicy readPolicy) {
+
+        record.setKey(key);
+
+        R previousRecord = records.put(key, record, readPolicy);
 
         if (previousRecord == null) {
             updateCostEstimate(entryCostEstimator.calculateEntryCost(key, record));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/proxy/DifferentPutIfAbsentStrategiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/proxy/DifferentPutIfAbsentStrategiesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.proxy;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DifferentPutIfAbsentStrategiesTest extends HazelcastTestSupport  {
+    @Test
+    public void testLatestWriteValue() throws Exception {
+        HazelcastInstance hz = createHazelcastInstance();
+        IMap<String, String> mapProxy = hz.getMap(randomMapName());
+        CountDownLatch locked = new CountDownLatch(1);
+        Runnable putWithLock = () -> {
+            mapProxy.lock("key");
+            try {
+                locked.countDown();
+                mapProxy.put("key", "put-value");
+            } finally {
+                mapProxy.unlock("key");
+            }
+        };
+
+        Callable<String> putIfAbsent = () -> {
+            locked.await();
+            return mapProxy.putIfAbsent("key", "put-if-absent-value", IMap.ReadPolicy.LATEST_WRITE);
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Future<String> result = executor.submit(putIfAbsent);
+        executor.submit(putWithLock);
+
+        assertEquals("put-value", result.get());
+    }
+
+    @Test(timeout = 2_000L)
+    public void testWeakConsistencyPutIfAbsent() throws Exception {
+        HazelcastInstance hz = createHazelcastInstance();
+        IMap<String, String> mapProxy = hz.getMap(randomMapName());
+
+        mapProxy.put("key", "prev-value");
+
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch putIfAbsentCompleted = new CountDownLatch(1);
+        Runnable putWithLock = () -> {
+            mapProxy.lock("key");
+            try {
+                locked.countDown();
+                putIfAbsentCompleted.await();
+                mapProxy.put("key", "put-value");
+            } catch (InterruptedException e) {
+                ignore(e);
+            } finally {
+                mapProxy.unlock("key");
+            }
+        };
+
+        Callable<String> putIfAbsent = () -> {
+            locked.await();
+            String value = mapProxy.putIfAbsent("key", "put-if-absent-value", IMap.ReadPolicy.WEAK);
+            putIfAbsentCompleted.countDown();
+            return value;
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Future<String> result = executor.submit(putIfAbsent);
+        executor.submit(putWithLock);
+
+        assertEquals("prev-value", result.get());
+    }
+}


### PR DESCRIPTION
The ultimate plan is to support #12155 use case.

This is a quick prototype of `IMap.putIfAbsent` version that supports key's lock. Basically, I added `ReadPolicy` enum that has two variants:
 * `LATEST_WRITE` - will wait till the lock is hold for particular key
 * `WEAK` - ignore the lock and put value into the `IMap`

@mmedenjak, @jerrinot, @ahmetmircik could you guys take a look and give your feedback on approach?

Thanks.
