### PR TITLE
Preparation for TLS host validation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -592,6 +592,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         }
     }
 
+    @SuppressWarnings("unchecked")
     protected ClientConnection createSocketConnection(Address target) {
         CandidateClusterContext currentClusterContext = discoveryService.current();
         SocketChannel socketChannel = null;
@@ -603,6 +604,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
             ChannelInitializerProvider channelInitializer = currentClusterContext.getChannelInitializerProvider();
             Channel channel = networking.register(null, channelInitializer, socketChannel, true);
+            channel.attributeMap().put(Address.class, target);
             channel.connect(resolveAddress(target), connectionTimeoutMillis);
 
             ClientConnection connection = new ClientConnection(client, connectionIdGen.incrementAndGet(), channel);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnector.java
@@ -163,11 +163,13 @@ class TcpIpConnector {
             }
         }
 
+        @SuppressWarnings("unchecked")
         private void tryToConnect(InetSocketAddress socketAddress, int timeout) throws Exception {
             SocketChannel socketChannel = SocketChannel.open();
 
             TcpIpConnection connection = null;
             Channel channel = endpointManager.newChannel(socketChannel, true);
+            channel.attributeMap().put(Address.class, address);
             try {
                 if (ioService.isSocketBind()) {
                     bindSocket(socketChannel);


### PR DESCRIPTION
Put peer's `Address` to the channel attribute map. To make it available for host identifier checks.