### PR TITLE
Make XmlClientConfigImportVariableReplacementTest serial

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -16,16 +16,14 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
 import com.hazelcast.config.AbstractConfigImportVariableReplacementTest.IdentityReplacer;
 import com.hazelcast.config.AbstractConfigImportVariableReplacementTest.TestReplacer;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
 import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.config.test.builders.ConfigReplacerBuilder;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,8 +40,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class XmlClientConfigImportVariableReplacementTest extends AbstractClientConfigImportVariableReplacementTest {
 
     private DeclarativeConfigFileHelper helper;


### PR DESCRIPTION
With the recent changes made to
`XmlClientConfigImportVariableReplacementTest`, it writes configurations
to test in working directory. If the same file is written by two or more
test cases and they overlap, the affected tests may fail. This is fixed
by making the test to run with the serial test runner.