### PR TITLE
Use smallInstanceConfig() in SlowOperationDetectorAbstractTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -51,7 +51,7 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
     private List<SlowEntryProcessor> entryProcessors = new ArrayList<>();
 
     HazelcastInstance getSingleNodeCluster(int slowOperationThresholdMillis) {
-        Config config = new Config();
+        Config config = smallInstanceConfig();
         config.setProperty(ClusterProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(),
                 valueOf(slowOperationThresholdMillis));
 


### PR DESCRIPTION
Minimize resources consumption by the test to reduce slow environment issues.

Closes https://github.com/hazelcast/hazelcast/issues/16108