### PR TITLE
Improve & fix CP group destruction handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -644,12 +644,13 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
         Map<UUID, CPMemberInfo> activeMembersMap = getActiveMembersMap();
         RaftEndpoint localEndpoint = getLocalCPMember().toRaftEndpoint();
         OperationService operationService = nodeEngine.getOperationService();
-        Operation op = new TerminateRaftNodesOp(Collections.singleton(group.id()));
         for (RaftEndpoint endpoint : group.members())  {
             if (endpoint.equals(localEndpoint)) {
                 terminateRaftNodeAsync(group.id());
             } else {
-                operationService.send(op, activeMembersMap.get(endpoint.getUuid()).getAddress());
+                Operation op = new TerminateRaftNodesOp(Collections.singleton(group.id()));
+                CPMemberInfo cpMember = activeMembersMap.get(endpoint.getUuid());
+                operationService.invokeOnTarget(RaftService.SERVICE_NAME, op, cpMember.getAddress());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -31,7 +31,6 @@ import com.hazelcast.cp.internal.raft.impl.RaftNode;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeStatus;
 import com.hazelcast.cp.internal.raftop.metadata.CompleteDestroyRaftGroupsOp;
 import com.hazelcast.cp.internal.raftop.metadata.CompleteRaftGroupMembershipChangesOp;
-import com.hazelcast.cp.internal.raftop.metadata.TerminateRaftNodesOp;
 import com.hazelcast.cp.internal.raftop.metadata.GetActiveCPMembersOp;
 import com.hazelcast.cp.internal.raftop.metadata.GetActiveRaftGroupIdsOp;
 import com.hazelcast.cp.internal.raftop.metadata.GetDestroyingRaftGroupIdsOp;
@@ -169,20 +168,7 @@ class RaftGroupMembershipManager {
                 return;
             }
 
-            if (!commitDestroyedRaftGroups(destroyedGroupIds)) {
-                return;
-            }
-
-            for (CPGroupId groupId : destroyedGroupIds) {
-                raftService.terminateRaftNode(groupId, true);
-            }
-
-            OperationService operationService = nodeEngine.getOperationService();
-            for (CPMemberInfo member : raftService.getMetadataGroupManager().getActiveMembers()) {
-                if (!member.equals(raftService.getLocalCPMember())) {
-                    operationService.send(new TerminateRaftNodesOp(destroyedGroupIds), member.getAddress());
-                }
-            }
+            commitDestroyedRaftGroups(destroyedGroupIds);
         }
 
         private Set<CPGroupId> destroyRaftGroups() {
@@ -230,7 +216,7 @@ class RaftGroupMembershipManager {
             }
         }
 
-        private boolean commitDestroyedRaftGroups(Set<CPGroupId> destroyedGroupIds) {
+        private void commitDestroyedRaftGroups(Set<CPGroupId> destroyedGroupIds) {
             RaftOp op = new CompleteDestroyRaftGroupsOp(destroyedGroupIds);
             CPGroupId metadataGroupId = raftService.getMetadataGroupId();
             Future<Collection<CPGroupId>> f = invocationManager.invoke(metadataGroupId, op);
@@ -238,10 +224,8 @@ class RaftGroupMembershipManager {
             try {
                 f.get();
                 logger.info("Terminated CP groups: " + destroyedGroupIds + " are committed.");
-                return true;
             } catch (Exception e) {
                 logger.severe("Cannot commit terminated CP groups: " + destroyedGroupIds, e);
-                return false;
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftIntegration.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cp.internal.raft.impl;
 
+import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.internal.raft.impl.dto.AppendFailureResponse;
 import com.hazelcast.cp.internal.raft.impl.dto.AppendRequest;
@@ -214,7 +215,7 @@ public interface RaftIntegration {
     void schedule(Runnable task, long delay, TimeUnit timeUnit);
 
     /**
-     * Creates a new instance of {@link SimpleCompletableFuture}.
+     * Creates a new instance of {@link InternalCompletableFuture}.
      * @return a new future
      */
     InternalCompletableFuture newCompletableFuture();
@@ -246,4 +247,10 @@ public interface RaftIntegration {
      * @param status new status
      */
     void onNodeStatusChange(RaftNodeStatus status);
+
+    /**
+     * Called when CP group is destroyed.
+     * @param groupId id of CP group
+     */
+    void onGroupDestroyed(CPGroupId groupId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
@@ -1447,8 +1447,11 @@ public final class RaftNodeImpl implements RaftNode {
             flushTaskSubmitted = false;
             RaftLog log = state.log();
             log.flush();
-            state.leaderState().flushedLogIndex(log.lastLogOrSnapshotIndex());
-            tryAdvanceCommitIndex();
+            LeaderState leaderState = state.leaderState();
+            if (leaderState != null) {
+                leaderState.flushedLogIndex(log.lastLogOrSnapshotIndex());
+                tryAdvanceCommitIndex();
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
@@ -427,4 +427,8 @@ public class LocalRaftIntegration implements RaftIntegration {
     @Override
     public void onNodeStatusChange(RaftNodeStatus status) {
     }
+
+    @Override
+    public void onGroupDestroyed(CPGroupId groupId) {
+    }
 }


### PR DESCRIPTION
- Add a core Raft hook to handle Raft group destruction
- Use invocation while terminating Raft nodes of destroyed group … Otherwise fire & forget operations may not reach the destination or be rejected for some reason.
- `LocalRaftGroup`: Terminate Raft nodes on group destroy … Otherwise Raft log files may remain open. This is especially needed on Windows which does not allow deletion of open files.
- Minor fix: Before `FlushTask` is executed, node can demote to follower, so it should gracefully handle this instead of failing with NPE.

Hopefully this will fix https://github.com/hazelcast/hazelcast-enterprise/issues/3310 once and for all. 🤞 
Fixes hazelcast/hazelcast-enterprise#3310 
Fixes hazelcast/hazelcast-enterprise#3219