### PR TITLE
Cleanup distributed objects after test execution

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.ITopic;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -80,6 +81,14 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
         hz = createHazelcastInstance(config);
 
         warmUpPartitions(hz);
+    }
+
+    @After
+    public void tearDown() {
+        // explicit cleanup is required because the MBean server is static
+        // cache statistics registrations will be left over when test's
+        // HazelcastInstance shuts down
+        destroyAllDistributedObjects(hz);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.monitor.impl.MemberStateImpl;
@@ -35,8 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.Collection;
 
 import static com.hazelcast.cache.CacheUtil.getDistributedObjectName;
 import static org.junit.Assert.assertEquals;
@@ -73,10 +70,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
     public void tearDown() {
         // explicit cleanup is required because the MBean server is static so registrations
         // will be left over when test's HazelcastInstance shuts down
-        Collection<DistributedObject> distributedObjects = hz.getDistributedObjects();
-        for (DistributedObject object : distributedObjects) {
-            object.destroy();
-        }
+        destroyAllDistributedObjects(hz);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -24,6 +24,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.instance.BuildInfoProvider;
@@ -1794,4 +1795,10 @@ public abstract class HazelcastTestSupport {
         return results;
     }
 
+    public static void destroyAllDistributedObjects(HazelcastInstance hz) {
+        Collection<DistributedObject> distributedObjects = hz.getDistributedObjects();
+        for (DistributedObject object : distributedObjects) {
+            object.destroy();
+        }
+    }
 }


### PR DESCRIPTION
Cache statistics are registered with the MBeanServer which is static,
so explicit cleanup is required after the test to avoid breaking
assertions in further test executions.

Fixes #15969 