### PR TITLE
[Test-Failure] Make ClientCacheClearTest time insensitive

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -133,7 +133,7 @@ public class ClientCacheClearTest extends CacheClearTest {
                     throws Exception {
                 assertEquals(1, counter.get());
             }
-        }, 2);
+        });
 
         // Make sure that the callback is not called for a while
         assertTrueAllTheTime(new AssertTask() {
@@ -193,7 +193,7 @@ public class ClientCacheClearTest extends CacheClearTest {
                     throws Exception {
                 assertEquals(1, counter.get());
             }
-        }, 2);
+        });
 
         // Make sure that the callback is not called for a while
         assertTrueAllTheTime(new AssertTask() {


### PR DESCRIPTION
Made the test time insensitive so that it will not fail if the jenkins build machine is busy and it takes time to send the invalidation event.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3299