### PR TITLE
Fix XmlConfigImportVariableReplacementTest failing on Windows

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigImportVariableReplacementTest.java
@@ -16,8 +16,9 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.config.helpers.IOUtils;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.helpers.IOUtils;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,6 +61,9 @@ public abstract class AbstractClientConfigImportVariableReplacementTest extends 
 
     @Test(expected = InvalidConfigurationException.class)
     public abstract void testImportNotExistingResourceThrowsException();
+
+    @Test(expected = HazelcastException.class)
+    public abstract void testImportNotExistingUrlResourceThrowsException();
 
     @Test
     public abstract void testReplacers() throws Exception;

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
 import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.config.test.builders.ConfigReplacerBuilder;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -284,6 +285,16 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
     public void testImportNotExistingResourceThrowsException() {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"notexisting.xml\"/>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        buildConfig(xml);
+    }
+
+    @Override
+    @Test(expected = HazelcastException.class)
+    public void testImportNotExistingUrlResourceThrowsException() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <import resource=\"file:///notexisting.xml\"/>\n"
                 + HAZELCAST_CLIENT_END_TAG;
 
         buildConfig(xml);

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
@@ -19,11 +19,12 @@ package com.hazelcast.client.config;
 import com.hazelcast.config.AbstractConfigImportVariableReplacementTest;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.replacer.EncryptionReplacer;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.RootCauseMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -247,6 +248,17 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
                 + "hazelcast-client:\n"
                 + "  import:\n"
                 + "    - notexisting.yaml";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = HazelcastException.class)
+    public void testImportNotExistingUrlResourceThrowsException() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  import:\n"
+                + "    - file:///notexisting.yaml";
 
         buildConfig(yaml);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.config.helpers.IOUtils;
 import com.hazelcast.config.replacer.PropertyReplacer;
 import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.core.HazelcastException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -72,6 +73,9 @@ public abstract class AbstractConfigImportVariableReplacementTest {
 
     @Test
     public abstract void testImportNotExistingResourceThrowsException();
+
+    @Test
+    public abstract void testImportNotExistingUrlResourceThrowsException();
 
     @Test
     public abstract void testImportNetworkConfigFromFile() throws Exception;
@@ -141,6 +145,10 @@ public abstract class AbstractConfigImportVariableReplacementTest {
 
     protected void expectInvalid() {
         InvalidConfigurationTest.expectInvalid(rule);
+    }
+
+    protected void expectHazelcastException() {
+        rule.expect(HazelcastException.class);
     }
 
     public static class IdentityReplacer implements ConfigReplacer {

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.config.test.builders.MapXmlStoreConfigBuilder;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -260,13 +259,13 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
     @Test(expected = InvalidConfigurationException.class)
     public void testImportEmptyResourceContent() throws Exception {
         String pathToEmptyFile = createEmptyFile();
-        buildConfig(xmlContentWithImportResource("file://" + pathToEmptyFile), null);
+        buildConfig(xmlContentWithImportResource(pathToEmptyFile), null);
     }
 
-    private String xmlContentWithImportResource(String url) {
+    private String xmlContentWithImportResource(String importPath) {
         return HAZELCAST_START_TAG
-            + "    <import resource=\"" + url + "\"/>\n"
-            + HAZELCAST_END_TAG;
+                + "    <import resource=\"" + importPath + "\"/>\n"
+                + HAZELCAST_END_TAG;
     }
 
     private String createEmptyFile() throws Exception {
@@ -283,6 +282,12 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
     @Test(expected = InvalidConfigurationException.class)
     public void testImportNotExistingResourceThrowsException() {
         buildConfig(xmlContentWithImportResource("not_existing.xml"), null);
+    }
+
+    @Override
+    @Test(expected = HazelcastException.class)
+    public void testImportNotExistingUrlResourceThrowsException() {
+        buildConfig(xmlContentWithImportResource("file:///not_existing.xml"), null);
     }
 
     @Test(expected = HazelcastException.class)
@@ -310,9 +315,9 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
                 + "        </join>\n"
                 + "    </network>\n"
                 + HAZELCAST_END_TAG;
-        String path = helper.givenConfigFileInWorkDir("config-netword.xml", networkConfig).getAbsolutePath();
+        String path = helper.givenConfigFileInWorkDir("config-network.xml", networkConfig).getAbsolutePath();
 
-        Config config = buildConfig(xmlContentWithImportResource("file:///" + path), null);
+        Config config = buildConfig(xmlContentWithImportResource(path), null);
         JoinConfig join = config.getNetworkConfig().getJoin();
         assertFalse(join.getMulticastConfig().isEnabled());
         assertTrue(join.getTcpIpConfig().isEnabled());
@@ -342,7 +347,7 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
                 + HAZELCAST_END_TAG;
         String path = helper.givenConfigFileInWorkDir("mymap.xml", mapConfig).getAbsolutePath();
 
-        Config config = buildConfig(xmlContentWithImportResource("file://" + path), null);
+        Config config = buildConfig(xmlContentWithImportResource(path), null);
 
         MapConfig myMapConfig = config.getMapConfig(mapName);
         assertEquals(mapName, myMapConfig.getName());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -18,9 +18,9 @@ package com.hazelcast.config;
 
 import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.RootCauseMatcher;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -198,6 +198,17 @@ public class YamlConfigImportVariableReplacementTest extends AbstractConfigImpor
                 + "hazelcast:\n"
                 + "  import:\n"
                 + "    - notexisting.yaml";
+        buildConfig(yaml, null);
+    }
+
+    @Override
+    @Test
+    public void testImportNotExistingUrlResourceThrowsException() {
+        expectHazelcastException();
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///notexisting.yaml";
         buildConfig(yaml, null);
     }
 


### PR DESCRIPTION
Recently the import and variable replacement logic in XML was improved
that introduced using `file:///` URLs for referencing the files to
import in tests. URLs take a different path in the ConfigLoader than 
file paths do. The difference between the two paths from the failing tests 
point of view is that the file path checks if the file
exists, while the URL path checks only if the URL is correct. In this
specific case the file path throws an `InvalidConfigurationException`,
because some part of the config (that is to be imported) missing. The
URL path, however, fails with a regular `HazelcastException`. In the
latter case, it cannot be determined if the configuration is invalid or
the resource is unavailable, maybe temporarily.

The tests are fixed by removing `file:///` URLs from the affected parts
of the tests, and adding a case that tests specifically the URL path.

Fixes #16054