### PR TITLE
Fix spotbugs issue in WithForcedEviction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WithForcedEviction.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WithForcedEviction.java
@@ -19,12 +19,6 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
 public final class WithForcedEviction {
-    public static final ForcedEviction[] EVICTIONS = new ForcedEviction[]{
-        new RecordStoreForcedEviction(),
-        new PartitionRecordStoreForcedEviction(),
-        new AllEntriesForcedEviction(),
-        new PartitionAllEntriesForcedEviction()
-    };
 
     public static final int DEFAULT_FORCED_EVICTION_RETRY_COUNT = 5;
     public static final String PROP_FORCED_EVICTION_RETRY_COUNT
@@ -32,6 +26,13 @@ public final class WithForcedEviction {
     public static final HazelcastProperty FORCED_EVICTION_RETRY_COUNT
               = new HazelcastProperty(PROP_FORCED_EVICTION_RETRY_COUNT,
                                       DEFAULT_FORCED_EVICTION_RETRY_COUNT);
+
+    static final ForcedEviction[] EVICTIONS = new ForcedEviction[]{
+        new RecordStoreForcedEviction(),
+        new PartitionRecordStoreForcedEviction(),
+        new AllEntriesForcedEviction(),
+        new PartitionAllEntriesForcedEviction()
+    };
 
     private WithForcedEviction() {
     }


### PR DESCRIPTION
Fixes the following spotbugs issue:
```
[ERROR] com.hazelcast.map.impl.operation.WithForcedEviction.EVICTIONS should be package protected [com.hazelcast.map.impl.operation.WithForcedEviction] At WithForcedEviction.java:[line 22] MS_PKGPROTECT
```