### PR TITLE
Add the built-in serializers for `Map.Entry` and `PriorityQueue`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
@@ -22,6 +22,8 @@ import com.hazelcast.nio.serialization.ByteArraySerializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 
 import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_BOOLEAN;
@@ -32,6 +34,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.C
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_CHAR_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DOUBLE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DOUBLE_ARRAY;
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_ENTRY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_FLOAT;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_FLOAT_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_INTEGER;
@@ -408,6 +411,25 @@ public final class ConstantSerializers {
         public void write(final ObjectDataOutput out, final UUID uuid) throws IOException {
             out.writeLong(uuid.getMostSignificantBits());
             out.writeLong(uuid.getLeastSignificantBits());
+        }
+    }
+
+    public static final class EntrySerializer extends SingletonSerializer<Map.Entry> {
+
+        @Override
+        public int getTypeId() {
+            return CONSTANT_TYPE_ENTRY;
+        }
+
+        @Override
+        public Map.Entry read(final ObjectDataInput in) throws IOException {
+            return new AbstractMap.SimpleEntry(in.readObject(), in.readObject());
+        }
+
+        @Override
+        public void write(final ObjectDataOutput out, final Map.Entry entry) throws IOException {
+            out.writeObject(entry.getKey());
+            out.writeObject(entry.getValue());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityQueueStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityQueueStreamSerializer.java
@@ -17,8 +17,10 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.PriorityQueue;
 
 /**
@@ -32,10 +34,19 @@ public class PriorityQueueStreamSerializer<E> extends AbstractCollectionStreamSe
     }
 
     @Override
+    public void write(ObjectDataOutput out, PriorityQueue<E> collection) throws IOException {
+        out.writeObject(collection.comparator());
+
+        super.write(out, collection);
+    }
+
+    @Override
     public PriorityQueue<E> read(ObjectDataInput in) throws IOException {
+        Comparator<E> comparator = in.readObject();
+
         int size = in.readInt();
 
-        PriorityQueue<E> collection = new PriorityQueue<>(size);
+        PriorityQueue<E> collection = new PriorityQueue<>(size, comparator);
 
         return deserializeEntries(in, size, collection);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityQueueStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityQueueStreamSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+
+import java.io.IOException;
+import java.util.PriorityQueue;
+
+/**
+ * The {@link PriorityQueue} serializer
+ */
+public class PriorityQueueStreamSerializer<E> extends AbstractCollectionStreamSerializer<PriorityQueue<E>> {
+
+    @Override
+    public int getTypeId() {
+        return SerializationConstants.JAVA_DEFAULT_TYPE_PRIORITY_QUEUE;
+    }
+
+    @Override
+    public PriorityQueue<E> read(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+
+        PriorityQueue<E> collection = new PriorityQueue<>(size);
+
+        return deserializeEntries(in, size, collection);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -65,66 +65,70 @@ public final class SerializationConstants {
 
     public static final int CONSTANT_TYPE_UUID = -21;
 
+    public static final int CONSTANT_TYPE_ENTRY = -22;
+
     // ------------------------------------------------------------
     // DEFAULT SERIALIZERS
 
-    public static final int JAVA_DEFAULT_TYPE_CLASS = -22;
+    public static final int JAVA_DEFAULT_TYPE_CLASS = -23;
 
-    public static final int JAVA_DEFAULT_TYPE_DATE = -23;
+    public static final int JAVA_DEFAULT_TYPE_DATE = -24;
 
-    public static final int JAVA_DEFAULT_TYPE_BIG_INTEGER = -24;
+    public static final int JAVA_DEFAULT_TYPE_BIG_INTEGER = -25;
 
-    public static final int JAVA_DEFAULT_TYPE_BIG_DECIMAL = -25;
+    public static final int JAVA_DEFAULT_TYPE_BIG_DECIMAL = -26;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY = -26;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY = -27;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_LIST = -27;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_LIST = -28;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -28;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -29;
 
-    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_LIST = -29;
-
-
-    public static final int JAVA_DEFAULT_TYPE_HASH_MAP = -30;
-
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_MAP = -31;
-
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_HASH_MAP = -32;
-
-    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_MAP = -33;
-
-    public static final int JAVA_DEFAULT_TYPE_TREE_MAP = -34;
+    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_LIST = -30;
 
 
-    public static final int JAVA_DEFAULT_TYPE_HASH_SET = -35;
+    public static final int JAVA_DEFAULT_TYPE_HASH_MAP = -31;
 
-    public static final int JAVA_DEFAULT_TYPE_TREE_SET = -36;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_MAP = -32;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_SET = -37;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_HASH_MAP = -33;
 
-    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_SET = -38;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_MAP = -34;
 
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_SET = -39;
+    public static final int JAVA_DEFAULT_TYPE_TREE_MAP = -35;
 
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_DEQUE = -40;
+    public static final int JAVA_DEFAULT_TYPE_HASH_SET = -36;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_BLOCKING_QUEUE = -41;
+    public static final int JAVA_DEFAULT_TYPE_TREE_SET = -37;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_BLOCKING_QUEUE = -42;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_SET = -38;
 
-    public static final int JAVA_DEFAULT_TYPE_PRIORITY_BLOCKING_QUEUE = -43;
+    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_SET = -39;
 
-    public static final int JAVA_DEFAULT_TYPE_DELAY_QUEUE = -44;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_SET = -40;
 
-    public static final int JAVA_DEFAULT_TYPE_SYNCHRONOUS_QUEUE = -45;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_TRANSFER_QUEUE = -46;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_DEQUE = -41;
+
+    public static final int JAVA_DEFAULT_TYPE_LINKED_BLOCKING_QUEUE = -42;
+
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_BLOCKING_QUEUE = -43;
+
+    public static final int JAVA_DEFAULT_TYPE_PRIORITY_BLOCKING_QUEUE = -44;
+
+    public static final int JAVA_DEFAULT_TYPE_DELAY_QUEUE = -45;
+
+    public static final int JAVA_DEFAULT_TYPE_SYNCHRONOUS_QUEUE = -46;
+
+    public static final int JAVA_DEFAULT_TYPE_LINKED_TRANSFER_QUEUE = -47;
+
+    public static final int JAVA_DEFAULT_TYPE_PRIORITY_QUEUE = -48;
 
     // NUMBER OF CONSTANT SERIALIZERS...
-    public static final int CONSTANT_SERIALIZERS_LENGTH = 47;
+    public static final int CONSTANT_SERIALIZERS_LENGTH = 49;
 
-    public static final int JAVA_DEFAULT_TYPE_ENUM = -48;
+    public static final int JAVA_DEFAULT_TYPE_ENUM = -50;
 
     // ------------------------------------------------------------
     // JAVA SERIALIZATION

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -53,6 +53,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -85,6 +86,7 @@ import static com.hazelcast.internal.serialization.impl.ConstantSerializers.Shor
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.StringSerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.TheByteArraySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.UuidSerializer;
+import static com.hazelcast.internal.serialization.impl.ConstantSerializers.EntrySerializer;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.EE_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.IDS_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.isFlagSet;
@@ -177,6 +179,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         registerConstant(Double.class, new DoubleSerializer());
         registerConstant(String.class, new StringSerializer());
         registerConstant(UUID.class, new UuidSerializer());
+        registerConstant(Map.Entry.class, new EntrySerializer());
         //Arrays of primitives and String
         registerConstant(byte[].class, new TheByteArraySerializer());
         registerConstant(boolean[].class, new BooleanArraySerializer());
@@ -217,6 +220,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         registerConstant(LinkedBlockingQueue.class, new LinkedBlockingQueueStreamSerializer());
         registerConstant(ArrayBlockingQueue.class, new ArrayBlockingQueueStreamSerializer());
         registerConstant(PriorityBlockingQueue.class, new PriorityBlockingQueueStreamSerializer());
+        registerConstant(PriorityQueue.class, new PriorityQueueStreamSerializer());
         registerConstant(DelayQueue.class, new DelayQueueStreamSerializer());
         registerConstant(SynchronousQueue.class, new SynchronousQueueStreamSerializer());
         registerConstant(LinkedTransferQueue.class, new LinkedTransferQueueStreamSerializer());

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/CollectionSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/CollectionSerializationTest.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.PriorityQueue;
 import java.util.TreeSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -67,6 +68,7 @@ public class CollectionSerializationTest {
                 new LinkedBlockingQueue(),
                 new ArrayBlockingQueue(2),
                 new PriorityBlockingQueue<>(5, new SerializationConcurrencyTest.PortablePersonComparator()),
+                new PriorityQueue<>(),
                 new DelayQueue(),
                 new LinkedTransferQueue());
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
@@ -39,8 +39,10 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.PriorityQueue;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -90,6 +92,7 @@ class ReferenceObjects {
     static long aLong = -50992225L;
     static String aString;
     static String anSqlString = "this > 5 AND this < 100";
+    static UUID aUUID = new UUID(aLong, anInt);
 
     static {
         CharBuffer cb = CharBuffer.allocate(Character.MAX_VALUE);
@@ -126,8 +129,7 @@ class ReferenceObjects {
     static AnIdentifiedDataSerializable anIdentifiedDataSerializable = new AnIdentifiedDataSerializable(
             aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString,
             booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
-            anInnerPortable,
-            (AnIdentifiedDataSerializable) null,
+            anInnerPortable, null,
             aCustomStreamSerializable,
             aCustomByteArraySerializable, aData);
     static APortable aPortable = new APortable(
@@ -200,16 +202,18 @@ class ReferenceObjects {
     static LinkedBlockingQueue linkedBlockingQueue = new LinkedBlockingQueue(nonNullList);
     static ArrayBlockingQueue arrayBlockingQueue = new ArrayBlockingQueue(5);
     static PriorityBlockingQueue priorityBlockingQueue = new PriorityBlockingQueue();
+    static PriorityQueue priorityQueue = new PriorityQueue();
     static {
         arrayBlockingQueue.offer(aPortable);
         priorityBlockingQueue.offer(anInt);
+        priorityQueue.offer(aString);
     }
     static DelayQueue delayQueue = new DelayQueue();
     static SynchronousQueue synchronousQueue = new SynchronousQueue();
     static LinkedTransferQueue linkedTransferQueue = new LinkedTransferQueue(nonNullList);
 
     static Object[] allTestObjects = {
-            aNullObject, aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString, anInnerPortable,
+            aNullObject, aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString, aUUID, anInnerPortable,
             booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
             aCustomStreamSerializable, aCustomByteArraySerializable,
             anIdentifiedDataSerializable, aPortable,
@@ -217,7 +221,7 @@ class ReferenceObjects {
             serializable, externalizable,
             arrayList, linkedList, copyOnWriteArrayList, concurrentSkipListMap, concurrentHashMap, linkedHashMap, treeMap,
             hashSet, treeSet, linkedHashSet, copyOnWriteArraySet, concurrentSkipListSet, arrayDeque, linkedBlockingQueue,
-            arrayBlockingQueue, priorityBlockingQueue, delayQueue, synchronousQueue, linkedTransferQueue,
+            arrayBlockingQueue, priorityQueue, priorityBlockingQueue, delayQueue, synchronousQueue, linkedTransferQueue,
 
             // predicates
             Predicates.alwaysTrue(),


### PR DESCRIPTION
Adds the built-in serializers for `Map.Entry` and `PriorityQueue`.

fixes https://github.com/hazelcast/hazelcast/issues/15179