### PR TITLE
Apply core Raft fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
@@ -153,8 +153,16 @@ final class NodeEngineRaftIntegration implements RaftIntegration {
 
     @Override
     public boolean isReachable(RaftEndpoint target) {
+        if (!isStartCompleted()) {
+            return true;
+        }
+
         CPMember targetMember = getCPMember(target);
         return targetMember != null && nodeEngine.getClusterService().getMember(targetMember.getAddress()) != null;
+    }
+
+    private boolean isStartCompleted() {
+        return nodeEngine.getNode().getNodeExtension().isStartCompleted();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
@@ -1365,6 +1365,10 @@ public final class RaftNodeImpl implements RaftNode {
         @Override
         protected void innerRun() {
             try {
+                if (state.role() == LEADER) {
+                    return;
+                }
+
                 RaftEndpoint leader = state.leader();
                 if (leader == null) {
                     if (state.role() == FOLLOWER) {


### PR DESCRIPTION
* Make Raft leader skip checking liveliness of the leader. Although it
has no harm normally, during restarts with circular IP changes a Raft
leader can incorrectly suspect that it is not reachable.

* Disable RaftIntegration.isReachable() optimization during restarts.
This optimization is to detect leader failures faster by relying on
Hazelcast's failure detection mechanisms but it can create false alarms
during restarts with circular IP changes.

Fixes the failure in https://github.com/hazelcast/hazelcast-enterprise/issues/3279#issuecomment-549269736

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3279