### PR TITLE
Fixes issues with ObjectDataInput/Output public API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryIterationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryIterationResult.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -72,8 +73,8 @@ public class CacheEntryIterationResult implements IdentifiedDataSerializable {
         int size = entries.size();
         out.writeInt(size);
         for (Map.Entry<Data, Data> entry : entries) {
-            out.writeData(entry.getKey());
-            out.writeData(entry.getValue());
+            IOUtil.writeData(out, entry.getKey());
+            IOUtil.writeData(out, entry.getValue());
         }
     }
 
@@ -83,8 +84,8 @@ public class CacheEntryIterationResult implements IdentifiedDataSerializable {
         int size = in.readInt();
         entries = new ArrayList<Map.Entry<Data, Data>>(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
-            Data value = in.readData();
+            Data key = IOUtil.readData(in);
+            Data value = IOUtil.readData(in);
             entries.add(new AbstractMap.SimpleEntry<Data, Data>(key, value));
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -88,9 +89,9 @@ public class CacheEventDataImpl
             throws IOException {
         out.writeUTF(name);
         out.writeInt(eventType.getType());
-        out.writeData(dataKey);
-        out.writeData(dataNewValue);
-        out.writeData(dataOldValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataNewValue);
+        IOUtil.writeData(out, dataOldValue);
         out.writeBoolean(isOldValueAvailable);
     }
 
@@ -99,9 +100,9 @@ public class CacheEventDataImpl
             throws IOException {
         name = in.readUTF();
         eventType = CacheEventType.getByType(in.readInt());
-        dataKey = in.readData();
-        dataNewValue = in.readData();
-        dataOldValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataNewValue = IOUtil.readData(in);
+        dataOldValue = IOUtil.readData(in);
         isOldValueAvailable = in.readBoolean();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIterationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIterationResult.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -71,7 +72,7 @@ public class CacheKeyIterationResult implements IdentifiedDataSerializable {
         int size = keys.size();
         out.writeInt(size);
         for (Data o : keys) {
-            out.writeData(o);
+            IOUtil.writeData(out, o);
         }
 
     }
@@ -83,7 +84,7 @@ public class CacheKeyIterationResult implements IdentifiedDataSerializable {
         int size = in.readInt();
         keys = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             keys.add(data);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.config.AbstractCacheConfig;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheConfigAccessor;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -87,16 +88,16 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> {
     protected void writeFactories(ObjectDataOutput out) throws IOException {
         assert (out instanceof SerializationServiceSupport) : "out must implement SerializationServiceSupport";
         SerializationService serializationService = ((SerializationServiceSupport) out).getSerializationService();
-        out.writeData(cacheLoaderFactory.getSerializedValue(serializationService));
-        out.writeData(cacheWriterFactory.getSerializedValue(serializationService));
-        out.writeData(expiryPolicyFactory.getSerializedValue(serializationService));
+        IOUtil.writeData(out, cacheLoaderFactory.getSerializedValue(serializationService));
+        IOUtil.writeData(out, cacheWriterFactory.getSerializedValue(serializationService));
+        IOUtil.writeData(out, expiryPolicyFactory.getSerializedValue(serializationService));
     }
 
     @Override
     protected void readFactories(ObjectDataInput in) throws IOException {
-        cacheLoaderFactory = DeferredValue.withSerializedValue(in.readData());
-        cacheWriterFactory = DeferredValue.withSerializedValue(in.readData());
-        expiryPolicyFactory = DeferredValue.withSerializedValue(in.readData());
+        cacheLoaderFactory = DeferredValue.withSerializedValue(IOUtil.readData(in));
+        cacheWriterFactory = DeferredValue.withSerializedValue(IOUtil.readData(in));
+        expiryPolicyFactory = DeferredValue.withSerializedValue(IOUtil.readData(in));
     }
 
     @Override
@@ -104,7 +105,7 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> {
         assert (out instanceof SerializationServiceSupport) : "out must implement SerializationServiceSupport";
         out.writeInt(listenerConfigurations.size());
         for (DeferredValue<CacheEntryListenerConfiguration<K, V>> config : listenerConfigurations) {
-            out.writeData(config.getSerializedValue(((SerializationServiceSupport) out).getSerializationService()));
+            IOUtil.writeData(out, config.getSerializedValue(((SerializationServiceSupport) out).getSerializationService()));
         }
     }
 
@@ -114,7 +115,7 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> {
         listenerConfigurations = createConcurrentSet();
         for (int i = 0; i < size; i++) {
             DeferredValue<CacheEntryListenerConfiguration<K, V>> serializedConfig =
-                    DeferredValue.withSerializedValue(in.readData());
+                    DeferredValue.withSerializedValue(IOUtil.readData(in));
             listenerConfigurations.add(serializedConfig);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
@@ -85,9 +86,9 @@ public class DeserializingEventJournalCacheEvent<K, V>
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(eventType);
-        out.writeData(toData(dataKey, objectKey));
-        out.writeData(toData(dataNewValue, objectNewValue));
-        out.writeData(toData(dataOldValue, objectOldValue));
+        IOUtil.writeData(out, toData(dataKey, objectKey));
+        IOUtil.writeData(out, toData(dataNewValue, objectNewValue));
+        IOUtil.writeData(out, toData(dataOldValue, objectOldValue));
     }
 
     private Data toData(Data data, Object o) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.CacheEventType;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -82,17 +83,17 @@ public class InternalEventJournalCacheEvent implements IdentifiedDataSerializabl
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(eventType);
-        out.writeData(dataKey);
-        out.writeData(dataNewValue);
-        out.writeData(dataOldValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataNewValue);
+        IOUtil.writeData(out, dataOldValue);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         eventType = in.readInt();
-        dataKey = in.readData();
-        dataNewValue = in.readData();
-        dataOldValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataNewValue = IOUtil.readData(in);
+        dataOldValue = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
@@ -18,6 +18,8 @@ package com.hazelcast.cache.impl.merge.entry;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.DataWriter;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -96,13 +98,14 @@ public class DefaultCacheEntryView
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        assert out instanceof DataWriter;
         out.writeLong(creationTime);
         out.writeLong(expirationTime);
         out.writeLong(lastAccessTime);
         out.writeLong(accessHit);
-        out.writeData(key);
-        out.writeData(value);
-        out.writeData(expiryPolicy);
+        IOUtil.writeData(out, key);
+        IOUtil.writeData(out, value);
+        IOUtil.writeData(out, expiryPolicy);
     }
 
     @Override
@@ -111,9 +114,9 @@ public class DefaultCacheEntryView
         expirationTime = in.readLong();
         lastAccessTime = in.readLong();
         accessHit = in.readLong();
-        key = in.readData();
-        value = in.readData();
-        expiryPolicy = in.readData();
+        key = IOUtil.readData(in);
+        value = IOUtil.readData(in);
+        expiryPolicy = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.internal.eviction.ExpiredKey;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
@@ -113,7 +114,7 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
         super.writeInternal(out);
         out.writeInt(expiredKeys.size());
         for (ExpiredKey expiredKey : expiredKeys) {
-            out.writeData(expiredKey.getKey());
+            IOUtil.writeData(out, expiredKey.getKey());
             out.writeLong(expiredKey.getCreationTime());
         }
         out.writeInt(primaryEntryCount);
@@ -125,7 +126,7 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
         int size = in.readInt();
         expiredKeys = new LinkedList<ExpiredKey>();
         for (int i = 0; i < size; i++) {
-            expiredKeys.add(new ExpiredKey(in.readData(), in.readLong()));
+            expiredKeys.add(new ExpiredKey(IOUtil.readData(in), in.readLong()));
         }
         primaryEntryCount = in.readInt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -92,7 +93,7 @@ public class CacheGetAllOperation
         } else {
             out.writeInt(keys.size());
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -107,7 +108,7 @@ public class CacheGetAllOperation
         if (size > -1) {
             keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 keys.add(key);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -74,7 +75,7 @@ public class CacheGetAllOperationFactory
         out.writeObject(expiryPolicy);
         out.writeInt(keys.size());
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
     }
 
@@ -86,7 +87,7 @@ public class CacheGetAllOperationFactory
         int size = in.readInt();
         keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             keys.add(data);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -78,7 +79,7 @@ public class CacheGetAndReplaceOperation extends MutatingCacheOperation {
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
         out.writeObject(expiryPolicy);
     }
 
@@ -86,7 +87,7 @@ public class CacheGetAndReplaceOperation extends MutatingCacheOperation {
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
         expiryPolicy = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -167,7 +168,7 @@ public class CacheLoadAllOperation
         if (keys != null) {
             out.writeInt(keys.size());
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -180,7 +181,7 @@ public class CacheLoadAllOperation
             int size = in.readInt();
             keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
-                keys.add(in.readData());
+                keys.add(IOUtil.readData(in));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -73,7 +74,7 @@ public class CacheLoadAllOperationFactory
         if (keys != null) {
             out.writeInt(keys.size());
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -88,7 +89,7 @@ public class CacheLoadAllOperationFactory
             int size = in.readInt();
             keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 keys.add(key);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -70,7 +71,7 @@ public class CachePutAllBackupOperation extends CacheOperation implements Backup
             for (Map.Entry<Data, CacheRecord> entry : cacheRecords.entrySet()) {
                 Data key = entry.getKey();
                 CacheRecord record = entry.getValue();
-                out.writeData(key);
+                IOUtil.writeData(out, key);
                 out.writeObject(record);
             }
         }
@@ -84,7 +85,7 @@ public class CachePutAllBackupOperation extends CacheOperation implements Backup
             int size = in.readInt();
             cacheRecords = createHashMap(size);
             for (int i = 0; i < size; i++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 CacheRecord record = in.readObject();
                 cacheRecords.put(key, record);
             }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -106,8 +107,8 @@ public class CachePutAllOperation extends CacheOperation
         out.writeInt(completionId);
         out.writeInt(entries.size());
         for (Map.Entry<Data, Data> entry : entries) {
-            out.writeData(entry.getKey());
-            out.writeData(entry.getValue());
+            IOUtil.writeData(out, entry.getKey());
+            IOUtil.writeData(out, entry.getValue());
         }
     }
 
@@ -119,8 +120,8 @@ public class CachePutAllOperation extends CacheOperation
         int size = in.readInt();
         entries = new ArrayList<Map.Entry<Data, Data>>(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
-            Data value = in.readData();
+            Data key = IOUtil.readData(in);
+            Data value = IOUtil.readData(in);
             entries.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(key, value));
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -82,7 +83,7 @@ public class CachePutIfAbsentOperation extends MutatingCacheOperation {
             throws IOException {
         super.writeInternal(out);
         out.writeObject(expiryPolicy);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
@@ -90,7 +91,7 @@ public class CachePutIfAbsentOperation extends MutatingCacheOperation {
             throws IOException {
         super.readInternal(in);
         expiryPolicy = in.readObject();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -88,7 +89,7 @@ public class CachePutOperation extends MutatingCacheOperation {
         super.writeInternal(out);
         out.writeBoolean(get);
         out.writeObject(expiryPolicy);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
@@ -97,7 +98,7 @@ public class CachePutOperation extends MutatingCacheOperation {
         super.readInternal(in);
         get = in.readBoolean();
         expiryPolicy = in.readObject();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -111,7 +112,7 @@ public class CacheRemoveAllBackupOperation
         if (keys != null) {
             out.writeInt(keys.size());
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -125,7 +126,7 @@ public class CacheRemoveAllBackupOperation
             int size = in.readInt();
             keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 keys.add(key);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -136,7 +137,7 @@ public class CacheRemoveAllOperation
         if (keys != null) {
             out.writeInt(keys.size());
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -150,7 +151,7 @@ public class CacheRemoveAllOperation
             int size = in.readInt();
             keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 keys.add(key);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -68,7 +69,7 @@ public class CacheRemoveAllOperationFactory implements OperationFactory, Identif
         out.writeInt(keys == null ? -1 : keys.size());
         if (keys != null) {
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -83,7 +84,7 @@ public class CacheRemoveAllOperationFactory implements OperationFactory, Identif
         }
         keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
-            keys.add(in.readData());
+            keys.add(IOUtil.readData(in));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -80,13 +81,13 @@ public class CacheRemoveOperation extends MutatingCacheOperation {
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeData(oldValue);
+        IOUtil.writeData(out, oldValue);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        oldValue = in.readData();
+        oldValue = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -89,8 +90,8 @@ public class CacheReplaceOperation extends MutatingCacheOperation {
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeData(newValue);
-        out.writeData(oldValue);
+        IOUtil.writeData(out, newValue);
+        IOUtil.writeData(out, oldValue);
         out.writeObject(expiryPolicy);
     }
 
@@ -98,8 +99,8 @@ public class CacheReplaceOperation extends MutatingCacheOperation {
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        newValue = in.readData();
-        oldValue = in.readData();
+        newValue = IOUtil.readData(in);
+        oldValue = IOUtil.readData(in);
         expiryPolicy = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -167,14 +168,14 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
                 final Data key = e.getKey();
                 final CacheRecord record = e.getValue();
 
-                out.writeData(key);
+                IOUtil.writeData(out, key);
                 out.writeObject(record);
             }
             // Empty data will terminate the iteration for read in case
             // expired entries were found while serializing, since the
             // real subCount will then be different from the one written
             // before
-            out.writeData(null);
+            IOUtil.writeData(out, null);
         }
 
         nearCacheStateHolder.writeData(out);
@@ -198,7 +199,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
             // subCount + 1 because of the DefaultData written as the last entry
             // which adds another Data entry at the end of the stream!
             for (int j = 0; j < subCount + 1; j++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 // Empty data received so reading can be stopped here since
                 // since the real object subCount might be different from
                 // the number on the stream due to found expired entries

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -78,9 +79,9 @@ public class CacheSetExpiryPolicyBackupOperation
         super.writeInternal(out);
         out.writeInt(keys.size());
         for (Data key: keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
-        out.writeData(expiryPolicy);
+        IOUtil.writeData(out, expiryPolicy);
     }
 
     @Override
@@ -89,9 +90,9 @@ public class CacheSetExpiryPolicyBackupOperation
         int s = in.readInt();
         keys = new ArrayList<Data>(s);
         while (s-- > 0) {
-            keys.add(in.readData());
+            keys.add(IOUtil.readData(in));
         }
-        expiryPolicy = in.readData();
+        expiryPolicy = IOUtil.readData(in);
 
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -85,9 +86,9 @@ public class CacheSetExpiryPolicyOperation extends CacheOperation
         super.writeInternal(out);
         out.writeInt(keys.size());
         for (Data key: keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
-        out.writeData(expiryPolicy);
+        IOUtil.writeData(out, expiryPolicy);
     }
 
     @Override
@@ -96,9 +97,9 @@ public class CacheSetExpiryPolicyOperation extends CacheOperation
         int s = in.readInt();
         keys = new ArrayList<Data>(s);
         while (s-- > 0) {
-            keys.add(in.readData());
+            keys.add(IOUtil.readData(in));
         }
-        expiryPolicy = in.readData();
+        expiryPolicy = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/KeyBasedCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/KeyBasedCacheOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -54,12 +55,12 @@ public abstract class KeyBasedCacheOperation extends CacheOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.record;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -63,15 +64,15 @@ public class CacheDataRecord extends AbstractCacheRecord<Data, Data> {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeData(value);
-        out.writeData(expiryPolicy);
+        IOUtil.writeData(out, value);
+        IOUtil.writeData(out, expiryPolicy);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        value = in.readData();
-        expiryPolicy = in.readData();
+        value = IOUtil.readData(in);
+        expiryPolicy = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEvent.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.collection;
 
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -73,7 +74,7 @@ public class CollectionEvent implements IdentifiedDataSerializable {
         out.writeUTF(name);
         out.writeInt(eventType.getType());
         caller.writeData(out);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
@@ -82,7 +83,7 @@ public class CollectionEvent implements IdentifiedDataSerializable {
         eventType = ItemEventType.getByType(in.readInt());
         caller = new Address();
         caller.readData(in);
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionItem.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionItem.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.collection;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -101,12 +102,12 @@ public class CollectionItem implements Comparable<CollectionItem>, IdentifiedDat
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(itemId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         itemId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.collection.operations;
 
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -57,7 +58,7 @@ public class CollectionAddAllBackupOperation extends CollectionOperation impleme
         out.writeInt(valueMap.size());
         for (Map.Entry<Long, Data> entry : valueMap.entrySet()) {
             out.writeLong(entry.getKey());
-            out.writeData(entry.getValue());
+            IOUtil.writeData(out, entry.getValue());
         }
     }
 
@@ -68,7 +69,7 @@ public class CollectionAddAllBackupOperation extends CollectionOperation impleme
         valueMap = createHashMap(size);
         for (int i = 0; i < size; i++) {
             final long itemId = in.readLong();
-            final Data value = in.readData();
+            final Data value = IOUtil.readData(in);
             valueMap.put(itemId, value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.collection.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -86,7 +87,7 @@ public class CollectionAddAllOperation extends CollectionBackupAwareOperation im
         super.writeInternal(out);
         out.writeInt(valueList.size());
         for (Data value : valueList) {
-            out.writeData(value);
+            IOUtil.writeData(out, value);
         }
     }
 
@@ -96,7 +97,7 @@ public class CollectionAddAllOperation extends CollectionBackupAwareOperation im
         final int size = in.readInt();
         valueList = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
-            Data value = in.readData();
+            Data value = IOUtil.readData(in);
             valueList.add(value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.collection.operations;
 
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -55,13 +56,13 @@ public class CollectionAddBackupOperation extends CollectionOperation implements
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(itemId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         itemId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.collection.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -76,12 +77,12 @@ public class CollectionAddOperation extends CollectionBackupAwareOperation imple
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionCompareAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionCompareAndRemoveOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.collection.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -81,7 +82,7 @@ public class CollectionCompareAndRemoveOperation extends CollectionBackupAwareOp
         out.writeBoolean(retain);
         out.writeInt(valueSet.size());
         for (Data value : valueSet) {
-            out.writeData(value);
+            IOUtil.writeData(out, value);
         }
     }
 
@@ -92,7 +93,7 @@ public class CollectionCompareAndRemoveOperation extends CollectionBackupAwareOp
         final int size = in.readInt();
         valueSet = createHashSet(size);
         for (int i = 0; i < size; i++) {
-            Data value = in.readData();
+            Data value = IOUtil.readData(in);
             valueSet.add(value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionContainsOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.collection.operations;
 
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -56,7 +57,7 @@ public class CollectionContainsOperation extends CollectionOperation implements 
         super.writeInternal(out);
         out.writeInt(valueSet.size());
         for (Data value : valueSet) {
-            out.writeData(value);
+            IOUtil.writeData(out, value);
         }
     }
 
@@ -66,7 +67,7 @@ public class CollectionContainsOperation extends CollectionOperation implements 
         final int size = in.readInt();
         valueSet = createHashSet(size);
         for (int i = 0; i < size; i++) {
-            Data value = in.readData();
+            Data value = IOUtil.readData(in);
             valueSet.add(value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.CollectionItem;
 import com.hazelcast.core.ItemEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -79,12 +80,12 @@ public class CollectionRemoveOperation extends CollectionBackupAwareOperation im
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListIndexOfOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListIndexOfOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.list.operations;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
 import com.hazelcast.collection.impl.list.ListContainer;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -55,13 +56,13 @@ public class ListIndexOfOperation extends CollectionOperation implements Readonl
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeBoolean(last);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         last = in.readBoolean();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetBackupOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.list.operations;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
 import com.hazelcast.collection.impl.list.ListContainer;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -58,7 +59,7 @@ public class ListSetBackupOperation extends CollectionOperation implements Backu
         super.writeInternal(out);
         out.writeLong(oldItemId);
         out.writeLong(itemId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
@@ -66,6 +67,6 @@ public class ListSetBackupOperation extends CollectionOperation implements Backu
         super.readInternal(in);
         oldItemId = in.readLong();
         itemId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.collection.impl.collection.CollectionItem;
 import com.hazelcast.collection.impl.collection.operations.CollectionBackupAwareOperation;
 import com.hazelcast.collection.impl.list.ListContainer;
 import com.hazelcast.core.ItemEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -81,13 +82,13 @@ public class ListSetOperation extends CollectionBackupAwareOperation implements 
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(index);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         index = in.readInt();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.queue;
 
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -50,7 +51,7 @@ public class QueueEvent implements IdentifiedDataSerializable {
         out.writeUTF(name);
         out.writeInt(eventType.getType());
         caller.writeData(out);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
@@ -59,7 +60,7 @@ public class QueueEvent implements IdentifiedDataSerializable {
         eventType = ItemEventType.getByType(in.readInt());
         caller = new Address();
         caller.readData(in);
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueItem.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueItem.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.queue;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -85,13 +86,13 @@ public class QueueItem implements IdentifiedDataSerializable, Comparable<QueueIt
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(itemId);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         itemId = in.readLong();
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.queue.operations;
 
 import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -62,7 +63,7 @@ public class AddAllBackupOperation extends QueueOperation implements BackupOpera
             long itemId = entry.getKey();
             Data value = entry.getValue();
             out.writeLong(itemId);
-            out.writeData(value);
+            IOUtil.writeData(out, value);
         }
     }
 
@@ -73,7 +74,7 @@ public class AddAllBackupOperation extends QueueOperation implements BackupOpera
         dataMap = createHashMap(size);
         for (int i = 0; i < size; i++) {
             long itemId = in.readLong();
-            Data value = in.readData();
+            Data value = IOUtil.readData(in);
             dataMap.put(itemId, value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -101,7 +102,7 @@ public class AddAllOperation extends QueueBackupAwareOperation implements Notifi
         super.writeInternal(out);
         out.writeInt(dataList.size());
         for (Data data : dataList) {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
     }
 
@@ -111,7 +112,7 @@ public class AddAllOperation extends QueueBackupAwareOperation implements Notifi
         int size = in.readInt();
         dataList = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
-            dataList.add(in.readData());
+            dataList.add(IOUtil.readData(in));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -100,7 +101,7 @@ public class CompareAndRemoveOperation extends QueueBackupAwareOperation impleme
         out.writeBoolean(retain);
         out.writeInt(dataList.size());
         for (Data data : dataList) {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
     }
 
@@ -111,7 +112,7 @@ public class CompareAndRemoveOperation extends QueueBackupAwareOperation impleme
         int size = in.readInt();
         dataList = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
-            dataList.add(in.readData());
+            dataList.add(IOUtil.readData(in));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ContainsOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.queue.operations;
 import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -65,7 +66,7 @@ public class ContainsOperation extends QueueOperation implements ReadonlyOperati
         super.writeInternal(out);
         out.writeInt(dataList.size());
         for (Data data : dataList) {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
     }
 
@@ -75,7 +76,7 @@ public class ContainsOperation extends QueueOperation implements ReadonlyOperati
         int size = in.readInt();
         dataList = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
-            dataList.add(in.readData());
+            dataList.add(IOUtil.readData(in));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.impl.queue.operations;
 
 import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -64,14 +65,14 @@ public final class OfferBackupOperation extends QueueOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
         out.writeLong(itemId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        data = in.readData();
+        data = IOUtil.readData(in);
         itemId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -120,12 +121,12 @@ public final class OfferOperation extends QueueBackupAwareOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -90,12 +91,12 @@ public class RemoveOperation extends QueueBackupAwareOperation implements Notifi
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveAddOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.txncollection.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -57,7 +58,7 @@ public class CollectionReserveAddOperation extends CollectionOperation implement
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         UUIDSerializationUtil.writeUUID(out, transactionId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
 
     }
 
@@ -65,6 +66,6 @@ public class CollectionReserveAddOperation extends CollectionOperation implement
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         transactionId = UUIDSerializationUtil.readUUID(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveRemoveOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.txncollection.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -61,7 +62,7 @@ public class CollectionReserveRemoveOperation extends CollectionOperation implem
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(reservedItemId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
         UUIDSerializationUtil.writeUUID(out, transactionId);
     }
 
@@ -69,7 +70,7 @@ public class CollectionReserveRemoveOperation extends CollectionOperation implem
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         reservedItemId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
         transactionId = UUIDSerializationUtil.readUUID(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddBackupOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.txncollection.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -56,13 +57,13 @@ public class CollectionTxnAddBackupOperation extends CollectionOperation impleme
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(itemId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         itemId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionBackupAwareOperation;
 import com.hazelcast.collection.impl.txncollection.CollectionTxnOperation;
 import com.hazelcast.core.ItemEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -85,13 +86,13 @@ public class CollectionTxnAddOperation extends CollectionBackupAwareOperation im
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(itemId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         itemId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferBackupOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.txnqueue.operations;
 import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.operations.QueueOperation;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -58,13 +59,13 @@ public class TxnOfferBackupOperation extends QueueOperation implements BackupOpe
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(itemId);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         itemId = in.readLong();
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -100,12 +101,12 @@ public class TxnOfferOperation extends BaseTxnQueueOperation implements Notifier
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.DeferredValue;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
@@ -96,7 +96,7 @@ public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K,
      * The ClassLoader to be used to resolve key &amp; value types, if set
      */
     protected transient ClassLoader classLoader;
-    protected transient InternalSerializationService serializationService;
+    protected transient SerializationService serializationService;
 
     /**
      * The {@link CacheEntryListenerConfiguration}s for the {@link javax.cache.configuration.Configuration}.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.merge.SplitBrainMergeTypeProvider;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes;
 import com.hazelcast.spi.tenantcontrol.TenantControl;
@@ -593,7 +594,8 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> implements Spli
         disablePerEntryInvalidationEvents = in.readBoolean();
 
         setClassLoader(in.getClassLoader());
-        this.serializationService = in.getSerializationService();
+        assert in instanceof SerializationServiceSupport;
+        this.serializationService = ((SerializationServiceSupport) in).getSerializationService();
 
         readPartitionLostListenerConfigs(in);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/AtomicRefSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/AtomicRefSnapshot.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cp.internal.datastructures.atomicref;
 
 import com.hazelcast.cp.internal.datastructures.spi.atomic.RaftAtomicValueSnapshot;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -50,12 +51,12 @@ public class AtomicRefSnapshot extends RaftAtomicValueSnapshot<Data> implements 
 
     @Override
     protected void writeValue(ObjectDataOutput out, Data value) throws IOException {
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected Data readValue(ObjectDataInput in) throws IOException {
-        return in.readData();
+        return IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/ApplyOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/ApplyOp.java
@@ -20,6 +20,7 @@ import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRef;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -131,7 +132,7 @@ public class ApplyOp extends AbstractAtomicRefOp implements IdentifiedDataSerial
     public void writeData(ObjectDataOutput out)
             throws IOException {
         super.writeData(out);
-        out.writeData(function);
+        IOUtil.writeData(out, function);
         out.writeUTF(returnValueType.name());
         out.writeBoolean(alter);
     }
@@ -140,7 +141,7 @@ public class ApplyOp extends AbstractAtomicRefOp implements IdentifiedDataSerial
     public void readData(ObjectDataInput in)
             throws IOException {
         super.readData(in);
-        function = in.readData();
+        function = IOUtil.readData(in);
         returnValueType = ReturnValueType.valueOf(in.readUTF());
         alter = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/CompareAndSetOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/CompareAndSetOp.java
@@ -19,6 +19,7 @@ package com.hazelcast.cp.internal.datastructures.atomicref.operation;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRef;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -63,15 +64,15 @@ public class CompareAndSetOp extends AbstractAtomicRefOp implements IdentifiedDa
     public void writeData(ObjectDataOutput out)
             throws IOException {
         super.writeData(out);
-        out.writeData(expectedValue);
-        out.writeData(newValue);
+        IOUtil.writeData(out, expectedValue);
+        IOUtil.writeData(out, newValue);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
         super.readData(in);
-        expectedValue = in.readData();
-        newValue = in.readData();
+        expectedValue = IOUtil.readData(in);
+        newValue = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/ContainsOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/ContainsOp.java
@@ -19,6 +19,7 @@ package com.hazelcast.cp.internal.datastructures.atomicref.operation;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRef;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -63,13 +64,13 @@ public class ContainsOp extends AbstractAtomicRefOp implements IndeterminateOper
     public void writeData(ObjectDataOutput out)
             throws IOException {
         super.writeData(out);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
         super.readData(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/SetOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/SetOp.java
@@ -19,6 +19,7 @@ package com.hazelcast.cp.internal.datastructures.atomicref.operation;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRef;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -61,7 +62,7 @@ public class SetOp extends AbstractAtomicRefOp implements IdentifiedDataSerializ
     public void writeData(ObjectDataOutput out)
             throws IOException {
         super.writeData(out);
-        out.writeData(newValue);
+        IOUtil.writeData(out, newValue);
         out.writeBoolean(returnOldValue);
     }
 
@@ -69,7 +70,7 @@ public class SetOp extends AbstractAtomicRefOp implements IdentifiedDataSerializ
     public void readData(ObjectDataInput in)
             throws IOException {
         super.readData(in);
-        newValue = in.readData();
+        newValue = IOUtil.readData(in);
         returnOldValue = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.durableexecutor.impl.operations;
 
 import com.hazelcast.durableexecutor.impl.DurableExecutorContainer;
 import com.hazelcast.durableexecutor.impl.DurableExecutorDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -51,14 +52,14 @@ public class TaskBackupOperation extends AbstractDurableExecutorOperation implem
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(sequence);
-        out.writeData(callableData);
+        IOUtil.writeData(out, callableData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         sequence = in.readInt();
-        callableData = in.readData();
+        callableData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.durableexecutor.impl.operations;
 
 import com.hazelcast.durableexecutor.impl.DurableExecutorContainer;
 import com.hazelcast.durableexecutor.impl.DurableExecutorDataSerializerHook;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -62,13 +63,13 @@ public class TaskOperation extends AbstractDurableExecutorOperation implements B
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(callableData);
+        IOUtil.writeData(out, callableData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        callableData = in.readData();
+        callableData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.executor.impl.operations;
 
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.executor.impl.ExecutorDataSerializerHook;
@@ -69,14 +70,14 @@ abstract class AbstractCallableTaskOperation extends Operation implements NamedO
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         UUIDSerializationUtil.writeUUID(out, uuid);
-        out.writeData(callableData);
+        IOUtil.writeData(out, callableData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
         uuid = UUIDSerializationUtil.readUUID(in);
-        callableData = in.readData();
+        callableData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/journal/DeserializingEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/journal/DeserializingEntry.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.journal;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -96,14 +97,14 @@ public class DeserializingEntry<K, V> implements Entry<K, V>, HazelcastInstanceA
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(toData(key, dataKey));
-        out.writeData(toData(value, dataValue));
+        IOUtil.writeData(out, toData(key, dataKey));
+        IOUtil.writeData(out, toData(value, dataValue));
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        dataKey = in.readData();
-        dataValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataValue = IOUtil.readData(in);
     }
 
     private Data toData(Object value, Data defaultValue) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockResourceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.locksupport;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
@@ -264,7 +265,7 @@ final class LockResourceImpl implements IdentifiedDataSerializable, LockResource
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(key);
+        IOUtil.writeData(out, key);
         UUIDSerializationUtil.writeUUID(out, owner);
         out.writeLong(threadId);
         out.writeLong(referenceId);
@@ -277,7 +278,7 @@ final class LockResourceImpl implements IdentifiedDataSerializable, LockResource
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        key = in.readData();
+        key = IOUtil.readData(in);
         owner = UUIDSerializationUtil.readUUID(in);
         threadId = in.readLong();
         referenceId = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/operations/AbstractLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/operations/AbstractLockOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.locksupport.operations;
 import com.hazelcast.internal.locksupport.LockDataSerializerHook;
 import com.hazelcast.internal.locksupport.LockSupportServiceImpl;
 import com.hazelcast.internal.locksupport.LockStoreImpl;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -156,7 +157,7 @@ public abstract class AbstractLockOperation extends Operation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(namespace);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
         out.writeLong(threadId);
         out.writeLong(leaseTime);
         out.writeLong(referenceCallId);
@@ -167,7 +168,7 @@ public abstract class AbstractLockOperation extends Operation
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         namespace = in.readObject();
-        key = in.readData();
+        key = IOUtil.readData(in);
         threadId = in.readLong();
         leaseTime = in.readLong();
         referenceCallId = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/SingleNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/SingleNearCacheInvalidation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.nearcache.impl.invalidation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -50,13 +51,13 @@ public class SingleNearCacheInvalidation extends Invalidation {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataInput.java
@@ -17,12 +17,13 @@
 package com.hazelcast.internal.nio;
 
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-public interface BufferObjectDataInput extends ObjectDataInput, Closeable {
+public interface BufferObjectDataInput extends ObjectDataInput, Closeable, DataReader, SerializationServiceSupport {
 
     int UTF_BUFFER_SIZE = 1024;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataOutput.java
@@ -23,7 +23,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-public interface BufferObjectDataOutput extends ObjectDataOutput, Closeable, SerializationServiceSupport {
+public interface BufferObjectDataOutput extends ObjectDataOutput, Closeable,
+                                                SerializationServiceSupport, DataWriter {
 
     void write(int position, int b);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/DataReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/DataReader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nio;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+/**
+ * Extends {@link DataInput} with ability to read {@link Data} from the input stream.
+ */
+public interface DataReader extends DataInput {
+
+    /**
+     * @return data read
+     * @throws IOException if it reaches end of file before finish reading
+     */
+    Data readData() throws IOException;
+
+    /**
+     * Reads to stored Data as an object instead of a Data instance.
+     * <p>
+     * The reason this method exists is that in some cases {@link Data} is stored on serialization, but on deserialization
+     * the actual object instance is needed. Getting access to the {@link Data} is easy by calling the {@link #readData()}
+     * method. But de-serializing the {@link Data} to an object instance is impossible because there is no reference to the
+     * {@link SerializationService}.
+     *
+     * @param <T> type of the object to be read
+     * @return the read Object
+     * @throws IOException if it reaches end of file before finish reading
+     */
+    <T> T readDataAsObject() throws IOException;
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/DataWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/DataWriter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nio;
+
+import com.hazelcast.nio.serialization.Data;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Extends {@link DataOutput} with the ability to write {@link Data} to the output stream.
+ */
+public interface DataWriter extends DataOutput {
+    /**
+     * @param data data to be written
+     * @throws IOException
+     */
+    void writeData(Data data) throws IOException;
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -118,7 +118,7 @@ public final class IOUtil {
         boolean isBinary = object instanceof Data;
         out.writeBoolean(isBinary);
         if (isBinary) {
-            out.writeData((Data) object);
+            writeData(out, (Data) object);
         } else {
             out.writeObject(object);
         }
@@ -128,9 +128,24 @@ public final class IOUtil {
     public static <T> T readObject(ObjectDataInput in) throws IOException {
         boolean isBinary = in.readBoolean();
         if (isBinary) {
-            return (T) in.readData();
+            return (T) readData(in);
         }
         return in.readObject();
+    }
+
+    public static void writeData(ObjectDataOutput out, Data data) throws IOException {
+        assert out instanceof DataWriter : "out must be an instance of DataWriter";
+        ((DataWriter) out).writeData(data);
+    }
+
+    public static Data readData(ObjectDataInput in) throws IOException {
+        assert in instanceof DataReader : "in must be an instance of DataReader";
+        return ((DataReader) in).readData();
+    }
+
+    public static <T> T readDataAsObject(ObjectDataInput in) throws IOException {
+        assert in instanceof DataReader : "in must be an instance of DataReader";
+        return ((DataReader) in).readDataAsObject();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.nio.DataWriter;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -26,7 +27,7 @@ import java.nio.ByteOrder;
 
 @SuppressWarnings("checkstyle:methodcount")
 final class EmptyObjectDataOutput extends VersionedObjectDataOutput
-        implements ObjectDataOutput, SerializationServiceSupport {
+        implements ObjectDataOutput, SerializationServiceSupport, DataWriter {
 
     @Override
     public void writeObject(Object object) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.nio.DataReader;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 
 import java.io.Closeable;
 import java.io.DataInputStream;
@@ -28,7 +30,8 @@ import java.nio.ByteOrder;
 import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.internal.nio.Bits.UTF_8;
 
-public class ObjectDataInputStream extends VersionedObjectDataInput implements Closeable {
+public class ObjectDataInputStream extends VersionedObjectDataInput
+        implements Closeable, DataReader, SerializationServiceSupport {
 
     private static final int SHORT_MASK = 0xFFFF;
 
@@ -351,6 +354,7 @@ public class ObjectDataInputStream extends VersionedObjectDataInput implements C
         return serializationService.getClassLoader();
     }
 
+    @Override
     public InternalSerializationService getSerializationService() {
         return serializationService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.nio.DataWriter;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -33,7 +34,7 @@ import static com.hazelcast.internal.nio.Bits.UTF_8;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class ObjectDataOutputStream extends VersionedObjectDataOutput
-        implements ObjectDataOutput, Closeable, SerializationServiceSupport {
+        implements ObjectDataOutput, Closeable, SerializationServiceSupport, DataWriter {
 
     private final InternalSerializationService serializationService;
     private final DataOutputStream dataOut;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -17,20 +17,20 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializableByConvention;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.ByteArraySerializer;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
-import com.hazelcast.internal.serialization.SerializableByConvention;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.serialization.VersionedPortable;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.partition.PartitioningStrategy;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DataCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DataCollection.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -45,7 +46,7 @@ public class DataCollection implements IdentifiedDataSerializable {
         int size = values.size();
         out.writeInt(size);
         for (Data o : values) {
-            out.writeData(o);
+            IOUtil.writeData(out, o);
         }
     }
 
@@ -54,7 +55,7 @@ public class DataCollection implements IdentifiedDataSerializable {
         int size = in.readInt();
         values = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             values.add(data);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryEventFilter.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -56,13 +57,13 @@ public class EntryEventFilter implements EventFilter, IdentifiedDataSerializable
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(includeValue);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         includeValue = in.readBoolean();
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -137,8 +138,8 @@ public final class MapEntries implements IdentifiedDataSerializable {
         int size = size();
         out.writeInt(size);
         for (int i = 0; i < size; i++) {
-            out.writeData(keys.get(i));
-            out.writeData(values.get(i));
+            IOUtil.writeData(out, keys.get(i));
+            IOUtil.writeData(out, values.get(i));
         }
     }
 
@@ -148,8 +149,8 @@ public final class MapEntries implements IdentifiedDataSerializable {
         keys = new ArrayList<>(size);
         values = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            keys.add(in.readData());
-            values.add(in.readData());
+            keys.add(IOUtil.readData(in));
+            values.add(IOUtil.readData(in));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.event;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -74,19 +75,19 @@ public class EntryEventData extends AbstractEventData {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeData(dataKey);
-        out.writeData(dataNewValue);
-        out.writeData(dataOldValue);
-        out.writeData(dataMergingValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataNewValue);
+        IOUtil.writeData(out, dataOldValue);
+        IOUtil.writeData(out, dataMergingValue);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        dataKey = in.readData();
-        dataNewValue = in.readData();
-        dataOldValue = in.readData();
-        dataMergingValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataNewValue = IOUtil.readData(in);
+        dataOldValue = IOUtil.readData(in);
+        dataMergingValue = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.iterator;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -44,14 +45,14 @@ public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Data>> 
 
     @Override
     void writeElement(ObjectDataOutput out, Entry<Data, Data> entry) throws IOException {
-        out.writeData(entry.getKey());
-        out.writeData(entry.getValue());
+        IOUtil.writeData(out, entry.getKey());
+        IOUtil.writeData(out, entry.getValue());
     }
 
     @Override
     Entry<Data, Data> readElement(ObjectDataInput in) throws IOException {
-        final Data key = in.readData();
-        final Data value = in.readData();
+        final Data key = IOUtil.readData(in);
+        final Data value = IOUtil.readData(in);
         return new AbstractMap.SimpleEntry<>(key, value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.iterator;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -45,12 +46,12 @@ public class MapKeysWithCursor extends AbstractCursor<Data> {
 
     @Override
     void writeElement(ObjectDataOutput out, Data element) throws IOException {
-        out.writeData(element);
+        IOUtil.writeData(out, element);
     }
 
     @Override
     Data readElement(ObjectDataInput in) throws IOException {
-        return in.readData();
+        return IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.journal;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -84,9 +85,9 @@ public class DeserializingEventJournalMapEvent<K, V>
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(eventType);
-        out.writeData(toData(dataKey, objectKey));
-        out.writeData(toData(dataNewValue, objectNewValue));
-        out.writeData(toData(dataOldValue, objectOldValue));
+        IOUtil.writeData(out, toData(dataKey, objectKey));
+        IOUtil.writeData(out, toData(dataNewValue, objectNewValue));
+        IOUtil.writeData(out, toData(dataOldValue, objectOldValue));
     }
 
     private Data toData(Data data, Object o) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.journal;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -80,17 +81,17 @@ public class InternalEventJournalMapEvent implements IdentifiedDataSerializable 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(eventType);
-        out.writeData(dataKey);
-        out.writeData(dataNewValue);
-        out.writeData(dataOldValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataNewValue);
+        IOUtil.writeData(out, dataOldValue);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         eventType = in.readInt();
-        dataKey = in.readData();
-        dataNewValue = in.readData();
-        dataOldValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataNewValue = IOUtil.readData(in);
+        dataOldValue = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -51,13 +52,13 @@ public class ContainsValueOperation extends MapOperation implements PartitionAwa
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(testValue);
+        IOUtil.writeData(out, testValue);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        testValue = in.readData();
+        testValue = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperationFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -45,13 +46,13 @@ public final class ContainsValueOperationFactory extends AbstractMapOperationFac
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
@@ -145,8 +146,8 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(modificationType != null ? modificationType.name() : "");
-        out.writeData(oldValue);
-        out.writeData(newValue);
+        IOUtil.writeData(out, oldValue);
+        IOUtil.writeData(out, newValue);
         UUIDSerializationUtil.writeUUID(out, caller);
         out.writeLong(begin);
         out.writeObject(entryBackupProcessor);
@@ -157,8 +158,8 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         super.readInternal(in);
         String modificationTypeName = in.readUTF();
         modificationType = modificationTypeName.equals("") ? null : EntryEventType.valueOf(modificationTypeName);
-        oldValue = in.readData();
-        newValue = in.readData();
+        oldValue = IOUtil.readData(in);
+        newValue = IOUtil.readData(in);
         caller = UUIDSerializationUtil.readUUID(in);
         begin = in.readLong();
         entryBackupProcessor = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.internal.eviction.ExpiredKey;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
@@ -132,7 +133,7 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
         out.writeUTF(name);
         out.writeInt(expiredKeys.size());
         for (ExpiredKey expiredKey : expiredKeys) {
-            out.writeData(expiredKey.getKey());
+            IOUtil.writeData(out, expiredKey.getKey());
             out.writeLong(expiredKey.getCreationTime());
         }
         out.writeInt(primaryEntryCount);
@@ -146,7 +147,7 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
         int size = in.readInt();
         expiredKeys = new LinkedList<>();
         for (int i = 0; i < size; i++) {
-            expiredKeys.add(new ExpiredKey(in.readData(), in.readLong()));
+            expiredKeys.add(new ExpiredKey(IOUtil.readData(in), in.readLong()));
         }
         primaryEntryCount = in.readInt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.ObjectDataInput;
@@ -78,7 +79,7 @@ public class GetAllOperation extends MapOperation implements ReadonlyOperation, 
         } else {
             out.writeInt(keys.size());
             for (Data key : keys) {
-                out.writeData(key);
+                IOUtil.writeData(out, key);
             }
         }
     }
@@ -89,7 +90,7 @@ public class GetAllOperation extends MapOperation implements ReadonlyOperation, 
         int size = in.readInt();
         if (size > -1) {
             for (int i = 0; i < size; i++) {
-                Data data = in.readData();
+                Data data = IOUtil.readData(in);
                 keys.add(data);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -65,16 +66,16 @@ public abstract class KeyBasedMapOperation extends MapOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(dataKey);
-        out.writeData(dataValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataValue);
         out.writeLong(threadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        dataKey = in.readData();
-        dataValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataValue = IOUtil.readData(in);
         threadId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.MapLoader;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -97,7 +98,7 @@ public class LoadAllOperation extends MapOperation implements PartitionAwareOper
         final int size = keys.size();
         out.writeInt(size);
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
         out.writeBoolean(replaceExistingValues);
     }
@@ -110,7 +111,7 @@ public class LoadAllOperation extends MapOperation implements PartitionAwareOper
             keys = new ArrayList<>(size);
         }
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             keys.add(data);
         }
         replaceExistingValues = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetAllOperationFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -49,7 +50,7 @@ public class MapGetAllOperationFactory extends AbstractMapOperationFactory {
         out.writeUTF(name);
         out.writeInt(keys.size());
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
     }
 
@@ -58,7 +59,7 @@ public class MapGetAllOperationFactory extends AbstractMapOperationFactory {
         name = in.readUTF();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             keys.add(data);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -57,7 +58,7 @@ public class MapLoadAllOperationFactory extends AbstractMapOperationFactory {
         final int size = keys.size();
         out.writeInt(size);
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
         out.writeBoolean(replaceExistingValues);
     }
@@ -70,7 +71,7 @@ public class MapLoadAllOperationFactory extends AbstractMapOperationFactory {
             keys = new ArrayList<>(size);
         }
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             keys.add(data);
         }
         replaceExistingValues = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -56,7 +57,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
         int size = in.readInt();
         keys = createLinkedHashSet(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
+            Data key = IOUtil.readData(in);
             keys.add(key);
         }
     }
@@ -67,7 +68,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
         out.writeObject(backupProcessor);
         out.writeInt(keys.size());
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
@@ -120,7 +121,7 @@ public class MultipleEntryOperation extends MapOperation
         int size = in.readInt();
         keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
+            Data key = IOUtil.readData(in);
             keys.add(key);
         }
 
@@ -132,7 +133,7 @@ public class MultipleEntryOperation extends MapOperation
         out.writeObject(entryProcessor);
         out.writeInt(keys.size());
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -53,7 +54,7 @@ public class MultipleEntryOperationFactory extends AbstractMapOperationFactory {
         out.writeUTF(name);
         out.writeInt(keys.size());
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
         out.writeObject(entryProcessor);
     }
@@ -64,7 +65,7 @@ public class MultipleEntryOperationFactory extends AbstractMapOperationFactory {
         int size = in.readInt();
         this.keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
+            Data key = IOUtil.readData(in);
             keys.add(key);
         }
         this.entryProcessor = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -88,7 +89,7 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
         final int size = keyValueSequence.size();
         out.writeInt(size);
         for (Data data : keyValueSequence) {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
     }
 
@@ -102,7 +103,7 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
         } else {
             final List<Data> tmpLoadingSequence = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                Data data = in.readData();
+                Data data = IOUtil.readData(in);
                 tmpLoadingSequence.add(data);
             }
             loadingSequence = tmpLoadingSequence;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
@@ -163,7 +164,7 @@ public class PutFromLoadAllOperation extends MapOperation
         final int size = keyValueSequence.size();
         out.writeInt(size);
         for (Data data : keyValueSequence) {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
     }
 
@@ -177,7 +178,7 @@ public class PutFromLoadAllOperation extends MapOperation
         } else {
             final List<Data> tmpKeyValueSequence = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                final Data data = in.readData();
+                final Data data = IOUtil.readData(in);
                 tmpKeyValueSequence.add(data);
             }
             loadingSequence = tmpKeyValueSequence;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReadonlyKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReadonlyKeyBasedMapOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -54,14 +55,14 @@ public abstract class ReadonlyKeyBasedMapOperation extends MapOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(dataKey);
+        IOUtil.writeData(out, dataKey);
         out.writeLong(threadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        dataKey = in.readData();
+        dataKey = IOUtil.readData(in);
         threadId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.recordstore.Storage;
@@ -78,7 +79,7 @@ public class RemoveFromLoadAllOperation extends MapOperation implements Partitio
         final int size = keys.size();
         out.writeInt(size);
         for (Data key : keys) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
     }
 
@@ -90,7 +91,7 @@ public class RemoveFromLoadAllOperation extends MapOperation implements Partitio
             keys = new ArrayList<>(size);
         }
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
+            Data data = IOUtil.readData(in);
             keys.add(data);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -67,13 +68,13 @@ public class RemoveIfSameOperation extends BaseRemoveOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(testValue);
+        IOUtil.writeData(out, testValue);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        testValue = in.readData();
+        testValue = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -70,13 +71,13 @@ public class ReplaceIfSameOperation extends BasePutOperation implements Mutating
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(expect);
+        IOUtil.writeData(out, expect);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        expect = in.readData();
+        expect = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
@@ -154,8 +155,8 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
                 Data value = mapServiceContext.toData(e.getValue());
                 long expirationTime = e.getExpirationTime();
 
-                out.writeData(key);
-                out.writeData(value);
+                IOUtil.writeData(out, key);
+                IOUtil.writeData(out, value);
                 out.writeLong(expirationTime);
                 out.writeLong(e.getStoreTime());
                 out.writeInt(e.getPartitionId());
@@ -198,8 +199,8 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
             int listSize = in.readInt();
             List<DelayedEntry> delayedEntriesList = new ArrayList<>(listSize);
             for (int j = 0; j < listSize; j++) {
-                Data key = in.readData();
-                Data value = in.readData();
+                Data key = IOUtil.readData(in);
+                Data value = IOUtil.readData(in);
                 long expirationTime = in.readLong();
                 long storeTime = in.readLong();
                 int partitionId = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultRow.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -69,14 +70,14 @@ public class QueryResultRow implements IdentifiedDataSerializable, Map.Entry<Dat
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(key);
-        out.writeData(value);
+        IOUtil.writeData(out, key);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        key = in.readData();
-        value = in.readData();
+        key = IOUtil.readData(in);
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.querycache.event;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -167,8 +168,8 @@ public class DefaultQueryCacheEventData implements QueryCacheEventData {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(sequence);
-        out.writeData(dataKey);
-        out.writeData(dataNewValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataNewValue);
         out.writeInt(eventType);
         out.writeInt(partitionId);
     }
@@ -176,8 +177,8 @@ public class DefaultQueryCacheEventData implements QueryCacheEventData {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         this.sequence = in.readLong();
-        this.dataKey = in.readData();
-        this.dataNewValue = in.readData();
+        this.dataKey = IOUtil.readData(in);
+        this.dataNewValue = IOUtil.readData(in);
         this.eventType = in.readInt();
         this.partitionId = in.readInt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordReaderWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordReaderWriter.java
@@ -22,6 +22,9 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
+import static com.hazelcast.internal.nio.IOUtil.readData;
+import static com.hazelcast.internal.nio.IOUtil.writeData;
+
 /**
  * Used when reading and writing records
  * for backup and replication operations
@@ -31,8 +34,8 @@ public enum RecordReaderWriter {
         @Override
         void writeRecord(ObjectDataOutput out,
                          Record record, Data dataValue) throws IOException {
-            out.writeData(record.getKey());
-            out.writeData(dataValue);
+            writeData(out, record.getKey());
+            writeData(out, dataValue);
             out.writeInt(record.getRawTtl());
             out.writeInt(record.getRawMaxIdle());
             out.writeInt(record.getRawCreationTime());
@@ -45,8 +48,8 @@ public enum RecordReaderWriter {
         @Override
         Record readRecord(ObjectDataInput in) throws IOException {
             DataRecord record = new DataRecord();
-            record.setKey(in.readData());
-            record.setValue(in.readData());
+            record.setKey(readData(in));
+            record.setValue(readData(in));
             record.setRawTtl(in.readInt());
             record.setRawMaxIdle(in.readInt());
             record.setRawCreationTime(in.readInt());
@@ -62,8 +65,8 @@ public enum RecordReaderWriter {
         @Override
         void writeRecord(ObjectDataOutput out,
                          Record record, Data dataValue) throws IOException {
-            out.writeData(record.getKey());
-            out.writeData(dataValue);
+            writeData(out, record.getKey());
+            writeData(out, dataValue);
             out.writeInt(record.getRawTtl());
             out.writeInt(record.getRawMaxIdle());
             out.writeInt(record.getRawCreationTime());
@@ -78,8 +81,8 @@ public enum RecordReaderWriter {
         @Override
         Record readRecord(ObjectDataInput in) throws IOException {
             DataRecordWithStats record = new DataRecordWithStats();
-            record.setKey(in.readData());
-            record.setValue(in.readData());
+            record.setKey(readData(in));
+            record.setValue(readData(in));
             record.setRawTtl(in.readInt());
             record.setRawMaxIdle(in.readInt());
             record.setRawCreationTime(in.readInt());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.tx;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.ThreadUtil;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
@@ -89,7 +90,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
         boolean isNullKey = key == null;
         out.writeBoolean(isNullKey);
         if (!isNullKey) {
-            out.writeData(key);
+            IOUtil.writeData(out, key);
         }
         out.writeLong(threadId);
         UUIDSerializationUtil.writeUUID(out, ownerUuid);
@@ -103,7 +104,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
         partitionId = in.readInt();
         boolean isNullKey = in.readBoolean();
         if (!isNullKey) {
-            key = in.readData();
+            key = IOUtil.readData(in);
         }
         threadId = in.readLong();
         ownerUuid = UUIDSerializationUtil.readUUID(in);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/VersionedValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/VersionedValue.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.tx;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -46,7 +47,7 @@ public class VersionedValue implements IdentifiedDataSerializable {
         boolean isNull = value == null;
         out.writeBoolean(isNull);
         if (!isNull) {
-            out.writeData(value);
+            IOUtil.writeData(out, value);
         }
     }
 
@@ -55,7 +56,7 @@ public class VersionedValue implements IdentifiedDataSerializable {
         version = in.readLong();
         boolean isNull = in.readBoolean();
         if (!isNull) {
-            value = in.readData();
+            value = IOUtil.readData(in);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.wan;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -84,13 +85,13 @@ public class MapReplicationRemove implements InternalWanReplicationEvent, Identi
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(mapName);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventFilter.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -48,13 +49,13 @@ public class MultiMapEventFilter implements EventFilter, IdentifiedDataSerializa
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(includeValue);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         includeValue = in.readBoolean();
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapMergeContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapMergeContainer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -89,7 +90,7 @@ public class MultiMapMergeContainer implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(key);
+        IOUtil.writeData(out, key);
         out.writeInt(records.size());
         for (MultiMapRecord record : records) {
             out.writeObject(record);
@@ -102,7 +103,7 @@ public class MultiMapMergeContainer implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        key = in.readData();
+        key = IOUtil.readData(in);
         int size = in.readInt();
         records = new ArrayList<MultiMapRecord>(size);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractKeyBasedMultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractKeyBasedMultiMapOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -50,13 +51,13 @@ public abstract class AbstractKeyBasedMultiMapOperation extends AbstractMultiMap
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(threadId);
-        out.writeData(dataKey);
+        IOUtil.writeData(out, dataKey);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         threadId = in.readLong();
-        dataKey = in.readData();
+        dataKey = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -78,16 +79,16 @@ public class ContainsEntryOperation extends AbstractMultiMapOperation implements
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(threadId);
-        out.writeData(key);
-        out.writeData(value);
+        IOUtil.writeData(out, key);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         threadId = in.readLong();
-        key = in.readData();
-        value = in.readData();
+        key = IOUtil.readData(in);
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetResponse.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.nio.ObjectDataInput;
@@ -82,11 +83,11 @@ public class EntrySetResponse implements IdentifiedDataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(map.size());
         for (Map.Entry<Data, Collection<Data>> entry : map.entrySet()) {
-            out.writeData(entry.getKey());
+            IOUtil.writeData(out, entry.getKey());
             Collection<Data> coll = entry.getValue();
             out.writeInt(coll.size());
             for (Data data : coll) {
-                out.writeData(data);
+                IOUtil.writeData(out, data);
             }
         }
     }
@@ -96,11 +97,11 @@ public class EntrySetResponse implements IdentifiedDataSerializable {
         int size = in.readInt();
         map = createHashMap(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
+            Data key = IOUtil.readData(in);
             int collSize = in.readInt();
             Collection<Data> coll = new ArrayList<Data>(collSize);
             for (int j = 0; j < collSize; j++) {
-                coll.add(in.readData());
+                coll.add(IOUtil.readData(in));
             }
             map.put(key, coll);
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -75,7 +76,7 @@ public class MergeBackupOperation extends AbstractMultiMapOperation implements B
         super.writeInternal(out);
         out.writeInt(backupEntries.size());
         for (Map.Entry<Data, Collection<MultiMapRecord>> entry : backupEntries.entrySet()) {
-            out.writeData(entry.getKey());
+            IOUtil.writeData(out, entry.getKey());
             Collection<MultiMapRecord> collection = entry.getValue();
             out.writeInt(collection.size());
             for (MultiMapRecord record : collection) {
@@ -90,7 +91,7 @@ public class MergeBackupOperation extends AbstractMultiMapOperation implements B
         int size = in.readInt();
         backupEntries = createHashMap(size);
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
+            Data key = IOUtil.readData(in);
             int collectionSize = in.readInt();
             Collection<MultiMapRecord> collection = new ArrayList<MultiMapRecord>(collectionSize);
             for (int j = 0; j < collectionSize; j++) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperationFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -79,8 +80,8 @@ public class MultiMapOperationFactory implements OperationFactory {
         out.writeUTF(name);
         out.writeInt(operationFactoryType.type);
         out.writeLong(threadId);
-        out.writeData(key);
-        out.writeData(value);
+        IOUtil.writeData(out, key);
+        IOUtil.writeData(out, value);
     }
 
     @Override
@@ -88,8 +89,8 @@ public class MultiMapOperationFactory implements OperationFactory {
         name = in.readUTF();
         operationFactoryType = OperationFactoryType.getByType(in.readInt());
         threadId = in.readLong();
-        key = in.readData();
-        value = in.readData();
+        key = IOUtil.readData(in);
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -64,7 +65,7 @@ public class MultiMapReplicationOperation extends Operation implements Identifie
             out.writeInt(collections.size());
             for (Map.Entry<Data, MultiMapValue> collectionEntry : collections.entrySet()) {
                 Data key = collectionEntry.getKey();
-                out.writeData(key);
+                IOUtil.writeData(out, key);
                 MultiMapValue multiMapValue = collectionEntry.getValue();
                 Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
                 out.writeInt(coll.size());
@@ -89,7 +90,7 @@ public class MultiMapReplicationOperation extends Operation implements Identifie
             int collectionSize = in.readInt();
             Map<Data, MultiMapValue> collections = createHashMap(collectionSize);
             for (int j = 0; j < collectionSize; j++) {
-                Data key = in.readData();
+                Data key = IOUtil.readData(in);
                 int collSize = in.readInt();
                 String collectionType = in.readUTF();
                 Collection<MultiMapRecord> coll;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -69,7 +70,7 @@ public class PutBackupOperation extends AbstractKeyBasedMultiMapOperation implem
         super.writeInternal(out);
         out.writeLong(recordId);
         out.writeInt(index);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
@@ -77,7 +78,7 @@ public class PutBackupOperation extends AbstractKeyBasedMultiMapOperation implem
         super.readInternal(in);
         recordId = in.readLong();
         index = in.readInt();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -90,14 +91,14 @@ public class PutOperation extends AbstractBackupAwareMultiMapOperation implement
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(index);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         index = in.readInt();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -61,13 +62,13 @@ public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation imp
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -85,13 +86,13 @@ public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implem
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.txn;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -73,7 +74,7 @@ public class MultiMapTransactionLogRecord implements TransactionLogRecord {
         for (Operation op : opList) {
             out.writeObject(op);
         }
-        out.writeData(key);
+        IOUtil.writeData(out, key);
         out.writeLong(ttl);
         out.writeLong(threadId);
     }
@@ -86,7 +87,7 @@ public class MultiMapTransactionLogRecord implements TransactionLogRecord {
         for (int i = 0; i < size; i++) {
             opList.add((Operation) in.readObject());
         }
-        key = in.readData();
+        key = IOUtil.readData(in);
         ttl = in.readLong();
         threadId = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.txn;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -61,14 +62,14 @@ public class TxnPutBackupOperation extends AbstractKeyBasedMultiMapOperation imp
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(recordId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         recordId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl.txn;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -93,14 +94,14 @@ public class TxnPutOperation extends AbstractKeyBasedMultiMapOperation implement
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(recordId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         recordId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.txn;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -70,14 +71,14 @@ public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation 
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(recordId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         recordId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl.txn;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
@@ -102,14 +103,14 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(recordId);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         recordId = in.readLong();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -16,10 +16,6 @@
 
 package com.hazelcast.nio;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.nio.serialization.Data;
-
 import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -91,32 +87,12 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
     <T> T readObject() throws IOException;
 
     /**
-     * Reads to stored Data as an object instead of a Data instance.
-     * <p>
-     * The reason this method exists is that in some cases {@link Data} is stored on serialization, but on deserialization
-     * the actual object instance is needed. Getting access to the {@link Data} is easy by calling the {@link #readData()}
-     * method. But de-serializing the {@link Data} to an object instance is impossible because there is no reference to the
-     * {@link SerializationService}.
-     *
-     * @param <T> type of the object to be read
-     * @return the read Object
-     * @throws IOException if it reaches end of file before finish reading
-     */
-    <T> T readDataAsObject() throws IOException;
-
-    /**
      * @param <T>    type of the object to be read
      * @param aClass the type of the class to use when reading
      * @return object array read
      * @throws IOException if it reaches end of file before finish reading
      */
     <T> T readObject(Class aClass) throws IOException;
-
-    /**
-     * @return data read
-     * @throws IOException if it reaches end of file before finish reading
-     */
-    Data readData() throws IOException;
 
     /**
      * Returns class loader that internally used for objects.
@@ -129,9 +105,4 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
      * @return ByteOrder BIG_ENDIAN or LITTLE_ENDIAN
      */
     ByteOrder getByteOrder();
-
-    /**
-     * @return serialization service for this object
-     */
-    InternalSerializationService getSerializationService();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.nio;
 
-import com.hazelcast.nio.serialization.Data;
-
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -86,12 +84,6 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
      * @throws IOException
      */
     void writeObject(Object object) throws IOException;
-
-    /**
-     * @param data data to be written
-     * @throws IOException
-     */
-    void writeData(Data data) throws IOException;
 
     /**
      * @return copy of internal byte array

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -54,13 +55,13 @@ public class ContainsKeyOperation extends AbstractNamedSerializableOperation imp
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsValueOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -60,13 +61,13 @@ public class ContainsValueOperation extends AbstractNamedSerializableOperation i
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeData(value);
+        IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        value = in.readData();
+        value = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -60,13 +61,13 @@ public class GetOperation extends AbstractNamedSerializableOperation implements 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.replicatedmap.impl.operation;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -77,16 +78,16 @@ public class PutOperation extends AbstractReplicatedMapOperation implements Part
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeData(key);
-        out.writeData(value);
+        IOUtil.writeData(out, key);
+        IOUtil.writeData(out, value);
         out.writeLong(ttl);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        key = in.readData();
-        value = in.readData();
+        key = IOUtil.readData(in);
+        value = IOUtil.readData(in);
         ttl = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.replicatedmap.impl.operation;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -67,13 +68,13 @@ public class RemoveOperation extends AbstractReplicatedMapOperation implements P
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeData(key);
+        IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        key = in.readData();
+        key = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -95,8 +96,8 @@ public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         response.writeData(out);
         out.writeUTF(name);
-        out.writeData(dataKey);
-        out.writeData(dataValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataValue);
         out.writeLong(ttl);
         out.writeBoolean(isRemove);
         out.writeObject(origin);
@@ -107,8 +108,8 @@ public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation
         response = new VersionResponsePair();
         response.readData(in);
         name = in.readUTF();
-        dataKey = in.readData();
-        dataValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataValue = IOUtil.readData(in);
         ttl = in.readLong();
         isRemove = in.readBoolean();
         origin = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -108,8 +109,8 @@ public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperat
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeLong(callId);
-        out.writeData(dataKey);
-        out.writeData(dataValue);
+        IOUtil.writeData(out, dataKey);
+        IOUtil.writeData(out, dataValue);
         response.writeData(out);
         out.writeLong(ttl);
         out.writeBoolean(isRemove);
@@ -119,8 +120,8 @@ public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperat
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
         callId = in.readLong();
-        dataKey = in.readData();
-        dataValue = in.readData();
+        dataKey = IOUtil.readData(in);
+        dataValue = IOUtil.readData(in);
         response = new VersionResponsePair();
         response.readData(in);
         ttl = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/RecordMigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/RecordMigrationInfo.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl.record;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -101,8 +102,8 @@ public class RecordMigrationInfo implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(key);
-        out.writeData(value);
+        IOUtil.writeData(out, key);
+        IOUtil.writeData(out, value);
         out.writeLong(ttl);
         out.writeLong(hits);
         out.writeLong(lastAccessTime);
@@ -112,8 +113,8 @@ public class RecordMigrationInfo implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        key = in.readData();
-        value = in.readData();
+        key = IOUtil.readData(in);
+        value = IOUtil.readData(in);
         ttl = in.readLong();
         hits = in.readLong();
         lastAccessTime = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IFunction;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -218,7 +219,7 @@ public class ReadResultSetImpl<O, E> extends AbstractList<E>
         out.writeInt(readCount);
         out.writeInt(size);
         for (int k = 0; k < size; k++) {
-            out.writeData(items[k]);
+            IOUtil.writeData(out, items[k]);
         }
         out.writeLongArray(seqs);
         out.writeLong(nextSeq);
@@ -230,7 +231,7 @@ public class ReadResultSetImpl<O, E> extends AbstractList<E>
         size = in.readInt();
         items = new Data[size];
         for (int k = 0; k < size; k++) {
-            items[k] = in.readData();
+            items[k] = IOUtil.readData(in);
         }
         seqs = in.readLongArray();
         nextSeq = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -569,7 +570,7 @@ public class RingbufferContainer<T, E> implements IdentifiedDataSerializable, No
         // we only write the actual content of the ringbuffer. So we don't write empty slots.
         for (long seq = ringbuffer.headSequence(); seq <= ringbuffer.tailSequence(); seq++) {
             if (inMemoryFormat == BINARY) {
-                out.writeData((Data) ringbuffer.read(seq));
+                IOUtil.writeData(out, (Data) ringbuffer.read(seq));
             } else {
                 out.writeObject(ringbuffer.read(seq));
             }
@@ -607,7 +608,7 @@ public class RingbufferContainer<T, E> implements IdentifiedDataSerializable, No
         long now = System.currentTimeMillis();
         for (long seq = headSequence; seq <= tailSequence; seq++) {
             if (inMemoryFormat == BINARY) {
-                ringbuffer.set(seq, (E) in.readData());
+                ringbuffer.set(seq, (E) IOUtil.readData(in));
             } else {
                 ringbuffer.set(seq, (E) in.readObject());
             }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.ringbuffer.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -65,7 +66,7 @@ public class AddAllBackupOperation extends AbstractRingBufferOperation implement
         out.writeLong(lastSequenceId);
         out.writeInt(items.length);
         for (Data item : items) {
-            out.writeData(item);
+            IOUtil.writeData(out, item);
         }
     }
 
@@ -76,7 +77,7 @@ public class AddAllBackupOperation extends AbstractRingBufferOperation implement
         int length = in.readInt();
         items = new Data[length];
         for (int k = 0; k < items.length; k++) {
-            items[k] = in.readData();
+            items[k] = IOUtil.readData(in);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.ringbuffer.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -120,7 +121,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
 
         out.writeInt(items.length);
         for (Data item : items) {
-            out.writeData(item);
+            IOUtil.writeData(out, item);
         }
     }
 
@@ -133,7 +134,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
         int length = in.readInt();
         items = new Data[length];
         for (int k = 0; k < items.length; k++) {
-            items[k] = in.readData();
+            items[k] = IOUtil.readData(in);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.ringbuffer.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -55,13 +56,13 @@ public class AddBackupOperation extends AbstractRingBufferOperation implements B
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(sequenceId);
-        out.writeData(item);
+        IOUtil.writeData(out, item);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         sequenceId = in.readLong();
-        item = in.readData();
+        item = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.ringbuffer.impl.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -113,14 +114,14 @@ public class AddOperation extends AbstractRingBufferOperation implements Notifie
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(item);
+        IOUtil.writeData(out, item);
         out.writeInt(overflowPolicy.getId());
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        item = in.readData();
+        item = IOUtil.readData(in);
         overflowPolicy = OverflowPolicy.getById(in.readInt());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SerializableList.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SerializableList.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -46,7 +47,7 @@ public final class SerializableList implements IdentifiedDataSerializable, Itera
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(collection.size());
         for (Data data : collection) {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
     }
 
@@ -55,7 +56,7 @@ public final class SerializableList implements IdentifiedDataSerializable, Itera
         int size = in.readInt();
         collection = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
-            collection.add(in.readData());
+            collection.add(IOUtil.readData(in));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.spi.impl.eventservice.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
@@ -71,25 +71,14 @@ public final class EventEnvelope implements IdentifiedDataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         UUIDSerializationUtil.writeUUID(out, id);
         out.writeUTF(serviceName);
-        boolean isBinary = event instanceof Data;
-        out.writeBoolean(isBinary);
-        if (isBinary) {
-            out.writeData((Data) event);
-        } else {
-            out.writeObject(event);
-        }
+        IOUtil.writeObject(out, event);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         id = UUIDSerializationUtil.readUUID(in);
         serviceName = in.readUTF();
-        boolean isBinary = in.readBoolean();
-        if (isBinary) {
-            event = in.readData();
-        } else {
-            event = in.readObject();
-        }
+        event = IOUtil.readObject(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/BinaryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/BinaryOperationFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.operationservice;
 
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -55,12 +56,12 @@ public final class BinaryOperationFactory implements OperationFactory, NodeAware
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(operationData);
+        IOUtil.writeData(out, operationData);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        operationData = in.readData();
+        operationData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationservice.impl.operations;
 
 import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.PartitionReplica;
@@ -43,6 +44,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static com.hazelcast.internal.nio.IOUtil.readDataAsObject;
 import static com.hazelcast.spi.impl.operationexecutor.OperationRunner.runDirect;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.internal.partition.IPartition.MAX_BACKUP_COUNT;
@@ -258,7 +260,7 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
             out.writeObject(backupOp);
         } else {
             out.writeBoolean(true);
-            out.writeData(backupOpData);
+            IOUtil.writeData(out, backupOpData);
         }
 
         if (originalCaller == null) {
@@ -287,7 +289,7 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         if (in.readBoolean()) {
-            backupOp = in.readDataAsObject();
+            backupOp = readDataAsObject(in);
         } else {
             backupOp = in.readObject();
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -18,11 +18,12 @@ package com.hazelcast.spi.impl.operationservice.impl.responses;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.internal.nio.IOUtil.readObject;
+import static com.hazelcast.internal.nio.IOUtil.writeObject;
 import static com.hazelcast.spi.impl.SpiDataSerializerHook.NORMAL_RESPONSE;
 
 /**
@@ -90,13 +91,7 @@ public class NormalResponse extends Response {
         // acks fit in a byte.
         out.writeByte(backupAcks);
 
-        final boolean isData = value instanceof Data;
-        out.writeBoolean(isData);
-        if (isData) {
-            out.writeData((Data) value);
-        } else {
-            out.writeObject(value);
-        }
+        writeObject(out, value);
     }
 
     @Override
@@ -104,12 +99,7 @@ public class NormalResponse extends Response {
         super.readData(in);
         backupAcks = in.readByte();
 
-        final boolean isData = in.readBoolean();
-        if (isData) {
-            value = in.readData();
-        } else {
-            value = in.readObject();
-        }
+        value = readObject(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.topic.impl;
 
 import com.hazelcast.config.TopicConfig;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -96,12 +97,12 @@ public class PublishOperation extends AbstractNamedOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeData(message);
+        IOUtil.writeData(out, message);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        message = in.readData();
+        message = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
@@ -17,6 +17,7 @@
 package com.hazelcast.topic.impl;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -57,7 +58,7 @@ class TopicEvent implements IdentifiedDataSerializable {
         out.writeUTF(name);
         out.writeLong(publishTime);
         out.writeObject(publisherAddress);
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
@@ -65,7 +66,7 @@ class TopicEvent implements IdentifiedDataSerializable {
         name = in.readUTF();
         publishTime = in.readLong();
         publisherAddress = in.readObject();
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
@@ -17,6 +17,7 @@
 package com.hazelcast.topic.impl.reliable;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -73,13 +74,13 @@ public class ReliableTopicMessage implements IdentifiedDataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(publishTime);
         out.writeObject(publisherAddress);
-        out.writeData(payload);
+        IOUtil.writeData(out, payload);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         publishTime = in.readLong();
         publisherAddress = in.readObject();
-        payload = in.readData();
+        payload = IOUtil.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.transaction.impl.xa.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -58,12 +59,12 @@ ClearRemoteTransactionBackupOperation extends AbstractXAOperation implements Bac
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeData(xidData);
+        IOUtil.writeData(out, xidData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        xidData = in.readData();
+        xidData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.transaction.impl.xa.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -73,12 +74,12 @@ public class ClearRemoteTransactionOperation extends AbstractXAOperation impleme
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeData(xidData);
+        IOUtil.writeData(out, xidData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        xidData = in.readData();
+        xidData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.transaction.impl.xa.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -56,12 +57,12 @@ public class FinalizeRemoteTransactionBackupOperation extends AbstractXAOperatio
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeData(xidData);
+        IOUtil.writeData(out, xidData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        xidData = in.readData();
+        xidData = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.transaction.impl.xa.operations;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -105,13 +106,13 @@ public class FinalizeRemoteTransactionOperation extends AbstractXAOperation impl
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeData(xidData);
+        IOUtil.writeData(out, xidData);
         out.writeBoolean(isCommit);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        xidData = in.readData();
+        xidData = IOUtil.readData(in);
         isCommit = in.readBoolean();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
@@ -26,6 +26,8 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.nio.DataReader;
+import com.hazelcast.internal.nio.DataWriter;
 import com.hazelcast.internal.partition.PartitionLostEventImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -56,6 +58,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -181,7 +184,8 @@ public class CachePartitionLostListenerTest extends AbstractPartitionLostListene
     @Test
     public void test_cachePartitionEventData_serialization() throws IOException {
         CachePartitionEventData cachePartitionEventData = new CachePartitionEventData("cacheName", 1, null);
-        ObjectDataOutput output = mock(ObjectDataOutput.class);
+        ObjectDataOutput output = mock(ObjectDataOutput.class,
+                withSettings().extraInterfaces(DataWriter.class));
         cachePartitionEventData.writeData(output);
 
         verify(output).writeUTF("cacheName");
@@ -192,7 +196,8 @@ public class CachePartitionLostListenerTest extends AbstractPartitionLostListene
     public void test_cachePartitionEventData_deserialization() throws IOException {
         CachePartitionEventData cachePartitionEventData = new CachePartitionEventData("", 0, null);
 
-        ObjectDataInput input = mock(ObjectDataInput.class);
+        ObjectDataInput input = mock(ObjectDataInput.class,
+                withSettings().extraInterfaces(DataReader.class));
         when(input.readUTF()).thenReturn("cacheName");
         when(input.readInt()).thenReturn(1);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -69,12 +70,12 @@ public class ByteArrayObjectDataInputIntegrationTest {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeData(data);
+            IOUtil.writeData(out, data);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            o = in.readDataAsObject();
+            o = IOUtil.readDataAsObject(in);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
@@ -33,6 +33,7 @@ import java.io.EOFException;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import static com.hazelcast.internal.nio.IOUtil.readData;
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.Assert.assertArrayEquals;
@@ -609,11 +610,11 @@ public class ByteArrayObjectDataInputTest extends HazelcastTestSupport {
         in.init((byteOrder == BIG_ENDIAN ? bytesBE : bytesLE), 0);
 
         in.position(bytesLE.length - 4);
-        Data nullData = in.readData();
+        Data nullData = readData(in);
         in.position(0);
-        Data theZeroLenghtArray = in.readData();
+        Data theZeroLenghtArray = readData(in);
         in.position(4);
-        Data data = in.readData();
+        Data data = readData(in);
 
         assertNull(nullData);
         assertEquals(0, theZeroLenghtArray.getType());

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableImplementsVersionedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableImplementsVersionedTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.internal.nio.DataReader;
+import com.hazelcast.internal.nio.DataWriter;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -43,7 +45,6 @@ import static com.hazelcast.test.ReflectionsHelper.filterNonConcreteClasses;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -176,7 +177,7 @@ public class DataSerializableImplementsVersionedTest {
     // overridden in EE
     protected ObjectDataOutput getObjectDataOutput() {
         ObjectDataOutput output = mock(ObjectDataOutput.class,
-                withSettings().extraInterfaces(SerializationServiceSupport.class));
+                withSettings().extraInterfaces(SerializationServiceSupport.class, DataWriter.class));
         when(((SerializationServiceSupport) output).getSerializationService())
                 .thenReturn(serializationService);
         return output;
@@ -184,6 +185,7 @@ public class DataSerializableImplementsVersionedTest {
 
     // overridden in EE
     protected ObjectDataInput getObjectDataInput() {
-        return spy(ObjectDataInput.class);
+        return mock(ObjectDataInput.class,
+                withSettings().extraInterfaces(DataReader.class));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -35,6 +35,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Random;
 
+import static com.hazelcast.internal.nio.IOUtil.readData;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static org.junit.Assert.assertArrayEquals;
@@ -321,11 +322,11 @@ public class ObjectDataInputStreamFinalMethodsTest {
         inputStream.init((byteOrder == BIG_ENDIAN ? bytesBE : bytesLE), 0);
 
         inputStream.position(bytesLE.length - 4);
-        Data nullData = in.readData();
+        Data nullData = readData(in);
         inputStream.position(0);
-        Data theZeroLenghtArray = in.readData();
+        Data theZeroLenghtArray = readData(in);
         inputStream.position(4);
-        Data data = in.readData();
+        Data data = readData(in);
 
         assertNull(nullData);
         assertEquals(0, theZeroLenghtArray.getType());

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/DataDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/DataDataSerializable.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.serialization;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -35,12 +36,12 @@ class DataDataSerializable implements DataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(data);
+        IOUtil.writeData(out, data);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        data = in.readData();
+        data = IOUtil.readData(in);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableClassVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableClassVersionTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.nio.IOUtil.readData;
+import static com.hazelcast.internal.nio.IOUtil.writeData;
 import static com.hazelcast.nio.serialization.PortableTest.createNamedPortableClassDefinition;
 import static com.hazelcast.nio.serialization.PortableTest.createSerializationService;
 import static org.junit.Assert.assertEquals;
@@ -142,11 +144,11 @@ public class PortableClassVersionTest {
 
         // emulate socket write by writing data to stream
         BufferObjectDataOutput out = serializationService.createObjectDataOutput(1024);
-        out.writeData(dataV1);
+        writeData(out, dataV1);
         byte[] bytes = out.toByteArray();
         // emulate socket read by reading data from stream
         BufferObjectDataInput in = serializationService2.createObjectDataInput(bytes);
-        dataV1 = in.readData();
+        dataV1 = readData(in);
 
         // serialize new portable version
         NamedPortableV2 portableV2 = new NamedPortableV2("portable-v2", 123, 500);

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortable.java
@@ -27,6 +27,9 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static com.hazelcast.internal.nio.IOUtil.readData;
+import static com.hazelcast.internal.nio.IOUtil.writeData;
+
 public class APortable implements Portable {
 
     private boolean bool;
@@ -218,7 +221,7 @@ public class APortable implements Portable {
         dataOutput.writeObject(customByteArraySerializableObject);
         dataOutput.writeObject(customStreamSerializableObject);
 
-        dataOutput.writeData(data);
+        writeData(dataOutput, data);
     }
 
     public void readPortable(PortableReader reader) throws IOException {
@@ -306,7 +309,7 @@ public class APortable implements Portable {
         customByteArraySerializableObject = dataInput.readObject();
         customStreamSerializableObject = dataInput.readObject();
 
-        data = dataInput.readData();
+        data = readData(dataInput);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnIdentifiedDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnIdentifiedDataSerializable.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.serialization.compatibility;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -180,7 +181,7 @@ public class AnIdentifiedDataSerializable implements IdentifiedDataSerializable 
         dataOutput.writeObject(customByteArraySerializableObject);
         dataOutput.writeObject(customStreamSerializableObject);
 
-        dataOutput.writeData(data);
+        IOUtil.writeData(dataOutput, data);
     }
 
     @Override
@@ -235,7 +236,7 @@ public class AnIdentifiedDataSerializable implements IdentifiedDataSerializable 
         customByteArraySerializableObject = dataInput.readObject();
         customStreamSerializableObject = dataInput.readObject();
 
-        data = dataInput.readData();
+        data = IOUtil.readData(dataInput);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_GetNewInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_GetNewInstanceTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -133,13 +134,13 @@ public class InvocationFuture_GetNewInstanceTest extends HazelcastTestSupport {
         @Override
         protected void writeInternal(ObjectDataOutput out) throws IOException {
             super.writeInternal(out);
-            out.writeData(response);
+            IOUtil.writeData(out, response);
         }
 
         @Override
         protected void readInternal(ObjectDataInput in) throws IOException {
             super.readInternal(in);
-            response = in.readData();
+            response = IOUtil.readData(in);
         }
     }
 }


### PR DESCRIPTION
- Do not expose `Data` in `ObjectDataOutput/Input` public API
- Same as above for `SerializationService` in `ObjectDataInput`

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3373
