### PR TITLE
Remove compatibility codepaths

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -35,7 +35,6 @@ import java.util.function.BiConsumer;
 
 import static com.hazelcast.cache.impl.AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE;
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
-import static com.hazelcast.config.MergePolicyConfig.DEFAULT_BATCH_SIZE;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
 class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordStore, CacheMergeTypes> {
@@ -49,7 +48,7 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
         super(CacheService.SERVICE_NAME, mergingStores, splitBrainHandlerService, nodeEngine);
 
         this.cacheService = nodeEngine.getService(SERVICE_NAME);
-        this.configs = new ConcurrentHashMap<String, CacheConfig>(cacheService.getConfigs());
+        this.configs = new ConcurrentHashMap<>(cacheService.getConfigs());
     }
 
     @Override
@@ -86,10 +85,8 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
 
     @Override
     protected int getBatchSize(String dataStructureName) {
-        // the batch size cannot be retrieved from the MergePolicyConfig,
-        // because there is no MergePolicyConfig in CacheConfig
-        // (adding it breaks backward compatibility)
-        return DEFAULT_BATCH_SIZE;
+        return cacheService.getConfigs().get(dataStructureName)
+                           .getMergePolicyConfig().getBatchSize();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -17,12 +17,12 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheStatistics;
+import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.cache.impl.event.InternalCachePartitionLostListenerAdapter;
 import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
 import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
-import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.internal.config.CacheConfigReadOnly;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
@@ -374,7 +374,9 @@ public class CacheProxy<K, V> extends CacheProxySupport<K, V>
 
     @Override
     public CacheStatistics getLocalCacheStatistics() {
-        // TODO: throw UnsupportedOperationException if cache statistics are not enabled (but it breaks backward compatibility)
+        if (!cacheConfig.isStatisticsEnabled()) {
+            throw new UnsupportedOperationException("Cache statistics are not enabled for " + nameWithPrefix);
+        }
         return getService().createCacheStatIfAbsent(cacheConfig.getNameWithPrefix());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
@@ -17,14 +17,13 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.diagnostics.Diagnostics;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.map.EntryLoader;
 import com.hazelcast.map.MapLoader;
 import com.hazelcast.map.MapLoaderLifecycleSupport;
 import com.hazelcast.map.MapStore;
 import com.hazelcast.map.PostProcessingMapStore;
-import com.hazelcast.internal.diagnostics.Diagnostics;
-import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
-import com.hazelcast.map.EntryLoader;
-import com.hazelcast.query.impl.getters.ReflectionHelper;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -154,14 +153,7 @@ public class MapStoreWrapper implements MapStore, MapLoaderLifecycleSupport {
     @Override
     public Iterable<Object> loadAllKeys() {
         if (isMapLoader()) {
-            Iterable<Object> allKeys;
-            try {
-                allKeys = mapLoader.loadAllKeys();
-            } catch (AbstractMethodError e) {
-                // Invoke reflectively to preserve backwards binary compatibility. Removable in v4.x
-                allKeys = ReflectionHelper.invokeMethod(mapLoader, "loadAllKeys");
-            }
-            return allKeys;
+            return (Iterable<Object>) mapLoader.loadAllKeys();
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -39,6 +39,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+import com.hazelcast.spi.impl.proxyservice.impl.DistributedObjectEventPacket;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.DistributedObjectDestroyOperation;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.InitializeDistributedObjectOperation;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.PostJoinProxyOperation;
@@ -76,6 +77,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int NOOP_TENANT_CONTROL = 22;
     public static final int USERNAME_PWD_CRED = 23;
     public static final int SIMPLE_TOKEN_CRED = 24;
+    public static final int DISTRIBUTED_OBJECT_EVENT_PACKET = 25;
 
     private static final DataSerializableFactory FACTORY = createFactoryInternal();
 
@@ -139,6 +141,8 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new UsernamePasswordCredentials();
                     case SIMPLE_TOKEN_CRED:
                         return new SimpleTokenCredentials();
+                    case DISTRIBUTED_OBJECT_EVENT_PACKET:
+                        return new DistributedObjectEventPacket();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -18,15 +18,14 @@ package com.hazelcast.spi.impl.proxyservice.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
 
 import static com.hazelcast.core.DistributedObjectEvent.EventType;
 
-@BinaryInterface
-public final class DistributedObjectEventPacket implements DataSerializable {
+public final class DistributedObjectEventPacket implements IdentifiedDataSerializable {
 
     private EventType eventType;
     private String serviceName;
@@ -57,15 +56,14 @@ public final class DistributedObjectEventPacket implements DataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(eventType == EventType.CREATED);
         out.writeUTF(serviceName);
-        // writing as object for backward-compatibility
-        out.writeObject(name);
+        out.writeUTF(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         eventType = in.readBoolean() ? EventType.CREATED : EventType.DESTROYED;
         serviceName = in.readUTF();
-        name = in.readObject();
+        name = in.readUTF();
     }
 
     @Override
@@ -75,5 +73,15 @@ public final class DistributedObjectEventPacket implements DataSerializable {
                 + ", serviceName='" + serviceName + '\''
                 + ", name=" + name
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SpiDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SpiDataSerializerHook.DISTRIBUTED_OBJECT_EVENT_PACKET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
@@ -54,15 +54,14 @@ public class DistributedObjectDestroyOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(serviceName);
-        out.writeObject(name);
-        // writing as object for backward-compatibility
+        out.writeUTF(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         serviceName = in.readUTF();
-        name = in.readObject();
+        name = in.readUTF();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -21,10 +21,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyInfo;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyRegistry;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
@@ -83,8 +83,7 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         if (len > 0) {
             for (ProxyInfo proxy : proxies) {
                 out.writeUTF(proxy.getServiceName());
-                out.writeObject(proxy.getObjectName());
-                // writing as object for backward-compatibility
+                out.writeUTF(proxy.getObjectName());
             }
         }
     }
@@ -94,9 +93,9 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         super.readInternal(in);
         int len = in.readInt();
         if (len > 0) {
-            proxies = new ArrayList<ProxyInfo>(len);
+            proxies = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
-                ProxyInfo proxy = new ProxyInfo(in.readUTF(), (String) in.readObject());
+                ProxyInfo proxy = new ProxyInfo(in.readUTF(), in.readUTF());
                 proxies.add(proxy);
             }
         }


### PR DESCRIPTION
Also removed BinaryInterface from DistributedObjectEventPacket as
supposedly it isn't sent to the client. This allows us to change the
serialization from DS to IDS.