### PR TITLE
Skip max invocation count check for recreateCachesOnCluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -88,7 +88,7 @@ final class ClientCacheHelper {
      * @see com.hazelcast.cache.impl.operation.AddCacheConfigOperation
      */
     static <K, V> CacheConfig<K, V> createCacheConfig(HazelcastClientInstanceImpl client,
-                                                      CacheConfig<K, V> newCacheConfig) {
+                                                      CacheConfig<K, V> newCacheConfig, boolean urgent) {
         try {
             String nameWithPrefix = newCacheConfig.getNameWithPrefix();
             int partitionId = client.getClientPartitionService().getPartitionId(nameWithPrefix);
@@ -97,7 +97,7 @@ final class ClientCacheHelper {
             ClientMessage request = CacheCreateConfigCodec
                     .encodeRequest(CacheConfigHolder.of(newCacheConfig, serializationService), true);
             ClientInvocation clientInvocation = new ClientInvocation(client, request, nameWithPrefix, partitionId);
-            Future<ClientMessage> future = clientInvocation.invoke();
+            Future<ClientMessage> future = urgent ? clientInvocation.invokeUrgent() : clientInvocation.invoke();
             final ClientMessage response = future.get();
             final CacheConfigHolder cacheConfigHolder = CacheCreateConfigCodec.decodeResponse(response).response;
             if (cacheConfigHolder == null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
@@ -55,7 +55,7 @@ public class ClientCacheProxyFactory implements ClientProxyFactory {
 
     public void recreateCachesOnCluster() {
         for (CacheConfig cacheConfig : configs.values()) {
-            ClientCacheHelper.createCacheConfig(client, cacheConfig);
+            ClientCacheHelper.createCacheConfig(client, cacheConfig, true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -141,7 +141,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
 
     @Override
     protected <K, V> void createCacheConfig(String cacheName, CacheConfig<K, V> config) {
-        ClientCacheHelper.createCacheConfig(client, config);
+        ClientCacheHelper.createCacheConfig(client, config, false);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -22,9 +22,13 @@ import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.executor.ExecutorServiceTestSupport;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Ignore;
@@ -39,6 +43,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
@@ -98,6 +103,59 @@ public class ClientCacheCreationTest extends CacheCreationTest {
         Thread.sleep(2000);
         Hazelcast.newHazelcastInstance();
         assertOpenEventually(cacheCreated);
+    }
+
+    @Test
+    public void recreateCacheOnRestartedCluster_whenMaxConcurrentInvocationLow() {
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setFailOnMaxBackoff(false);
+        clientConfig.setProperty(ClientProperty.MAX_CONCURRENT_INVOCATIONS.getName(), "1");
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        HazelcastClientCachingProvider cachingProvider = createClientCachingProvider(client);
+        final CacheManager cacheManager = cachingProvider.getCacheManager();
+        MutableConfiguration configuration = new MutableConfiguration();
+        cacheManager.createCache("xmlCache", configuration);
+
+        IExecutorService executorService = client.getExecutorService("exec");
+        //keep the slot for one invocation to test if client can reconnect even if all slots are kept
+        CountDownLatch testFinished = new CountDownLatch(1);
+        executorService.submit(new ExecutorServiceTestSupport.SleepingTask(0),
+                new ExecutionCallback<Boolean>() {
+                    @Override
+                    public void onResponse(Boolean response) {
+                        try {
+                            testFinished.await();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        try {
+                            testFinished.await();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                });
+
+        hazelcastInstance.shutdown();
+
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                try {
+                    instance.getCacheManager().getCache("xmlCache");
+                } catch (Exception e) {
+                    fail();
+                }
+            }
+        });
+        testFinished.countDown();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
@@ -119,14 +119,14 @@ public class ClientCacheHelperTest extends HazelcastTestSupport {
 
     @Test
     public void testCreateCacheConfig_whenSyncCreate_thenReturnNewConfig() {
-        CacheConfig<String, String> actualConfig = createCacheConfig(client, newCacheConfig);
+        CacheConfig<String, String> actualConfig = createCacheConfig(client, newCacheConfig, false);
 
         assertNotEquals(cacheConfig, actualConfig);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testCreateCacheConfig_rethrowsExceptions() {
-        createCacheConfig(exceptionThrowingClient, newCacheConfig);
+        createCacheConfig(exceptionThrowingClient, newCacheConfig, false);
     }
 
     @Test


### PR DESCRIPTION
Invocations on cluster restart like registering listeners,
creating proxies are all urgent and they are not checked for
max invocation count.
recreateCachesOnCluster also will not checked with the changes
in this pr.

fixes https://github.com/hazelcast/hazelcast/issues/15556