### PR TITLE
Do not expose SerializationService in ObjectDataOutput

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.CacheConfigAccessor;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.tenantcontrol.TenantControl;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -84,7 +85,8 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> {
 
     @Override
     protected void writeFactories(ObjectDataOutput out) throws IOException {
-        SerializationService serializationService = out.getSerializationService();
+        assert (out instanceof SerializationServiceSupport) : "out must implement SerializationServiceSupport";
+        SerializationService serializationService = ((SerializationServiceSupport) out).getSerializationService();
         out.writeData(cacheLoaderFactory.getSerializedValue(serializationService));
         out.writeData(cacheWriterFactory.getSerializedValue(serializationService));
         out.writeData(expiryPolicyFactory.getSerializedValue(serializationService));
@@ -99,9 +101,10 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> {
 
     @Override
     protected void writeListenerConfigurations(ObjectDataOutput out) throws IOException {
+        assert (out instanceof SerializationServiceSupport) : "out must implement SerializationServiceSupport";
         out.writeInt(listenerConfigurations.size());
         for (DeferredValue<CacheEntryListenerConfiguration<K, V>> config : listenerConfigurations) {
-            out.writeData(config.getSerializedValue(out.getSerializationService()));
+            out.writeData(config.getSerializedValue(((SerializationServiceSupport) out).getSerializationService()));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataOutput.java
@@ -17,14 +17,13 @@
 package com.hazelcast.internal.nio;
 
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-public interface BufferObjectDataOutput extends ObjectDataOutput, Closeable {
-
-    int UTF_BUFFER_SIZE = 1024;
+public interface BufferObjectDataOutput extends ObjectDataOutput, Closeable, SerializationServiceSupport {
 
     void write(int position, int b);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -19,12 +19,14 @@ package com.hazelcast.internal.serialization.impl;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
 
 @SuppressWarnings("checkstyle:methodcount")
-final class EmptyObjectDataOutput extends VersionedObjectDataOutput implements ObjectDataOutput {
+final class EmptyObjectDataOutput extends VersionedObjectDataOutput
+        implements ObjectDataOutput, SerializationServiceSupport {
 
     @Override
     public void writeObject(Object object) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 
 import java.io.Closeable;
 import java.io.DataOutputStream;
@@ -31,7 +32,8 @@ import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.internal.nio.Bits.UTF_8;
 
 @SuppressWarnings("checkstyle:methodcount")
-public class ObjectDataOutputStream extends VersionedObjectDataOutput implements ObjectDataOutput, Closeable {
+public class ObjectDataOutputStream extends VersionedObjectDataOutput
+        implements ObjectDataOutput, Closeable, SerializationServiceSupport {
 
     private final InternalSerializationService serializationService;
     private final DataOutputStream dataOut;

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -17,7 +17,6 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -109,9 +108,4 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
      * @return ByteOrder BIG_ENDIAN or LITTLE_ENDIAN
      */
     ByteOrder getByteOrder();
-
-    /**
-     * @return serialization service for this object
-     */
-    SerializationService getSerializationService();
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableImplementsVersionedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableImplementsVersionedTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.VersionAware;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,10 +41,12 @@ import java.util.Set;
 import static com.hazelcast.test.ReflectionsHelper.REFLECTIONS;
 import static com.hazelcast.test.ReflectionsHelper.filterNonConcreteClasses;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Iterates over all {@link DataSerializable} and {@link IdentifiedDataSerializable} classes
@@ -172,8 +175,10 @@ public class DataSerializableImplementsVersionedTest {
 
     // overridden in EE
     protected ObjectDataOutput getObjectDataOutput() {
-        ObjectDataOutput output = spy(ObjectDataOutput.class);
-        when(output.getSerializationService()).thenReturn(serializationService);
+        ObjectDataOutput output = mock(ObjectDataOutput.class,
+                withSettings().extraInterfaces(SerializationServiceSupport.class));
+        when(((SerializationServiceSupport) output).getSerializationService())
+                .thenReturn(serializationService);
         return output;
     }
 


### PR DESCRIPTION
`SerializationService` is now internal API and shouldn't be accessible
via public API methods.

Instead, internal interfaces/implementations of `ObjectDataOutput`
implement `SerializationServiceSupport` and we make use of this
interface in `PreJoinCacheConfig` where serialization service is 
needed to implement deferred serialization/deserialization of
user customizations.

thanks @sancar for noticing the issue