### PR TITLE
improvements to processing xml map configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.internal.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Configuration sections for the members shared by XML and YAML based
  * configurations
@@ -64,6 +67,14 @@ public enum ConfigSections {
     CP_SUBSYSTEM("cp-subsystem", false),
     METRICS("metrics", false);
 
+    public static final Map<String, ConfigSections> NAME_MAPPING = new HashMap<>();
+
+    static {
+        for (ConfigSections element : values()) {
+            NAME_MAPPING.put(element.name, element);
+        }
+    }
+
     final boolean multipleOccurrence;
     private final String name;
 
@@ -73,12 +84,7 @@ public enum ConfigSections {
     }
 
     public static boolean canOccurMultipleTimes(String name) {
-        for (ConfigSections element : values()) {
-            if (name.equals(element.name)) {
-                return element.multipleOccurrence;
-            }
-        }
-        return false;
+        return NAME_MAPPING.get(name).multipleOccurrence;
     }
 
     public boolean isEqual(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -91,6 +91,14 @@ import static java.lang.String.format;
 @SuppressWarnings({"checkstyle:classfanoutcomplexity", "checkstyle:methodcount"})
 public final class ConfigValidator {
 
+    public static final EnumSet<MaxSizePolicy> MAP_SUPPORTED_NATIVE_MAX_SIZE_POLICIES
+        = EnumSet.of(PER_NODE, PER_PARTITION, USED_NATIVE_MEMORY_PERCENTAGE,
+                     FREE_NATIVE_MEMORY_PERCENTAGE, USED_NATIVE_MEMORY_SIZE, FREE_NATIVE_MEMORY_SIZE);
+
+    public static final EnumSet<MaxSizePolicy> MAP_SUPPORTED_ON_HEAP_MAX_SIZE_POLICIES
+        = EnumSet.of(PER_NODE, PER_PARTITION, USED_HEAP_SIZE, USED_HEAP_PERCENTAGE,
+                     FREE_HEAP_SIZE, FREE_HEAP_PERCENTAGE);
+
     public static final EnumSet<EvictionPolicy> COMMONLY_SUPPORTED_EVICTION_POLICIES = EnumSet.of(LRU, LFU);
 
     private static final EnumSet<MaxSizePolicy> NEAR_CACHE_SUPPORTED_ON_HEAP_MAX_SIZE_POLICIES
@@ -98,14 +106,6 @@ public final class ConfigValidator {
 
     private static final EnumSet<EvictionPolicy> MAP_SUPPORTED_EVICTION_POLICIES
             = EnumSet.of(LRU, LFU, RANDOM, NONE);
-
-    private static final EnumSet<MaxSizePolicy> MAP_SUPPORTED_NATIVE_MAX_SIZE_POLICIES
-            = EnumSet.of(PER_NODE, PER_PARTITION, USED_NATIVE_MEMORY_PERCENTAGE,
-            FREE_NATIVE_MEMORY_PERCENTAGE, USED_NATIVE_MEMORY_SIZE, FREE_NATIVE_MEMORY_SIZE);
-
-    private static final EnumSet<MaxSizePolicy> MAP_SUPPORTED_ON_HEAP_MAX_SIZE_POLICIES
-            = EnumSet.of(PER_NODE, PER_PARTITION, USED_HEAP_SIZE, USED_HEAP_PERCENTAGE,
-            FREE_HEAP_SIZE, FREE_HEAP_PERCENTAGE);
 
     private static final EnumSet<MaxSizePolicy> CACHE_SUPPORTED_ON_HEAP_MAX_SIZE_POLICIES
             = EnumSet.of(ENTRY_COUNT);

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.config;
 
 import com.hazelcast.config.AttributeConfig;
+import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
@@ -27,9 +28,11 @@ import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.InvalidConfigurationException;
@@ -39,13 +42,18 @@ import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
+import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.MerkleTreeConfig;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.MulticastConfig;
+import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.config.PNCounterConfig;
+import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionConfig.PermissionType;
 import com.hazelcast.config.PredicateConfig;
@@ -82,6 +90,8 @@ import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
 import com.hazelcast.internal.yaml.YamlScalar;
 import com.hazelcast.internal.yaml.YamlSequence;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.query.impl.IndexUtils;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -98,6 +108,7 @@ import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
 import static com.hazelcast.internal.config.yaml.W3cDomUtil.getWrappedYamlMapping;
 import static com.hazelcast.internal.config.yaml.W3cDomUtil.getWrappedYamlSequence;
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
 import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
@@ -108,6 +119,8 @@ import static java.lang.Integer.parseInt;
         "checkstyle:classfanoutcomplexity",
         "checkstyle:classdataabstractioncoupling"})
 public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
+    private static final ILogger LOGGER = Logger.getLogger(YamlMemberDomConfigProcessor.class);
+
     public YamlMemberDomConfigProcessor(boolean domLevel3, Config config) {
         super(domLevel3, config);
     }
@@ -335,6 +348,146 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
             mapConfig.setName(mapNode.getNodeName());
             handleMapNode(mapNode, mapConfig);
         }
+    }
+
+    @SuppressWarnings("checkstyle:methodlength")
+    private void handleMapNode(Node parentNode, final MapConfig mapConfig) throws Exception {
+        for (Node node : childElements(parentNode)) {
+            String nodeName = cleanNodeName(node);
+            String value = getTextContent(node).trim();
+            if ("backup-count".equals(nodeName)) {
+                mapConfig.setBackupCount(getIntegerValue("backup-count", value));
+            } else if ("metadata-policy".equals(nodeName)) {
+                mapConfig.setMetadataPolicy(MetadataPolicy.valueOf(upperCaseInternal(value)));
+            } else if ("in-memory-format".equals(nodeName)) {
+                mapConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
+            } else if ("async-backup-count".equals(nodeName)) {
+                mapConfig.setAsyncBackupCount(getIntegerValue("async-backup-count", value));
+            } else if ("eviction".equals(nodeName)) {
+                mapConfig.setEvictionConfig(getEvictionConfig(node, false, true));
+            } else if ("time-to-live-seconds".equals(nodeName)) {
+                mapConfig.setTimeToLiveSeconds(getIntegerValue("time-to-live-seconds", value));
+            } else if ("max-idle-seconds".equals(nodeName)) {
+                mapConfig.setMaxIdleSeconds(getIntegerValue("max-idle-seconds", value));
+            } else if ("map-store".equals(nodeName)) {
+                MapStoreConfig mapStoreConfig = createMapStoreConfig(node);
+                mapConfig.setMapStoreConfig(mapStoreConfig);
+            } else if ("near-cache".equals(nodeName)) {
+                mapConfig.setNearCacheConfig(handleNearCacheConfig(node));
+            } else if ("merge-policy".equals(nodeName)) {
+                MergePolicyConfig mergePolicyConfig = createMergePolicyConfig(node);
+                mapConfig.setMergePolicyConfig(mergePolicyConfig);
+            } else if ("merkle-tree".equals(nodeName)) {
+                MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig();
+                handleViaReflection(node, mapConfig, merkleTreeConfig);
+            } else if ("event-journal".equals(nodeName)) {
+                EventJournalConfig eventJournalConfig = new EventJournalConfig();
+                handleViaReflection(node, mapConfig, eventJournalConfig);
+            } else if ("hot-restart".equals(nodeName)) {
+                mapConfig.setHotRestartConfig(createHotRestartConfig(node));
+            } else if ("read-backup-data".equals(nodeName)) {
+                mapConfig.setReadBackupData(getBooleanValue(value));
+            } else if ("statistics-enabled".equals(nodeName)) {
+                mapConfig.setStatisticsEnabled(getBooleanValue(value));
+            } else if ("cache-deserialized-values".equals(nodeName)) {
+                CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString(value);
+                mapConfig.setCacheDeserializedValues(cacheDeserializedValues);
+            } else if ("wan-replication-ref".equals(nodeName)) {
+                mapWanReplicationRefHandle(node, mapConfig);
+            } else if ("indexes".equals(nodeName)) {
+                mapIndexesHandle(node, mapConfig);
+            } else if ("attributes".equals(nodeName)) {
+                attributesHandle(node, mapConfig);
+            } else if ("entry-listeners".equals(nodeName)) {
+                handleEntryListeners(node, entryListenerConfig -> {
+                    mapConfig.addEntryListenerConfig(entryListenerConfig);
+                    return null;
+                });
+            } else if ("partition-lost-listeners".equals(nodeName)) {
+                mapPartitionLostListenerHandle(node, mapConfig);
+            } else if ("partition-strategy".equals(nodeName)) {
+                mapConfig.setPartitioningStrategyConfig(new PartitioningStrategyConfig(value));
+            } else if ("split-brain-protection-ref".equals(nodeName)) {
+                mapConfig.setSplitBrainProtectionName(value);
+            } else if ("query-caches".equals(nodeName)) {
+                mapQueryCacheHandler(node, mapConfig);
+            }
+        }
+        config.addMapConfig(mapConfig);
+    }
+
+    private NearCacheConfig handleNearCacheConfig(Node node) {
+        String name = getAttribute(node, "name");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(name);
+        Boolean serializeKeys = null;
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            String value = getTextContent(child).trim();
+            if ("time-to-live-seconds".equals(nodeName)) {
+                nearCacheConfig.setTimeToLiveSeconds(Integer.parseInt(value));
+            } else if ("max-idle-seconds".equals(nodeName)) {
+                nearCacheConfig.setMaxIdleSeconds(Integer.parseInt(value));
+            } else if ("in-memory-format".equals(nodeName)) {
+                nearCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
+            } else if ("serialize-keys".equals(nodeName)) {
+                serializeKeys = Boolean.parseBoolean(value);
+                nearCacheConfig.setSerializeKeys(serializeKeys);
+            } else if ("invalidate-on-change".equals(nodeName)) {
+                nearCacheConfig.setInvalidateOnChange(Boolean.parseBoolean(value));
+            } else if ("cache-local-entries".equals(nodeName)) {
+                nearCacheConfig.setCacheLocalEntries(Boolean.parseBoolean(value));
+            } else if ("local-update-policy".equals(nodeName)) {
+                NearCacheConfig.LocalUpdatePolicy policy = NearCacheConfig.LocalUpdatePolicy.valueOf(value);
+                nearCacheConfig.setLocalUpdatePolicy(policy);
+            } else if ("eviction".equals(nodeName)) {
+                nearCacheConfig.setEvictionConfig(getEvictionConfig(child, true, false));
+            }
+        }
+        if (serializeKeys != null && !serializeKeys && nearCacheConfig.getInMemoryFormat() == InMemoryFormat.NATIVE) {
+            LOGGER.warning("The Near Cache doesn't support keys by-reference with NATIVE in-memory-format."
+                               + " This setting will have no effect!");
+        }
+        return nearCacheConfig;
+    }
+
+    private MapStoreConfig createMapStoreConfig(Node node) {
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        NamedNodeMap attributes = node.getAttributes();
+        for (int a = 0; a < attributes.getLength(); a++) {
+            Node att = attributes.item(a);
+            String value = getTextContent(att).trim();
+            if ("enabled".equals(att.getNodeName())) {
+                mapStoreConfig.setEnabled(getBooleanValue(value));
+            } else if ("initial-mode".equals(att.getNodeName())) {
+                MapStoreConfig.InitialLoadMode mode = MapStoreConfig.InitialLoadMode
+                    .valueOf(upperCaseInternal(getTextContent(att)));
+                mapStoreConfig.setInitialLoadMode(mode);
+            }
+        }
+        for (Node n : childElements(node)) {
+            String nodeName = cleanNodeName(n);
+            if ("class-name".equals(nodeName)) {
+                mapStoreConfig.setClassName(getTextContent(n).trim());
+            } else if ("factory-class-name".equals(nodeName)) {
+                mapStoreConfig.setFactoryClassName(getTextContent(n).trim());
+            } else if ("write-delay-seconds".equals(nodeName)) {
+                mapStoreConfig.setWriteDelaySeconds(getIntegerValue("write-delay-seconds", getTextContent(n).trim()
+                ));
+            } else if ("write-batch-size".equals(nodeName)) {
+                mapStoreConfig.setWriteBatchSize(getIntegerValue("write-batch-size", getTextContent(n).trim()
+                ));
+            } else if ("write-coalescing".equals(nodeName)) {
+                String writeCoalescing = getTextContent(n).trim();
+                if (isNullOrEmpty(writeCoalescing)) {
+                    mapStoreConfig.setWriteCoalescing(MapStoreConfig.DEFAULT_WRITE_COALESCING);
+                } else {
+                    mapStoreConfig.setWriteCoalescing(getBooleanValue(writeCoalescing));
+                }
+            } else if ("properties".equals(nodeName)) {
+                fillProperties(n, mapStoreConfig.getProperties());
+            }
+        }
+        return mapStoreConfig;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/AbstractEvictionConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/AbstractEvictionConfigProcessor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
+
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
+
+public abstract class AbstractEvictionConfigProcessor implements Processor<EvictionConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+
+    AbstractEvictionConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    abstract EvictionConfig evictionConfigWithDefaults();
+
+    abstract void validate(EvictionConfig evictionConfig);
+
+    abstract int sizeDefault();
+
+    abstract EvictionPolicy defaultEvictionPolicy();
+
+    @Override
+    public EvictionConfig process() {
+        EvictionConfig evictionConfig = evictionConfigWithDefaults();
+
+        Node sizeNode = node.getAttributes().getNamedItem("size");
+        Node maxSizePolicyNode = node.getAttributes().getNamedItem("max-size-policy");
+        Node evictionPolicyNode = node.getAttributes().getNamedItem("eviction-policy");
+        Node comparatorClassNameNode = node.getAttributes().getNamedItem("comparator-class-name");
+
+        if (sizeNode != null) {
+            evictionConfig.setSize(getIntegerValue("size", getTextContent(sizeNode, domLevel3)));
+            if (evictionConfig.getSize() == 0) {
+                evictionConfig.setSize(sizeDefault());
+            }
+        }
+        if (maxSizePolicyNode != null) {
+            evictionConfig.setMaxSizePolicy(
+                MaxSizePolicy.valueOf(upperCaseInternal(getTextContent(maxSizePolicyNode, domLevel3))));
+        }
+        if (evictionPolicyNode != null) {
+            evictionConfig.setEvictionPolicy(
+                EvictionPolicy.valueOf(upperCaseInternal(getTextContent(evictionPolicyNode, domLevel3))));
+        }
+        if (comparatorClassNameNode != null) {
+            evictionConfig.setComparatorClassName(getTextContent(comparatorClassNameNode, domLevel3));
+        }
+
+        try {
+            validate(evictionConfig);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidConfigurationException(e.getMessage());
+        }
+        return evictionConfig;
+    }
+
+    void assertOnlyComparatorClassOrComparatorConfigured(String comparatorClassName, EvictionPolicyComparator comparator) {
+        if (comparatorClassName != null && comparator != null) {
+            throw new InvalidConfigurationException("Only one of the `comparator class name` and `comparator`"
+                                                        + " can be configured in the eviction configuration!");
+        }
+    }
+
+    void assertOnlyEvictionPolicyOrComparatorClassNameOrComparatorConfigured(EvictionPolicy evictionPolicy,
+                                                                             String comparatorClassName,
+                                                                             EvictionPolicyComparator comparator) {
+        if (evictionPolicy != defaultEvictionPolicy()) {
+            if (!isNullOrEmpty(comparatorClassName)) {
+                throw new InvalidConfigurationException(
+                    "Only one of the `eviction policy` and `comparator class name` can be configured!");
+            }
+            if (comparator != null) {
+                throw new InvalidConfigurationException(
+                    "Only one of the `eviction policy` and `comparator` can be configured!");
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/AttributeConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/AttributeConfigProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.AttributeConfig;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+
+class AttributeConfigProcessor implements Processor<AttributeConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+
+    AttributeConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    @Override
+    public AttributeConfig process() {
+        NamedNodeMap attrs = node.getAttributes();
+        String extractor = getTextContent(attrs.getNamedItem("extractor-class-name"), domLevel3);
+        String className = getTextContent(node, domLevel3);
+        return new AttributeConfig(className, extractor);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/CollectionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/CollectionProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import org.w3c.dom.Node;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+
+class CollectionProcessor<T> {
+    private final Node node;
+    private final String tag;
+    private final Function<Node, Processor<T>> itemProcessor;
+    private final Consumer<T> configConsumer;
+
+    CollectionProcessor(Node node, String tag, Function<Node, Processor<T>> itemProcessor, Consumer<T> configConsumer) {
+        this.node = node;
+        this.tag = tag;
+        this.itemProcessor = itemProcessor;
+        this.configConsumer = configConsumer;
+    }
+
+    public void process() {
+        streamOfChildElements(node)
+            .filter(indexNode -> tag.equals(cleanNodeName(indexNode)))
+            .map(itemProcessor)
+            .map(Processor::process)
+            .forEach(configConsumer);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/EntryListenerProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/EntryListenerProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.EntryListenerConfig;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+
+class EntryListenerProcessor implements Processor<EntryListenerConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+
+    EntryListenerProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    @Override
+    public EntryListenerConfig process() {
+        NamedNodeMap attrs = node.getAttributes();
+        boolean incValue = getBooleanValue(getTextContent(attrs.getNamedItem("include-value"), domLevel3));
+        boolean local = getBooleanValue(getTextContent(attrs.getNamedItem("local"), domLevel3));
+        String listenerClass = getTextContent(node, domLevel3);
+        return new EntryListenerConfig(listenerClass, local, incValue);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/EventJournalConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/EventJournalConfigProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.EventJournalConfig;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfAttributes;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+
+class EventJournalConfigProcessor implements Processor<EventJournalConfig> {
+    private final Node node;
+    private final Map<String, BiConsumer<EventJournalConfig, Node>> map = new HashMap<>();
+
+    EventJournalConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        map.put("enabled", (config, value) -> config.setEnabled(getBooleanValue(getTextContent(value, domLevel3))));
+        map.put("capacity",
+                (config, value) -> config.setCapacity(getIntegerValue("capacity", getTextContent(value, domLevel3))));
+        map.put("time-to-live-seconds",
+                (config, value) ->
+                    config.setTimeToLiveSeconds(getIntegerValue("time-to-live-seconds", getTextContent(value, domLevel3))));
+    }
+
+    @Override
+    public EventJournalConfig process() {
+        EventJournalConfig eventJournalConfig = new EventJournalConfig();
+        Stream.concat(streamOfAttributes(node), streamOfChildElements(node))
+            .forEach(node -> map.get(cleanNodeName(node)).accept(eventJournalConfig, node));
+        return eventJournalConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/HotRestartConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/HotRestartConfigProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.HotRestartConfig;
+
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+
+class HotRestartConfigProcessor implements Processor<HotRestartConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+
+    HotRestartConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    @Override
+    public HotRestartConfig process() {
+        HotRestartConfig hotRestartConfig = new HotRestartConfig();
+        hotRestartConfig.setEnabled(isEnabled());
+
+        streamOfChildElements(node)
+            .filter(child -> "fsync".equals(cleanNodeName(child)))
+            .forEach(child -> hotRestartConfig.setFsync(getBooleanValue(getTextContent(child, domLevel3))));
+        return hotRestartConfig;
+    }
+
+    private boolean isEnabled() {
+        Node attrEnabled = node.getAttributes().getNamedItem("enabled");
+        return getBooleanValue(getTextContent(attrEnabled, domLevel3));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/IMapEvictionConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/IMapEvictionConfigProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.internal.config.ConfigValidator;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
+
+import org.w3c.dom.Node;
+
+import java.util.EnumSet;
+
+import static java.lang.String.format;
+
+class IMapEvictionConfigProcessor extends AbstractEvictionConfigProcessor {
+    IMapEvictionConfigProcessor(Node node, boolean domLevel3) {
+        super(node, domLevel3);
+    }
+
+    @Override
+    EvictionConfig evictionConfigWithDefaults() {
+        return new EvictionConfig()
+            .setEvictionPolicy(MapConfig.DEFAULT_EVICTION_POLICY)
+            .setMaxSizePolicy(MapConfig.DEFAULT_MAX_SIZE_POLICY)
+            .setSize(MapConfig.DEFAULT_MAX_SIZE);
+    }
+
+    @Override
+    int sizeDefault() {
+        return MapConfig.DEFAULT_MAX_SIZE;
+    }
+
+    @Override
+    EvictionPolicy defaultEvictionPolicy() {
+        return MapConfig.DEFAULT_EVICTION_POLICY;
+    }
+
+    @Override
+    void validate(EvictionConfig evictionConfig) {
+        EvictionPolicy evictionPolicy = evictionConfig.getEvictionPolicy();
+        String comparatorClassName = evictionConfig.getComparatorClassName();
+        EvictionPolicyComparator comparator = evictionConfig.getComparator();
+
+        assertOnlyComparatorClassOrComparatorConfigured(comparatorClassName, comparator);
+        assertOnlyEvictionPolicyOrComparatorClassNameOrComparatorConfigured(evictionPolicy, comparatorClassName, comparator);
+
+        assertSupportedMaxSizePolicyIsSet(evictionConfig.getMaxSizePolicy());
+    }
+
+    private void assertSupportedMaxSizePolicyIsSet(MaxSizePolicy maxSizePolicy) {
+        if (!ConfigValidator.MAP_SUPPORTED_ON_HEAP_MAX_SIZE_POLICIES.contains(maxSizePolicy)
+            && !ConfigValidator.MAP_SUPPORTED_NATIVE_MAX_SIZE_POLICIES.contains(maxSizePolicy)) {
+
+            EnumSet<MaxSizePolicy> allMaxSizePolicies = EnumSet.copyOf(ConfigValidator.MAP_SUPPORTED_ON_HEAP_MAX_SIZE_POLICIES);
+            allMaxSizePolicies.addAll(ConfigValidator.MAP_SUPPORTED_NATIVE_MAX_SIZE_POLICIES);
+
+            String msg = format("IMap eviction config doesn't support max size policy `%s`. "
+                                    + "Please select a valid one: %s.", maxSizePolicy, allMaxSizePolicies);
+
+            throw new InvalidConfigurationException(msg);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/IndexProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/IndexProcessor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.IndexConfig;
+import com.hazelcast.config.IndexType;
+import com.hazelcast.internal.config.DomConfigHelper;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+
+class IndexProcessor implements Processor<IndexConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+
+    IndexProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    @Override
+    public IndexConfig process() {
+        IndexConfig indexConfig = new IndexConfig().setName(name()).setType(type());
+
+        streamOfChildElements(node)
+            .filter(attributesNode -> "attributes".equals(cleanNodeName(attributesNode)))
+            .flatMap(DomConfigHelper::streamOfChildElements)
+            .filter(attributeNode -> "attribute".equals(cleanNodeName(attributeNode)))
+            .map(attributeNode -> getTextContent(attributeNode, domLevel3))
+            .forEach(indexConfig::addAttribute);
+        return indexConfig;
+    }
+
+    private IndexType type() {
+        NamedNodeMap attrs = node.getAttributes();
+        String typeStr = getTextContent(attrs.getNamedItem("type"), domLevel3);
+        if (typeStr.isEmpty()) {
+            typeStr = IndexConfig.DEFAULT_TYPE.name();
+        }
+        typeStr = typeStr.toLowerCase();
+        IndexType type;
+        if (typeStr.equals(IndexType.SORTED.name().toLowerCase())) {
+            type = IndexType.SORTED;
+        } else if (typeStr.equals(IndexType.HASH.name().toLowerCase())) {
+            type = IndexType.HASH;
+        } else {
+            throw new IllegalArgumentException("Unsupported index type: " + typeStr);
+        }
+        return type;
+    }
+
+    private String name() {
+        NamedNodeMap attrs = node.getAttributes();
+        String name = getTextContent(attrs.getNamedItem("name"), domLevel3);
+        if (name.isEmpty()) {
+            name = null;
+        }
+        return name;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MapConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MapConfigProcessor.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapPartitionLostListenerConfig;
+import com.hazelcast.config.MetadataPolicy;
+import com.hazelcast.config.PartitioningStrategyConfig;
+import com.hazelcast.function.BiConsumerEx;
+import com.hazelcast.internal.config.DomConfigHelper;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.hazelcast.internal.config.DomConfigHelper.childElements;
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
+
+@SuppressWarnings("checkstyle:classdataabstractioncoupling")
+public class MapConfigProcessor {
+    private final Node node;
+    private final boolean domLevel3;
+    private final Map<String, BiConsumerEx<MapConfig, Node>> attributeActions = new HashMap<>();
+
+    @SuppressWarnings({"checkstyle:methodlength", "checkstyle:executablestatementcount"})
+    public MapConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+        attributeActions.put(
+            "backup-count",
+            (config, child) ->
+                config.setBackupCount(getIntegerValue("backup-count", getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "metadata-policy",
+            (config, child) ->
+                config.setMetadataPolicy(MetadataPolicy.valueOf(upperCaseInternal(getTextContent(child, domLevel3).trim())))
+        );
+        attributeActions.put(
+            "in-memory-format",
+            (config, child) ->
+                config.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(getTextContent(child, domLevel3).trim())))
+        );
+        attributeActions.put(
+            "async-backup-count",
+            (config, child) ->
+                config.setAsyncBackupCount(getIntegerValue("async-backup-count", getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "eviction",
+            (config, child) ->
+                config.setEvictionConfig(new IMapEvictionConfigProcessor(child, domLevel3).process())
+        );
+        attributeActions.put(
+            "time-to-live-seconds",
+            (mapConfig, child) ->
+                mapConfig.setTimeToLiveSeconds(getIntegerValue("time-to-live-seconds", getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "max-idle-seconds",
+            (mapConfig, child) ->
+                mapConfig.setMaxIdleSeconds(getIntegerValue("max-idle-seconds", getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put("map-store", (mapConfig, child) ->
+            mapConfig.setMapStoreConfig(new MapStoreProcessor(child, domLevel3).process()));
+        attributeActions.put(
+            "near-cache",
+            (mapConfig, child) ->
+                mapConfig.setNearCacheConfig(new NearCacheConfigProcessor(child, domLevel3).process())
+        );
+        attributeActions.put(
+            "merge-policy",
+            (mapConfig, child) ->
+                mapConfig.setMergePolicyConfig(new MergePolicyConfigProcessor(child, domLevel3).process()));
+        attributeActions.put("merkle-tree", (mapConfig, child) ->
+            mapConfig.setMerkleTreeConfig(new MerkleTreeConfigProcessor(child, domLevel3).process()));
+        attributeActions.put(
+            "event-journal",
+            (mapConfig, child) ->
+                mapConfig.setEventJournalConfig(new EventJournalConfigProcessor(child, domLevel3).process())
+        );
+        attributeActions.put(
+            "hot-restart",
+            (mapConfig, child) ->
+                mapConfig.setHotRestartConfig(new HotRestartConfigProcessor(child, domLevel3).process())
+        );
+        attributeActions.put(
+            "read-backup-data",
+            (mapConfig, child) -> mapConfig.setReadBackupData(getBooleanValue(getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "statistics-enabled",
+            (mapConfig, child) -> mapConfig.setStatisticsEnabled(getBooleanValue(getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "cache-deserialized-values",
+            (mapConfig, child) ->
+                mapConfig.setCacheDeserializedValues(CacheDeserializedValues.parseString(getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "wan-replication-ref",
+            (mapConfig, child) ->
+                mapConfig.setWanReplicationRef(new WanReplicationRefProcessor(child, domLevel3).process())
+        );
+        attributeActions.put(
+            "indexes",
+            (mapConfig, child) ->
+                streamOfChildElements(child)
+                    .filter(indexNode -> "index".equals(cleanNodeName(indexNode)))
+                    .map(indexNode -> new IndexProcessor(indexNode, domLevel3).process())
+                    .forEach(mapConfig::addIndexConfig)
+        );
+        attributeActions.put(
+            "attributes",
+            (mapConfig, child) ->
+                streamOfChildElements(child)
+                    .filter(extractorNode -> "attribute".equals(cleanNodeName(extractorNode)))
+                    .map(extractorNode -> new AttributeConfigProcessor(extractorNode, domLevel3).process())
+                    .forEach(mapConfig::addAttributeConfig)
+        );
+        attributeActions.put(
+            "entry-listeners",
+            (mapConfig, child) ->
+                streamOfChildElements(child)
+                    .filter(listenerNode -> "entry-listener".equals(cleanNodeName(listenerNode)))
+                    .map(listenerNode -> new EntryListenerProcessor(listenerNode, domLevel3).process())
+                    .forEach(mapConfig::addEntryListenerConfig)
+        );
+        attributeActions.put(
+            "partition-lost-listeners",
+            (mapConfig, child) ->
+                streamOfChildElements(child)
+                    .filter(listenerNode -> "partition-lost-listener".equals(cleanNodeName(listenerNode)))
+                    .map(listenerNode -> new MapPartitionLostListenerConfig(getTextContent(listenerNode, domLevel3)))
+                    .forEach(mapConfig::addMapPartitionLostListenerConfig)
+        );
+        attributeActions.put(
+            "partition-strategy",
+            (mapConfig, child) ->
+                mapConfig.setPartitioningStrategyConfig(new PartitioningStrategyConfig(getTextContent(child, domLevel3).trim()))
+        );
+        attributeActions.put(
+            "split-brain-protection-ref",
+            (mapConfig, child) -> mapConfig.setSplitBrainProtectionName(getTextContent(child, domLevel3).trim())
+        );
+        attributeActions.put(
+            "query-caches",
+            (mapConfig, child) ->
+                streamOfChildElements(child)
+                    .filter(queryCacheNode -> "query-cache".equals(cleanNodeName(queryCacheNode)))
+                    .map(queryCacheNode -> new QueryCacheConfigProcessor(queryCacheNode, domLevel3).process())
+                    .forEach(mapConfig::addQueryCacheConfig)
+        );
+    }
+
+    public MapConfig process() {
+        String name = DomConfigHelper.getAttribute(node, "name", domLevel3);
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setName(name);
+        for (Node node : childElements(node)) {
+            String nodeName = cleanNodeName(node);
+            attributeActions.getOrDefault(
+                nodeName,
+                (config, nodeAndValue) -> {
+                    throw new IllegalArgumentException("Node with name " + nodeName + " was not found");
+                }
+                ).accept(mapConfig, node);
+        }
+        return mapConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MapStoreProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MapStoreProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.internal.config.DomConfigHelper;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import static com.hazelcast.config.MapStoreConfig.DEFAULT_WRITE_COALESCING;
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode;
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfAttributes;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
+
+class MapStoreProcessor implements Processor<MapStoreConfig> {
+    private final Node node;
+    private final Map<String, BiConsumer<MapStoreConfig, Node>> map = new HashMap<>();
+
+    MapStoreProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        map.put(
+            "enabled",
+            (mapStoreConfig, child) -> mapStoreConfig.setEnabled(getBooleanValue(getTextContent(child, domLevel3).trim())));
+        map.put(
+            "initial-mode",
+            (mapStoreConfig, child) ->
+                mapStoreConfig.setInitialLoadMode(InitialLoadMode.valueOf(upperCaseInternal(getTextContent(child, domLevel3)))));
+        map.put(
+            "class-name",
+            (mapStoreConfig, child) -> mapStoreConfig.setClassName(getTextContent(child, domLevel3).trim())
+        );
+        map.put(
+            "factory-class-name",
+            (mapStoreConfig, child) -> mapStoreConfig.setFactoryClassName(getTextContent(child, domLevel3).trim())
+        );
+        map.put(
+            "write-delay-seconds",
+            (mapStoreConfig, child) ->
+                mapStoreConfig.setWriteDelaySeconds(
+                    getIntegerValue("write-delay-seconds", getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "write-batch-size",
+            (mapStoreConfig, child) ->
+                mapStoreConfig.setWriteBatchSize(getIntegerValue("write-batch-size", getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "write-coalescing",
+            (mapStoreConfig, child) -> mapStoreConfig.setWriteCoalescing(
+                    Optional.of(getTextContent(child, domLevel3))
+                        .filter(s -> !s.isEmpty())
+                        .map(DomConfigHelper::getBooleanValue)
+                        .orElse(DEFAULT_WRITE_COALESCING))
+        );
+        map.put(
+            "properties",
+            (mapStoreConfig, child) -> Optional.ofNullable(mapStoreConfig.getProperties())
+                    .ifPresent(properties -> streamOfChildElements(child)
+                            .forEach(n -> properties.setProperty(key(n, domLevel3), getTextContent(n, domLevel3).trim())))
+        );
+    }
+
+    private String key(Node node, boolean domLevel3) {
+        final String name = cleanNodeName(node);
+        return "property".equals(name)
+            ? getTextContent(node.getAttributes().getNamedItem("name"), domLevel3).trim()
+            // old way - probably should be deprecated
+            : name;
+    }
+
+    @Override
+    public MapStoreConfig process() {
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        Stream.concat(streamOfAttributes(node), streamOfChildElements(node))
+            .forEach(node -> map.get(cleanNodeName(node)).accept(mapStoreConfig, node));
+        return mapStoreConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MergePolicyConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MergePolicyConfigProcessor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.internal.config.DomConfigHelper;
+
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+
+class MergePolicyConfigProcessor implements Processor<MergePolicyConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+
+    MergePolicyConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    @Override
+    public MergePolicyConfig process() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
+        mergePolicyConfig.setPolicy(DomConfigHelper.getTextContent(node, domLevel3).trim());
+        final String att = DomConfigHelper.getAttribute(node, "batch-size", domLevel3);
+        if (att != null) {
+            mergePolicyConfig.setBatchSize(getIntegerValue("batch-size", att));
+        }
+        return mergePolicyConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MerkleTreeConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/MerkleTreeConfigProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.MerkleTreeConfig;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfAttributes;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+
+public class MerkleTreeConfigProcessor implements Processor<MerkleTreeConfig> {
+    private final Node node;
+    private final Map<String, BiConsumer<MerkleTreeConfig, Node>> map = new HashMap<>();
+
+    MerkleTreeConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        map.put(
+            "enabled",
+            (merkleTreeConfig, child) -> merkleTreeConfig.setEnabled(getBooleanValue(getTextContent(child, domLevel3))));
+        map.put(
+            "depth",
+            (merkleTreeConfig, child) -> merkleTreeConfig.setDepth(getIntegerValue("depth", getTextContent(child, domLevel3))));
+    }
+
+    @Override
+    public MerkleTreeConfig process() {
+        MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig();
+        Stream.concat(streamOfAttributes(node), streamOfChildElements(node))
+            .forEach(node -> map.get(cleanNodeName(node)).accept(merkleTreeConfig, node));
+        return merkleTreeConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/NearCacheConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/NearCacheConfigProcessor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getAttribute;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
+
+class NearCacheConfigProcessor implements Processor<NearCacheConfig> {
+    private static final ILogger LOGGER = Logger.getLogger(NearCacheConfigProcessor.class);
+    private final Node node;
+    private final boolean domLevel3;
+    private final Map<String, BiConsumer<NearCacheConfig, Node>> map = new HashMap<>();
+
+    NearCacheConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+        map.put(
+            "time-to-live-seconds",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setTimeToLiveSeconds(
+                    getIntegerValue("time-to-live-seconds", getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "max-idle-seconds",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setMaxIdleSeconds(getIntegerValue("max-idle-seconds", getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "in-memory-format",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setInMemoryFormat(
+                    InMemoryFormat.valueOf(upperCaseInternal(getTextContent(child, domLevel3).trim())))
+        );
+        map.put(
+            "serialize-keys",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setSerializeKeys(getBooleanValue(getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "invalidate-on-change",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setInvalidateOnChange(getBooleanValue(getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "cache-local-entries",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setCacheLocalEntries(getBooleanValue(getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "local-update-policy",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setLocalUpdatePolicy(LocalUpdatePolicy.valueOf(getTextContent(child, domLevel3).trim()))
+        );
+        map.put(
+            "eviction",
+            (nearCacheConfig, child) ->
+                nearCacheConfig.setEvictionConfig(new NearCacheEvictionConfigProcessor(child, domLevel3).process())
+        );
+    }
+
+    @Override
+    public NearCacheConfig process() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(name());
+        streamOfChildElements(node)
+            .forEach(child -> map.get(cleanNodeName(child)).accept(nearCacheConfig, child));
+        if (nearCacheConfig.isSerializeKeys() && nearCacheConfig.getInMemoryFormat() == InMemoryFormat.NATIVE) {
+            LOGGER.warning(
+                "The Near Cache doesn't support keys by-reference with NATIVE in-memory-format."
+                    + " This setting will have no effect!");
+        }
+        return nearCacheConfig;
+    }
+
+    private String name() {
+        return getAttribute(node, "name", domLevel3);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/NearCacheEvictionConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/NearCacheEvictionConfigProcessor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
+
+import org.w3c.dom.Node;
+
+class NearCacheEvictionConfigProcessor extends AbstractEvictionConfigProcessor {
+    NearCacheEvictionConfigProcessor(Node node, boolean domLevel3) {
+        super(node, domLevel3);
+    }
+
+    @Override
+    EvictionConfig evictionConfigWithDefaults() {
+        return new EvictionConfig();
+    }
+
+    @Override
+    void validate(EvictionConfig evictionConfig) {
+        EvictionPolicy evictionPolicy = evictionConfig.getEvictionPolicy();
+        String comparatorClassName = evictionConfig.getComparatorClassName();
+        EvictionPolicyComparator comparator = evictionConfig.getComparator();
+
+        assertOnlyComparatorClassOrComparatorConfigured(comparatorClassName, comparator);
+        assertOnlyEvictionPolicyOrComparatorClassNameOrComparatorConfigured(
+            evictionPolicy,
+            comparatorClassName,
+            comparator
+        );
+    }
+
+    @Override
+    int sizeDefault() {
+        return 0;
+    }
+
+    @Override
+    EvictionPolicy defaultEvictionPolicy() {
+        return EvictionConfig.DEFAULT_EVICTION_POLICY;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/PredicateConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/PredicateConfigProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.PredicateConfig;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+
+class PredicateConfigProcessor implements Processor<PredicateConfig> {
+    private final boolean domLevel3;
+    private final Node node;
+
+    PredicateConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+    }
+
+    @Override
+    public PredicateConfig process() {
+        NamedNodeMap predicateAttributes = node.getAttributes();
+        String predicateType = getTextContent(predicateAttributes.getNamedItem("type"), domLevel3);
+        String value = getTextContent(node, domLevel3);
+        PredicateConfig predicateConfig = new PredicateConfig();
+        if ("class-name".equals(predicateType)) {
+            predicateConfig.setClassName(value);
+        } else if ("sql".equals(predicateType)) {
+            predicateConfig.setSql(value);
+        }
+        return predicateConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/Processor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/Processor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+interface Processor<T> {
+    T process();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/QueryCacheConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/QueryCacheConfigProcessor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.QueryCacheConfig;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static com.hazelcast.internal.config.DomConfigHelper.childElements;
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
+
+class QueryCacheConfigProcessor implements Processor<QueryCacheConfig> {
+    private final Node node;
+    private final boolean domLevel3;
+    private final Map<String, BiConsumer<QueryCacheConfig, Node>> childNameToConsumer = new HashMap<>();
+
+    QueryCacheConfigProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+        childNameToConsumer.put(
+            "entry-listeners",
+            (queryCacheConfig, childNode) -> new CollectionProcessor<>(
+                childNode,
+                "entry-listener",
+                listenerNode -> new EntryListenerProcessor(listenerNode, domLevel3),
+                queryCacheConfig::addEntryListenerConfig
+            ).process()
+        );
+        childNameToConsumer.put(
+            "include-value",
+            (queryCacheConfig, childNode) ->
+                queryCacheConfig.setIncludeValue(getBooleanValue(nodeValue(domLevel3, childNode)))
+        );
+        childNameToConsumer.put("batch-size", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setBatchSize(getIntegerValue("batch-size", nodeValue(domLevel3, childNode))));
+        childNameToConsumer.put("buffer-size", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setBufferSize(getIntegerValue("buffer-size", nodeValue(domLevel3, childNode))));
+        childNameToConsumer.put("delay-seconds", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setDelaySeconds(getIntegerValue("delay-seconds", nodeValue(domLevel3, childNode))));
+        childNameToConsumer.put("in-memory-format", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(nodeValue(domLevel3, childNode)))));
+        childNameToConsumer.put("coalesce", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setCoalesce(getBooleanValue(nodeValue(domLevel3, childNode))));
+        childNameToConsumer.put("populate", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setPopulate(getBooleanValue(nodeValue(domLevel3, childNode))));
+        childNameToConsumer.put(
+            "indexes",
+            (queryCacheConfig, childNode) ->
+                new CollectionProcessor<>(
+                    childNode,
+                    "index",
+                    indexNode -> new IndexProcessor(indexNode, domLevel3),
+                    queryCacheConfig::addIndexConfig
+                ).process()
+        );
+        childNameToConsumer.put("predicate", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setPredicateConfig(new PredicateConfigProcessor(childNode, domLevel3).process()));
+        childNameToConsumer.put("eviction", (queryCacheConfig, childNode) ->
+            queryCacheConfig.setEvictionConfig(new QueryCacheEvictionConfigProcessor(childNode, domLevel3).process()));
+    }
+
+    private String nodeValue(boolean domLevel3, Node node) {
+        return getTextContent(node, domLevel3).trim();
+    }
+
+    @Override
+    public QueryCacheConfig process() {
+        QueryCacheConfig queryCacheConfig = new QueryCacheConfig(cacheName());
+        for (Node child : childElements(node)) {
+            childNameToConsumer.get(cleanNodeName(child)).accept(queryCacheConfig, child);
+        }
+        return queryCacheConfig;
+    }
+
+    private String cacheName() {
+        return getTextContent(node.getAttributes().getNamedItem("name"), domLevel3);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/QueryCacheEvictionConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/QueryCacheEvictionConfigProcessor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.internal.config.ConfigValidator;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
+
+import org.w3c.dom.Node;
+
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+import static java.lang.String.format;
+
+class QueryCacheEvictionConfigProcessor extends AbstractEvictionConfigProcessor {
+    QueryCacheEvictionConfigProcessor(Node node, boolean domLevel3) {
+        super(node, domLevel3);
+    }
+
+    @Override
+    EvictionConfig evictionConfigWithDefaults() {
+        return new EvictionConfig();
+    }
+
+    @Override
+    int sizeDefault() {
+        return 0;
+    }
+
+    @Override
+    EvictionPolicy defaultEvictionPolicy() {
+        return EvictionConfig.DEFAULT_EVICTION_POLICY;
+    }
+
+    @Override
+    void validate(EvictionConfig evictionConfig) {
+        EvictionPolicy evictionPolicy = evictionConfig.getEvictionPolicy();
+        String comparatorClassName = evictionConfig.getComparatorClassName();
+        EvictionPolicyComparator comparator = evictionConfig.getComparator();
+
+        assertOnlyComparatorClassOrComparatorConfigured(comparatorClassName, comparator);
+
+        if (!ConfigValidator.COMMONLY_SUPPORTED_EVICTION_POLICIES.contains(evictionPolicy)) {
+            assertSupportedEvictionPolicyOrComparatorIsSet(evictionPolicy, comparatorClassName, comparator);
+        } else {
+            assertOnlyEvictionPolicyOrComparatorClassNameOrComparatorConfigured(
+                evictionPolicy,
+                comparatorClassName,
+                comparator
+            );
+        }
+    }
+
+    private void assertSupportedEvictionPolicyOrComparatorIsSet(EvictionPolicy evictionPolicy,
+                                                                String comparatorClassName,
+                                                                EvictionPolicyComparator comparator) {
+        if (isNullOrEmpty(comparatorClassName) && comparator == null) {
+            String msg = format(
+                "Eviction policy `%s` is not supported. Either you can provide a custom one or "
+                    + "you can use a supported one: %s.",
+                evictionPolicy,
+                ConfigValidator.COMMONLY_SUPPORTED_EVICTION_POLICIES
+            );
+
+            throw new InvalidConfigurationException(msg);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/processors/WanReplicationRefProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/processors/WanReplicationRefProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config.processors;
+
+import com.hazelcast.config.WanReplicationRef;
+
+import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.config.DomConfigHelper.getAttribute;
+import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
+import static com.hazelcast.internal.config.DomConfigHelper.streamOfChildElements;
+
+class WanReplicationRefProcessor implements Processor<WanReplicationRef> {
+    private final Node node;
+    private final boolean domLevel3;
+    private final Map<String, BiConsumer<WanReplicationRef, Node>> map = new HashMap<>();
+
+    WanReplicationRefProcessor(Node node, boolean domLevel3) {
+        this.node = node;
+        this.domLevel3 = domLevel3;
+        map.put(
+            "merge-policy",
+            (wanReplicationRef, child) -> wanReplicationRef.setMergePolicy(getTextContent(child, domLevel3))
+        );
+        map.put(
+            "republishing-enabled",
+            (wanReplicationRef, child) ->
+                wanReplicationRef.setRepublishingEnabled(getBooleanValue(getTextContent(child, domLevel3)))
+        );
+        map.put(
+            "filters",
+            (wanReplicationRef, child) -> streamOfChildElements(child)
+                    .filter(filter -> "filter-impl".equals(cleanNodeName(filter)))
+                    .forEach(filter -> wanReplicationRef.addFilter(getTextContent(filter, domLevel3)))
+        );
+    }
+
+    @Override
+    public WanReplicationRef process() {
+        WanReplicationRef wanReplicationRef = new WanReplicationRef();
+        wanReplicationRef.setName(name());
+        streamOfChildElements(node)
+            .forEach(child -> map.get(cleanNodeName(child)).accept(wanReplicationRef, child));
+        return wanReplicationRef;
+    }
+
+    private String name() {
+        return getAttribute(node, "name", domLevel3);
+    }
+}


### PR DESCRIPTION
Start working on #16009 ... in this PR I rework how xml configuration for `MapConfig` is processed.

I introduce `Processor<T>` and `CollectionProcessor<T>` entities for processing xml configurations.
I really like the idea tearing apart `ConfigValidator`, `MemberDomConfigProcessor` and `YamlMemberDomConfigProcessor` into group of small classes

@ahmetmircik @mmedenjak could you guys take a look and give you feedback on approach?
Thank you