### PR TITLE
Attempted fix for WanRESTTest and MapWanSyncRESTTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
@@ -58,28 +58,29 @@ public class WanRESTTest extends HazelcastTestSupport {
     public final OverridePropertyRule overridePropertyRule = set(HAZELCAST_TEST_USE_NETWORK, "true");
 
     @Before
-    public void initInstance() {
+    public void setupFactoryAndMock() {
         wanServiceMock = mock(WanReplicationService.class);
         factory = new CustomNodeExtensionTestInstanceFactory(
                 node -> new WanServiceMockingDefaultNodeExtension(node, wanServiceMock));
-        HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
-        communicator = new HTTPCommunicator(instance);
     }
 
     @Test
     public void pauseSuccess() throws Exception {
+        startInstance();
         assertSuccess(communicator.wanPausePublisher("atob", "B"));
         verify(wanServiceMock, times(1)).pause("atob", "B");
     }
 
     @Test
     public void stopSuccess() throws Exception {
+        startInstance();
         assertSuccess(communicator.wanStopPublisher("atob", "B"));
         verify(wanServiceMock, times(1)).stop("atob", "B");
     }
 
     @Test
     public void resumeSuccess() throws Exception {
+        startInstance();
         assertSuccess(communicator.wanResumePublisher("atob", "B"));
         verify(wanServiceMock, times(1)).resume("atob", "B");
     }
@@ -89,6 +90,8 @@ public class WanRESTTest extends HazelcastTestSupport {
         UUID expectedUuid = UUID.randomUUID();
         when(wanServiceMock.consistencyCheck("atob", "B", "mapName"))
                 .thenReturn(expectedUuid);
+        startInstance();
+
         String result = communicator.wanMapConsistencyCheck("atob", "B", "mapName");
         assertSuccess(result);
         assertUuid(result, expectedUuid);
@@ -98,8 +101,9 @@ public class WanRESTTest extends HazelcastTestSupport {
     @Test
     public void syncSuccess() throws Exception {
         UUID expectedUuid = UUID.randomUUID();
-        when(wanServiceMock.syncMap("atob", "B", "mapName"))
-                .thenReturn(expectedUuid);
+        when(wanServiceMock.syncMap("atob", "B", "mapName")).thenReturn(expectedUuid);
+        startInstance();
+
         String result = communicator.syncMapOverWAN("atob", "B", "mapName");
         assertSuccess(result);
         assertUuid(result, expectedUuid);
@@ -109,8 +113,9 @@ public class WanRESTTest extends HazelcastTestSupport {
     @Test
     public void syncAllSuccess() throws Exception {
         UUID expectedUuid = UUID.randomUUID();
-        when(wanServiceMock.syncAllMaps("atob", "B"))
-                .thenReturn(expectedUuid);
+        when(wanServiceMock.syncAllMaps("atob", "B")).thenReturn(expectedUuid);
+        startInstance();
+
         String result = communicator.syncMapsOverWAN("atob", "B");
         assertSuccess(result);
         assertUuid(result, expectedUuid);
@@ -122,6 +127,8 @@ public class WanRESTTest extends HazelcastTestSupport {
         doThrow(new RuntimeException("Error occurred"))
                 .when(wanServiceMock)
                 .pause("atob", "B");
+        startInstance();
+
         assertFail(communicator.wanPausePublisher("atob", "B"));
         verify(wanServiceMock, times(1)).pause("atob", "B");
     }
@@ -131,6 +138,8 @@ public class WanRESTTest extends HazelcastTestSupport {
         doThrow(new RuntimeException("Error occurred"))
                 .when(wanServiceMock)
                 .stop("atob", "B");
+        startInstance();
+
         assertFail(communicator.wanStopPublisher("atob", "B"));
         verify(wanServiceMock, times(1)).stop("atob", "B");
     }
@@ -140,6 +149,8 @@ public class WanRESTTest extends HazelcastTestSupport {
         doThrow(new RuntimeException("Error occurred"))
                 .when(wanServiceMock)
                 .resume("atob", "B");
+        startInstance();
+
         assertFail(communicator.wanResumePublisher("atob", "B"));
         verify(wanServiceMock, times(1)).resume("atob", "B");
     }
@@ -149,6 +160,8 @@ public class WanRESTTest extends HazelcastTestSupport {
         doThrow(new RuntimeException("Error occurred"))
                 .when(wanServiceMock)
                 .consistencyCheck("atob", "B", "mapName");
+        startInstance();
+
         assertFail(communicator.wanMapConsistencyCheck("atob", "B", "mapName"));
         verify(wanServiceMock, times(1)).consistencyCheck("atob", "B", "mapName");
     }
@@ -158,8 +171,15 @@ public class WanRESTTest extends HazelcastTestSupport {
         doThrow(new RuntimeException("Error occurred"))
                 .when(wanServiceMock)
                 .syncMap("atob", "B", "mapName");
+        startInstance();
+
         assertFail(communicator.syncMapOverWAN("atob", "B", "mapName"));
         verify(wanServiceMock, times(1)).syncMap("atob", "B", "mapName");
+    }
+
+    private void startInstance() {
+        HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
+        communicator = new HTTPCommunicator(instance);
     }
 
     @Test
@@ -167,6 +187,8 @@ public class WanRESTTest extends HazelcastTestSupport {
         doThrow(new RuntimeException("Error occurred"))
                 .when(wanServiceMock)
                 .syncAllMaps("atob", "B");
+        startInstance();
+
         assertFail(communicator.syncMapsOverWAN("atob", "B"));
         verify(wanServiceMock, times(1)).syncAllMaps("atob", "B");
     }


### PR DESCRIPTION
The issue we've recently encountered was that wiremock stubbing was
being done on a wrong method. This may happen if, during stubbing, some
other method is called on the mock instance. For example, in the code:
`when(wanServiceMock.syncAllMaps("atob", "B")).thenReturn(expectedUuid)`
if we were to invoke `wanServiceMock.toString()` after the call to the
`when` method but before the call to the `thenReturn` method, the
`expectedUUID` would have been set on the `toString()` method, which is
wrong. This is an inherent issue with wiremock and can be easily
reproduced with debugging in an IDE.

With this fact, we assume there was some call to the mock instance
during stubbing, which caused both tests to fail. We eliminate this
cause by setting up the stubbing before we even start the instance.

In the worst case, this is a wrong assumption and we will just get another test failure later.

Fixes:
https://github.com/hazelcast/hazelcast/issues/16053
https://github.com/hazelcast/hazelcast-enterprise/issues/3364

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3367