### PR TITLE
Support for force-init and publish of uninitialized proxies

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -125,6 +125,12 @@ public class ProxyServiceImpl
         return count;
     }
 
+    public void initializeAndPublishProxies() {
+        for (ProxyRegistry registry : registries.values()) {
+            registry.initializeAndPublishProxies();
+        }
+    }
+
     @Override
     public void initializeDistributedObject(String serviceName, String name) {
         checkServiceNameNotNull(serviceName);


### PR DESCRIPTION
Added functionality to ProxyServiceImpl to force-initialize
and publish all uninitialized proxy objects. Remove the proxy
future if proxy initialization failed.

Forward port of https://github.com/hazelcast/hazelcast/pull/15986
Relates to https://github.com/hazelcast/hazelcast-enterprise/issues/3325