### PR TITLE
Improve AbstractProxySessionManagerTest

### DIFF
--- a/hazelcast/src/test/resources/log4j2-debug-cp.xml
+++ b/hazelcast/src/test/resources/log4j2-debug-cp.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.internal.cluster" level="debug"/>
+        <Logger name="com.hazelcast.cp" level="debug"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
- Improved `sessionHeartbeatsAreSent_whenSessionInUse` test to
make it more resilient to hiccups.
- Enabled CP debug logs in this test.

Fixes #15735
Fixes #16077