### PR TITLE
Fixes the Map.Entry serializer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.serialization.StreamSerializer;
 
 import java.io.IOException;
 import java.util.AbstractMap;
-import java.util.Map;
 import java.util.UUID;
 
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_BOOLEAN;
@@ -34,7 +33,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.C
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_CHAR_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DOUBLE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DOUBLE_ARRAY;
-import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_ENTRY;
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SIMPLE_ENTRY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_FLOAT;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_FLOAT_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_INTEGER;
@@ -44,6 +43,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.C
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_NULL;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SHORT;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SHORT_ARRAY;
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SIMPLE_IMMUTABLE_ENTRY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_STRING;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_STRING_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_UUID;
@@ -414,20 +414,39 @@ public final class ConstantSerializers {
         }
     }
 
-    public static final class EntrySerializer extends SingletonSerializer<Map.Entry> {
+    public static final class SimpleEntrySerializer extends SingletonSerializer<AbstractMap.SimpleEntry> {
 
         @Override
         public int getTypeId() {
-            return CONSTANT_TYPE_ENTRY;
+            return CONSTANT_TYPE_SIMPLE_ENTRY;
         }
 
         @Override
-        public Map.Entry read(final ObjectDataInput in) throws IOException {
+        public AbstractMap.SimpleEntry read(final ObjectDataInput in) throws IOException {
             return new AbstractMap.SimpleEntry(in.readObject(), in.readObject());
         }
 
         @Override
-        public void write(final ObjectDataOutput out, final Map.Entry entry) throws IOException {
+        public void write(final ObjectDataOutput out, final AbstractMap.SimpleEntry entry) throws IOException {
+            out.writeObject(entry.getKey());
+            out.writeObject(entry.getValue());
+        }
+    }
+
+    public static final class SimpleImmutableEntrySerializer extends SingletonSerializer<AbstractMap.SimpleImmutableEntry> {
+
+        @Override
+        public int getTypeId() {
+            return CONSTANT_TYPE_SIMPLE_IMMUTABLE_ENTRY;
+        }
+
+        @Override
+        public AbstractMap.SimpleImmutableEntry read(final ObjectDataInput in) throws IOException {
+            return new AbstractMap.SimpleImmutableEntry(in.readObject(), in.readObject());
+        }
+
+        @Override
+        public void write(final ObjectDataOutput out, final AbstractMap.SimpleImmutableEntry entry) throws IOException {
             out.writeObject(entry.getKey());
             out.writeObject(entry.getValue());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -65,68 +65,70 @@ public final class SerializationConstants {
 
     public static final int CONSTANT_TYPE_UUID = -21;
 
-    public static final int CONSTANT_TYPE_ENTRY = -22;
+    public static final int CONSTANT_TYPE_SIMPLE_ENTRY = -22;
+
+    public static final int CONSTANT_TYPE_SIMPLE_IMMUTABLE_ENTRY = -23;
 
     // ------------------------------------------------------------
     // DEFAULT SERIALIZERS
 
-    public static final int JAVA_DEFAULT_TYPE_CLASS = -23;
+    public static final int JAVA_DEFAULT_TYPE_CLASS = -24;
 
-    public static final int JAVA_DEFAULT_TYPE_DATE = -24;
+    public static final int JAVA_DEFAULT_TYPE_DATE = -25;
 
-    public static final int JAVA_DEFAULT_TYPE_BIG_INTEGER = -25;
+    public static final int JAVA_DEFAULT_TYPE_BIG_INTEGER = -26;
 
-    public static final int JAVA_DEFAULT_TYPE_BIG_DECIMAL = -26;
+    public static final int JAVA_DEFAULT_TYPE_BIG_DECIMAL = -27;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY = -27;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY = -28;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_LIST = -28;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_LIST = -29;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -29;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_LIST = -30;
 
-    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_LIST = -30;
-
-
-    public static final int JAVA_DEFAULT_TYPE_HASH_MAP = -31;
-
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_MAP = -32;
-
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_HASH_MAP = -33;
-
-    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_MAP = -34;
-
-    public static final int JAVA_DEFAULT_TYPE_TREE_MAP = -35;
+    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_LIST = -31;
 
 
-    public static final int JAVA_DEFAULT_TYPE_HASH_SET = -36;
+    public static final int JAVA_DEFAULT_TYPE_HASH_MAP = -32;
 
-    public static final int JAVA_DEFAULT_TYPE_TREE_SET = -37;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_MAP = -33;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_SET = -38;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_HASH_MAP = -34;
 
-    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_SET = -39;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_MAP = -35;
 
-    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_SET = -40;
+    public static final int JAVA_DEFAULT_TYPE_TREE_MAP = -36;
 
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_DEQUE = -41;
+    public static final int JAVA_DEFAULT_TYPE_HASH_SET = -37;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_BLOCKING_QUEUE = -42;
+    public static final int JAVA_DEFAULT_TYPE_TREE_SET = -38;
 
-    public static final int JAVA_DEFAULT_TYPE_ARRAY_BLOCKING_QUEUE = -43;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_HASH_SET = -39;
 
-    public static final int JAVA_DEFAULT_TYPE_PRIORITY_BLOCKING_QUEUE = -44;
+    public static final int JAVA_DEFAULT_TYPE_COPY_ON_WRITE_ARRAY_SET = -40;
 
-    public static final int JAVA_DEFAULT_TYPE_DELAY_QUEUE = -45;
+    public static final int JAVA_DEFAULT_TYPE_CONCURRENT_SKIP_LIST_SET = -41;
 
-    public static final int JAVA_DEFAULT_TYPE_SYNCHRONOUS_QUEUE = -46;
 
-    public static final int JAVA_DEFAULT_TYPE_LINKED_TRANSFER_QUEUE = -47;
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_DEQUE = -42;
 
-    public static final int JAVA_DEFAULT_TYPE_PRIORITY_QUEUE = -48;
+    public static final int JAVA_DEFAULT_TYPE_LINKED_BLOCKING_QUEUE = -43;
+
+    public static final int JAVA_DEFAULT_TYPE_ARRAY_BLOCKING_QUEUE = -44;
+
+    public static final int JAVA_DEFAULT_TYPE_PRIORITY_BLOCKING_QUEUE = -45;
+
+    public static final int JAVA_DEFAULT_TYPE_DELAY_QUEUE = -46;
+
+    public static final int JAVA_DEFAULT_TYPE_SYNCHRONOUS_QUEUE = -47;
+
+    public static final int JAVA_DEFAULT_TYPE_LINKED_TRANSFER_QUEUE = -48;
+
+    public static final int JAVA_DEFAULT_TYPE_PRIORITY_QUEUE = -49;
 
     // NUMBER OF CONSTANT SERIALIZERS...
-    public static final int CONSTANT_SERIALIZERS_LENGTH = 49;
+    public static final int CONSTANT_SERIALIZERS_LENGTH = 50;
 
     public static final int JAVA_DEFAULT_TYPE_ENUM = -50;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,7 +87,7 @@ import static com.hazelcast.internal.serialization.impl.ConstantSerializers.Shor
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.StringSerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.TheByteArraySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.UuidSerializer;
-import static com.hazelcast.internal.serialization.impl.ConstantSerializers.EntrySerializer;
+import static com.hazelcast.internal.serialization.impl.ConstantSerializers.SimpleEntrySerializer;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.EE_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.IDS_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.isFlagSet;
@@ -179,7 +180,8 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         registerConstant(Double.class, new DoubleSerializer());
         registerConstant(String.class, new StringSerializer());
         registerConstant(UUID.class, new UuidSerializer());
-        registerConstant(Map.Entry.class, new EntrySerializer());
+        registerConstant(AbstractMap.SimpleEntry.class, new SimpleEntrySerializer());
+        registerConstant(AbstractMap.SimpleImmutableEntry.class, new ConstantSerializers.SimpleImmutableEntrySerializer());
         //Arrays of primitives and String
         registerConstant(byte[].class, new TheByteArraySerializer());
         registerConstant(boolean[].class, new BooleanArraySerializer());

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.CharBuffer;
+import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -126,6 +127,10 @@ class ReferenceObjects {
     static CustomByteArraySerializable aCustomByteArraySerializable = new CustomByteArraySerializable(anInt, aFloat);
     static Portable[] portables = {anInnerPortable, anInnerPortable, anInnerPortable};
 
+    static AbstractMap.SimpleEntry aSimpleMapEntry = new AbstractMap.SimpleEntry(aString, anInnerPortable);
+    static AbstractMap.SimpleImmutableEntry aSimpleImmutableMapEntry = new AbstractMap.SimpleImmutableEntry(aString,
+            anInnerPortable);
+
     static AnIdentifiedDataSerializable anIdentifiedDataSerializable = new AnIdentifiedDataSerializable(
             aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString,
             booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
@@ -164,7 +169,7 @@ class ReferenceObjects {
             booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
             aCustomStreamSerializable, aCustomByteArraySerializable,
             anIdentifiedDataSerializable, aPortable,
-            aDate, aBigInteger, aBigDecimal, aClass, anEnum,
+            aDate, aBigInteger, aBigDecimal, aClass, anEnum, aSimpleMapEntry, aSimpleImmutableMapEntry,
             serializable, externalizable));
 
     static ArrayList arrayList = new ArrayList(asList(aNullObject, nonNullList));
@@ -214,7 +219,7 @@ class ReferenceObjects {
 
     static Object[] allTestObjects = {
             aNullObject, aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString, aUUID, anInnerPortable,
-            booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
+            aSimpleMapEntry, aSimpleImmutableMapEntry, booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
             aCustomStreamSerializable, aCustomByteArraySerializable,
             anIdentifiedDataSerializable, aPortable,
             aDate, aBigInteger, aBigDecimal, aClass, anEnum,


### PR DESCRIPTION
Fixed the entry serializer. Replaced it with two concrete Map.Entry implementations, the `AbstractMap.SimpleEntry` and `AbstractMap.SimpleImmutableEntry`. Also updated the binary serialization tests to include these two types.

related to issue https://github.com/hazelcast/hazelcast/issues/15179