### PR TITLE
Remove hazelcast.discovery.* properties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -510,7 +510,9 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             }
         }
 
-        discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(clazz, properties));
+        DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(clazz, properties);
+        discoveryStrategyConfig.setEnabled(true);
+        discoveryConfig.addDiscoveryStrategyConfig(discoveryStrategyConfig);
     }
 
     private void handleAliasedDiscoveryStrategy(Node node, ClientNetworkConfig clientNetworkConfig, String tag) {

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -107,22 +107,6 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.client.invocation.backoff.timeout.millis", -1, MILLISECONDS);
 
     /**
-     * <p>Enables the Discovery SPI lookup over the old native implementations. This property is temporary and will
-     * eventually be removed when the experimental marker is removed.</p>
-     * <p>Discovery SPI is <b>disabled</b> by default</p>
-     */
-    public static final HazelcastProperty DISCOVERY_SPI_ENABLED
-            = new HazelcastProperty("hazelcast.discovery.enabled", false);
-
-    /**
-     * <p>Enables the Discovery Joiner to use public ips from DiscoveredNode. This property is temporary and will
-     * eventually be removed when the experimental marker is removed.</p>
-     * <p>Discovery SPI is <b>disabled</b> by default</p>
-     */
-    public static final HazelcastProperty DISCOVERY_SPI_PUBLIC_IP_ENABLED
-            = new HazelcastProperty("hazelcast.discovery.public.ip.enabled", false);
-
-    /**
      * Controls the number of IO input threads. Defaults to -1, so the system will decide.
      *
      * If client is a smart client, it will default to 3 otherwise it will default to 1.

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -33,6 +33,8 @@ import java.util.Map;
  * based on a parsed XML or configured manually using the config API
  */
 public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
+
+    private boolean enabled;
     private String className;
     // we skip serialization since this may be a user-supplied object and
     // it may not be serializable. Since we send the WAN config in the
@@ -135,10 +137,19 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
         return ConfigDataSerializerHook.DISCOVERY_STRATEGY_CONFIG;
     }
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public DiscoveryStrategyConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(className);
-
+        out.writeBoolean(enabled);
         out.writeInt(properties.size());
         for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
             out.writeUTF(entry.getKey());
@@ -149,6 +160,7 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         className = in.readUTF();
+        enabled = in.readBoolean();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             properties.put(in.readUTF(), (Comparable) in.readObject());

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AliasedDiscoveryConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AliasedDiscoveryConfigUtils.java
@@ -108,7 +108,9 @@ public final class AliasedDiscoveryConfigUtils {
         for (String key : config.getProperties().keySet()) {
             putIfKeyNotNull(properties, key, config.getProperties().get(key));
         }
-        return new DiscoveryStrategyConfig(className, properties);
+        DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(className, properties);
+        discoveryStrategyConfig.setEnabled(true);
+        return discoveryStrategyConfig;
     }
 
     private static void validateConfig(AliasedDiscoveryConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1366,7 +1366,9 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             }
         }
 
-        discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(clazz, properties));
+        DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(clazz, properties);
+        discoveryStrategyConfig.setEnabled(true);
+        discoveryConfig.addDiscoveryStrategyConfig(discoveryStrategyConfig);
     }
 
     private void handleAliasedDiscoveryStrategy(JoinConfig joinConfig, Node node, String tag) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -927,22 +927,6 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.jcache.provider.type");
 
     /**
-     * <p>Enables the Discovery SPI lookup over the old native implementations. This property is temporary and will
-     * eventually be removed when the experimental marker is removed.</p>
-     * <p>Discovery SPI is <b>disabled</b> by default</p>
-     */
-    public static final HazelcastProperty DISCOVERY_SPI_ENABLED
-            = new HazelcastProperty("hazelcast.discovery.enabled", false);
-
-    /**
-     * <p>Enables the Discovery Joiner to use public ips from DiscoveredNode. This property is temporary and will
-     * eventually be removed when the experimental marker is removed.</p>
-     * <p>Discovery SPI is <b>disabled</b> by default</p>
-     */
-    public static final HazelcastProperty DISCOVERY_SPI_PUBLIC_IP_ENABLED
-            = new HazelcastProperty("hazelcast.discovery.public.ip.enabled", false);
-
-    /**
      * Hazelcast serialization version. This is single byte value between 1 and Max supported serialization version.
      *
      * @see BuildInfo#getSerializationVersion()

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -237,9 +237,7 @@
             Set its "enabled" attribute to true for cluster discovery in the Hazelcast Cloud infrastructure. You need to
             define the mandatory <discovery-token> used by the discovery mechanism.
         * <discovery-strategies>:
-            Set its "enabled" attribute to true for cluster discovery in various cloud infrastructures. You also need to set the
-            value of "hazelcast.discovery.enabled" property to true. See the description of the <properties> element
-            to learn how to do this.
+            Set its "enabled" attribute to true for cluster discovery in various cloud infrastructures.
             You can define multiple discovery strategies using the <discovery-strategy> sub-element and its
             properties. Please refer to
             http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -205,9 +205,7 @@ hazelcast-client:
   #     Set its "enabled" sub-element to true for cluster discovery in the Hazelcast Cloud infrastructure. You need to
   #     define the mandatory "discovery-token" sub-node used by the discovery mechanism.
   # * "discovery-strategies":
-  #     Set its "enabled" sub-element to true for discovery in various cloud infrastructures. You also need to set the
-  #     value of "hazelcast.discovery.enabled" property to true. See the description of the "properties" element
-  #     to learn how to do this.
+  #     Set its "enabled" sub-element to true for discovery in various cloud infrastructures.
   #     You can define multiple discovery strategies using the "discovery-strategy" sub-element and its
   #     properties. Please refer to
   #     http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -515,9 +515,7 @@
             Please refer to https://github.com/hazelcast/hazelcast-eureka#hazelcast-configuration for
             the configuration details.
         - <discovery-strategies>:
-            Set its "enabled" attribute to true for discovery in various cloud infrastructures. You also need to set the
-            value of "hazelcast.discovery.enabled" property to true. See the description of the <properties> element
-            to learn how to do this.
+            Set its "enabled" attribute to true for discovery in various cloud infrastructures.
             You can define multiple discovery strategies using the <discovery-strategy> sub-element and its
             properties. Please refer to
             http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members
@@ -2695,9 +2693,7 @@
                 Please refer to https://github.com/hazelcast/hazelcast-eureka#hazelcast-configuration for
                 the configuration details.
             - <discovery-strategies>:
-                Set its "enabled" attribute to true for discovery in various cloud infrastructures. You also need to set the
-                value of "hazelcast.discovery.enabled" property to true. See the description of the <properties> element
-                to learn how to do this.
+                Set its "enabled" attribute to true for discovery in various cloud infrastructures.
                 You can define multiple discovery strategies using the <discovery-strategy> sub-element and its
                 properties. Please refer to
                 http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -504,9 +504,7 @@ hazelcast:
   #         Please refer to https://github.com/hazelcast/hazelcast-eureka#hazelcast-configuration for
   #         the configuration details.
   # - "discovery-strategies":
-  #     Set its "enabled" attribute to true for discovery in various cloud infrastructures. You also need to set the
-  #     value of "hazelcast.discovery.enabled" property to true. See the description of the "properties" element
-  #     to learn how to do this.
+  #     Set its "enabled" attribute to true for discovery in various cloud infrastructures.
   #     You can define multiple discovery strategies and its properties. Please refer to
   #     http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members
   #     to see the properties you can use.
@@ -2641,9 +2639,7 @@ hazelcast:
   #          Please refer to https://github.com/hazelcast/hazelcast-eureka#hazelcast-configuration for
   #          the configuration details.
   #      - "discovery-strategies":
-  #          Set its "enabled" sub-element to true for discovery in various cloud infrastructures. You also need to set the
-  #          value of "hazelcast.discovery.enabled" property to true. See the description of the "properties" element
-  #          to learn how to do this.
+  #          Set its "enabled" sub-element to true for discovery in various cloud infrastructures.
   #          You can define multiple discovery strategies using the "discovery-strategy" sub-element and its
   #          properties. Please refer to
   #          http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.config.ClientClasspathXmlConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
@@ -33,7 +34,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
@@ -47,7 +47,6 @@ import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -133,8 +132,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     @Test
     public void testNodeStartup() {
         Config config = new Config();
-        config.setProperty("hazelcast.discovery.enabled", "true");
-
         config.getNetworkConfig().setPort(50001);
         InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
         interfaces.clear();
@@ -151,6 +148,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        strategyConfig.setEnabled(true);
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         final HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
@@ -159,11 +157,11 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
         try {
             ClientConfig clientConfig = new ClientConfig();
-            clientConfig.setProperty("hazelcast.discovery.enabled", "true");
             discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
             discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
             strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+            strategyConfig.setEnabled(true);
             discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
             final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
@@ -185,8 +183,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
         //Given
         Config config = new Config();
-        config.setProperty("hazelcast.discovery.enabled", "true");
-
         config.getNetworkConfig().setPort(50001);
         InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
         interfaces.clear();
@@ -207,15 +203,16 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        strategyConfig.setEnabled(true);
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         final HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setProperty("hazelcast.discovery.enabled", "true");
         discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        strategyConfig.setEnabled(true);
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
@@ -239,10 +236,10 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         Hazelcast.newHazelcastInstance(config);
         ClientConfig clientConfig = new ClientConfig();
 
-        clientConfig.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
         DiscoveryConfig discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
         DiscoveryStrategyFactory factory = new ExceptionThrowingDiscoveryStrategyFactory();
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        strategyConfig.setEnabled(true);
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         HazelcastClient.newHazelcastClient(clientConfig);
@@ -276,7 +273,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void test_enabled_whenDiscoveryConfigIsNull() {
         ClientConfig config = new ClientConfig();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.setDiscoveryConfig(null);
@@ -285,8 +281,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     @Test
     public void test_enabled_whenDiscoveryConfigIsEmpty() {
         ClientConfig config = new ClientConfig();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
-
         config.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
 
         try {
@@ -299,7 +293,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     @Test
     public void test_CustomDiscoveryService_whenDiscoveredNodes_isNull() {
         ClientConfig config = new ClientConfig();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         final DiscoveryService discoveryService = mock(DiscoveryService.class);
         when(discoveryService.discoverNodes()).thenReturn(null);
@@ -325,7 +318,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     @Test
     public void test_CustomDiscoveryService_whenDiscoveredNodes_isEmpty() {
         ClientConfig config = new ClientConfig();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         final DiscoveryService discoveryService = mock(DiscoveryService.class);
         when(discoveryService.discoverNodes()).thenReturn(Collections.<DiscoveryNode>emptyList());
@@ -352,12 +344,11 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         Hazelcast.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(2000);
         networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(
-                new DiscoveryStrategyConfig(new NoMemberDiscoveryStrategyFactory(), Collections.<String, Comparable>emptyMap()));
+                new DiscoveryStrategyConfig(new NoMemberDiscoveryStrategyFactory(), Collections.<String, Comparable>emptyMap()).setEnabled(true));
 
         HazelcastClient.newHazelcastClient(clientConfig);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ConflictingConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ConflictingConfigTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,36 +30,11 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ConflictingConfigTest {
 
-
-    @Test(expected = IllegalStateException.class)
-    public void testHazelcastCloud_and_DiscoverySPIEnabled() {
-        ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().getCloudConfig().setEnabled(true);
-        config.setProperty(ClientProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
-        HazelcastClient.newHazelcastClient(config);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testHazelcastCloudViaProperty_and_DiscoverySPIEnabled() {
-        ClientConfig config = new ClientConfig();
-        config.setProperty(ClientProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
-        config.setProperty(ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN.getName(), "TOKEN");
-        HazelcastClient.newHazelcastClient(config);
-    }
-
     @Test(expected = IllegalStateException.class)
     public void testHazelcastCloud_firstClass_and_propertyBased() {
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN.getName(), "TOKEN");
         config.getNetworkConfig().getCloudConfig().setEnabled(true);
-        HazelcastClient.newHazelcastClient(config);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testClusterMembersGiven_and_DiscoverySPIEnabled() {
-        ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().addAddress("127.0.0.1");
-        config.setProperty(ClientProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
         HazelcastClient.newHazelcastClient(config);
     }
 
@@ -77,18 +51,6 @@ public class ConflictingConfigTest {
         ClientConfig config = new ClientConfig();
         config.getNetworkConfig().addAddress("127.0.0.1");
         config.setProperty(ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN.getName(), "TOKEN");
-        HazelcastClient.newHazelcastClient(config);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/15576")
-    public void testAwsEnabled_and_DiscoverySPIEnabled() {
-        ClientConfig config = new ClientConfig();
-        config.getNetworkConfig().getAwsConfig()
-                .setEnabled(true)
-                .setProperty("access-key", "12345")
-                .setProperty("secret-key", "56789");
-        config.setProperty(ClientProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
         HazelcastClient.newHazelcastClient(config);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -17,20 +17,18 @@
 package com.hazelcast.client.test;
 
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
-import com.hazelcast.client.impl.connection.AddressProvider;
-import com.hazelcast.client.impl.connection.Addresses;
+import com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
-import com.hazelcast.client.properties.ClientProperty;
+import com.hazelcast.client.impl.connection.AddressProvider;
+import com.hazelcast.client.impl.connection.Addresses;
 import com.hazelcast.client.util.AddressHelper;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
@@ -93,16 +91,12 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     }
 
     private AddressProvider createAddressProvider(ClientConfig config) {
-        boolean discoveryEnabled = new HazelcastProperties(config.getProperties())
-                .getBoolean(ClientProperty.DISCOVERY_SPI_ENABLED);
-
         List<DiscoveryStrategyConfig> aliasedDiscoveryConfigs =
                 ClientAliasedDiscoveryConfigUtils.createDiscoveryStrategyConfigs(config);
 
         List<String> userConfiguredAddresses = config.getNetworkConfig().getAddresses();
 
-        boolean isAtLeastAProviderConfigured = discoveryEnabled || !aliasedDiscoveryConfigs.isEmpty()
-                || !userConfiguredAddresses.isEmpty();
+        boolean isAtLeastAProviderConfigured = !aliasedDiscoveryConfigs.isEmpty() || !userConfiguredAddresses.isEmpty();
 
         if (isAtLeastAProviderConfigured) {
             // address providers or addresses are configured explicitly, don't add more addresses

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.spi.discovery;
 
+import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
@@ -31,13 +34,10 @@ import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.partition.membergroup.DefaultMemberGroup;
 import com.hazelcast.partition.membergroup.MemberGroup;
 import com.hazelcast.partition.membergroup.MemberGroupFactory;
@@ -49,7 +49,6 @@ import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -108,7 +107,6 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
     @Test(expected = InvalidConfigurationException.class)
     public void whenStrategyClassNameNotExist_thenFailFast() {
         Config config = new Config();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         DiscoveryConfig discoveryConfig = new DiscoveryConfig();
         discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig("non.existing.ClassName"));
@@ -124,7 +122,6 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
         // than once.
 
         Config config = new Config();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         JoinConfig join = config.getNetworkConfig().getJoin();
         join.getMulticastConfig().setEnabled(false);
@@ -395,15 +392,12 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void test_enabled_whenDiscoveryConfigIsNull() {
         Config config = new Config();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
-
         config.getNetworkConfig().getJoin().setDiscoveryConfig(null);
     }
 
     @Test
     public void testCustomDiscoveryService_whenDiscoveredNodes_isNull() {
         Config config = new Config();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         DiscoveryServiceProvider discoveryServiceProvider = new DiscoveryServiceProvider() {
             public DiscoveryService newDiscoveryService(DiscoveryServiceSettings arg0) {
@@ -424,7 +418,6 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
     @Test
     public void testCustomDiscoveryService_whenDiscoveredNodes_isEmpty() {
         Config config = new Config();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         final DiscoveryService discoveryService = mock(DiscoveryService.class);
         DiscoveryServiceProvider discoveryServiceProvider = new DiscoveryServiceProvider() {
@@ -448,7 +441,6 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
         // this test has no assert. it's a regression test checking an instance can start when a SPI-driven member group
         // strategy is configured. see #11681
         Config config = new Config();
-        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
         JoinConfig joinConfig = config.getNetworkConfig().getJoin();
         joinConfig.getMulticastConfig().setEnabled(false);
 
@@ -758,6 +750,7 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        strategyConfig.setEnabled(true);
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
         return config;
     }

--- a/hazelcast/src/test/resources/hazelcast-client-discovery-spi-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-discovery-spi-test.xml
@@ -20,10 +20,6 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd">
 
-  <properties>
-    <property name="hazelcast.discovery.enabled">true</property>
-  </properties>
-
   <network>
     <discovery-strategies>
       <node-filter class="com.hazelcast.client.impl.spi.impl.discovery.ClientDiscoverySpiTest$TestNodeFilter"/>

--- a/hazelcast/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
@@ -20,10 +20,6 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd">
 
-    <properties>
-        <property name="hazelcast.discovery.enabled">true</property>
-    </properties>
-
     <connection-strategy>
         <connection-retry>
             <multiplier>2</multiplier>

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -20,10 +20,6 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
-    <properties>
-        <property name="hazelcast.discovery.enabled">true</property>
-    </properties>
-
     <network>
         <discovery-strategies>
             <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
@@ -20,10 +20,6 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-    <properties>
-        <property name="hazelcast.discovery.enabled">true</property>
-    </properties>
-
     <network>
         <port>6001</port>
         <join>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
@@ -20,10 +20,6 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-    <properties>
-        <property name="hazelcast.discovery.enabled">true</property>
-    </properties>
-
     <network>
         <port>6001</port>
         <join>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -20,10 +20,6 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-  <properties>
-    <property name="hazelcast.discovery.enabled">true</property>
-  </properties>
-
   <network>
     <join>
       <multicast enabled="false"/>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
@@ -20,10 +20,6 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-  <properties>
-    <property name="hazelcast.discovery.enabled">true</property>
-  </properties>
-
   <network>
     <join>
       <multicast enabled="false"/>

--- a/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -20,10 +20,6 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
 
-    <properties>
-        <property name="hazelcast.discovery.enabled">true</property>
-    </properties>
-
     <network>
         <join>
             <multicast enabled="false"/>


### PR DESCRIPTION
Removed following temporary properties
"hazelcast.discovery.enabled" and
"hazelcast.discovery.public.ip.enabled"

"hazelcast.discovery.public.ip.enabled"
If any of the aliased configs uses public api, than public ip
is enabled.

"hazelcast.discovery.enabled"
For discovery service to be enabled, either
 1. one of the aliased configs should be enabled,
 2. one of the custom strategy configs should be enabled
 3. a custom service provider should be provided by the user.