### PR TITLE
Fix for AbstractListenersOnReconnectTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/ExecutionService.java
@@ -61,11 +61,6 @@ public interface ExecutionService {
     String CLIENT_QUERY_EXECUTOR = "hz:client-query";
 
     /**
-     * Name of the client management executor.
-     */
-    String CLIENT_MANAGEMENT_EXECUTOR = "hz:client-management";
-
-    /**
      * Name of the client transaction executor.
      */
     String CLIENT_BLOCKING_EXECUTOR = "hz:client-blocking-tasks";

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -19,9 +19,9 @@ package com.hazelcast.client.listeners;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.ClientTestUtil;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.spi.impl.listener.ClientConnectionRegistration;
 import com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl;
-import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.cluster.Member;
@@ -29,19 +29,21 @@ import com.hazelcast.cluster.MemberAttributeEvent;
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.MembershipListener;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
-import com.hazelcast.test.AssertTask;
 import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -52,6 +54,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.client.properties.ClientProperty.HEARTBEAT_INTERVAL;
 import static com.hazelcast.client.properties.ClientProperty.HEARTBEAT_TIMEOUT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -75,22 +78,20 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     //-------------------------- testListenersTerminateRandomNode --------------------- //
     @Test
-    public void testListenersNonSmartRoutingTerminateRandomNode() {
-        factory.newInstances(null, 3);
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersTerminateRandomNode();
+    public void testListenersTerminateRandomNode_smart() {
+        testListenersTerminateRandomNode(true);
     }
 
     @Test
-    public void testListenersSmartRoutingTerminateRandomNode() {
-        factory.newInstances(null, 3);
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersTerminateRandomNode();
+    public void testListenersTerminateRandomNode_nonSmart() {
+        testListenersTerminateRandomNode(false);
     }
 
-    private void testListenersTerminateRandomNode() {
+    private void testListenersTerminateRandomNode(boolean isSmartClient) {
+        factory.newInstances(null, 3);
+        ClientConfig clientConfig = createClientConfig(isSmartClient);
+        client = factory.newHazelcastClient(clientConfig);
+
         setupListener();
 
         terminateRandomNode();
@@ -121,46 +122,31 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersTemporaryNetworkBlockage --------------------- //
 
     @Test
-    public void testTemporaryBlockedNoDisconnectionSmartRouting() {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
+    public void testListenersTemporaryNetworkBlockage_smart_singleServer() {
+        testListenersTemporaryNetworkBlockage(true, 1);
     }
 
     @Test
-    public void testTemporaryBlockedNoDisconnectionNonSmartRouting() {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getNonSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
+    public void testListenersTemporaryNetworkBlockage_nonSmart_singleServer() {
+        testListenersTemporaryNetworkBlockage(false, 1);
     }
 
     @Test
-    public void testTemporaryBlockedNoDisconnectionMultipleServerSmartRouting() {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
+    public void testListenersTemporaryNetworkBlockage_smart_multipleServer() {
+        testListenersTemporaryNetworkBlockage(true, 3);
     }
 
     @Test
-    public void testTemporaryBlockedNoDisconnectionMultipleServerNonSmartRouting() {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getNonSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
+    public void testListenersTemporaryNetworkBlockage_nonSmart_multipleServer() {
+        testListenersTemporaryNetworkBlockage(false, 3);
     }
 
-    private void testListenersTemporaryNetworkBlockage() {
+    private void testListenersTemporaryNetworkBlockage(boolean isSmart, int clusterSize) {
+        factory.newInstances(null, clusterSize);
+
+        ClientConfig clientConfig = createClientConfig(isSmart);
+        client = factory.newHazelcastClient(clientConfig);
+
         setupListener();
 
         HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
@@ -185,61 +171,43 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersHeartbeatTimeoutToCluster --------------------- //
 
     @Test
-    public void testClusterReconnectDueToHeartbeatSmartRouting() {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersHeartbeatTimeoutToCluster();
+    public void testListenersHeartbeatTimeoutToCluster_smart_singleServer() {
+        testListenersHeartbeatTimeoutToCluster(true, 1);
     }
 
     @Test
-    public void testClusterReconnectMultipleServersDueToHeartbeatSmartRouting() {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersHeartbeatTimeoutToCluster();
+    public void testListenersHeartbeatTimeoutToCluster_nonSmart_singleServer() {
+        testListenersHeartbeatTimeoutToCluster(false, 1);
     }
 
     @Test
-    public void testClusterReconnectDueToHeartbeatNonSmartRouting() {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getNonSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersHeartbeatTimeoutToCluster();
+    public void testListenersHeartbeatTimeoutToCluster_smart_multipleServer() {
+        testListenersHeartbeatTimeoutToCluster(true, 3);
     }
 
     @Test
-    public void testClusterReconnectMultipleServerDueToHeartbeatNonSmartRouting() {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getNonSmartClientConfigWithHeartbeat();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersHeartbeatTimeoutToCluster();
+    public void testListenersHeartbeatTimeoutToCluster_nonSmart_multipleServer() {
+        testListenersHeartbeatTimeoutToCluster(false, 3);
     }
 
-    private void testListenersHeartbeatTimeoutToCluster() {
-        setupListener();
-
-        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
-        final CountDownLatch connectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
-                    disconnectedLatch.countDown();
-                }
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
-                    connectedLatch.countDown();
-                }
+    private void testListenersHeartbeatTimeoutToCluster(boolean isSmartClient, int nodeCount) {
+        factory.newInstances(null, nodeCount);
+        ClientConfig clientConfig = createClientConfig(isSmartClient);
+        ListenerConfig listenerConfig = new ListenerConfig();
+        CountDownLatch disconnectedLatch = new CountDownLatch(1);
+        CountDownLatch connectedLatch = new CountDownLatch(2);
+        listenerConfig.setImplementation((LifecycleListener) event -> {
+            if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
+                disconnectedLatch.countDown();
+            }
+            if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
+                connectedLatch.countDown();
             }
         });
+        clientConfig.addListenerConfig(listenerConfig);
+        client = factory.newHazelcastClient(clientConfig);
+
+        setupListener();
 
         for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
             blockMessagesFromInstance(instance, client);
@@ -260,61 +228,46 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersTerminateCluster --------------------- //
 
     @Test
-    public void testListenersSmartRoutingMultipleServer() {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersTerminateCluster();
+    public void testListenersTerminateCluster_smart_singleServer() {
+        testListenersTerminateCluster(true, 1);
     }
 
     @Test
-    public void testListenersNonSmartRoutingMultipleServer() {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersTerminateCluster();
+    public void testListenersTerminateCluster_nonSmart_singleServer() {
+        testListenersTerminateCluster(false, 1);
     }
 
     @Test
-    public void testListenersSmartRouting() {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersTerminateCluster();
+    public void testListenersTerminateCluster_smart_multipleServer() {
+        testListenersTerminateCluster(true, 3);
     }
 
     @Test
-    public void testListenersNonSmartRouting() {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTerminateCluster();
+    public void testListenersTerminateCluster_nonSmart_multipleServer() {
+        testListenersTerminateCluster(false, 3);
     }
 
-    private void testListenersTerminateCluster() {
-        setupListener();
+    private void testListenersTerminateCluster(boolean isSmartClient, int clusterSize) {
+        factory.newInstances(null, clusterSize);
 
-        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
-        final CountDownLatch connectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
-                    disconnectedLatch.countDown();
-                }
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
-                    connectedLatch.countDown();
-                }
+        ClientConfig clientConfig = createClientConfig(isSmartClient);
+        ListenerConfig listenerConfig = new ListenerConfig();
+        CountDownLatch disconnectedLatch = new CountDownLatch(1);
+        CountDownLatch connectedLatch = new CountDownLatch(2);
+        listenerConfig.setImplementation((LifecycleListener) event -> {
+            if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
+                disconnectedLatch.countDown();
+            }
+            if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
+                connectedLatch.countDown();
             }
         });
+        clientConfig.addListenerConfig(listenerConfig);
+        client = factory.newHazelcastClient(clientConfig);
+
+        setupListener();
 
         validateRegistrationsOnMembers(factory);
-
 
         for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
             instance.getLifecycleService().terminate();
@@ -346,21 +299,18 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
-                    NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
-                    EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
-                    EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
-                    Member member = instance.getCluster().getLocalMember();
-                    assertNotNull(member.toString(), serviceSegment);
-                    ConcurrentMap registrationIdMap = serviceSegment.getRegistrationIdMap();
-                    assertEquals(member.toString() + " Current registrations:" + registrationIdMap, 1,
-                            registrationIdMap.size());
-                    System.out.println("Current registrations at member " + member.toString() + ": "
-                            + registrationIdMap);
-                }
+        assertTrueEventually(() -> {
+            for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
+                NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
+                EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
+                EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
+                Member member = instance.getCluster().getLocalMember();
+                assertNotNull(member.toString(), serviceSegment);
+                ConcurrentMap registrationIdMap = serviceSegment.getRegistrationIdMap();
+                assertEquals(member.toString() + " Current registrations:" + registrationIdMap, 1,
+                        registrationIdMap.size());
+                ILogger logger = nodeEngineImpl.getLogger(AbstractListenersOnReconnectTest.class);
+                logger.warning("Current registrations at member " + member.toString() + ": " + registrationIdMap);
             }
         });
     }
@@ -371,28 +321,27 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
                                        final HazelcastClientInstanceImpl clientInstanceImpl) {
         final boolean smartRouting = clientInstanceImpl.getClientConfig().getNetworkConfig().isSmartRouting();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                int size = smartRouting ? clusterSize : 1;
-                Map<Connection, ClientConnectionRegistration> registrations = getClientEventRegistrations(client,
-                        registrationId);
-                assertEquals(size, registrations.size());
-                if (smartRouting) {
-                    Collection<Member> members = clientInstanceImpl.getClientClusterService().getMemberList();
-                    for (Connection registeredSubscriber : registrations.keySet()) {
-                        boolean contains = false;
-                        for (Member member : members) {
-                            contains |= registeredSubscriber.getEndPoint().equals(member.getAddress());
-                        }
-                        assertTrue("Registered member " + registeredSubscriber + " is not in the cluster member list " + members,
-                                contains);
+        assertTrueEventually(() -> {
+            int size = smartRouting ? clusterSize : 1;
+            Map<Connection, ClientConnectionRegistration> registrations = getClientEventRegistrations(client,
+                    registrationId);
+            assertEquals(size, registrations.size());
+            if (smartRouting) {
+                Collection<Member> members = clientInstanceImpl.getClientClusterService().getMemberList();
+                for (Connection registeredSubscriber : registrations.keySet()) {
+                    boolean contains = false;
+                    for (Member member : members) {
+                        contains |= registeredSubscriber.getEndPoint().equals(member.getAddress());
                     }
-                } else {
-                    Connection subscriber = registrations.keySet().iterator().next();
-                    assertEquals(clientInstanceImpl.getConnectionManager().getActiveConnections().iterator().next().getEndPoint(),
-                            subscriber.getEndPoint());
+                    assertTrue("Registered member " + registeredSubscriber + " is not in the cluster member list " + members,
+                            contains);
                 }
+            } else {
+                Iterator<Connection> expectedIterator = registrations.keySet().iterator();
+                assertTrue(expectedIterator.hasNext());
+                Iterator<ClientConnection> iterator = clientInstanceImpl.getConnectionManager().getActiveConnections().iterator();
+                assertTrue(iterator.hasNext());
+                assertEquals(iterator.next(), expectedIterator.next());
             }
         });
     }
@@ -410,13 +359,10 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
         assertOpenEventually(eventsLatch);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() {
-                int count = eventCount.get();
-                assertEquals("Received event count is " + count + " but it is expected to stay at " + EVENT_COUNT, EVENT_COUNT,
-                        eventCount.get());
-            }
+        assertTrueAllTheTime(() -> {
+            int count = eventCount.get();
+            assertEquals("Received event count is " + count
+                    + " but it is expected to stay at " + EVENT_COUNT, EVENT_COUNT, count);
         }, 3);
     }
 
@@ -434,31 +380,13 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         return listenerService.getActiveRegistrations(id);
     }
 
-    private ClientConfig getNonSmartClientConfigWithHeartbeat() {
-        ClientConfig clientConfig = getSmartClientConfigWithHeartbeat();
-        clientConfig.getNetworkConfig().setSmartRouting(false);
-        return clientConfig;
-    }
-
-    private ClientConfig getSmartClientConfigWithHeartbeat() {
+    private ClientConfig createClientConfig(boolean isSmart) {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
+        clientConfig.getNetworkConfig().setSmartRouting(isSmart);
         clientConfig.getNetworkConfig().setRedoOperation(true);
-        clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(20)));
-        clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(1)));
-        return clientConfig;
-    }
-
-    private ClientConfig getSmartClientConfig() {
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
-        clientConfig.getNetworkConfig().setRedoOperation(true);
-        return clientConfig;
-    }
-
-    private ClientConfig getNonSmartClientConfig() {
-        ClientConfig clientConfig = getSmartClientConfig();
-        clientConfig.getNetworkConfig().setSmartRouting(false);
+        clientConfig.setProperty(HEARTBEAT_TIMEOUT.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(20)));
+        clientConfig.setProperty(HEARTBEAT_INTERVAL.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(1)));
         return clientConfig;
     }
 


### PR DESCRIPTION
Since CLIENT_CONNECTED event is fired in an executor, the initial
one can be delivered late so that it could be count as `reconnect`,
even though the client is not reconnected yet.

Added the listener in the config to count both initial and second
CONNECTED event to make the test more consistent.

Added `hasNext` check for iterators to make sure eventual assertions
will work correctly.

The log that is added to diagnose the test is converted to Ilogger
to be able to track which test it belongs to.

fixes https://github.com/hazelcast/hazelcast/issues/8254