### PR TITLE
Support for force-init and publish of uninitialized proxies (take 2)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -126,7 +126,9 @@ public class ProxyServiceImpl
 
     public void initializeAndPublishProxies() {
         for (ProxyRegistry registry : registries.values()) {
-            registry.initializeAndPublishProxies();
+            for (String name : registry.getDistributedObjectNames()) {
+                registry.initializeProxy(name, true);
+            }
         }
     }
 
@@ -243,7 +245,12 @@ public class ProxyServiceImpl
         if (eventPacket.getEventType() == CREATED) {
             try {
                 final ProxyRegistry registry = getOrCreateRegistry(serviceName);
-                if (!registry.contains(eventPacket.getName())) {
+                if (registry.contains(eventPacket.getName())) {
+                    // proxy exists, make sure it is initialized
+                    // listeners will not be called if the proxy is initialized
+                    // here (they were called when the proxy was created)
+                    registry.initializeProxy(eventPacket.getName(), false);
+                } else {
                     registry.createProxy(eventPacket.getName(), false, true);
                     // listeners will be called if proxy is created here.
                 }


### PR DESCRIPTION
Added functionality to ProxyServiceImpl to force-initialize and publish
all uninitialized proxy objects.

This commit also extends ProxyServiceImpl.dispatchEvent()
to initialize the proxy if it exists already but is uninitialized.
The motivation for this change is to deal with a possible
concurrency issue in hazelcast/hazelcast-enterprise#3343:
When we force-initialize map proxies, this may trigger index
creation on other members' partition threads. This triggers
record store creation and - in the case when Hot Restart is
enabled - also creation of uninitialized proxies. If this happens
after those members are done force-initializing their uninitialized
proxies, they end up with uninitialized proxies. As a consequence,
`getDistributedObjects()` will return incorrect results.

Relates to hazelcast/hazelcast-enterprise#3325
Required for hazelcast/hazelcast-enterprise#3343 (EE)