### PR TITLE
Remove compatibility codepaths

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -35,7 +35,6 @@ import java.util.function.BiConsumer;
 
 import static com.hazelcast.cache.impl.AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE;
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
-import static com.hazelcast.config.MergePolicyConfig.DEFAULT_BATCH_SIZE;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
 class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordStore, CacheMergeTypes> {
@@ -49,7 +48,7 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
         super(CacheService.SERVICE_NAME, mergingStores, splitBrainHandlerService, nodeEngine);
 
         this.cacheService = nodeEngine.getService(SERVICE_NAME);
-        this.configs = new ConcurrentHashMap<String, CacheConfig>(cacheService.getConfigs());
+        this.configs = new ConcurrentHashMap<>(cacheService.getConfigs());
     }
 
     @Override
@@ -86,10 +85,8 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
 
     @Override
     protected int getBatchSize(String dataStructureName) {
-        // the batch size cannot be retrieved from the MergePolicyConfig,
-        // because there is no MergePolicyConfig in CacheConfig
-        // (adding it breaks backward compatibility)
-        return DEFAULT_BATCH_SIZE;
+        return cacheService.getConfigs().get(dataStructureName)
+                           .getMergePolicyConfig().getBatchSize();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -92,7 +92,7 @@ import static java.util.Collections.emptyMap;
 public class CacheProxy<K, V> extends CacheProxySupport<K, V>
         implements EventJournalReader<EventJournalCacheEvent<K, V>> {
 
-    private final CacheStatistics EMPTY_CACHE_STATS = new CacheStatisticsImpl(Clock.currentTimeMillis());
+    private static final CacheStatistics EMPTY_CACHE_STATS = new CacheStatisticsImpl(Clock.currentTimeMillis());
 
     CacheProxy(CacheConfig<K, V> cacheConfig, NodeEngine nodeEngine, ICacheService cacheService) {
         super(cacheConfig, nodeEngine, cacheService);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.InitialMembershipEvent;
 import com.hazelcast.cluster.InitialMembershipListener;
@@ -39,14 +40,15 @@ import com.hazelcast.internal.cluster.impl.operations.ShutdownNodeOp;
 import com.hazelcast.internal.cluster.impl.operations.TriggerExplicitSuspicionOp;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.services.ManagedService;
 import com.hazelcast.internal.services.MemberAttributeServiceEvent;
 import com.hazelcast.internal.services.MembershipAwareService;
 import com.hazelcast.internal.services.TransactionalService;
+import com.hazelcast.internal.util.UuidUtil;
+import com.hazelcast.internal.util.executor.ExecutorType;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -61,8 +63,6 @@ import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
-import com.hazelcast.internal.util.UuidUtil;
-import com.hazelcast.internal.util.executor.ExecutorType;
 import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -82,10 +82,10 @@ import java.util.concurrent.locks.ReentrantLock;
 import static com.hazelcast.cluster.impl.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEMBER_SELECTOR;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
-import static com.hazelcast.spi.impl.executionservice.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
+import static com.hazelcast.spi.impl.executionservice.ExecutionService.SYSTEM_EXECUTOR;
 import static java.lang.String.format;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
@@ -106,7 +106,6 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private static final String STATE_MUST_NOT_BE_NULL = "State must not be null!";
     private static final String VERSION_MUST_NOT_BE_NULL = "Version must not be null!";
 
-    private final boolean useLegacyMemberListFormat;
     private final Node node;
     private final ILogger logger;
     private final NodeEngineImpl nodeEngine;
@@ -129,8 +128,6 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
         logger = node.getLogger(ClusterService.class.getName());
         clusterClock = new ClusterClockImpl(logger);
-
-        useLegacyMemberListFormat = node.getProperties().getBoolean(ClusterProperty.USE_LEGACY_MEMBER_LIST_FORMAT);
 
         membershipManager = new MembershipManager(node, this, lock);
         clusterStateManager = new ClusterStateManager(node, lock);
@@ -799,20 +796,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         }
     }
 
-    private String legacyMemberListString() {
-        StringBuilder sb = new StringBuilder("\n\nMembers [");
-        Collection<MemberImpl> members = getMemberImpls();
-        sb.append(members.size());
-        sb.append("] {");
-        for (Member member : members) {
-            sb.append("\n\t").append(member);
-        }
-        sb.append("\n}\n");
-        return sb.toString();
-    }
-
     public String getMemberListString() {
-        return useLegacyMemberListFormat ? legacyMemberListString() : membershipManager.memberListString();
+        return membershipManager.memberListString();
     }
 
     void printMemberList() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
@@ -17,14 +17,13 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.diagnostics.Diagnostics;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.map.EntryLoader;
 import com.hazelcast.map.MapLoader;
 import com.hazelcast.map.MapLoaderLifecycleSupport;
 import com.hazelcast.map.MapStore;
 import com.hazelcast.map.PostProcessingMapStore;
-import com.hazelcast.internal.diagnostics.Diagnostics;
-import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
-import com.hazelcast.map.EntryLoader;
-import com.hazelcast.query.impl.getters.ReflectionHelper;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -154,14 +153,7 @@ public class MapStoreWrapper implements MapStore, MapLoaderLifecycleSupport {
     @Override
     public Iterable<Object> loadAllKeys() {
         if (isMapLoader()) {
-            Iterable<Object> allKeys;
-            try {
-                allKeys = mapLoader.loadAllKeys();
-            } catch (AbstractMethodError e) {
-                // Invoke reflectively to preserve backwards binary compatibility. Removable in v4.x
-                allKeys = ReflectionHelper.invokeMethod(mapLoader, "loadAllKeys");
-            }
-            return allKeys;
+            return (Iterable<Object>) mapLoader.loadAllKeys();
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -39,6 +39,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+import com.hazelcast.spi.impl.proxyservice.impl.DistributedObjectEventPacket;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.DistributedObjectDestroyOperation;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.InitializeDistributedObjectOperation;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.PostJoinProxyOperation;
@@ -76,6 +77,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int NOOP_TENANT_CONTROL = 22;
     public static final int USERNAME_PWD_CRED = 23;
     public static final int SIMPLE_TOKEN_CRED = 24;
+    public static final int DISTRIBUTED_OBJECT_EVENT_PACKET = 25;
 
     private static final DataSerializableFactory FACTORY = createFactoryInternal();
 
@@ -139,6 +141,8 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new UsernamePasswordCredentials();
                     case SIMPLE_TOKEN_CRED:
                         return new SimpleTokenCredentials();
+                    case DISTRIBUTED_OBJECT_EVENT_PACKET:
+                        return new DistributedObjectEventPacket();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -18,15 +18,14 @@ package com.hazelcast.spi.impl.proxyservice.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
 
 import static com.hazelcast.core.DistributedObjectEvent.EventType;
 
-@BinaryInterface
-public final class DistributedObjectEventPacket implements DataSerializable {
+public final class DistributedObjectEventPacket implements IdentifiedDataSerializable {
 
     private EventType eventType;
     private String serviceName;
@@ -57,15 +56,14 @@ public final class DistributedObjectEventPacket implements DataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(eventType == EventType.CREATED);
         out.writeUTF(serviceName);
-        // writing as object for backward-compatibility
-        out.writeObject(name);
+        out.writeUTF(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         eventType = in.readBoolean() ? EventType.CREATED : EventType.DESTROYED;
         serviceName = in.readUTF();
-        name = in.readObject();
+        name = in.readUTF();
     }
 
     @Override
@@ -75,5 +73,15 @@ public final class DistributedObjectEventPacket implements DataSerializable {
                 + ", serviceName='" + serviceName + '\''
                 + ", name=" + name
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SpiDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SpiDataSerializerHook.DISTRIBUTED_OBJECT_EVENT_PACKET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
@@ -54,15 +54,14 @@ public class DistributedObjectDestroyOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(serviceName);
-        out.writeObject(name);
-        // writing as object for backward-compatibility
+        out.writeUTF(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         serviceName = in.readUTF();
-        name = in.readObject();
+        name = in.readUTF();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -21,10 +21,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyInfo;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyRegistry;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
@@ -83,8 +83,7 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         if (len > 0) {
             for (ProxyInfo proxy : proxies) {
                 out.writeUTF(proxy.getServiceName());
-                out.writeObject(proxy.getObjectName());
-                // writing as object for backward-compatibility
+                out.writeUTF(proxy.getObjectName());
             }
         }
     }
@@ -94,9 +93,9 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         super.readInternal(in);
         int len = in.readInt();
         if (len > 0) {
-            proxies = new ArrayList<ProxyInfo>(len);
+            proxies = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
-                ProxyInfo proxy = new ProxyInfo(in.readUTF(), (String) in.readObject());
+                ProxyInfo proxy = new ProxyInfo(in.readUTF(), in.readUTF());
                 proxies.add(proxy);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -946,13 +946,6 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.init.cluster.version");
 
     /**
-     * Enables legacy (pre-3.9) member list format which is printed in logs. New format is introduced by 3.9
-     * includes member list version.
-     */
-    public static final HazelcastProperty USE_LEGACY_MEMBER_LIST_FORMAT
-            = new HazelcastProperty("hazelcast.legacy.memberlist.format.enabled", false);
-
-    /**
      * Controls whether we apply more strict checks upon BIND requests towards a cluster member.
      * The checks mainly validate the remote BIND request against the remote address as found in the socket.
      * By default they are disabled, to avoid connectivity issues when deployed under NAT'ed infrastructure.

--- a/hazelcast/src/main/java/com/hazelcast/topic/MessageListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/MessageListener.java
@@ -28,6 +28,7 @@ import java.util.EventListener;
  *
  * @param <E> message
  */
+@FunctionalInterface
 public interface MessageListener<E> extends EventListener {
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -79,14 +79,10 @@ public class CacheStatsTest extends CacheTestSupport {
 
     @Test
     public void testStatisticsDisabled() {
-        long now = System.currentTimeMillis();
-
         CacheConfig cacheConfig = createCacheConfig();
         cacheConfig.setStatisticsEnabled(false);
         ICache<Integer, String> cache = createCache(cacheConfig);
         CacheStatistics stats = cache.getLocalCacheStatistics();
-
-        assertTrue(stats.getCreationTime() >= now);
 
         final int ENTRY_COUNT = 100;
 


### PR DESCRIPTION
- removed some compatibility codepaths
- removed BinaryInterface from DistributedObjectEventPacket as
supposedly it isn't sent to the client. This allows us to change the
serialization from DS to IDS
- removed legacy member list output and the GroupProperty to configure it
- removed unused method
- made MessageListener a FunctionalInterface