### PR TITLE
Small metrics improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -91,21 +91,21 @@ public class MetricsPlugin extends DiagnosticsPlugin {
         @Override
         public void collectLong(MetricDescriptor descriptor, long value) {
             if (descriptor.isTargetIncluded(DIAGNOSTICS)) {
-                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.toString(), value);
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.metricString(), value);
             }
         }
 
         @Override
         public void collectDouble(MetricDescriptor descriptor, double value) {
             if (descriptor.isTargetIncluded(DIAGNOSTICS)) {
-                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.toString(), value);
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.metricString(), value);
             }
         }
 
         @Override
         public void collectException(MetricDescriptor descriptor, Exception e) {
             if (descriptor.isTargetIncluded(DIAGNOSTICS)) {
-                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.toString(),
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.metricString(),
                         e.getClass().getName() + ':' + e.getMessage());
             }
         }
@@ -113,7 +113,7 @@ public class MetricsPlugin extends DiagnosticsPlugin {
         @Override
         public void collectNoValue(MetricDescriptor descriptor) {
             if (descriptor.isTargetIncluded(DIAGNOSTICS)) {
-                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.toString(), "NA");
+                writer.writeSectionKeyValue(SECTION_NAME, timeMillis, descriptor.metricString(), "NA");
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -466,6 +466,8 @@ public class MetricsCompressor {
         private void extractMetrics() throws IOException {
             for (int i = 0; i < countMetrics; i++) {
                 MetricDescriptor descriptor = readMetricDescriptor();
+                lastDescriptor.copy(descriptor);
+
                 int typeOrdinal = dis.readUnsignedByte();
                 ValueType type = ValueType.valueOf(typeOrdinal);
 
@@ -480,7 +482,6 @@ public class MetricsCompressor {
                         throw new IllegalStateException("Unexpected metric value type: " + type + " with ordinal " + typeOrdinal);
                 }
 
-                lastDescriptor.copy(descriptor);
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -66,7 +66,7 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
         });
 
         plugin.run(logWriter);
-        assertContains("[metric=broken,excludedTargets={}]=java.lang.RuntimeException:error");
+        assertContains("[metric=broken]=java.lang.RuntimeException:error");
     }
 
     @Test
@@ -74,8 +74,8 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
         plugin.run(logWriter);
 
         // we just test a few to make sure the metrics are written
-        assertContains("[unit=count,metric=client.endpoint.count,excludedTargets={}]=0");
-        assertContains("[unit=count,metric=operation.responseQueueSize,excludedTargets={}]=0");
+        assertContains("[unit=count,metric=client.endpoint.count]=0");
+        assertContains("[unit=count,metric=operation.responseQueueSize]=0");
     }
 
     @Test
@@ -84,10 +84,10 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
 
         plugin.run(logWriter);
 
-        assertContains("[unit=count,metric=test.notExcludedLong,excludedTargets={}]=1");
-        assertNotContains("[unit=count,metric=test.excludedLong,excludedTargets={}]=1");
-        assertContains("[unit=count,metric=test.notExcludedDouble,excludedTargets={}]=1.5");
-        assertNotContains("[unit=count,metric=test.excludedDouble,excludedTargets={}]=2.5");
+        assertContains("[unit=count,metric=test.notExcludedLong]=1");
+        assertNotContains("[unit=count,metric=test.excludedLong]=1");
+        assertContains("[unit=count,metric=test.notExcludedDouble]=1.5");
+        assertNotContains("[unit=count,metric=test.excludedDouble]=2.5");
     }
 
     private static class ExclusionProbeSource {


### PR DESCRIPTION
Two improvements/fixes:
- **Ignore descriptor mutations in `extractMetrics()`**
When decompressing and extracting a metric, mutating its
`MetricDescriptor` impacts extracting the subsequent metric too if that
metric shares at least one field with the modified one. This is fixed
by copying the extracted descriptor into `lastDescriptor` before it is
passed to the `MetricConsumer` where it can be modified.
- **Use `metricString()` instead of `toString()` in `MetricsPlugin`**
`MetricDescriptor.toString()` includes `excludedTargets` too, which is
irrelevant info for the diagnostics. Therefore,
`MetricDescriptor.metricString()` without `excludedTargets` is used
instead of `toString()`.