### PR TITLE
Fixed DynamicConfigBouncingTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
@@ -22,6 +22,9 @@ import com.hazelcast.spi.eviction.EvictionPolicyComparator;
  * {@link ICache} specific {@link EvictionPolicyComparator}
  * for comparing {@link CacheEntryView}s to be evicted.
  *
+ * Implementors of the comparator have to implement {@code equals} and {@code hashCode} methods
+ * to support correct config comparison.
+ *
  * @param <K> type of the key
  * @param <V> type of the value
  * @see EvictionPolicyComparator

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
@@ -42,4 +42,17 @@ public class LFUEvictionPolicyComparator
     public String toString() {
         return "LFUEvictionPolicyComparator{" + super.toString() + "} ";
     }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        return getClass().equals(o.getClass());
+    }
+
+    @Override
+    public final int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.internal.eviction.impl.comparator;
 
+import com.hazelcast.internal.serialization.SerializableByConvention;
 import com.hazelcast.spi.eviction.EvictableEntryView;
 import com.hazelcast.spi.eviction.EvictionPolicyComparator;
-import com.hazelcast.internal.serialization.SerializableByConvention;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LRU}
@@ -41,5 +41,18 @@ public class LRUEvictionPolicyComparator
     @Override
     public String toString() {
         return "LRUEvictionPolicyComparator{" + super.toString() + "} ";
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        return getClass().equals(o.getClass());
+    }
+
+    @Override
+    public final int hashCode() {
+        return getClass().hashCode();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
@@ -41,4 +41,17 @@ public class RandomEvictionPolicyComparator
     public String toString() {
         return "RandomEvictionPolicyComparator{" + super.toString() + "} ";
     }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        return getClass().equals(o.getClass());
+    }
+
+    @Override
+    public final int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/MapEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapEvictionPolicyComparator.java
@@ -23,6 +23,9 @@ import com.hazelcast.spi.eviction.EvictionPolicyComparator;
  * {@link IMap} specific {@link EvictionPolicyComparator} for
  * comparing {@link com.hazelcast.core.EntryView}s to be evicted.
  *
+ * Implementors of the comparator have to implement {@code equals} and {@code hashCode} methods
+ * to support correct config comparison.
+ *
  * @param <K> type of the key
  * @param <V> type of the value
  * @see EvictionPolicyComparator


### PR DESCRIPTION
Fixed a regression caused by
https://github.com/hazelcast/hazelcast/pull/15939 so that
MapEvictionPolicyComparator has no proper equals/hasCode methods
implementation. As a result, EvictionConfig#equals returns wrong result.

Fixes: https://github.com/hazelcast/hazelcast/issues/16035