### PR TITLE
Fixes issue AIX and OSMBean getFreePhysicalMemorySize

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.util.OperatingSystemMXBeanSupport;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
 import java.lang.management.ClassLoadingMXBean;
@@ -149,6 +150,11 @@ final class TimedMemberStateFactoryHelper {
     }
 
     private static Long get(OperatingSystemMXBean mbean, String methodName, Long defaultValue) {
+        if (OperatingSystemMXBeanSupport.GET_FREE_PHYSICAL_MEMORY_SIZE_DISABLED
+                && methodName.equals("getFreePhysicalMemorySize")) {
+            return defaultValue;
+        }
+
         try {
             Method method = mbean.getClass().getMethod(methodName);
             method.setAccessible(true);

--- a/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
@@ -19,19 +19,35 @@ package com.hazelcast.util;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Support class for reading attributes from OperatingSystemMXBean.
  */
+@SuppressWarnings("checkstyle:declarationorder")
 public final class OperatingSystemMXBeanSupport {
 
+    static final String COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED = "hazelcast.os.free.physical.memory.disabled";
+    /**
+     * On AIX it can happen that the getFreePhysicalMemorySize method is very slow.
+     * This flags allows one to prevent executing this method and returns the default.
+     *
+     * This field is made volatile for testing purposes. Having this field volatile isn't relevant for performance
+     * since the logic for obtaining the attribute isn't very efficient.
+     */
+    @SuppressWarnings({"checkstyle:visibilitymodifier", "checkstyle:staticvariablename"})
+    public static volatile boolean GET_FREE_PHYSICAL_MEMORY_SIZE_DISABLED
+            = Boolean.getBoolean(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED);
     private static final OperatingSystemMXBean OPERATING_SYSTEM_MX_BEAN = ManagementFactory.getOperatingSystemMXBean();
     private static final double PERCENTAGE_MULTIPLIER = 100d;
 
     private OperatingSystemMXBeanSupport() {
+    }
+
+    // for testing purposes.
+    static void reload() {
+        GET_FREE_PHYSICAL_MEMORY_SIZE_DISABLED = Boolean.getBoolean(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED);
     }
 
     /**
@@ -41,15 +57,19 @@ public final class OperatingSystemMXBeanSupport {
      * @param defaultValue default value if the attribute value is null
      * @return value of the attribute
      */
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public static long readLongAttribute(String attributeName, long defaultValue) {
         try {
             String methodName = "get" + attributeName;
+            if (GET_FREE_PHYSICAL_MEMORY_SIZE_DISABLED && methodName.equals("getFreePhysicalMemorySize")) {
+                return defaultValue;
+            }
+
             OperatingSystemMXBean systemMXBean = OPERATING_SYSTEM_MX_BEAN;
             Method method = systemMXBean.getClass().getMethod(methodName);
+
             // the method is public in Java 9
-            if (!Modifier.isPublic(method.getModifiers())) {
-                method.setAccessible(true);
-            }
+            method.setAccessible(true);
 
             Object value = method.invoke(systemMXBean);
             if (value == null) {
@@ -68,7 +88,6 @@ public final class OperatingSystemMXBeanSupport {
             if (value instanceof Number) {
                 return ((Number) value).longValue();
             }
-
         } catch (RuntimeException re) {
             throw re;
         } catch (Exception ignored) {

--- a/hazelcast/src/test/java/com/hazelcast/util/OperatingSystemMXBeanSupport_FreePhysicalMemorySizeDisabledTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/OperatingSystemMXBeanSupport_FreePhysicalMemorySizeDisabledTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.util.OperatingSystemMXBeanSupport.COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("checkstyle:magicnumber")
+public class OperatingSystemMXBeanSupport_FreePhysicalMemorySizeDisabledTest {
+
+    private static final int DEFAULT_VALUE = -1;
+
+    @After
+    public void after() {
+        System.clearProperty(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED);
+        OperatingSystemMXBeanSupport.reload();
+    }
+
+    @Test
+    public void whenDisabled() {
+        System.setProperty(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED, "true");
+        OperatingSystemMXBeanSupport.reload();
+        long result = OperatingSystemMXBeanSupport.readLongAttribute("FreePhysicalMemorySize", DEFAULT_VALUE);
+        assertEquals(DEFAULT_VALUE, result);
+    }
+
+    @Test
+    public void whenDefault() {
+        OperatingSystemMXBeanSupport.reload();
+        long result = OperatingSystemMXBeanSupport.readLongAttribute("FreePhysicalMemorySize", DEFAULT_VALUE);
+        assertNotEquals(DEFAULT_VALUE, result);
+    }
+
+    @Test
+    public void whenEnabled() {
+        System.setProperty(COM_HAZELCAST_FREE_PHYSICAL_MEMORY_SIZE_DISABLED, "false");
+        OperatingSystemMXBeanSupport.reload();
+        long result = OperatingSystemMXBeanSupport.readLongAttribute("FreePhysicalMemorySize", DEFAULT_VALUE);
+        assertNotEquals(DEFAULT_VALUE, result);
+    }
+}


### PR DESCRIPTION
A flag is added to supress retrieving this value. On AIX there
is one customer that runs into multi seconds execution times
for this method.

Backport of https://github.com/hazelcast/hazelcast/pull/16039