### PR TITLE
Fix failing AnswerTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -63,16 +63,29 @@ public class MultiMapPartitionContainer {
 
     /**
      * Returns the {@link MultiMapContainer} with the given {@code name}
-     * if exists or {@code null otherwise}. Depending on the {@code isAccess}
-     * parameter this call updates the {@code lastAccessTime} field of the
-     * container.
+     * if exists or {@code null otherwise}, without updating the
+     * {@code lastAccessTime} field of the container.
      *
-     * @param name     The name of the container to retrieve
-     * @param isAccess Indicates whether or not this call should be treated
-     *                 as an access
+     * @param name The name of the container to retrieve
      * @return the container or {@code null} if doesn't exist
      */
-    public MultiMapContainer getMultiMapContainer(String name, boolean isAccess) {
+    public MultiMapContainer getMultiMapContainerWithoutAccess(String name) {
+        return getMultiMapContainer(name, false);
+    }
+
+    /**
+     * Returns the {@link MultiMapContainer} with the given {@code name}
+     * if exists or {@code null otherwise} and updates the
+     * {@code lastAccessTime} field of the container.
+     *
+     * @param name The name of the container to retrieve
+     * @return the container or {@code null} if doesn't exist
+     */
+    public MultiMapContainer getMultiMapContainer(String name) {
+        return getMultiMapContainer(name, true);
+    }
+
+    private MultiMapContainer getMultiMapContainer(String name, boolean isAccess) {
         MultiMapContainer container = containerMap.get(name);
         if (container != null && isAccess) {
             container.access();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -215,7 +215,14 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
             boolean isLocalPartition = partition.isLocal();
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
             // we should not treat retrieving the container on backups an access
-            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name, isLocalPartition);
+
+            MultiMapContainer multiMapContainer;
+            if (isLocalPartition) {
+                multiMapContainer = partitionContainer.getMultiMapContainer(name);
+            } else {
+                multiMapContainer = partitionContainer.getMultiMapContainerWithoutAccess(name);
+            }
+
             if (multiMapContainer == null) {
                 continue;
             }
@@ -396,7 +403,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         for (int partitionId = 0; partitionId < nodeEngine.getPartitionService().getPartitionCount(); partitionId++) {
             IPartition partition = nodeEngine.getPartitionService().getPartition(partitionId, false);
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(partitionId);
-            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name, false);
+            MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainerWithoutAccess(name);
             if (multiMapContainer == null) {
                 continue;
             }

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestUtil.java
@@ -63,7 +63,7 @@ public final class MultiMapTestUtil {
                     continue;
                 }
                 MultiMapPartitionContainer partitionContainer = mapService.getPartitionContainer(partitionId);
-                MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(multiMapName, false);
+                MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainerWithoutAccess(multiMapName);
                 if (multiMapContainer == null) {
                     continue;
                 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
@@ -423,7 +423,7 @@ public class AnswerTest extends HazelcastTestSupport {
         multiMap.put(key, "value2");
 
         MultiMapPartitionContainer partitionContainer = multiMapService.getPartitionContainer(partitionId);
-        MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer("myMultiMap", false);
+        MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer("myMultiMap");
 
         ConcurrentMap<Data, MultiMapValue> multiMapValues = multiMapContainer.getMultiMapValues();
         for (Map.Entry<Data, MultiMapValue> entry : multiMapValues.entrySet()) {


### PR DESCRIPTION
Follow-up on #16003 that fixed #16001 by introducing a second parameter
to `MultiMapPartitionContainer#getMultiMapContainer(String,boolean)` to
indicate whether or not the container should be `access()`'ed. This broke 
`AnswerTest` that can't be fixed easily since  
`getMultiMapContainer(String,boolean)` doesn't exist in HZ 3.11. Therefore,
the test is fixed by making the aforementioned method private and adding 
back the previously existing `getMultiMapContainer(String name)` while 
introducing `getMultiMapContainerWithoutAccess(String name)` that 
delegate to the private `getMultiMapContainer(String,boolean)`.

Fixes #16011