### PR TITLE
Remove providing cache near cache metrics on member

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -55,7 +55,6 @@ import com.hazelcast.internal.util.InvocationUtil;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.internal.util.ServiceLoader;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.nearcache.NearCacheStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -888,20 +887,6 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
                 .withPrefix("cache")
                 .withDiscriminator("name", cacheName);
             context.collect(dsDescriptor, localInstanceStats);
-        }
-
-        // near cache
-        for (Map.Entry<String, CacheStatisticsImpl> entry : statistics.entrySet()) {
-            String cacheName = entry.getKey();
-            CacheStatisticsImpl cacheStatsImpl = entry.getValue();
-            NearCacheStats nearCacheStats = cacheStatsImpl.getNearCacheStatistics();
-            if (nearCacheStats != null) {
-                MetricDescriptor nearCacheDescriptor = descriptor
-                    .copy()
-                    .withPrefix("cache.nearcache")
-                    .withDiscriminator("name", cacheName);
-                context.collect(nearCacheDescriptor, nearCacheStats);
-            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -88,6 +88,7 @@ import static com.hazelcast.cache.impl.AbstractCacheRecordStore.SOURCE_NOT_AVAIL
 import static com.hazelcast.cache.impl.PreJoinCacheConfig.asCacheConfig;
 import static com.hazelcast.config.CacheConfigAccessor.getTenantControl;
 import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
+import static com.hazelcast.internal.metrics.impl.ProviderHelper.provide;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.FutureUtil.RETHROW_EVERYTHING;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
@@ -875,18 +876,6 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
     @Override
     public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
-        Map<String, LocalCacheStats> stats = getStats();
-
-        // cache
-        for (Map.Entry<String, LocalCacheStats> entry : stats.entrySet()) {
-            String cacheName = entry.getKey();
-            LocalCacheStats localInstanceStats = entry.getValue();
-
-            MetricDescriptor dsDescriptor = descriptor
-                .copy()
-                .withPrefix("cache")
-                .withDiscriminator("name", cacheName);
-            context.collect(dsDescriptor, localInstanceStats);
-        }
+        provide(descriptor, context, "cache", getStats());
     }
 }


### PR DESCRIPTION
There is no cache near cache metrics available on the member side.
This change removes the code attempts to provide them.

Some explanation:
`CacheStatisticsImpl.getNearCacheStatistics()` is clear on that it should
never be called. Added the near cache metrics when copied the related
code from the previously existing `StatisticsAwareMetricSet` that had the
following

```
private NearCacheStats getNearCacheStats(LocalInstanceStats localInstanceStats) {
    if (localInstanceStats instanceof LocalMapStatsImpl) {
        LocalMapStats localMapStats = (LocalMapStats) localInstanceStats;
        return localMapStats.getNearCacheStats();
    } else if (localInstanceStats instanceof CacheStatistics) {
        CacheStatistics localMapStats = (CacheStatistics) localInstanceStats;
        return localMapStats.getNearCacheStatistics();
    } else {
        return null;
    }
}
```

Note that the second branch (the `else if`) was always a dead branch for
two reasons:
- `ICacheService` didn't implement `StatisticsAwareService` interface until
recently, so `StatisticsAwareMetricSet` has never seen cache metrics.
- Since it implemented the interface, its `getStats()` returns
`LocalCacheStat` instances, not `CacheStatistics` instances. Therefore, the
branch was not taken again.

Fixes hazelcast/hazelcast-enterprise#3388