### PR TITLE
[3.12.z] Fix Address.equals and hashCode to use IP address instead of hostname

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -47,6 +47,8 @@ public final class Address implements IdentifiedDataSerializable {
     private String scopeId;
     private boolean hostSet;
 
+    private InetSocketAddress socketAddr;
+
     public Address() {
     }
 
@@ -72,7 +74,7 @@ public final class Address implements IdentifiedDataSerializable {
 
     public Address(String hostname, InetAddress inetAddress, int port) {
         checkNotNull(inetAddress, "inetAddress can't be null");
-
+        socketAddr = new InetSocketAddress(inetAddress, port);
         type = (inetAddress instanceof Inet4Address) ? IPV4 : IPV6;
         String[] addressArgs = inetAddress.getHostAddress().split("\\%");
         host = hostname != null ? hostname : addressArgs[0];
@@ -89,6 +91,7 @@ public final class Address implements IdentifiedDataSerializable {
         this.type = address.type;
         this.scopeId = address.scopeId;
         this.hostSet = address.hostSet;
+        this.socketAddr = address.socketAddr;
     }
 
     public String getHost() {
@@ -162,6 +165,7 @@ public final class Address implements IdentifiedDataSerializable {
             byte[] address = new byte[len];
             in.readFully(address);
             host = bytesToString(address);
+            socketAddr = new InetSocketAddress(host, port);
         }
     }
 
@@ -174,14 +178,12 @@ public final class Address implements IdentifiedDataSerializable {
             return false;
         }
         final Address address = (Address) o;
-        return port == address.port && this.type == address.type && this.host.equals(address.host);
+        return this.type == address.type && this.socketAddr.equals(address.socketAddr);
     }
 
     @Override
     public int hashCode() {
-        int result = port;
-        result = 31 * result + host.hashCode();
-        return result;
+        return socketAddr.hashCode();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/AddressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/AddressTest.java
@@ -16,16 +16,21 @@
 
 package com.hazelcast.nio;
 
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeLocalhostResolvesTo_127_0_0_1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class AddressTest {
 
@@ -38,5 +43,20 @@ public class AddressTest {
     @Test(expected = NullPointerException.class)
     public void newAddress_InetSocketAddress_whenNull() throws UnknownHostException {
         new Address((InetSocketAddress) null);
+    }
+
+    @Test
+    public void testEqualsBasedOnSocksInetAddress() throws UnknownHostException {
+        assumeLocalhostResolvesTo_127_0_0_1();
+        Address address1 = new Address("127.0.0.1", 5701);
+        Address address2 = new Address("localhost", 5701);
+        Address address3 = new Address("localhost", 5702);
+        Address address4 = new Address("foobarx", InetAddress.getByName("127.0.0.1"), 5702);
+        Address address5 = new Address("member.hazelcast.com", InetAddress.getByName("10.0.0.1"), 5701);
+        assertEquals(address1, address2);
+        assertEquals(address3, address4);
+        assertNotEquals(address1, address3);
+        assertNotEquals(address2, address5);
+        assertNotEquals(address3, address5);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpEndpointManager_AddressMappingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpEndpointManager_AddressMappingTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
+import static com.hazelcast.test.HazelcastTestSupport.assumeLocalhostResolvesTo_127_0_0_1;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TcpIpEndpointManager_AddressMappingTest {
+
+    @AfterClass
+    public static void afterClass() {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    /**
+     * Regression test for https://github.com/hazelcast/hazelcast/issues/15722
+     */
+    @Test
+    public void regression15722() {
+        assumeLocalhostResolvesTo_127_0_0_1();
+        HazelcastInstance hz1 = newMember("127.0.0.1");
+        try {
+            HazelcastInstance hz2 = newMember("localhost");
+            assertClusterSize(1, hz1, hz2);
+        } finally {
+            Hazelcast.shutdownAll();
+        }
+    }
+
+    private static HazelcastInstance newMember(String hostname) {
+        Config config = smallInstanceConfig().setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+        config.getGroupConfig().setName(hostname);
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(true).clear().addMember(hostname);
+        return Hazelcast.newHazelcastInstance(config);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -78,6 +78,8 @@ import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1702,6 +1704,20 @@ public abstract class HazelcastTestSupport {
         ByteOrder configuredByteOrder = serializationService.getByteOrder();
         assumeTrue(format("Assumed configured byte order %s, but was %s", assumedByteOrder, configuredByteOrder),
                 configuredByteOrder.equals(assumedByteOrder));
+    }
+
+    /**
+     * Throws {@link AssumptionViolatedException} if the "localhost" hostname doesn't resolve to 127.0.0.1.
+     */
+    public static void assumeLocalhostResolvesTo_127_0_0_1() {
+        boolean resolvedToLoopback = false;
+        try {
+            InetAddress ia = InetAddress.getByName("localhost");
+            resolvedToLoopback = "127.0.0.1".equals(ia.getHostAddress());
+        } catch (UnknownHostException e) {
+            // OK
+        }
+        assumeTrue("The localhost doesn't resolve to 127.0.0.1. Skipping the test.", resolvedToLoopback);
     }
 
     /**


### PR DESCRIPTION
Fixes #15722 (in `maintanence-3.x`).