### PR TITLE
OSMBean.getFreePhysicalMemorySize supression option 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -24,15 +24,16 @@ import com.hazelcast.internal.management.dto.ManagedExecutorDTO;
 import com.hazelcast.internal.management.dto.OperationServiceDTO;
 import com.hazelcast.internal.management.dto.PartitionServiceBeanDTO;
 import com.hazelcast.internal.management.dto.ProxyServiceDTO;
-import com.hazelcast.internal.partition.InternalPartitionService;
-import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.internal.monitor.impl.MemberStateImpl;
 import com.hazelcast.internal.nio.NetworkingService;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.util.OperatingSystemMXBeanSupport;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
+import com.hazelcast.internal.util.executor.ManagedExecutorService;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
-import com.hazelcast.spi.impl.proxyservice.ProxyService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.internal.util.executor.ManagedExecutorService;
+import com.hazelcast.spi.impl.proxyservice.ProxyService;
 
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
@@ -53,7 +54,8 @@ final class TimedMemberStateFactoryHelper {
 
     private static final int PERCENT_MULTIPLIER = 100;
 
-    private TimedMemberStateFactoryHelper() { }
+    private TimedMemberStateFactoryHelper() {
+    }
 
     static void registerJMXBeans(HazelcastInstanceImpl instance, MemberStateImpl memberState) {
         final EventService es = instance.node.nodeEngine.getEventService();
@@ -149,6 +151,11 @@ final class TimedMemberStateFactoryHelper {
     }
 
     private static Long get(OperatingSystemMXBean mbean, String methodName, Long defaultValue) {
+        if (OperatingSystemMXBeanSupport.GET_FREE_PHYSICAL_MEMORY_SIZE_DISABLED
+                && methodName.equals("getFreePhysicalMemorySize")) {
+            return defaultValue;
+        }
+
         try {
             Method method = mbean.getClass().getMethod(methodName);
             method.setAccessible(true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/OperatingSystemMXBeanSupport_FreePhysicalMemorySizeDisabledTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/OperatingSystemMXBeanSupport_FreePhysicalMemorySizeDisabledTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.util.OperatingSystemMXBeanSupport.COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("checkstyle:magicnumber")
+public class OperatingSystemMXBeanSupport_FreePhysicalMemorySizeDisabledTest {
+
+    private static final int DEFAULT_VALUE = -1;
+
+    @After
+    public void after() {
+        System.clearProperty(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED);
+        OperatingSystemMXBeanSupport.reload();
+    }
+
+    @Test
+    public void whenDisabled() {
+        System.setProperty(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED, "true");
+        OperatingSystemMXBeanSupport.reload();
+        long result = OperatingSystemMXBeanSupport.readLongAttribute("FreePhysicalMemorySize", DEFAULT_VALUE);
+        assertEquals(DEFAULT_VALUE, result);
+    }
+
+    @Test
+    public void whenDefault() {
+        OperatingSystemMXBeanSupport.reload();
+        long result = OperatingSystemMXBeanSupport.readLongAttribute("FreePhysicalMemorySize", DEFAULT_VALUE);
+        assertNotEquals(DEFAULT_VALUE, result);
+    }
+
+    @Test
+    public void whenEnabled() {
+        System.setProperty(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED, "false");
+        OperatingSystemMXBeanSupport.reload();
+        long result = OperatingSystemMXBeanSupport.readLongAttribute("FreePhysicalMemorySize", DEFAULT_VALUE);
+        assertNotEquals(DEFAULT_VALUE, result);
+    }
+}


### PR DESCRIPTION
Adds option to disable the retrieval of this method.

We have one customer that runs in to multisecond execution times of the method when he runs under AIX.