### PR TITLE
Prevent unneeded map-loading related operation propagation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -785,7 +785,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         Data key = mergingEntry.getKey();
         Record record = getRecordOrNull(key, now, false);
         Object newValue;
-        Object oldValue = null;
+        Object oldValue;
         if (record == null) {
             newValue = mergePolicy.merge(mergingEntry, null);
             if (newValue == null) {


### PR DESCRIPTION
This PR addresses found issue while working on https://github.com/hazelcast/hazelcast-enterprise/issues/859

- No point to start key loading process when there is no key to load. Hence it causes propagation of `KeyLoadStatusOperation` and `TriggerLoadIfNeededOperation` operations.