### PR TITLE
Ensure record store adapter runs in partition threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
@@ -88,7 +88,7 @@ public class PartitionScanRunner {
         Map.Entry<Integer, Map.Entry> nearestAnchorEntry =
                 pagingPredicate == null ? null : pagingPredicate.getNearestAnchorEntry();
 
-        recordStore.loadAwareIterator(new BiConsumer<Data, Record>() {
+        recordStore.forEachAfterLoad(new BiConsumer<Data, Record>() {
             LazyMapEntry queryEntry = new LazyMapEntry();
 
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
@@ -29,7 +30,6 @@ import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.OperationService;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.Collection;
 
@@ -208,7 +208,7 @@ public class QueryRunner {
 
     protected Result populateEmptyResult(Query query, Collection<Integer> initialPartitions) {
         return resultProcessorRegistry.get(query.getResultType())
-                                      .populateResult(query, queryResultSizeLimiter.getNodeResultLimit(initialPartitions.size()));
+                .populateResult(query, queryResultSizeLimiter.getNodeResultLimit(initialPartitions.size()));
     }
 
     protected Result populateNonEmptyResult(Query query, Collection<QueryableEntry> entries,
@@ -254,8 +254,8 @@ public class QueryRunner {
         return null;
     }
 
-    protected Result runUsingPartitionScanSafely(Query query, Predicate predicate, PartitionIdSet partitions,
-                                                 int migrationStamp) {
+    protected Result runUsingPartitionScanSafely(Query query, Predicate predicate,
+                                                 PartitionIdSet partitions, int migrationStamp) {
 
         if (!validateMigrationStamp(migrationStamp)) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -235,7 +235,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public void loadAwareIterator(BiConsumer<Data, Record> consumer, boolean backup) {
+    public void forEachAfterLoad(BiConsumer<Data, Record> consumer, boolean backup) {
         checkIfLoaded();
         forEach(consumer, backup);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -300,7 +300,7 @@ public interface RecordStore<R extends Record> {
      * @param consumer to inject logic @param backup   <code>true</code>
      *                 if a backup partition, otherwise <code>false</code>.
      */
-    void loadAwareIterator(BiConsumer<Data, R> consumer, boolean backup);
+    void forEachAfterLoad(BiConsumer<Data, R> consumer, boolean backup);
 
     /**
      * Fetches specified number of keys from provided tableIndex.


### PR DESCRIPTION
Changes:
- renamed loadAwareIterator method to have consisting naming with other similar ones
- added checks for record store adapter to ensure methods run in partition threads. If it is run in another thread visibility issues can be seen for HD memory.
- freed HD memory of evicted record by disposing it.