### PR TITLE
Change BlockingMessageTasks to work asynchronously

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
@@ -35,8 +35,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static java.util.Collections.EMPTY_MAP;
 
-public abstract class AbstractMultiTargetMessageTask<P>
-        extends AbstractAsyncMessageTask<P, Object> {
+public abstract class AbstractMultiTargetMessageTask<P> extends AbstractAsyncMessageTask<P, Object> {
 
     protected AbstractMultiTargetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxiesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxiesMessageTask.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 
 
 public class CreateProxiesMessageTask extends AbstractMultiTargetMessageTask<ClientCreateProxiesCodec.RequestParameters>
-        implements Supplier<Operation>, BlockingMessageTask {
+        implements Supplier<Operation> {
 
     public CreateProxiesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DestroyProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DestroyProxyMessageTask.java
@@ -18,27 +18,55 @@ package com.hazelcast.client.impl.protocol.task;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
-import com.hazelcast.spi.impl.proxyservice.ProxyService;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.proxyservice.impl.operations.DistributedObjectDestroyOperation;
 
 import java.security.Permission;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 
+import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.security.permission.ActionConstants.getPermission;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.WARNING;
 
-public class DestroyProxyMessageTask extends AbstractCallableMessageTask<ClientDestroyProxyCodec.RequestParameters>
-        implements BlockingMessageTask {
+public class DestroyProxyMessageTask extends AbstractMultiTargetMessageTask<ClientDestroyProxyCodec.RequestParameters> {
 
     public DestroyProxyMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
-        ProxyService proxyService = nodeEngine.getProxyService();
-        proxyService.destroyDistributedObject(parameters.serviceName, parameters.name);
+    protected Supplier<Operation> createOperationSupplier() {
+        return () -> new DistributedObjectDestroyOperation(parameters.serviceName, parameters.name);
+    }
+
+    @Override
+    protected Object reduce(Map<Member, Object> map) throws Throwable {
+        for (Object result : map.values()) {
+            if (result instanceof Throwable) {
+                handleException((Throwable) result);
+            }
+        }
         return null;
+    }
+
+    @Override
+    public Collection<Member> getTargets() {
+        return nodeEngine.getClusterService().getMembers();
+    }
+
+    private void handleException(Throwable throwable) {
+        boolean causedByInactiveInstance = peel(throwable) instanceof HazelcastInstanceNotActiveException;
+        Level level = causedByInactiveInstance ? FINEST : WARNING;
+        logger.log(level, "Error while destroying a proxy.", throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DestroyProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DestroyProxyMessageTask.java
@@ -37,15 +37,21 @@ import static com.hazelcast.security.permission.ActionConstants.getPermission;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
-public class DestroyProxyMessageTask extends AbstractMultiTargetMessageTask<ClientDestroyProxyCodec.RequestParameters> {
+public class DestroyProxyMessageTask extends AbstractMultiTargetMessageTask<ClientDestroyProxyCodec.RequestParameters>
+        implements Supplier<Operation> {
 
     public DestroyProxyMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
+    public Operation get() {
+        return new DistributedObjectDestroyOperation(parameters.serviceName, parameters.name);
+    }
+
+    @Override
     protected Supplier<Operation> createOperationSupplier() {
-        return () -> new DistributedObjectDestroyOperation(parameters.serviceName, parameters.name);
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
@@ -18,63 +18,43 @@ package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ContinuousQueryDestroyCacheCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
-import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.impl.Node;
-import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.map.impl.querycache.subscriber.operation.DestroyQueryCacheOperation;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.internal.util.FutureUtil;
+import com.hazelcast.map.impl.querycache.subscriber.operation.DestroyQueryCacheOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Client Protocol Task for handling messages with type ID:
- * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_DESTROYCACHE}
+ * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryDestroyCacheCodec#REQUEST_MESSAGE_TYPE}
  */
 public class MapDestroyCacheMessageTask
-        extends AbstractCallableMessageTask<ContinuousQueryDestroyCacheCodec.RequestParameters> implements BlockingMessageTask {
+        extends AbstractMultiTargetMessageTask<ContinuousQueryDestroyCacheCodec.RequestParameters>
+        implements Supplier<Operation> {
 
     public MapDestroyCacheMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
-        ClusterService clusterService = clientEngine.getClusterService();
-        Collection<MemberImpl> members = clusterService.getMemberImpls();
-        List<Future<Boolean>> futures = new ArrayList<Future<Boolean>>(members.size());
-        createInvocations(members, futures);
-        Collection<Boolean> results = FutureUtil.returnWithDeadline(futures, 1, TimeUnit.MINUTES);
-        return reduce(results);
+    protected Supplier<Operation> createOperationSupplier() {
+        return this;
     }
 
-    private boolean reduce(Collection<Boolean> results) {
-        return !results.contains(Boolean.FALSE);
+    @Override
+    protected Object reduce(Map<Member, Object> map) throws Throwable {
+        return !map.values().contains(Boolean.FALSE);
     }
 
-    private void createInvocations(Collection<MemberImpl> members, List<Future<Boolean>> futures) {
-        OperationServiceImpl operationService = nodeEngine.getOperationService();
-        for (MemberImpl member : members) {
-            DestroyQueryCacheOperation operation =
-                    new DestroyQueryCacheOperation(parameters.mapName, parameters.cacheName);
-            operation.setCallerUuid(endpoint.getUuid());
-            Address address = member.getAddress();
-            InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(SERVICE_NAME, operation, address);
-            Future future = invocationBuilder.invoke();
-            futures.add(future);
-        }
+    @Override
+    public Collection<Member> getTargets() {
+        return clientEngine.getClusterService().getMembers();
     }
 
     @Override
@@ -110,5 +90,12 @@ public class MapDestroyCacheMessageTask
     @Override
     public Object[] getParameters() {
         return null;
+    }
+
+    @Override
+    public Operation get() {
+        DestroyQueryCacheOperation operation = new DestroyQueryCacheOperation(parameters.mapName, parameters.cacheName);
+        operation.setCallerUuid(endpoint.getUuid());
+        return operation;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+
 /**
  * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryDestroyCacheCodec#REQUEST_MESSAGE_TYPE}
@@ -69,7 +71,7 @@ public class MapDestroyCacheMessageTask
 
     @Override
     public String getServiceName() {
-        return null;
+        return SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
@@ -72,12 +72,12 @@ public class MapExecuteWithPredicateMessageTask
 
     @Override
     protected OperationFactory createOperationFactory() {
+        Predicate targetPredicate = predicate;
         if (predicate instanceof PartitionPredicate) {
-            Predicate targetPredicate = ((PartitionPredicate) predicate).getTarget();
-            return new OperationFactoryWrapper(createOperationFactory(targetPredicate), endpoint.getUuid());
+            targetPredicate = ((PartitionPredicate) predicate).getTarget();
         }
 
-        return new OperationFactoryWrapper(createOperationFactory(predicate), endpoint.getUuid());
+        return createOperationFactory(targetPredicate);
     }
 
     private OperationFactory createOperationFactory(Predicate predicate) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.impl.protocol.task.map;
 
-import com.hazelcast.client.impl.operations.OperationFactoryWrapper;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapExecuteWithPredicateCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiPartitionMessageTask;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
@@ -48,7 +48,7 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
  * Client Protocol Task for handling messages with type ID:
- * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_PUBLISHERCREATE}
+ * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryPublisherCreateCodec#REQUEST_MESSAGE_TYPE}
  */
 public class MapPublisherCreateMessageTask
         extends AbstractCallableMessageTask<ContinuousQueryPublisherCreateCodec.RequestParameters>

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
@@ -41,7 +41,7 @@ public class DistributedObjectDestroyOperation
 
     @Override
     public void run() throws Exception {
-        ProxyServiceImpl proxyService = getService();
+        ProxyServiceImpl proxyService = getNodeEngine().getService(ProxyServiceImpl.SERVICE_NAME);
         proxyService.destroyLocalDistributedObject(serviceName, name, false);
     }
 


### PR DESCRIPTION
Changed the following BlockingMessageTask's to work asynchronously.

1. MapDestroyCacheMessageTask
2. MapExecuteWithPredicateMessageTask
3. CreateProxiesMessageTask
4. DestroyProxyMessageTask

partial fix to https://github.com/hazelcast/hazelcast/issues/15085