### PR TITLE
Move JsonSerializable to private API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/LocalInstanceStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LocalInstanceStats.java
@@ -16,17 +16,10 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.json.JsonSerializable;
-
 /**
  * Base interface for local instance statistics.
  */
-public interface LocalInstanceStats extends JsonSerializable {
-
-    /**
-     * Default value for unavailable statistics.
-     */
-    long STAT_NOT_AVAILABLE = -99L;
+public interface LocalInstanceStats {
 
     /**
      * Returns the creation time of this distributed object instance on this member.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.monitor.MemberState;
 import com.hazelcast.internal.monitor.impl.MemberStateImpl;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AdvancedNetworkStatsDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AdvancedNetworkStatsDTO.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.management.dto;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.nio.AggregateEndpointManager;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.EnumMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTO.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.Map;
 import java.util.Map.Entry;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListDTO.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.management.dto;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListEntryDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListEntryDTO.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getString;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTO.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.config.HotRestartClusterDataRecoveryPolicy;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ConnectionManagerDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ConnectionManagerDTO.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.internal.jmx.NetworkingServiceMBean;
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.nio.AggregateEndpointManager;
 import com.hazelcast.internal.nio.EndpointManager;
 import com.hazelcast.internal.nio.NetworkingService;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/CustomWanPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/CustomWanPublisherConfigDTO.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.management.dto;
 import com.hazelcast.config.CustomWanPublisherConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.function.Consumer;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryConfigDTO.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.Collection;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryStrategyConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryStrategyConfigDTO.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.management.dto;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.fromJsonObject;
 import static com.hazelcast.internal.util.JsonUtil.toJsonObject;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/EventServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/EventServiceDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.eventservice.EventService;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/EvictionConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/EvictionConfigDTO.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getInt;
 import static com.hazelcast.internal.util.JsonUtil.getString;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MXBeansDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MXBeansDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonObject;
 
 import java.util.HashMap;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ManagedExecutorDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ManagedExecutorDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.util.executor.ManagedExecutorService;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
@@ -26,7 +26,7 @@ import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapStoreConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapStoreConfigDTO.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.util.StringUtil;
 
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MergePolicyConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MergePolicyConfigDTO.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getInt;
 import static com.hazelcast.internal.util.JsonUtil.getString;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/NearCacheConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/NearCacheConfigDTO.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getBoolean;
 import static com.hazelcast.internal.util.JsonUtil.getInt;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/NearCachePreloaderConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/NearCachePreloaderConfigDTO.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getBoolean;
 import static com.hazelcast.internal.util.JsonUtil.getInt;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/OperationServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/OperationServiceDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PartitionServiceBeanDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PartitionServiceBeanDTO.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.cluster.Address;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PermissionConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PermissionConfigDTO.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.config.PermissionConfig;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ProxyServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ProxyServiceDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.proxyservice.ProxyService;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationInvocationDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationInvocationDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.json.JsonObject;
 
 import static com.hazelcast.internal.util.JsonUtil.getInt;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanBatchReplicationPublisherConfigDTO.java
@@ -30,7 +30,7 @@ import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.function.Consumer;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanConsumerConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanConsumerConfigDTO.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.management.dto;
 import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.fromJsonObject;
 import static com.hazelcast.internal.util.JsonUtil.toJsonObject;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanReplicationConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanReplicationConfigDTO.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 /**
  * A JSON representation of {@link WanReplicationConfig}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanSyncConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanSyncConfigDTO.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.ConsistencyCheckStrategy;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 /**
  * A JSON representation of {@link WanSyncConfig}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/UpdatePermissionConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/UpdatePermissionConfigRequest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.management.request;
 
 import com.hazelcast.config.PermissionConfig;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.management.dto.PermissionConfigDTO;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/HotRestartState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/HotRestartState.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.monitor;
 
 import com.hazelcast.hotrestart.BackupTaskStatus;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 /**
  * Hot Restart statistics to be used by {@link MemberState} implementations.

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/LocalWanPublisherStats.java
@@ -18,7 +18,7 @@
 package com.hazelcast.internal.monitor;
 
 import com.hazelcast.wan.WanPublisherState;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.wan.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
 import com.hazelcast.wan.WanSyncStats;
 import com.hazelcast.wan.ConsistencyCheckResult;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/MemberPartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/MemberPartitionState.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.monitor;
 
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.List;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/MemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/MemberState.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.monitor;
 
 import com.hazelcast.collection.LocalQueueStats;
 import com.hazelcast.executor.LocalExecutorStats;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.management.dto.MXBeansDTO;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/NodeState.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.monitor;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStats.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 import com.hazelcast.nearcache.NearCacheStats;
@@ -30,7 +31,7 @@ import java.util.Map;
  * disabled in {@link ReplicatedMapConfig}.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class EmptyLocalReplicatedMapStats implements LocalReplicatedMapStats {
+public class EmptyLocalReplicatedMapStats implements LocalReplicatedMapStats, JsonSerializable {
 
     private final JsonObject jsonObject;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalCacheStatsImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.monitor.LocalCacheStats;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static com.hazelcast.internal.metrics.ProbeUnit.PERCENT;
@@ -42,7 +43,7 @@ import static com.hazelcast.internal.util.JsonUtil.getLong;
  *
  * @see com.hazelcast.cache.CacheStatistics
  */
-public class LocalCacheStatsImpl implements LocalCacheStats {
+public class LocalCacheStatsImpl implements LocalCacheStats, JsonSerializable {
 
     @Probe(unit = MS)
     private long creationTime;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalExecutorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalExecutorStatsImpl.java
@@ -20,12 +20,13 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.executor.LocalExecutorStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 
-public class LocalExecutorStatsImpl implements LocalExecutorStats {
+public class LocalExecutorStatsImpl implements LocalExecutorStats, JsonSerializable {
 
     private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> PENDING = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "pending");

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
@@ -20,13 +20,14 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.monitor.LocalFlakeIdGeneratorStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
-public class LocalFlakeIdGeneratorStatsImpl implements LocalFlakeIdGeneratorStats {
+public class LocalFlakeIdGeneratorStatsImpl implements LocalFlakeIdGeneratorStats, JsonSerializable {
 
     private static final AtomicLongFieldUpdater<LocalFlakeIdGeneratorStatsImpl> BATCH_COUNT =
             newUpdater(LocalFlakeIdGeneratorStatsImpl.class, "batchCount");

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalGCStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalGCStatsImpl.java
@@ -20,10 +20,11 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.memory.GarbageCollectorStats;
 import com.hazelcast.internal.monitor.LocalGCStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 
-public class LocalGCStatsImpl implements LocalGCStats {
+public class LocalGCStatsImpl implements LocalGCStats, JsonSerializable {
 
     private long creationTime;
     private long minorCount;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalIndexStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalIndexStatsImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.query.LocalIndexStats;
 
 /**
@@ -25,7 +26,7 @@ import com.hazelcast.query.LocalIndexStats;
  * public API.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class LocalIndexStatsImpl implements LocalIndexStats {
+public class LocalIndexStatsImpl implements LocalIndexStats, JsonSerializable {
 
     @Probe
     private volatile long creationTime;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.json.JsonObject.Member;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.nearcache.NearCacheStats;
 import com.hazelcast.query.LocalIndexStats;
@@ -45,7 +46,7 @@ import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
  * Default implementation of {@link LocalMapStats}
  */
 @SuppressWarnings({"checkstyle:methodcount"})
-public class LocalMapStatsImpl implements LocalMapStats {
+public class LocalMapStatsImpl implements LocalMapStats, JsonSerializable {
 
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> LAST_ACCESS_TIME =
             newUpdater(LocalMapStatsImpl.class, "lastAccessTime");
@@ -498,7 +499,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
         root.add("heapCost", heapCost);
         root.add("merkleTreesCost", merkleTreesCost);
         if (nearCacheStats != null) {
-            root.add("nearCacheStats", nearCacheStats.toJson());
+            root.add("nearCacheStats", ((JsonSerializable) nearCacheStats).toJson());
         }
 
         root.add("queryCount", queryCount);
@@ -507,7 +508,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
         if (!localIndexStats.isEmpty()) {
             JsonObject indexes = new JsonObject();
             for (Map.Entry<String, LocalIndexStats> indexEntry : localIndexStats.entrySet()) {
-                indexes.add(indexEntry.getKey(), indexEntry.getValue().toJson());
+                indexes.add(indexEntry.getKey(), ((JsonSerializable) indexEntry.getValue()).toJson());
             }
             root.add("indexStats", indexes);
         }
@@ -550,7 +551,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
         JsonValue jsonNearCacheStats = json.get("nearCacheStats");
         if (jsonNearCacheStats != null) {
             nearCacheStats = new NearCacheStatsImpl();
-            nearCacheStats.fromJson(jsonNearCacheStats.asObject());
+            ((JsonSerializable) nearCacheStats).fromJson(jsonNearCacheStats.asObject());
         }
 
         queryCount = getLong(json, "queryCount", -1L);

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMemoryStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMemoryStatsImpl.java
@@ -20,11 +20,12 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.memory.MemoryStats;
 import com.hazelcast.internal.monitor.LocalGCStats;
 import com.hazelcast.internal.monitor.LocalMemoryStats;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 import static com.hazelcast.internal.util.JsonUtil.getObject;
 
-public class LocalMemoryStatsImpl implements LocalMemoryStats {
+public class LocalMemoryStatsImpl implements LocalMemoryStats, JsonSerializable {
 
     public static final String JSON_CREATION_TIME = "creationTime";
     public static final String JSON_TOTAL_PHYSICAL = "totalPhysical";
@@ -216,7 +217,7 @@ public class LocalMemoryStatsImpl implements LocalMemoryStats {
         if (gcStats == null) {
             gcStats = new LocalGCStatsImpl();
         }
-        root.add(JSON_GC_STATS, gcStats.toJson());
+        root.add(JSON_GC_STATS, ((JsonSerializable) gcStats).toJson());
         return root;
     }
 
@@ -234,7 +235,7 @@ public class LocalMemoryStatsImpl implements LocalMemoryStats {
         usedHeap = getLong(json, JSON_USED_HEAP, -1L);
         gcStats = new LocalGCStatsImpl();
         if (json.get(JSON_GC_STATS) != null) {
-            gcStats.fromJson(getObject(json, JSON_GC_STATS));
+            ((JsonSerializable) gcStats).fromJson(getObject(json, JSON_GC_STATS));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalOperationStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalOperationStatsImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.monitor.LocalOperationStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +35,7 @@ import static com.hazelcast.internal.util.JsonUtil.getLong;
 /**
  * Hazelcast statistic implementations for local operations.
  */
-public class LocalOperationStatsImpl implements LocalOperationStats {
+public class LocalOperationStatsImpl implements LocalOperationStats, JsonSerializable {
 
     private long maxVisibleSlowOperationCount;
     private List<SlowOperationDTO> slowOperations;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalPNCounterStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalPNCounterStatsImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.monitor.LocalPNCounterStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
@@ -29,7 +30,7 @@ import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 /**
  * Local PN counter statistics thread safe implementation
  */
-public class LocalPNCounterStatsImpl implements LocalPNCounterStats {
+public class LocalPNCounterStatsImpl implements LocalPNCounterStats, JsonSerializable {
     private static final AtomicLongFieldUpdater<LocalPNCounterStatsImpl> TOTAL_INCREMENT_OPERATION_COUNT =
             newUpdater(LocalPNCounterStatsImpl.class, "totalIncrementOperationCount");
     private static final AtomicLongFieldUpdater<LocalPNCounterStatsImpl> TOTAL_DECREMENT_OPERATION_COUNT =

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.collection.LocalQueueStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
@@ -27,7 +28,7 @@ import static com.hazelcast.internal.util.JsonUtil.getInt;
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
-public class LocalQueueStatsImpl implements LocalQueueStats {
+public class LocalQueueStatsImpl implements LocalQueueStats, JsonSerializable {
 
     private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_OFFERS =
             newUpdater(LocalQueueStatsImpl.class, "numberOfOffers");

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 import com.hazelcast.internal.util.Clock;
@@ -34,7 +35,7 @@ import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
  * able to transform those between wire format and instance view.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
+public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, JsonSerializable {
 
     private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> LAST_ACCESS_TIME =
             newUpdater(LocalReplicatedMapStatsImpl.class, "lastAccessTime");

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.impl.reliable.ReliableMessageRunner;
 import com.hazelcast.internal.util.Clock;
@@ -27,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
-public class LocalTopicStatsImpl implements LocalTopicStats {
+public class LocalTopicStatsImpl implements LocalTopicStats, JsonSerializable {
 
     private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_PUBLISHES =
             newUpdater(LocalTopicStatsImpl.class, "totalPublishes");

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalWanStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalWanStatsImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.monitor.LocalWanPublisherStats;
 import com.hazelcast.internal.monitor.LocalWanStats;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +31,7 @@ import java.util.Map;
  * A single WAN replication scheme can contain multiple WAN replication
  * publishers, identified by name.
  */
-public class LocalWanStatsImpl implements LocalWanStats {
+public class LocalWanStatsImpl implements LocalWanStats, JsonSerializable {
     /**
      * Local WAN replication statistics for a single scheme, grouped by WAN
      * publisher ID.

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/MemberStateImpl.java
@@ -400,13 +400,13 @@ public class MemberStateImpl implements MemberState {
         }
         root.add("clients", clientsArray);
         root.add("beans", beans.toJson());
-        root.add("memoryStats", ((JsonSerializable) memoryStats).toJson());
-        root.add("operationStats", ((JsonSerializable) operationStats).toJson());
+        addJsonIfSerializable(root, "memoryStats", memoryStats);
+        addJsonIfSerializable(root, "operationStats", operationStats);
         root.add("memberPartitionState", memberPartitionState.toJson());
         root.add("nodeState", nodeState.toJson());
         root.add("hotRestartState", hotRestartState.toJson());
         root.add("clusterHotRestartStatus", clusterHotRestartStatus.toJson());
-        root.add("wanSyncState", ((JsonSerializable) wanSyncState).toJson());
+        addJsonIfSerializable(root, "wanSyncState", wanSyncState);
 
         JsonObject clientStatsObject = new JsonObject();
         for (Map.Entry<UUID, String> entry : clientStats.entrySet()) {
@@ -421,9 +421,32 @@ public class MemberStateImpl implements MemberState {
     private static void serializeMap(JsonObject root, String key, Map<String, ?> map) {
         final JsonObject jsonObject = new JsonObject();
         for (Entry<String, ?> e : map.entrySet()) {
-            jsonObject.add(e.getKey(), ((JsonSerializable) e.getValue()).toJson());
+            addJsonIfSerializable(jsonObject, e.getKey(), e.getValue());
         }
         root.add(key, jsonObject);
+    }
+
+    private static void addJsonIfSerializable(JsonObject root, String key, Object value) {
+        if (value instanceof JsonSerializable) {
+            root.add(key, ((JsonSerializable) value).toJson());
+        }
+    }
+
+    private static <T> void putDeserializedIfSerializable(Map<String, T> deserializedValueMap,
+                                                          String key,
+                                                          JsonObject serializedJson,
+                                                          T instance) {
+        if (instance instanceof JsonSerializable) {
+            ((JsonSerializable) instance).fromJson(serializedJson);
+            deserializedValueMap.put(key, instance);
+        }
+    }
+
+    private static <T> T readJsonIfDeserializable(JsonObject serializedJson, T instance) {
+        if (instance instanceof JsonSerializable) {
+            ((JsonSerializable) instance).fromJson(serializedJson);
+        }
+        return instance;
     }
 
     @Override
@@ -468,9 +491,8 @@ public class MemberStateImpl implements MemberState {
             multiMapStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "replicatedMapStats", new JsonObject())) {
-            LocalReplicatedMapStats stats = new LocalReplicatedMapStatsImpl();
-            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
-            replicatedMapStats.put(next.getName(), stats);
+            putDeserializedIfSerializable(replicatedMapStats, next.getName(), next.getValue().asObject(),
+                    new LocalReplicatedMapStatsImpl());
         }
         for (JsonObject.Member next : getObject(json, "queueStats")) {
             LocalQueueStatsImpl stats = new LocalQueueStatsImpl();
@@ -498,19 +520,16 @@ public class MemberStateImpl implements MemberState {
             executorStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "cacheStats", new JsonObject())) {
-            LocalCacheStats stats = new LocalCacheStatsImpl();
-            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
-            cacheStats.put(next.getName(), stats);
+            putDeserializedIfSerializable(cacheStats, next.getName(), next.getValue().asObject(),
+                    new LocalCacheStatsImpl());
         }
         for (JsonObject.Member next : getObject(json, "wanStats", new JsonObject())) {
-            LocalWanStats stats = new LocalWanStatsImpl();
-            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
-            wanStats.put(next.getName(), stats);
+            putDeserializedIfSerializable(wanStats, next.getName(), next.getValue().asObject(),
+                    new LocalWanStatsImpl());
         }
         for (JsonObject.Member next : getObject(json, "flakeIdStats", new JsonObject())) {
-            LocalFlakeIdGeneratorStats stats = new LocalFlakeIdGeneratorStatsImpl();
-            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
-            flakeIdGeneratorStats.put(next.getName(), stats);
+            putDeserializedIfSerializable(flakeIdGeneratorStats, next.getName(), next.getValue().asObject(),
+                    new LocalFlakeIdGeneratorStatsImpl());
         }
         for (JsonObject.Member next : getObject(json, "runtimeProps")) {
             runtimeProps.put(next.getName(), next.getValue().asLong());
@@ -525,11 +544,11 @@ public class MemberStateImpl implements MemberState {
         beans.fromJson(getObject(json, "beans"));
         JsonObject jsonMemoryStats = getObject(json, "memoryStats", null);
         if (jsonMemoryStats != null) {
-            ((JsonSerializable) memoryStats).fromJson(jsonMemoryStats);
+            memoryStats = readJsonIfDeserializable(jsonMemoryStats, memoryStats);
         }
         JsonObject jsonOperationStats = getObject(json, "operationStats", null);
         if (jsonOperationStats != null) {
-            ((JsonSerializable) operationStats).fromJson(jsonOperationStats);
+            operationStats = readJsonIfDeserializable(jsonOperationStats, operationStats);
         }
         JsonObject jsonMemberPartitionState = getObject(json, "memberPartitionState", null);
         if (jsonMemberPartitionState != null) {
@@ -553,8 +572,7 @@ public class MemberStateImpl implements MemberState {
         }
         JsonObject jsonWanSyncState = getObject(json, "wanSyncState", null);
         if (jsonWanSyncState != null) {
-            wanSyncState = new WanSyncStateImpl();
-            ((JsonSerializable) wanSyncState).fromJson(jsonWanSyncState);
+            wanSyncState = readJsonIfDeserializable(jsonWanSyncState, new WanSyncStateImpl());
         }
         for (JsonObject.Member next : getObject(json, "clientStats")) {
             clientStats.put(UUID.fromString(next.getName()), next.getValue().asString());

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/MemberStateImpl.java
@@ -39,7 +39,7 @@ import com.hazelcast.internal.monitor.MemberPartitionState;
 import com.hazelcast.internal.monitor.MemberState;
 import com.hazelcast.internal.monitor.NodeState;
 import com.hazelcast.internal.monitor.WanSyncState;
-import com.hazelcast.json.JsonSerializable;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.multimap.LocalMultiMapStats;
 import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
@@ -66,20 +66,20 @@ public class MemberStateImpl implements MemberState {
     private UUID uuid;
     private UUID cpMemberUuid;
     private String name;
-    private Map<EndpointQualifier, Address> endpoints = new HashMap<EndpointQualifier, Address>();
-    private Map<String, Long> runtimeProps = new HashMap<String, Long>();
-    private Map<String, LocalMapStats> mapStats = new HashMap<String, LocalMapStats>();
-    private Map<String, LocalMultiMapStats> multiMapStats = new HashMap<String, LocalMultiMapStats>();
-    private Map<String, LocalQueueStats> queueStats = new HashMap<String, LocalQueueStats>();
-    private Map<String, LocalTopicStats> topicStats = new HashMap<String, LocalTopicStats>();
-    private Map<String, LocalTopicStats> reliableTopicStats = new HashMap<String, LocalTopicStats>();
-    private Map<String, LocalPNCounterStats> pnCounterStats = new HashMap<String, LocalPNCounterStats>();
-    private Map<String, LocalExecutorStats> executorStats = new HashMap<String, LocalExecutorStats>();
-    private Map<String, LocalReplicatedMapStats> replicatedMapStats = new HashMap<String, LocalReplicatedMapStats>();
-    private Map<String, LocalCacheStats> cacheStats = new HashMap<String, LocalCacheStats>();
-    private Map<String, LocalWanStats> wanStats = new HashMap<String, LocalWanStats>();
-    private Map<String, LocalFlakeIdGeneratorStats> flakeIdGeneratorStats = new HashMap<String, LocalFlakeIdGeneratorStats>();
-    private Collection<ClientEndPointDTO> clients = new HashSet<ClientEndPointDTO>();
+    private Map<EndpointQualifier, Address> endpoints = new HashMap<>();
+    private Map<String, Long> runtimeProps = new HashMap<>();
+    private Map<String, LocalMapStats> mapStats = new HashMap<>();
+    private Map<String, LocalMultiMapStats> multiMapStats = new HashMap<>();
+    private Map<String, LocalQueueStats> queueStats = new HashMap<>();
+    private Map<String, LocalTopicStats> topicStats = new HashMap<>();
+    private Map<String, LocalTopicStats> reliableTopicStats = new HashMap<>();
+    private Map<String, LocalPNCounterStats> pnCounterStats = new HashMap<>();
+    private Map<String, LocalExecutorStats> executorStats = new HashMap<>();
+    private Map<String, LocalReplicatedMapStats> replicatedMapStats = new HashMap<>();
+    private Map<String, LocalCacheStats> cacheStats = new HashMap<>();
+    private Map<String, LocalWanStats> wanStats = new HashMap<>();
+    private Map<String, LocalFlakeIdGeneratorStats> flakeIdGeneratorStats = new HashMap<>();
+    private Collection<ClientEndPointDTO> clients = new HashSet<>();
     private Map<UUID, String> clientStats = new HashMap<>();
     private MXBeansDTO beans = new MXBeansDTO();
     private LocalMemoryStats memoryStats = new LocalMemoryStatsImpl();
@@ -348,6 +348,7 @@ public class MemberStateImpl implements MemberState {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public JsonObject toJson() {
         final JsonObject root = new JsonObject();
         root.add("address", address);
@@ -399,13 +400,13 @@ public class MemberStateImpl implements MemberState {
         }
         root.add("clients", clientsArray);
         root.add("beans", beans.toJson());
-        root.add("memoryStats", memoryStats.toJson());
-        root.add("operationStats", operationStats.toJson());
+        root.add("memoryStats", ((JsonSerializable) memoryStats).toJson());
+        root.add("operationStats", ((JsonSerializable) operationStats).toJson());
         root.add("memberPartitionState", memberPartitionState.toJson());
         root.add("nodeState", nodeState.toJson());
         root.add("hotRestartState", hotRestartState.toJson());
         root.add("clusterHotRestartStatus", clusterHotRestartStatus.toJson());
-        root.add("wanSyncState", wanSyncState.toJson());
+        root.add("wanSyncState", ((JsonSerializable) wanSyncState).toJson());
 
         JsonObject clientStatsObject = new JsonObject();
         for (Map.Entry<UUID, String> entry : clientStats.entrySet()) {
@@ -417,10 +418,10 @@ public class MemberStateImpl implements MemberState {
         return root;
     }
 
-    private static void serializeMap(JsonObject root, String key, Map<String, ? extends JsonSerializable> map) {
+    private static void serializeMap(JsonObject root, String key, Map<String, ?> map) {
         final JsonObject jsonObject = new JsonObject();
-        for (Entry<String, ? extends JsonSerializable> e : map.entrySet()) {
-            jsonObject.add(e.getKey(), e.getValue().toJson());
+        for (Entry<String, ?> e : map.entrySet()) {
+            jsonObject.add(e.getKey(), ((JsonSerializable) e.getValue()).toJson());
         }
         root.add(key, jsonObject);
     }
@@ -468,7 +469,7 @@ public class MemberStateImpl implements MemberState {
         }
         for (JsonObject.Member next : getObject(json, "replicatedMapStats", new JsonObject())) {
             LocalReplicatedMapStats stats = new LocalReplicatedMapStatsImpl();
-            stats.fromJson(next.getValue().asObject());
+            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
             replicatedMapStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "queueStats")) {
@@ -498,17 +499,17 @@ public class MemberStateImpl implements MemberState {
         }
         for (JsonObject.Member next : getObject(json, "cacheStats", new JsonObject())) {
             LocalCacheStats stats = new LocalCacheStatsImpl();
-            stats.fromJson(next.getValue().asObject());
+            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
             cacheStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "wanStats", new JsonObject())) {
             LocalWanStats stats = new LocalWanStatsImpl();
-            stats.fromJson(next.getValue().asObject());
+            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
             wanStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "flakeIdStats", new JsonObject())) {
             LocalFlakeIdGeneratorStats stats = new LocalFlakeIdGeneratorStatsImpl();
-            stats.fromJson(next.getValue().asObject());
+            ((JsonSerializable) stats).fromJson(next.getValue().asObject());
             flakeIdGeneratorStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "runtimeProps")) {
@@ -524,11 +525,11 @@ public class MemberStateImpl implements MemberState {
         beans.fromJson(getObject(json, "beans"));
         JsonObject jsonMemoryStats = getObject(json, "memoryStats", null);
         if (jsonMemoryStats != null) {
-            memoryStats.fromJson(jsonMemoryStats);
+            ((JsonSerializable) memoryStats).fromJson(jsonMemoryStats);
         }
         JsonObject jsonOperationStats = getObject(json, "operationStats", null);
         if (jsonOperationStats != null) {
-            operationStats.fromJson(jsonOperationStats);
+            ((JsonSerializable) operationStats).fromJson(jsonOperationStats);
         }
         JsonObject jsonMemberPartitionState = getObject(json, "memberPartitionState", null);
         if (jsonMemberPartitionState != null) {
@@ -553,7 +554,7 @@ public class MemberStateImpl implements MemberState {
         JsonObject jsonWanSyncState = getObject(json, "wanSyncState", null);
         if (jsonWanSyncState != null) {
             wanSyncState = new WanSyncStateImpl();
-            wanSyncState.fromJson(jsonWanSyncState);
+            ((JsonSerializable) wanSyncState).fromJson(jsonWanSyncState);
         }
         for (JsonObject.Member next : getObject(json, "clientStats")) {
             clientStats.put(UUID.fromString(next.getName()), next.getValue().asString());

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/NearCacheStatsImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.nearcache.NearCacheStats;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -28,7 +29,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 @SuppressWarnings("checkstyle:methodcount")
-public class NearCacheStatsImpl implements NearCacheStats {
+public class NearCacheStatsImpl implements NearCacheStats, JsonSerializable {
 
     private static final double PERCENTAGE = 100.0;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/WanSyncStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/WanSyncStateImpl.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.monitor.impl;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.monitor.WanSyncState;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.wan.impl.WanSyncStatus;
 
-public class WanSyncStateImpl implements WanSyncState {
+public class WanSyncStateImpl implements WanSyncState, JsonSerializable {
 
     private long creationTime;
     private WanSyncStatus status = WanSyncStatus.READY;

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSerializable.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.json;
+package com.hazelcast.json.internal;
 
 import com.hazelcast.internal.json.JsonObject;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStatsTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -68,7 +69,7 @@ public class EmptyLocalReplicatedMapStatsTest {
 
     @Test
     public void testSerialization() {
-        JsonObject serialized = localReplicatedMapStats.toJson();
+        JsonObject serialized = ((JsonSerializable) localReplicatedMapStats).toJson();
         EmptyLocalReplicatedMapStats deserialized = new EmptyLocalReplicatedMapStats();
         deserialized.fromJson(serialized);
 
@@ -105,7 +106,7 @@ public class EmptyLocalReplicatedMapStatsTest {
     @Test
     public void testToJsonReturnSameKeysAsRegularEmptyStats() {
         JsonObject jsonOfRegularEmptyStats = new LocalReplicatedMapStatsImpl().toJson();
-        JsonObject actual = localReplicatedMapStats.toJson();
+        JsonObject actual = ((JsonSerializable) localReplicatedMapStats).toJson();
         assertEquals(jsonOfRegularEmptyStats.size(), actual.size());
         assertEquals(jsonOfRegularEmptyStats.names(), actual.names());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalWanStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalWanStatsImplTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.internal.monitor.LocalWanPublisherStats;
 import com.hazelcast.internal.monitor.LocalWanStats;
@@ -59,7 +60,7 @@ public class LocalWanStatsImplTest {
         JsonObject serialized = localWanStats.toJson();
 
         LocalWanStats deserialized = new LocalWanStatsImpl();
-        deserialized.fromJson(serialized);
+        ((JsonSerializable) deserialized).fromJson(serialized);
 
         LocalWanPublisherStats deserializedTokyo = deserialized.getLocalWanPublisherStats().get("tokyo");
         LocalWanPublisherStats deserializedSingapore = deserialized.getLocalWanPublisherStats().get("singapore");

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.spi.impl.operationexecutor.slowoperationdetector;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.monitor.LocalOperationStats;
+import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.map.IMap;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
@@ -95,7 +97,10 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
 
     static JsonObject getOperationStats(HazelcastInstance instance) {
         TimedMemberStateFactory timedMemberStateFactory = new TimedMemberStateFactory(getHazelcastInstanceImpl(instance));
-        return timedMemberStateFactory.createTimedMemberState().getMemberState().getOperationStats().toJson();
+        LocalOperationStats operationStats = timedMemberStateFactory.createTimedMemberState()
+                                                                    .getMemberState()
+                                                                    .getOperationStats();
+        return ((JsonSerializable) operationStats).toJson();
     }
 
     static Collection<SlowOperationLog> getSlowOperationLogsAndAssertNumberOfSlowOperationLogs(final HazelcastInstance instance,


### PR DESCRIPTION
JsonSerializable is supposed to be used only when exchanging statistics
with management center. Previously, it was public API because some
statistics classes such as LocalMapStats were exposed as public methods.

Now we move JsonSerializable to private API. Because of this, we have to
cast whenever we want to transform from/to JSON as most internal code
exchanges stats interfaces such as LocalMapStats. The alternative is
that the internal API exchanges concrete classes such as
LocalMapStatsImpl but this is not possible since sometimes there are two
different implementations for the same stats interface.

Addresses https://github.com/hazelcast/hazelcast/pull/15888#discussion_r340582364
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3358