### PR TITLE
dont allow to connect to address if it is a loopback

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Address.java
@@ -28,6 +28,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -184,5 +185,13 @@ public final class Address implements IdentifiedDataSerializable {
             throw new IllegalArgumentException("Can't resolve address: " + inetSocketAddress);
         }
         return address;
+    }
+
+    public boolean isLocal() {
+        try {
+            return getInetAddress().isLoopbackAddress();
+        } catch (UnknownHostException e) {
+            throw sneakyThrow(e);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/NodeIOService.java
@@ -226,7 +226,7 @@ public class NodeIOService implements IOService {
 
     @Override
     public void shouldConnectTo(Address address) {
-        if (node.getThisAddress().equals(address)) {
+        if (node.getThisAddress().equals(address) || address.isLocal()) {
             throw new RuntimeException("Connecting to self! " + address);
         }
     }


### PR DESCRIPTION
Possible fix for #6906

`NodeIOService#shouldConnectTo` is modified to throw `RuntimeException` when Hazelcast node is trying to connect to itself or if the `Address` is a loopback

@gurbuzali, @jerrinot, @mmedenjak could you guys please have a look?
Thank you 