### PR TITLE
Fix unneeded iterations and object creation on bulk client responses

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -525,16 +525,11 @@ public class ClientCacheProxy<K, V> extends ClientCacheProxySupport<K, V>
         }
 
         int keysSize = keys.size();
-        List<Data> dataKeys = new LinkedList<Data>();
-        List<Object> resultingKeyValuePairs = new ArrayList<Object>(keysSize * 2);
-        getAllInternal(keys, dataKeys, expiryPolicy, resultingKeyValuePairs, startNanos);
-
+        List<Data> dataKeys = new LinkedList<>();
         Map<K, V> result = createHashMap(keysSize);
-        for (int i = 0; i < resultingKeyValuePairs.size(); ) {
-            K key = toObject(resultingKeyValuePairs.get(i++));
-            V value = toObject(resultingKeyValuePairs.get(i++));
-            result.put(key, value);
-        }
+        getAllInternal(keys, dataKeys, expiryPolicy, result, startNanos, (key, value) -> {
+            result.put(toObject(key), toObject(value));
+        });
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -529,8 +529,10 @@ public class ClientCacheProxy<K, V> extends ClientCacheProxySupport<K, V>
         int keysSize = keys.size();
         List<Data> dataKeys = new LinkedList<>();
         Map<K, V> result = createHashMap(keysSize);
-        getAllInternal(keys, dataKeys, expiryPolicy, result, startNanos, (key, value) -> {
-            result.put(toObject(key), toObject(value));
+        getAllInternal(keys, dataKeys, expiryPolicy, result, startNanos, (keyData, valueData) -> {
+            K key = toObject(keyData);
+            V value = toObject(valueData);
+            result.put(key, value);
         });
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -101,9 +101,11 @@ public class ClientCacheProxy<K, V> extends ClientCacheProxySupport<K, V>
     protected void onInitialize() {
         super.onInitialize();
         eventJournalReadResponseDecoder = message -> {
-            final CacheEventJournalReadCodec.ResponseParameters params = CacheEventJournalReadCodec.decodeResponse(message);
+            List<Data> items = new ArrayList<>();
+            final CacheEventJournalReadCodec.ResponseParameters params
+                    = CacheEventJournalReadCodec.decodeResponse(message, items::add);
             final ReadResultSetImpl resultSet = new ReadResultSetImpl<>(
-                    params.readCount, params.items, params.itemSeqs, params.nextSeq);
+                    params.readCount, items, params.itemSeqs, params.nextSeq);
             resultSet.setSerializationService(getSerializationService());
             return resultSet;
         };

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -95,9 +95,11 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, name, partitionIndex);
                 ClientInvocationFuture future = clientInvocation.invoke();
-                CacheIterateCodec.ResponseParameters responseParameters = CacheIterateCodec.decodeResponse(future.get());
-                setLastTableIndex(responseParameters.keys, responseParameters.tableIndex);
-                return responseParameters.keys;
+                List<Data> keys = new ArrayList<>();
+                CacheIterateCodec.ResponseParameters responseParameters
+                        = CacheIterateCodec.decodeResponse(future.get(), keys::add);
+                setLastTableIndex(keys, responseParameters.tableIndex);
+                return keys;
             } catch (Exception e) {
                 throw rethrow(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -81,8 +81,8 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
                 ClientInvocationFuture future = clientInvocation.invoke();
                 List result = new ArrayList();
                 CacheIterateEntriesCodec.ResponseParameters responseParameters = CacheIterateEntriesCodec.decodeResponse(
-                        future.get(), (key, value) -> {
-                            result.add(new AbstractMap.SimpleEntry<>(key, value));
+                        future.get(), (keyData, valueData) -> {
+                            result.add(new AbstractMap.SimpleEntry<>(keyData, valueData));
                         });
                 setLastTableIndex(result, responseParameters.tableIndex);
                 return result;

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -31,7 +31,6 @@ import javax.cache.Cache;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -28,7 +28,10 @@ import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.internal.serialization.Data;
 
 import javax.cache.Cache;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
@@ -77,10 +80,13 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, name, partitionIndex);
                 ClientInvocationFuture future = clientInvocation.invoke();
+                List result = new ArrayList();
                 CacheIterateEntriesCodec.ResponseParameters responseParameters = CacheIterateEntriesCodec.decodeResponse(
-                        future.get());
-                setLastTableIndex(responseParameters.entries, responseParameters.tableIndex);
-                return responseParameters.entries;
+                        future.get(), (key, value) -> {
+                            result.add(new AbstractMap.SimpleEntry<>(key, value));
+                        });
+                setLastTableIndex(result, responseParameters.tableIndex);
+                return result;
             } catch (Exception e) {
                 throw rethrow(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("eecf3edd946e53710cfdd858c09120bb")
+@Generated("907312a27e772de2aa4e3b1f4adfe6b5")
 public final class CacheEventJournalReadCodec {
     //hex: 0x132100
     public static final int REQUEST_MESSAGE_TYPE = 1253632;
@@ -134,11 +134,6 @@ public final class CacheEventJournalReadCodec {
         /**
          * TODO DOC
          */
-        public java.util.List<com.hazelcast.internal.serialization.Data> items;
-
-        /**
-         * TODO DOC
-         */
         public @Nullable long[] itemSeqs;
 
         /**
@@ -160,13 +155,13 @@ public final class CacheEventJournalReadCodec {
         return clientMessage;
     }
 
-    public static CacheEventJournalReadCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static CacheEventJournalReadCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> itemsConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.readCount = decodeInt(initialFrame.content, RESPONSE_READ_COUNT_FIELD_OFFSET);
         response.nextSeq = decodeLong(initialFrame.content, RESPONSE_NEXT_SEQ_FIELD_OFFSET);
-        response.items = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, itemsConsumer);
         response.itemSeqs = CodecUtil.decodeNullable(iterator, LongArrayCodec::decode);
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * configured javax.cache.integration.CacheLoader might be called to retrieve the values of the keys from any kind
  * of external resource.
  */
-@Generated("32d5f111176a266fb5d9fada189b90b8")
+@Generated("7415d38c4479e4ea457eda2e6bc54f0c")
 public final class CacheGetAllCodec {
     //hex: 0x130900
     public static final int REQUEST_MESSAGE_TYPE = 1247488;
@@ -97,12 +97,6 @@ public final class CacheGetAllCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * A map of entries that were found for the given keys. Keys not found
-         * in the cache are not in the returned map.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -115,12 +109,12 @@ public final class CacheGetAllCodec {
         return clientMessage;
     }
 
-    public static CacheGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static CacheGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * CacheEntryRemoveListeners notified. java.util.Iterator#next() may return null if the entry is no longer present,
  * has expired or has been evicted.
  */
-@Generated("82951d7d3cf7e210da2d2635c04517c9")
+@Generated("3572c87ee19b21beb8f438f6fb8dc4df")
 public final class CacheIterateCodec {
     //hex: 0x130E00
     public static final int REQUEST_MESSAGE_TYPE = 1248768;
@@ -103,11 +103,6 @@ public final class CacheIterateCodec {
          * The slot number (or index) to start the iterator
          */
         public int tableIndex;
-
-        /**
-         * TODO DOC
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> keys;
     }
 
     public static ClientMessage encodeResponse(int tableIndex, java.util.Collection<com.hazelcast.internal.serialization.Data> keys) {
@@ -121,12 +116,12 @@ public final class CacheIterateCodec {
         return clientMessage;
     }
 
-    public static CacheIterateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static CacheIterateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> keysConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.tableIndex = decodeInt(initialFrame.content, RESPONSE_TABLE_INDEX_FIELD_OFFSET);
-        response.keys = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, keysConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateEntriesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateEntriesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of entries from the specified partition starting from specified table index.
  */
-@Generated("1609ce3c9a290f199b3a1b72931ff05d")
+@Generated("84d0b0f8a3e769f145304e7ff2b55082")
 public final class CacheIterateEntriesCodec {
     //hex: 0x131C00
     public static final int REQUEST_MESSAGE_TYPE = 1252352;
@@ -100,11 +100,6 @@ public final class CacheIterateEntriesCodec {
          * The slot number (or index) to start the iterator
          */
         public int tableIndex;
-
-        /**
-         * TODO DOC
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries;
     }
 
     public static ClientMessage encodeResponse(int tableIndex, java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries) {
@@ -118,12 +113,12 @@ public final class CacheIterateEntriesCodec {
         return clientMessage;
     }
 
-    public static CacheIterateEntriesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static CacheIterateEntriesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> entriesBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.tableIndex = decodeInt(initialFrame.content, RESPONSE_TABLE_INDEX_FIELD_OFFSET);
-        response.entries = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, entriesBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("dd8958f1c8c6b89060131c7977d747d6")
+@Generated("f10d550551ef4d98a7413e11b12859c0")
 public final class ContinuousQueryPublisherCreateCodec {
     //hex: 0x160200
     public static final int REQUEST_MESSAGE_TYPE = 1442304;
@@ -133,11 +133,6 @@ public final class ContinuousQueryPublisherCreateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * Array of keys.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -150,12 +145,12 @@ public final class ContinuousQueryPublisherCreateCodec {
         return clientMessage;
     }
 
-    public static ContinuousQueryPublisherCreateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ContinuousQueryPublisherCreateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("091c253e73378fb0f841c13563ff5851")
+@Generated("3a26a868a896dd9c3e6a430425f6e5ad")
 public final class ContinuousQueryPublisherCreateWithValueCodec {
     //hex: 0x160100
     public static final int REQUEST_MESSAGE_TYPE = 1442048;
@@ -133,11 +133,6 @@ public final class ContinuousQueryPublisherCreateWithValueCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * Array of key-value pairs.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -150,12 +145,12 @@ public final class ContinuousQueryPublisherCreateWithValueCodec {
         return clientMessage;
     }
 
-    public static ContinuousQueryPublisherCreateWithValueCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ContinuousQueryPublisherCreateWithValueCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListGetAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return the all elements of this collection
  */
-@Generated("088fb0119293cb1fb1964ac433024a50")
+@Generated("8505df216c38a626134d868436b65cf4")
 public final class ListGetAllCodec {
     //hex: 0x050A00
     public static final int REQUEST_MESSAGE_TYPE = 330240;
@@ -79,11 +79,6 @@ public final class ListGetAllCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * An array of all item values in the list.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -96,12 +91,12 @@ public final class ListGetAllCodec {
         return clientMessage;
     }
 
-    public static ListGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ListGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIteratorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIteratorCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns an iterator over the elements in this list in proper sequence.
  */
-@Generated("4d031395eb408af261146c3194195045")
+@Generated("0b11398c2ea535ed23f03a9ab7de0d43")
 public final class ListIteratorCodec {
     //hex: 0x051600
     public static final int REQUEST_MESSAGE_TYPE = 333312;
@@ -79,11 +79,6 @@ public final class ListIteratorCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * An iterator over the elements in this list in proper sequence
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -96,12 +91,12 @@ public final class ListIteratorCodec {
         return clientMessage;
     }
 
-    public static ListIteratorCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ListIteratorCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListListIteratorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListListIteratorCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * ListIterator#next next. An initial call to ListIterator#previous previous would return the element with the
  * specified index minus one.
  */
-@Generated("15e5eeede0859571d9d5f75ddae7e480")
+@Generated("a4707aa3ae5f626d06e54b2b8ff899d0")
 public final class ListListIteratorCodec {
     //hex: 0x051700
     public static final int REQUEST_MESSAGE_TYPE = 333568;
@@ -89,12 +89,6 @@ public final class ListListIteratorCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * a list iterator over the elements in this list (in proper
-         * sequence), starting at the specified position in the list
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -107,12 +101,12 @@ public final class ListListIteratorCodec {
         return clientMessage;
     }
 
-    public static ListListIteratorCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ListListIteratorCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSubCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSubCodec.java
@@ -46,7 +46,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * structurally modified in any way other than via the returned list.(Structural modifications are those that change
  * the size of this list, or otherwise perturb it in such a fashion that iterations in progress may yield incorrect results.)
  */
-@Generated("ec62ddf76355012ac7c87f62f90e6794")
+@Generated("b06fb093c37ef4440c883c48d3846f19")
 public final class ListSubCodec {
     //hex: 0x051500
     public static final int REQUEST_MESSAGE_TYPE = 333056;
@@ -104,11 +104,6 @@ public final class ListSubCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * A view of the specified range within this list
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -121,12 +116,12 @@ public final class ListSubCodec {
         return clientMessage;
     }
 
-    public static ListSubCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ListSubCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("afed730a18957fc8c91177020067f87a")
+@Generated("43613089b289ebf9fbde585c54f03125")
 public final class MapEntriesWithPagingPredicateCodec {
     //hex: 0x013600
     public static final int REQUEST_MESSAGE_TYPE = 79360;
@@ -86,11 +86,6 @@ public final class MapEntriesWithPagingPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * key-value pairs for the query.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -103,12 +98,12 @@ public final class MapEntriesWithPagingPredicateCodec {
         return clientMessage;
     }
 
-    public static MapEntriesWithPagingPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapEntriesWithPagingPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("b659ca4150882da79b81820d07c7936b")
+@Generated("91f2ee3edb719dc94766e0c5907b4559")
 public final class MapEntriesWithPredicateCodec {
     //hex: 0x012800
     public static final int REQUEST_MESSAGE_TYPE = 75776;
@@ -89,11 +89,6 @@ public final class MapEntriesWithPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * result key-value entry collection of the query.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -106,12 +101,12 @@ public final class MapEntriesWithPredicateCodec {
         return clientMessage;
     }
 
-    public static MapEntriesWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapEntriesWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntrySetCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
  * if query result size limit is configured.
  */
-@Generated("2bf0932dfb05cf730c00bb9a42452203")
+@Generated("6739c12dd9002b36059261e7f12af37f")
 public final class MapEntrySetCodec {
     //hex: 0x012500
     public static final int REQUEST_MESSAGE_TYPE = 75008;
@@ -82,11 +82,6 @@ public final class MapEntrySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * a set clone of the keys mappings in this map
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -99,12 +94,12 @@ public final class MapEntrySetCodec {
         return clientMessage;
     }
 
-    public static MapEntrySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapEntrySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("343e247a8cf3940e85e24f3ece5a870f")
+@Generated("81dda55b61887e09c91ac08d52fb9b67")
 public final class MapEventJournalReadCodec {
     //hex: 0x014400
     public static final int REQUEST_MESSAGE_TYPE = 82944;
@@ -134,11 +134,6 @@ public final class MapEventJournalReadCodec {
         /**
          * TODO DOC
          */
-        public java.util.List<com.hazelcast.internal.serialization.Data> items;
-
-        /**
-         * TODO DOC
-         */
         public @Nullable long[] itemSeqs;
 
         /**
@@ -160,13 +155,13 @@ public final class MapEventJournalReadCodec {
         return clientMessage;
     }
 
-    public static MapEventJournalReadCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapEventJournalReadCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> itemsConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.readCount = decodeInt(initialFrame.content, RESPONSE_READ_COUNT_FIELD_OFFSET);
         response.nextSeq = decodeLong(initialFrame.content, RESPONSE_NEXT_SEQ_FIELD_OFFSET);
-        response.items = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, itemsConsumer);
         response.itemSeqs = CodecUtil.decodeNullable(iterator, LongArrayCodec::decode);
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
  */
-@Generated("b9e390ae3dff2eaff42ee391608a49b3")
+@Generated("10e257367c4c8d1a534c77b9fcbfd1a4")
 public final class MapExecuteOnAllKeysCodec {
     //hex: 0x013000
     public static final int REQUEST_MESSAGE_TYPE = 77824;
@@ -86,11 +86,6 @@ public final class MapExecuteOnAllKeysCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * results of entry process on the entries
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -103,12 +98,12 @@ public final class MapExecuteOnAllKeysCodec {
         return clientMessage;
     }
 
-    public static MapExecuteOnAllKeysCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapExecuteOnAllKeysCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
  * each key in the collection.
  */
-@Generated("3b0acabecfcd040ffabf046b51c28c68")
+@Generated("23db56e7a887b7437982c07a1a638ee6")
 public final class MapExecuteOnKeysCodec {
     //hex: 0x013200
     public static final int REQUEST_MESSAGE_TYPE = 78336;
@@ -94,11 +94,6 @@ public final class MapExecuteOnKeysCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * results of entry process on the entries with the provided keys
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -111,12 +106,12 @@ public final class MapExecuteOnKeysCodec {
         return clientMessage;
     }
 
-    public static MapExecuteOnKeysCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapExecuteOnKeysCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
  * Returns the results mapped by each key in the map.
  */
-@Generated("df9fcb93f23f454b6b7275857e66a048")
+@Generated("44eac82aac7d269fcdf490bbf0942949")
 public final class MapExecuteWithPredicateCodec {
     //hex: 0x013100
     public static final int REQUEST_MESSAGE_TYPE = 78080;
@@ -94,11 +94,6 @@ public final class MapExecuteWithPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * results of entry process on the entries matching the query criteria
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -111,12 +106,12 @@ public final class MapExecuteWithPredicateCodec {
         return clientMessage;
     }
 
-    public static MapExecuteWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapExecuteWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchEntriesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchEntriesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of entries from the specified partition starting from specified table index.
  */
-@Generated("705da8ffb9be61d0e2f007e9266709c5")
+@Generated("fb728f24015ff00402cf5a67efd65607")
 public final class MapFetchEntriesCodec {
     //hex: 0x013900
     public static final int REQUEST_MESSAGE_TYPE = 80128;
@@ -100,11 +100,6 @@ public final class MapFetchEntriesCodec {
          * The slot number (or index) to start the iterator
          */
         public int tableIndex;
-
-        /**
-         * TODO DOC
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries;
     }
 
     public static ClientMessage encodeResponse(int tableIndex, java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries) {
@@ -118,12 +113,12 @@ public final class MapFetchEntriesCodec {
         return clientMessage;
     }
 
-    public static MapFetchEntriesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapFetchEntriesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> entriesBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.tableIndex = decodeInt(initialFrame.content, RESPONSE_TABLE_INDEX_FIELD_OFFSET);
-        response.entries = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, entriesBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchKeysCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of keys from the specified partition starting from specified table index.
  */
-@Generated("43fd6949f3fbfd20c3635d3d5884b5a5")
+@Generated("9fbbd7bfd0dafd9db91437534e4416d2")
 public final class MapFetchKeysCodec {
     //hex: 0x013800
     public static final int REQUEST_MESSAGE_TYPE = 79872;
@@ -100,11 +100,6 @@ public final class MapFetchKeysCodec {
          * The slot number (or index) to start the iterator
          */
         public int tableIndex;
-
-        /**
-         * TODO DOC
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> keys;
     }
 
     public static ClientMessage encodeResponse(int tableIndex, java.util.Collection<com.hazelcast.internal.serialization.Data> keys) {
@@ -118,12 +113,12 @@ public final class MapFetchKeysCodec {
         return clientMessage;
     }
 
-    public static MapFetchKeysCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapFetchKeysCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> keysConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.tableIndex = decodeInt(initialFrame.content, RESPONSE_TABLE_INDEX_FIELD_OFFSET);
-        response.keys = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, keysConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("b4a045fac3c9252c6483540e8f1ad70d")
+@Generated("e856b4543fa50e5ce20ffc88826a999a")
 public final class MapGetAllCodec {
     //hex: 0x012300
     public static final int REQUEST_MESSAGE_TYPE = 74496;
@@ -90,11 +90,6 @@ public final class MapGetAllCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * values for the provided keys.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -107,12 +102,12 @@ public final class MapGetAllCodec {
         return clientMessage;
     }
 
-    public static MapGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
  * throw a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("c2783069e2f36cdf9823169184e2e833")
+@Generated("dbd3bf983e9f71cea8d260f8a7d56026")
 public final class MapKeySetCodec {
     //hex: 0x012200
     public static final int REQUEST_MESSAGE_TYPE = 74240;
@@ -81,11 +81,6 @@ public final class MapKeySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * a set clone of the keys contained in this map.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -98,12 +93,12 @@ public final class MapKeySetCodec {
         return clientMessage;
     }
 
-    public static MapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("fbe27536230b58008220c95a8d6d9f3a")
+@Generated("9a94507acad7a7149e4916049c20aecc")
 public final class MapKeySetWithPagingPredicateCodec {
     //hex: 0x013400
     public static final int REQUEST_MESSAGE_TYPE = 78848;
@@ -86,11 +86,6 @@ public final class MapKeySetWithPagingPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * result keys for the query.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -103,12 +98,12 @@ public final class MapKeySetWithPagingPredicateCodec {
         return clientMessage;
     }
 
-    public static MapKeySetWithPagingPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapKeySetWithPagingPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("e5707a0db71b3eb09724b08a500a2d2b")
+@Generated("7331897ca28c25900f8c27f53b26e4da")
 public final class MapKeySetWithPredicateCodec {
     //hex: 0x012600
     public static final int REQUEST_MESSAGE_TYPE = 75264;
@@ -89,11 +89,6 @@ public final class MapKeySetWithPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * result key set for the query.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -106,12 +101,12 @@ public final class MapKeySetWithPredicateCodec {
         return clientMessage;
     }
 
-    public static MapKeySetWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapKeySetWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
  * if query result size limit is configured.
  */
-@Generated("a04f8d5d12949cb4c359e9185b723d5f")
+@Generated("d785ebee0f155ed894c3e63e92edd3ac")
 public final class MapValuesCodec {
     //hex: 0x012400
     public static final int REQUEST_MESSAGE_TYPE = 74752;
@@ -82,11 +82,6 @@ public final class MapValuesCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * All values in the map
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -99,12 +94,12 @@ public final class MapValuesCodec {
         return clientMessage;
     }
 
-    public static MapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("0d62f70c18edef3a464d038bcb8056ab")
+@Generated("c88cd467f41b38037ca5ae48823193f2")
 public final class MapValuesWithPagingPredicateCodec {
     //hex: 0x013500
     public static final int REQUEST_MESSAGE_TYPE = 79104;
@@ -89,11 +89,6 @@ public final class MapValuesWithPagingPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * values for the query.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -106,12 +101,12 @@ public final class MapValuesWithPagingPredicateCodec {
         return clientMessage;
     }
 
-    public static MapValuesWithPagingPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapValuesWithPagingPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("0c1611d97cf0296b0a0a404ba292e106")
+@Generated("1304893935cbee4ef227a32c5ea431a2")
 public final class MapValuesWithPredicateCodec {
     //hex: 0x012700
     public static final int REQUEST_MESSAGE_TYPE = 75520;
@@ -89,11 +89,6 @@ public final class MapValuesWithPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * result value collection of the query.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -106,12 +101,12 @@ public final class MapValuesWithPredicateCodec {
         return clientMessage;
     }
 
-    public static MapValuesWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MapValuesWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapEntrySetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the set of key-value pairs in the multimap.The collection is NOT backed by the map, so changes to the map
  * are NOT reflected in the collection, and vice-versa
  */
-@Generated("0113f3007414e2d2909083e6d4a99fcb")
+@Generated("6c07803e339fb8a697166e7db89ca378")
 public final class MultiMapEntrySetCodec {
     //hex: 0x020600
     public static final int REQUEST_MESSAGE_TYPE = 132608;
@@ -80,11 +80,6 @@ public final class MultiMapEntrySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -97,12 +92,12 @@ public final class MultiMapEntrySetCodec {
         return clientMessage;
     }
 
-    public static MultiMapEntrySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MultiMapEntrySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapGetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
  * the map are NOT reflected in the collection, and vice-versa.
  */
-@Generated("db66720c0c0cc69502fc0e0891356bbe")
+@Generated("d6f56cc697606f015543514558828696")
 public final class MultiMapGetCodec {
     //hex: 0x020200
     public static final int REQUEST_MESSAGE_TYPE = 131584;
@@ -94,11 +94,6 @@ public final class MultiMapGetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * The collection of the values associated with the key.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -111,12 +106,12 @@ public final class MultiMapGetCodec {
         return clientMessage;
     }
 
-    public static MultiMapGetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MultiMapGetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapKeySetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the set of keys in the multimap.The collection is NOT backed by the map, so changes to the map are NOT
  * reflected in the collection, and vice-versa.
  */
-@Generated("9f076a717a548534cd14c03a64b6c6d7")
+@Generated("a6cb8e3cb62f3ff1ff3efb496d8cfdde")
 public final class MultiMapKeySetCodec {
     //hex: 0x020400
     public static final int REQUEST_MESSAGE_TYPE = 132096;
@@ -80,11 +80,6 @@ public final class MultiMapKeySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -97,12 +92,12 @@ public final class MultiMapKeySetCodec {
         return clientMessage;
     }
 
-    public static MultiMapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MultiMapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("c00eacf935157e47d9d3a484c974a79c")
+@Generated("1bb14a4a9ea78a7d836e1b8fd8c385af")
 public final class MultiMapRemoveCodec {
     //hex: 0x020300
     public static final int REQUEST_MESSAGE_TYPE = 131840;
@@ -93,11 +93,6 @@ public final class MultiMapRemoveCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * True if the size of the multimap changed after the remove operation, false otherwise.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -110,12 +105,12 @@ public final class MultiMapRemoveCodec {
         return clientMessage;
     }
 
-    public static MultiMapRemoveCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MultiMapRemoveCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValuesCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the collection of values in the multimap.The collection is NOT backed by the map, so changes to the map
  * are NOT reflected in the collection, and vice-versa.
  */
-@Generated("9dc9d79d7550b3e25ac59dd09d8bc59a")
+@Generated("931551eed91008d6d943f87b8ea0e7fb")
 public final class MultiMapValuesCodec {
     //hex: 0x020500
     public static final int REQUEST_MESSAGE_TYPE = 132352;
@@ -80,11 +80,6 @@ public final class MultiMapValuesCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * The collection of values in the multimap. the returned collection might be modifiable but it has no effect on the multimap.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -97,12 +92,12 @@ public final class MultiMapValuesCodec {
         return clientMessage;
     }
 
-    public static MultiMapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static MultiMapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * thrown. Attempts to drain a queue to itself result in ILLEGAL_ARGUMENT. Further, the behavior of
  * this operation is undefined if the specified collection is modified while the operation is in progress.
  */
-@Generated("93028a1431659b1efa039addd8d4de28")
+@Generated("008e0bfab490019814cfb49fe3b3687d")
 public final class QueueDrainToCodec {
     //hex: 0x030900
     public static final int REQUEST_MESSAGE_TYPE = 198912;
@@ -83,11 +83,6 @@ public final class QueueDrainToCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * list of all removed data in queue
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -100,12 +95,12 @@ public final class QueueDrainToCodec {
         return clientMessage;
     }
 
-    public static QueueDrainToCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static QueueDrainToCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToMaxSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToMaxSizeCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * ILLEGAL_ARGUMENT. Further, the behavior of this operation is undefined if the specified collection is
  * modified while the operation is in progress.
  */
-@Generated("41666410223f51f96e226b7632dd3386")
+@Generated("5723beb3ceca1bdfeae857c7f8733259")
 public final class QueueDrainToMaxSizeCodec {
     //hex: 0x030A00
     public static final int REQUEST_MESSAGE_TYPE = 199168;
@@ -90,11 +90,6 @@ public final class QueueDrainToMaxSizeCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * list of all removed data in result of this method
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -107,12 +102,12 @@ public final class QueueDrainToMaxSizeCodec {
         return clientMessage;
     }
 
-    public static QueueDrainToMaxSizeCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static QueueDrainToMaxSizeCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueIteratorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueIteratorCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns an iterator over the elements in this collection.  There are no guarantees concerning the order in which
  * the elements are returned (unless this collection is an instance of some class that provides a guarantee).
  */
-@Generated("fb67bb3c39460058f3cbed729bb7f58f")
+@Generated("329ccf87d167fb0fa070eea24ea0cbac")
 public final class QueueIteratorCodec {
     //hex: 0x030800
     public static final int REQUEST_MESSAGE_TYPE = 198656;
@@ -80,11 +80,6 @@ public final class QueueIteratorCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * list of all data in queue
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -97,12 +92,12 @@ public final class QueueIteratorCodec {
         return clientMessage;
     }
 
-    public static QueueIteratorCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static QueueIteratorCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapEntrySetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("e8b92a196203e364fe0ddd89ba70f21a")
+@Generated("22ce36f36152e649635b3c09f535a7e2")
 public final class ReplicatedMapEntrySetCodec {
     //hex: 0x0D1100
     public static final int REQUEST_MESSAGE_TYPE = 856320;
@@ -79,11 +79,6 @@ public final class ReplicatedMapEntrySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * A lazy set view of the mappings contained in this map.
-         */
-        public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response) {
@@ -96,12 +91,12 @@ public final class ReplicatedMapEntrySetCodec {
         return clientMessage;
     }
 
-    public static ReplicatedMapEntrySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ReplicatedMapEntrySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.BiConsumer<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> responseBiConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode);
+        EntryListCodec.decode(iterator, DataCodec::decode, DataCodec::decode, responseBiConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapKeySetCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * very poor performance if called repeatedly (for example, in a loop). If the use case is different from querying
  * the data, please copy the resulting set into a new java.util.HashSet.
  */
-@Generated("6ee72ad4363000312b3e2a758eb0cb54")
+@Generated("0e995ed78a2a5a88c06abf12366f5c21")
 public final class ReplicatedMapKeySetCodec {
     //hex: 0x0D0F00
     public static final int REQUEST_MESSAGE_TYPE = 855808;
@@ -84,11 +84,6 @@ public final class ReplicatedMapKeySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * A lazy set view of the keys contained in this map.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -101,12 +96,12 @@ public final class ReplicatedMapKeySetCodec {
         return clientMessage;
     }
 
-    public static ReplicatedMapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ReplicatedMapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapValuesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * TODO DOC
  */
-@Generated("ae791cede73d29423eb90b11c99c4cbf")
+@Generated("2d9c02b3bbc3b7989275ed4efceaf548")
 public final class ReplicatedMapValuesCodec {
     //hex: 0x0D1000
     public static final int REQUEST_MESSAGE_TYPE = 856064;
@@ -79,11 +79,6 @@ public final class ReplicatedMapValuesCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * A collection view of the values contained in this map.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -96,12 +91,12 @@ public final class ReplicatedMapValuesCodec {
         return clientMessage;
     }
 
-    public static ReplicatedMapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static ReplicatedMapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
  * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
  */
-@Generated("d57a43e01b76e67cdd5fcba4601b5962")
+@Generated("16119b8c0315755f18fade716b04440c")
 public final class RingbufferReadManyCodec {
     //hex: 0x170900
     public static final int REQUEST_MESSAGE_TYPE = 1509632;
@@ -126,11 +126,6 @@ public final class RingbufferReadManyCodec {
         /**
          * TODO DOC
          */
-        public java.util.List<com.hazelcast.internal.serialization.Data> items;
-
-        /**
-         * TODO DOC
-         */
         public @Nullable long[] itemSeqs;
 
         /**
@@ -152,13 +147,13 @@ public final class RingbufferReadManyCodec {
         return clientMessage;
     }
 
-    public static RingbufferReadManyCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static RingbufferReadManyCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> itemsConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.readCount = decodeInt(initialFrame.content, RESPONSE_READ_COUNT_FIELD_OFFSET);
         response.nextSeq = decodeLong(initialFrame.content, RESPONSE_NEXT_SEQ_FIELD_OFFSET);
-        response.items = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, itemsConsumer);
         response.itemSeqs = CodecUtil.decodeNullable(iterator, LongArrayCodec::decode);
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetGetAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return the all elements of this collection
  */
-@Generated("9847c140a5710d7c354633f5d36c7d31")
+@Generated("5603b37be8e43cc64c5f0e8439c80ed4")
 public final class SetGetAllCodec {
     //hex: 0x060A00
     public static final int REQUEST_MESSAGE_TYPE = 395776;
@@ -79,11 +79,6 @@ public final class SetGetAllCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * Array of all values in the Set
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -96,12 +91,12 @@ public final class SetGetAllCodec {
         return clientMessage;
     }
 
-    public static SetGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static SetGetAllCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("8f10f83cca7ff6d30b3e34a795a231cd")
+@Generated("f8442cc63811fa895b021ef4e7f3482d")
 public final class TransactionalMapKeySetCodec {
     //hex: 0x0E0E00
     public static final int REQUEST_MESSAGE_TYPE = 921088;
@@ -96,11 +96,6 @@ public final class TransactionalMapKeySetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * A set clone of the keys contained in this map.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -113,12 +108,12 @@ public final class TransactionalMapKeySetCodec {
         return clientMessage;
     }
 
-    public static TransactionalMapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static TransactionalMapKeySetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("d70c43da868d3349158da3c9c8cd5396")
+@Generated("074ff05757331b2e468f00ed6aacc39d")
 public final class TransactionalMapKeySetWithPredicateCodec {
     //hex: 0x0E0F00
     public static final int REQUEST_MESSAGE_TYPE = 921344;
@@ -104,11 +104,6 @@ public final class TransactionalMapKeySetWithPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * Result key set for the query.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -121,12 +116,12 @@ public final class TransactionalMapKeySetWithPredicateCodec {
         return clientMessage;
     }
 
-    public static TransactionalMapKeySetWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static TransactionalMapKeySetWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
  * distributed query, so it may throw a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("45c0ee285155fc472acf794c0d60456c")
+@Generated("d3fee63f9ce7185a26eb7dab6501195e")
 public final class TransactionalMapValuesCodec {
     //hex: 0x0E1000
     public static final int REQUEST_MESSAGE_TYPE = 921600;
@@ -96,11 +96,6 @@ public final class TransactionalMapValuesCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * All values in the map
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -113,12 +108,12 @@ public final class TransactionalMapValuesCodec {
         return clientMessage;
     }
 
-    public static TransactionalMapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static TransactionalMapValuesCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("dce5e976db11cd5eb966263fc06856e0")
+@Generated("dee3de412896290db8418ebec6d17c39")
 public final class TransactionalMapValuesWithPredicateCodec {
     //hex: 0x0E1100
     public static final int REQUEST_MESSAGE_TYPE = 921856;
@@ -104,11 +104,6 @@ public final class TransactionalMapValuesWithPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * Result value collection of the query.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -121,12 +116,12 @@ public final class TransactionalMapValuesWithPredicateCodec {
         return clientMessage;
     }
 
-    public static TransactionalMapValuesWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static TransactionalMapValuesWithPredicateCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the collection of values associated with the key.
  */
-@Generated("06f3780cd5c8b158c560fc95ac9529a8")
+@Generated("070bde8bd9dcf050c26a32558d6ec83d")
 public final class TransactionalMultiMapGetCodec {
     //hex: 0x0F0200
     public static final int REQUEST_MESSAGE_TYPE = 983552;
@@ -101,11 +101,6 @@ public final class TransactionalMultiMapGetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * The collection of the values associated with the key
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -118,12 +113,12 @@ public final class TransactionalMultiMapGetCodec {
         return clientMessage;
     }
 
-    public static TransactionalMultiMapGetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static TransactionalMultiMapGetCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("573864d2ae283f885c7d1f1579c53591")
+@Generated("2f334a367347758b24e02d4aca3d9292")
 public final class TransactionalMultiMapRemoveCodec {
     //hex: 0x0F0300
     public static final int REQUEST_MESSAGE_TYPE = 983808;
@@ -101,11 +101,6 @@ public final class TransactionalMultiMapRemoveCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-
-        /**
-         * True if the size of the multimap changed after the remove operation, false otherwise.
-         */
-        public java.util.List<com.hazelcast.internal.serialization.Data> response;
     }
 
     public static ClientMessage encodeResponse(java.util.Collection<com.hazelcast.internal.serialization.Data> response) {
@@ -118,12 +113,12 @@ public final class TransactionalMultiMapRemoveCodec {
         return clientMessage;
     }
 
-    public static TransactionalMultiMapRemoveCodec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    public static TransactionalMultiMapRemoveCodec.ResponseParameters decodeResponse(ClientMessage clientMessage, java.util.function.Consumer<com.hazelcast.internal.serialization.Data> responseConsumer) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
         //empty initial frame
         iterator.next();
-        response.response = ListMultiFrameCodec.decode(iterator, DataCodec::decode);
+        ListMultiFrameCodec.decode(iterator, DataCodec::decode, responseConsumer);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListMultiFrameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListMultiFrameCodec.java
@@ -114,7 +114,7 @@ public final class ListMultiFrameCodec {
     public static <T> void decodeNullable(ClientMessage.ForwardFrameIterator iterator,
                                           Function<ClientMessage.ForwardFrameIterator, T> decodeFunction,
                                           Consumer<T> consumer) {
-        if (nextFrameIsNullEndFrame(iterator)) {
+        if (!nextFrameIsNullEndFrame(iterator)) {
             decode(iterator, decodeFunction, consumer);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientListProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientListProxy.java
@@ -53,6 +53,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -148,9 +149,9 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     public Iterator<E> iterator() {
         ClientMessage request = ListIteratorCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
-        ListIteratorCodec.ResponseParameters resultParameters = ListIteratorCodec.decodeResponse(response);
-        List<Data> resultCollection = resultParameters.response;
-        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService()).iterator();
+        List<Data> result = new ArrayList<>();
+        ListIteratorCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<E>(result, getSerializationService()).iterator();
     }
 
     @Override
@@ -272,8 +273,9 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     private Collection<E> getAll() {
         ClientMessage request = ListGetAllCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
-        ListGetAllCodec.ResponseParameters resultParameters = ListGetAllCodec.decodeResponse(response);
-        return new UnmodifiableLazyList<E>(resultParameters.response, getSerializationService());
+        List<Data> result = new ArrayList<>();
+        ListGetAllCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<E>(result, getSerializationService());
     }
 
     @Override
@@ -305,18 +307,18 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     public ListIterator<E> listIterator(int index) {
         ClientMessage request = ListListIteratorCodec.encodeRequest(name, index);
         ClientMessage response = invokeOnPartition(request);
-        ListListIteratorCodec.ResponseParameters resultParameters = ListListIteratorCodec.decodeResponse(response);
-        List<Data> resultCollection = resultParameters.response;
-        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService()).listIterator();
+        List<Data> result = new ArrayList<>();
+        ListListIteratorCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<E>(result, getSerializationService()).listIterator();
     }
 
     @Override
     public List<E> subList(int fromIndex, int toIndex) {
         ClientMessage request = ListSubCodec.encodeRequest(name, fromIndex, toIndex);
         ClientMessage response = invokeOnPartition(request);
-        ListSubCodec.ResponseParameters resultParameters = ListSubCodec.decodeResponse(response);
-        List<Data> resultCollection = resultParameters.response;
-        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService());
+        List<Data> result = new ArrayList<>();
+        ListSubCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<E>(result, getSerializationService());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -1253,7 +1253,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         List<Entry> resultList = new ArrayList<>();
         MapKeySetWithPagingPredicateCodec.decodeResponse(response, data -> {
             K key = toObject(data);
-            resultList.add(new AbstractMap.SimpleEntry<K, V>(key, null));
+            resultList.add(new AbstractMap.SimpleImmutableEntry<K, V>(key, null));
         });
 
         return (Set<K>) getSortedQueryResultSet(resultList, pagingPredicate, IterationType.KEY);
@@ -1336,7 +1336,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         MapValuesWithPagingPredicateCodec.decodeResponse(response, (keyData, valueData) -> {
             K key = toObject(keyData);
             V value = toObject(valueData);
-            resultList.add(new AbstractMap.SimpleEntry<>(key, value));
+            resultList.add(new AbstractMap.SimpleImmutableEntry<>(key, value));
         });
 
         return (Collection<V>) getSortedQueryResultSet(resultList, pagingPredicate, IterationType.VALUE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -149,7 +149,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMultiMapProxy.java
@@ -165,7 +165,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     public Set<K> keySet() {
         ClientMessage request = MultiMapKeySetCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
-        Set<K> keySet = new HashSet<K>(0);
+        Set<K> keySet = new HashSet<>();
         MultiMapKeySetCodec.decodeResponse(response, data -> {
             K key = toObject(data);
             keySet.add(key);
@@ -190,8 +190,10 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
         ClientMessage response = invoke(request);
 
         Set<Map.Entry<K, V>> entrySet = createHashSet(0);
-        MultiMapEntrySetCodec.decodeResponse(response, (key, value) -> {
-            entrySet.add(new AbstractMap.SimpleEntry<>(toObject(key), toObject(value)));
+        MultiMapEntrySetCodec.decodeResponse(response, (keyData, valueData) -> {
+            K key = toObject(keyData);
+            V value = toObject(valueData);
+            entrySet.add(new AbstractMap.SimpleEntry<>(key, value));
         });
 
         return entrySet;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientQueueProxy.java
@@ -248,8 +248,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         ClientMessage response = invokeOnPartition(request);
         MutableInteger size = new MutableInteger();
         QueueDrainToCodec.decodeResponse(response, data -> {
-            E e = toObject(data);
-            objects.add(e);
+            E element = toObject(data);
+            objects.add(element);
             size.getAndInc();
         });
         return size.value;
@@ -263,8 +263,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         ClientMessage response = invokeOnPartition(request);
         MutableInteger size = new MutableInteger();
         QueueDrainToMaxSizeCodec.decodeResponse(response, data -> {
-            E e = toObject(data);
-            c.add(e);
+            E element = toObject(data);
+            c.add(element);
             size.getAndInc();
         });
         return size.value;
@@ -335,14 +335,12 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     public Object[] toArray() {
         ClientMessage request = QueueIteratorCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
-        List<Data> result = new ArrayList<>();
-        QueueIteratorCodec.decodeResponse(response, result::add);
-        int i = 0;
-        Object[] array = new Object[result.size()];
-        for (Data data : result) {
-            array[i++] = toObject(data);
-        }
-        return array;
+        List<Object> result = new ArrayList<>();
+        QueueIteratorCodec.decodeResponse(response, data -> {
+            Object element = toObject(data);
+            result.add(element);
+        });
+        return result.toArray();
     }
 
     @Nonnull
@@ -352,17 +350,12 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
 
         ClientMessage request = QueueIteratorCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
-        List<Data> result = new ArrayList<>();
-        QueueIteratorCodec.decodeResponse(response, result::add);
-        int size = result.size();
-        if (ts.length < size) {
-            ts = (T[]) java.lang.reflect.Array.newInstance(ts.getClass().getComponentType(), size);
-        }
-        int i = 0;
-        for (Data data : result) {
-            ts[i++] = (T) toObject(data);
-        }
-        return ts;
+        List<T> result = new ArrayList<>();
+        QueueIteratorCodec.decodeResponse(response, data -> {
+            T element = (T) toObject(data);
+            result.add(element);
+        });
+        return result.toArray((T[]) java.lang.reflect.Array.newInstance(ts.getClass().getComponentType(), 0));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
@@ -471,13 +471,10 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     public Set<Entry<K, V>> entrySet() {
         ClientMessage request = ReplicatedMapEntrySetCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request, targetPartitionId);
-        ReplicatedMapEntrySetCodec.ResponseParameters result = ReplicatedMapEntrySetCodec.decodeResponse(response);
-        List<Entry> entries = new ArrayList<>(result.response.size());
-        for (Entry<Data, Data> dataEntry : result.response) {
-            K key = toObject(dataEntry.getKey());
-            V value = toObject(dataEntry.getValue());
-            entries.add(new AbstractMap.SimpleImmutableEntry<>(key, value));
-        }
+        List<Entry> entries = new ArrayList<>();
+        ReplicatedMapEntrySetCodec.decodeResponse(response, (key, value) -> {
+            entries.add(new AbstractMap.SimpleEntry<>(toObject(key), toObject(value)));
+        });
         return (Set) new ResultSet(entries, IterationType.ENTRY);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
@@ -474,8 +474,10 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
         ClientMessage request = ReplicatedMapEntrySetCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request, targetPartitionId);
         List<Entry> entries = new ArrayList<>();
-        ReplicatedMapEntrySetCodec.decodeResponse(response, (key, value) -> {
-            entries.add(new AbstractMap.SimpleEntry<>(toObject(key), toObject(value)));
+        ReplicatedMapEntrySetCodec.decodeResponse(response, (keyData, valueData) -> {
+            K key = toObject(keyData);
+            V value = toObject(valueData);
+            entries.add(new AbstractMap.SimpleEntry<>(key, value));
         });
         return (Set) new ResultSet(entries, IterationType.ENTRY);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
@@ -477,7 +477,7 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
         ReplicatedMapEntrySetCodec.decodeResponse(response, (keyData, valueData) -> {
             K key = toObject(keyData);
             V value = toObject(valueData);
-            entries.add(new AbstractMap.SimpleEntry<>(key, value));
+            entries.add(new AbstractMap.SimpleImmutableEntry<>(key, value));
         });
         return (Set) new ResultSet(entries, IterationType.ENTRY);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientRingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientRingbufferProxy.java
@@ -43,7 +43,9 @@ import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -86,9 +88,11 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         partitionId = getContext().getPartitionService().getPartitionId(partitionKey);
 
         readManyAsyncResponseDecoder = clientMessage -> {
-            final RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(clientMessage);
+            List<Data> items = new ArrayList<>();
+            final RingbufferReadManyCodec.ResponseParameters params
+                    = RingbufferReadManyCodec.decodeResponse(clientMessage, items::add);
             final ReadResultSetImpl readResultSet = new ReadResultSetImpl(
-                    params.readCount, params.items, params.itemSeqs, params.nextSeq);
+                    params.readCount, items, params.itemSeqs, params.nextSeq);
             readResultSet.setSerializationService(getSerializationService());
             return readResultSet;
         };

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientSetProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientSetProxy.java
@@ -43,6 +43,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -210,9 +211,9 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     private Collection<E> getAll() {
         ClientMessage request = SetGetAllCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
-        SetGetAllCodec.ResponseParameters resultParameters = SetGetAllCodec.decodeResponse(response);
-        List<Data> resultCollection = resultParameters.response;
-        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService());
+        List<Data> result = new ArrayList<>();
+        SetGetAllCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<E>(result, getSerializationService());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
@@ -514,10 +514,11 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     @Override
     protected <R> BiConsumer<Data, Data> createResponseConsumer(Map<K, R> result) {
-        return (key, value) -> {
-            K deserializedKey = toObject(key);
-            invalidateNearCache(serializeKeys ? key : deserializedKey);
-            result.put(deserializedKey, toObject(value));
+        return (keyData, valueData) -> {
+            K key = toObject(keyData);
+            R value = toObject(valueData);
+            invalidateNearCache(serializeKeys ? keyData : key);
+            result.put(key, value);
         };
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTxnMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTxnMapProxy.java
@@ -197,10 +197,10 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         ClientMessage request = TransactionalMapKeySetCodec.encodeRequest(name, getTransactionId(), getThreadId());
         ClientMessage response = invoke(request);
 
-        HashSet<K> keySet = new HashSet<K>(0);
+        HashSet<K> keySet = new HashSet<>();
         TransactionalMapKeySetCodec.decodeResponse(response, data -> {
-            Object key = toObject(data);
-            keySet.add((K) key);
+            K key = (K) toObject(data);
+            keySet.add(key);
         });
 
         return keySet;
@@ -214,11 +214,11 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         ClientMessage request = TransactionalMapKeySetWithPredicateCodec
                 .encodeRequest(name, getTransactionId(), getThreadId(), toData(predicate));
         ClientMessage response = invoke(request);
-        HashSet<K> keySet = new HashSet<K>(0);
+        HashSet<K> keySet = new HashSet<>();
 
         TransactionalMapKeySetWithPredicateCodec.decodeResponse(response, data -> {
-            Object key = toObject(data);
-            keySet.add((K) key);
+            K key = (K) toObject(data);
+            keySet.add(key);
         });
 
         return keySet;
@@ -244,8 +244,8 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         ClientMessage response = invoke(request);
         List<V> values = new ArrayList<>();
         TransactionalMapValuesWithPredicateCodec.decodeResponse(response, data -> {
-            Object value = toObject(data);
-            values.add((V) value);
+            V value = (V) toObject(data);
+            values.add(value);
         });
 
         return values;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTxnMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTxnMultiMapProxy.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.transaction.TransactionException;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -60,8 +61,9 @@ public class ClientTxnMultiMapProxy<K, V> extends ClientTxnProxy implements Tran
         ClientMessage request = TransactionalMultiMapGetCodec.encodeRequest(name, getTransactionId(), getThreadId(), toData(key));
 
         ClientMessage response = invoke(request);
-        List<Data> collection = TransactionalMultiMapGetCodec.decodeResponse(response).response;
-        return new UnmodifiableLazyList<V>(collection, getSerializationService());
+        List<Data> result = new ArrayList<>();
+        TransactionalMultiMapGetCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<V>(result, getSerializationService());
     }
 
     @Override
@@ -77,8 +79,9 @@ public class ClientTxnMultiMapProxy<K, V> extends ClientTxnProxy implements Tran
         ClientMessage request = TransactionalMultiMapRemoveCodec
                 .encodeRequest(name, getTransactionId(), getThreadId(), toData(key));
         ClientMessage response = invoke(request);
-        List<Data> collection = TransactionalMultiMapRemoveCodec.decodeResponse(response).response;
-        return new UnmodifiableLazyList<V>(collection, getSerializationService());
+        List<Data> result = new ArrayList<>();
+        TransactionalMultiMapRemoveCodec.decodeResponse(response, result::add);
+        return new UnmodifiableLazyList<V>(result, getSerializationService());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
@@ -28,7 +28,10 @@ import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndConstructo
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
 import com.hazelcast.internal.serialization.Data;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -51,8 +54,10 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
         ClientMessage response = (ClientMessage) invokerWrapper.invoke(publisherCreateMessage, urgent);
 
         if (info.isIncludeValue()) {
-            Collection<Map.Entry<Data, Data>> result =
-                    ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(response).response;
+            Collection<Map.Entry<Data, Data>> result = new ArrayList<>();
+            ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(response, (key, value) -> {
+                result.add(new AbstractMap.SimpleEntry<>(key, value));
+            });
             prepopulate(queryCache, result);
         } else {
             List<Data> result = ContinuousQueryPublisherCreateCodec.decodeResponse(response).response;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
@@ -46,15 +46,15 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
         ClientMessage response = (ClientMessage) invokerWrapper.invoke(publisherCreateMessage, urgent);
 
         if (info.isIncludeValue()) {
-            ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(response, (key, value) -> {
+            ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(response, (keyData, valueData) -> {
                 if (!queryCache.reachedMaxCapacity()) {
-                    queryCache.prepopulate(key, value);
+                    queryCache.prepopulate(keyData, valueData);
                 }
             });
         } else {
-            ContinuousQueryPublisherCreateCodec.decodeResponse(response, (elem) -> {
+            ContinuousQueryPublisherCreateCodec.decodeResponse(response, (data) -> {
                 if (!queryCache.reachedMaxCapacity()) {
-                    queryCache.prepopulate(elem, null);
+                    queryCache.prepopulate(data, null);
                 }
             });
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
@@ -23,17 +23,9 @@ import com.hazelcast.client.impl.protocol.codec.ContinuousQueryPublisherCreateWi
 import com.hazelcast.map.impl.querycache.InvokerWrapper;
 import com.hazelcast.map.impl.querycache.accumulator.AccumulatorInfo;
 import com.hazelcast.map.impl.querycache.subscriber.AbstractQueryCacheEndToEndConstructor;
-import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndConstructor;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
 import com.hazelcast.internal.serialization.Data;
-
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Client-side implementation of {@code QueryCacheEndToEndConstructor}.

--- a/hazelcast/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -28,6 +28,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.iterator.AbstractMapPartitionIterator;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.nio.serialization.Data;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -67,9 +68,11 @@ public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterat
         ClientInvocation clientInvocation = new ClientInvocation(client, request, mapProxy.getName(), partitionId);
         try {
             ClientInvocationFuture f = clientInvocation.invoke();
-            MapFetchKeysCodec.ResponseParameters responseParameters = MapFetchKeysCodec.decodeResponse(f.get());
-            setLastTableIndex(responseParameters.keys, responseParameters.tableIndex);
-            return responseParameters.keys;
+            List<Data> keys = new ArrayList<>();
+            MapFetchKeysCodec.ResponseParameters responseParameters
+                    = MapFetchKeysCodec.decodeResponse(f.get(), keys::add);
+            setLastTableIndex(keys, responseParameters.tableIndex);
+            return keys;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -28,7 +28,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.iterator.AbstractMapPartitionIterator;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.ExceptionUtil;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.internal.serialization.Data;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -85,8 +85,8 @@ public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterat
             ClientInvocationFuture f = clientInvocation.invoke();
             List result = new ArrayList();
             MapFetchEntriesCodec.ResponseParameters responseParameters
-                    = MapFetchEntriesCodec.decodeResponse(f.get(), (key, value) -> {
-                result.add(new AbstractMap.SimpleEntry<>(key, value));
+                    = MapFetchEntriesCodec.decodeResponse(f.get(), (keyData, valueData) -> {
+                result.add(new AbstractMap.SimpleEntry<>(keyData, valueData));
             });
             setLastTableIndex(result, responseParameters.tableIndex);
             return result;

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
@@ -1040,8 +1040,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 110;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapKeySetCodec.ResponseParameters parameters = MapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapKeySetCodec.ResponseParameters parameters = MapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1073,8 +1074,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 114;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapValuesCodec.ResponseParameters parameters = MapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapValuesCodec.ResponseParameters parameters = MapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1106,8 +1108,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapKeySetWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 118;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapKeySetWithPredicateCodec.ResponseParameters parameters = MapKeySetWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapKeySetWithPredicateCodec.ResponseParameters parameters = MapKeySetWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1122,8 +1125,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapValuesWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 120;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapValuesWithPredicateCodec.ResponseParameters parameters = MapValuesWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapValuesWithPredicateCodec.ResponseParameters parameters = MapValuesWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1330,8 +1334,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapKeySetWithPagingPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 146;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapKeySetWithPagingPredicateCodec.ResponseParameters parameters = MapKeySetWithPagingPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapKeySetWithPagingPredicateCodec.ResponseParameters parameters = MapKeySetWithPagingPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1395,9 +1400,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapFetchKeysCodec_decodeResponse() {
         int fileClientMessageIndex = 154;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapFetchKeysCodec.ResponseParameters parameters = MapFetchKeysCodec.decodeResponse(fromFile);
+        List<Data> keysList = new ArrayList<>();
+        MapFetchKeysCodec.ResponseParameters parameters = MapFetchKeysCodec.decodeResponse(fromFile, keysList::add);
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfData, parameters.keys));
+        assertTrue(isEqual(aListOfData, keysList));
     }
 
     @Test
@@ -1625,9 +1631,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapEventJournalReadCodec_decodeResponse() {
         int fileClientMessageIndex = 180;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEventJournalReadCodec.ResponseParameters parameters = MapEventJournalReadCodec.decodeResponse(fromFile);
+        List<Data> itemsList = new ArrayList<>();
+        MapEventJournalReadCodec.ResponseParameters parameters = MapEventJournalReadCodec.decodeResponse(fromFile, itemsList::add);
         assertTrue(isEqual(anInt, parameters.readCount));
-        assertTrue(isEqual(aListOfData, parameters.items));
+        assertTrue(isEqual(aListOfData, itemsList));
         assertTrue(isEqual(null, parameters.itemSeqs));
         assertTrue(isEqual(aLong, parameters.nextSeq));
     }
@@ -1740,8 +1747,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MultiMapGetCodec_decodeResponse() {
         int fileClientMessageIndex = 194;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapGetCodec.ResponseParameters parameters = MultiMapGetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapGetCodec.ResponseParameters parameters = MultiMapGetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1756,8 +1764,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MultiMapRemoveCodec_decodeResponse() {
         int fileClientMessageIndex = 196;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapRemoveCodec.ResponseParameters parameters = MultiMapRemoveCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapRemoveCodec.ResponseParameters parameters = MultiMapRemoveCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1772,8 +1781,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MultiMapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 198;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapKeySetCodec.ResponseParameters parameters = MultiMapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapKeySetCodec.ResponseParameters parameters = MultiMapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1788,8 +1798,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MultiMapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 200;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapValuesCodec.ResponseParameters parameters = MultiMapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapValuesCodec.ResponseParameters parameters = MultiMapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2225,8 +2236,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_QueueIteratorCodec_decodeResponse() {
         int fileClientMessageIndex = 252;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        QueueIteratorCodec.ResponseParameters parameters = QueueIteratorCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        QueueIteratorCodec.ResponseParameters parameters = QueueIteratorCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2241,8 +2253,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_QueueDrainToCodec_decodeResponse() {
         int fileClientMessageIndex = 254;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        QueueDrainToCodec.ResponseParameters parameters = QueueDrainToCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        QueueDrainToCodec.ResponseParameters parameters = QueueDrainToCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2257,8 +2270,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_QueueDrainToMaxSizeCodec_decodeResponse() {
         int fileClientMessageIndex = 256;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        QueueDrainToMaxSizeCodec.ResponseParameters parameters = QueueDrainToMaxSizeCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        QueueDrainToMaxSizeCodec.ResponseParameters parameters = QueueDrainToMaxSizeCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2656,8 +2670,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ListGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 304;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListGetAllCodec.ResponseParameters parameters = ListGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListGetAllCodec.ResponseParameters parameters = ListGetAllCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2848,8 +2863,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ListSubCodec_decodeResponse() {
         int fileClientMessageIndex = 327;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListSubCodec.ResponseParameters parameters = ListSubCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListSubCodec.ResponseParameters parameters = ListSubCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2864,8 +2880,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ListIteratorCodec_decodeResponse() {
         int fileClientMessageIndex = 329;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListIteratorCodec.ResponseParameters parameters = ListIteratorCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListIteratorCodec.ResponseParameters parameters = ListIteratorCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2880,8 +2897,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ListListIteratorCodec_decodeResponse() {
         int fileClientMessageIndex = 331;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListListIteratorCodec.ResponseParameters parameters = ListListIteratorCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListListIteratorCodec.ResponseParameters parameters = ListListIteratorCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -3039,8 +3057,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_SetGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 351;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        SetGetAllCodec.ResponseParameters parameters = SetGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        SetGetAllCodec.ResponseParameters parameters = SetGetAllCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -3971,8 +3990,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ReplicatedMapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 460;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ReplicatedMapKeySetCodec.ResponseParameters parameters = ReplicatedMapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ReplicatedMapKeySetCodec.ResponseParameters parameters = ReplicatedMapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -3987,8 +4007,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ReplicatedMapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 462;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ReplicatedMapValuesCodec.ResponseParameters parameters = ReplicatedMapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ReplicatedMapValuesCodec.ResponseParameters parameters = ReplicatedMapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4263,8 +4284,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_TransactionalMapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 495;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapKeySetCodec.ResponseParameters parameters = TransactionalMapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapKeySetCodec.ResponseParameters parameters = TransactionalMapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4279,8 +4301,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_TransactionalMapKeySetWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 497;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapKeySetWithPredicateCodec.ResponseParameters parameters = TransactionalMapKeySetWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapKeySetWithPredicateCodec.ResponseParameters parameters = TransactionalMapKeySetWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4295,8 +4318,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_TransactionalMapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 499;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapValuesCodec.ResponseParameters parameters = TransactionalMapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapValuesCodec.ResponseParameters parameters = TransactionalMapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4311,8 +4335,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_TransactionalMapValuesWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 501;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapValuesWithPredicateCodec.ResponseParameters parameters = TransactionalMapValuesWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapValuesWithPredicateCodec.ResponseParameters parameters = TransactionalMapValuesWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4359,8 +4384,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_TransactionalMultiMapGetCodec_decodeResponse() {
         int fileClientMessageIndex = 507;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMultiMapGetCodec.ResponseParameters parameters = TransactionalMultiMapGetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMultiMapGetCodec.ResponseParameters parameters = TransactionalMultiMapGetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4375,8 +4401,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_TransactionalMultiMapRemoveCodec_decodeResponse() {
         int fileClientMessageIndex = 509;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMultiMapRemoveCodec.ResponseParameters parameters = TransactionalMultiMapRemoveCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMultiMapRemoveCodec.ResponseParameters parameters = TransactionalMultiMapRemoveCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4837,9 +4864,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_CacheIterateCodec_decodeResponse() {
         int fileClientMessageIndex = 566;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheIterateCodec.ResponseParameters parameters = CacheIterateCodec.decodeResponse(fromFile);
+        List<Data> keysList = new ArrayList<>();
+        CacheIterateCodec.ResponseParameters parameters = CacheIterateCodec.decodeResponse(fromFile, keysList::add);
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfData, parameters.keys));
+        assertTrue(isEqual(aListOfData, keysList));
     }
 
     @Test
@@ -5193,9 +5221,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_CacheEventJournalReadCodec_decodeResponse() {
         int fileClientMessageIndex = 607;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheEventJournalReadCodec.ResponseParameters parameters = CacheEventJournalReadCodec.decodeResponse(fromFile);
+        List<Data> itemsList = new ArrayList<>();
+        CacheEventJournalReadCodec.ResponseParameters parameters = CacheEventJournalReadCodec.decodeResponse(fromFile, itemsList::add);
         assertTrue(isEqual(anInt, parameters.readCount));
-        assertTrue(isEqual(aListOfData, parameters.items));
+        assertTrue(isEqual(aListOfData, itemsList));
         assertTrue(isEqual(null, parameters.itemSeqs));
         assertTrue(isEqual(aLong, parameters.nextSeq));
     }
@@ -5398,8 +5427,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ContinuousQueryPublisherCreateCodec_decodeResponse() {
         int fileClientMessageIndex = 633;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ContinuousQueryPublisherCreateCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ContinuousQueryPublisherCreateCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -5635,9 +5665,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_RingbufferReadManyCodec_decodeResponse() {
         int fileClientMessageIndex = 661;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        RingbufferReadManyCodec.ResponseParameters parameters = RingbufferReadManyCodec.decodeResponse(fromFile);
+        List<Data> itemsList = new ArrayList<>();
+        RingbufferReadManyCodec.ResponseParameters parameters = RingbufferReadManyCodec.decodeResponse(fromFile, itemsList::add);
         assertTrue(isEqual(anInt, parameters.readCount));
-        assertTrue(isEqual(aListOfData, parameters.items));
+        assertTrue(isEqual(aListOfData, itemsList));
         assertTrue(isEqual(null, parameters.itemSeqs));
         assertTrue(isEqual(aLong, parameters.nextSeq));
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,9 +33,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
@@ -1053,8 +1056,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 112;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapGetAllCodec.ResponseParameters parameters = MapGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapGetAllCodec.ResponseParameters parameters = MapGetAllCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1085,8 +1089,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapEntrySetCodec_decodeResponse() {
         int fileClientMessageIndex = 116;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEntrySetCodec.ResponseParameters parameters = MapEntrySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapEntrySetCodec.ResponseParameters parameters = MapEntrySetCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1133,8 +1138,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapEntriesWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 122;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEntriesWithPredicateCodec.ResponseParameters parameters = MapEntriesWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapEntriesWithPredicateCodec.ResponseParameters parameters = MapEntriesWithPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1258,8 +1264,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapExecuteOnAllKeysCodec_decodeResponse() {
         int fileClientMessageIndex = 138;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapExecuteOnAllKeysCodec.ResponseParameters parameters = MapExecuteOnAllKeysCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapExecuteOnAllKeysCodec.ResponseParameters parameters = MapExecuteOnAllKeysCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1274,8 +1281,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapExecuteWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 140;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapExecuteWithPredicateCodec.ResponseParameters parameters = MapExecuteWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapExecuteWithPredicateCodec.ResponseParameters parameters = MapExecuteWithPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1290,8 +1298,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapExecuteOnKeysCodec_decodeResponse() {
         int fileClientMessageIndex = 142;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapExecuteOnKeysCodec.ResponseParameters parameters = MapExecuteOnKeysCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapExecuteOnKeysCodec.ResponseParameters parameters = MapExecuteOnKeysCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1337,8 +1346,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapValuesWithPagingPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 148;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapValuesWithPagingPredicateCodec.ResponseParameters parameters = MapValuesWithPagingPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapValuesWithPagingPredicateCodec.ResponseParameters parameters = MapValuesWithPagingPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1353,8 +1363,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapEntriesWithPagingPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 150;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEntriesWithPagingPredicateCodec.ResponseParameters parameters = MapEntriesWithPagingPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapEntriesWithPagingPredicateCodec.ResponseParameters parameters = MapEntriesWithPagingPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1401,9 +1412,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MapFetchEntriesCodec_decodeResponse() {
         int fileClientMessageIndex = 156;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapFetchEntriesCodec.ResponseParameters parameters = MapFetchEntriesCodec.decodeResponse(fromFile);
+        List<Map.Entry<Data, Data>> entriesList = new ArrayList<>();
+        MapFetchEntriesCodec.ResponseParameters parameters = MapFetchEntriesCodec.decodeResponse(fromFile, (key, value) -> entriesList.add(new AbstractMap.SimpleEntry<>(key, value)));
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfDataToData, parameters.entries));
+        assertTrue(isEqual(aListOfDataToData, entriesList));
     }
 
     @Test
@@ -1792,8 +1804,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_MultiMapEntrySetCodec_decodeResponse() {
         int fileClientMessageIndex = 202;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapEntrySetCodec.ResponseParameters parameters = MultiMapEntrySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MultiMapEntrySetCodec.ResponseParameters parameters = MultiMapEntrySetCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -3990,8 +4003,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ReplicatedMapEntrySetCodec_decodeResponse() {
         int fileClientMessageIndex = 464;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ReplicatedMapEntrySetCodec.ResponseParameters parameters = ReplicatedMapEntrySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        ReplicatedMapEntrySetCodec.ResponseParameters parameters = ReplicatedMapEntrySetCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -4742,8 +4756,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_CacheGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 556;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheGetAllCodec.ResponseParameters parameters = CacheGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        CacheGetAllCodec.ResponseParameters parameters = CacheGetAllCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -5059,9 +5074,10 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_CacheIterateEntriesCodec_decodeResponse() {
         int fileClientMessageIndex = 595;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheIterateEntriesCodec.ResponseParameters parameters = CacheIterateEntriesCodec.decodeResponse(fromFile);
+        List<Map.Entry<Data, Data>> entriesList = new ArrayList<>();
+        CacheIterateEntriesCodec.ResponseParameters parameters = CacheIterateEntriesCodec.decodeResponse(fromFile, (key, value) -> entriesList.add(new AbstractMap.SimpleEntry<>(key, value)));
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfDataToData, parameters.entries));
+        assertTrue(isEqual(aListOfDataToData, entriesList));
     }
 
     @Test
@@ -5365,8 +5381,9 @@ public class ClientCompatibilityNullTest_2_0 {
     public void test_ContinuousQueryPublisherCreateWithValueCodec_decodeResponse() {
         int fileClientMessageIndex = 631;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ContinuousQueryPublisherCreateWithValueCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        ContinuousQueryPublisherCreateWithValueCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
@@ -1040,8 +1040,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 110;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapKeySetCodec.ResponseParameters parameters = MapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapKeySetCodec.ResponseParameters parameters = MapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1073,8 +1074,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 114;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapValuesCodec.ResponseParameters parameters = MapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapValuesCodec.ResponseParameters parameters = MapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1106,8 +1108,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapKeySetWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 118;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapKeySetWithPredicateCodec.ResponseParameters parameters = MapKeySetWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapKeySetWithPredicateCodec.ResponseParameters parameters = MapKeySetWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1122,8 +1125,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapValuesWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 120;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapValuesWithPredicateCodec.ResponseParameters parameters = MapValuesWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapValuesWithPredicateCodec.ResponseParameters parameters = MapValuesWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1330,8 +1334,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapKeySetWithPagingPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 146;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapKeySetWithPagingPredicateCodec.ResponseParameters parameters = MapKeySetWithPagingPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MapKeySetWithPagingPredicateCodec.ResponseParameters parameters = MapKeySetWithPagingPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1395,9 +1400,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapFetchKeysCodec_decodeResponse() {
         int fileClientMessageIndex = 154;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapFetchKeysCodec.ResponseParameters parameters = MapFetchKeysCodec.decodeResponse(fromFile);
+        List<Data> keysList = new ArrayList<>();
+        MapFetchKeysCodec.ResponseParameters parameters = MapFetchKeysCodec.decodeResponse(fromFile, keysList::add);
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfData, parameters.keys));
+        assertTrue(isEqual(aListOfData, keysList));
     }
 
     @Test
@@ -1625,9 +1631,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapEventJournalReadCodec_decodeResponse() {
         int fileClientMessageIndex = 180;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEventJournalReadCodec.ResponseParameters parameters = MapEventJournalReadCodec.decodeResponse(fromFile);
+        List<Data> itemsList = new ArrayList<>();
+        MapEventJournalReadCodec.ResponseParameters parameters = MapEventJournalReadCodec.decodeResponse(fromFile, itemsList::add);
         assertTrue(isEqual(anInt, parameters.readCount));
-        assertTrue(isEqual(aListOfData, parameters.items));
+        assertTrue(isEqual(aListOfData, itemsList));
         assertTrue(isEqual(aLongArray, parameters.itemSeqs));
         assertTrue(isEqual(aLong, parameters.nextSeq));
     }
@@ -1740,8 +1747,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MultiMapGetCodec_decodeResponse() {
         int fileClientMessageIndex = 194;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapGetCodec.ResponseParameters parameters = MultiMapGetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapGetCodec.ResponseParameters parameters = MultiMapGetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1756,8 +1764,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MultiMapRemoveCodec_decodeResponse() {
         int fileClientMessageIndex = 196;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapRemoveCodec.ResponseParameters parameters = MultiMapRemoveCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapRemoveCodec.ResponseParameters parameters = MultiMapRemoveCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1772,8 +1781,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MultiMapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 198;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapKeySetCodec.ResponseParameters parameters = MultiMapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapKeySetCodec.ResponseParameters parameters = MultiMapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -1788,8 +1798,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MultiMapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 200;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapValuesCodec.ResponseParameters parameters = MultiMapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        MultiMapValuesCodec.ResponseParameters parameters = MultiMapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2225,8 +2236,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_QueueIteratorCodec_decodeResponse() {
         int fileClientMessageIndex = 252;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        QueueIteratorCodec.ResponseParameters parameters = QueueIteratorCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        QueueIteratorCodec.ResponseParameters parameters = QueueIteratorCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2241,8 +2253,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_QueueDrainToCodec_decodeResponse() {
         int fileClientMessageIndex = 254;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        QueueDrainToCodec.ResponseParameters parameters = QueueDrainToCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        QueueDrainToCodec.ResponseParameters parameters = QueueDrainToCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2257,8 +2270,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_QueueDrainToMaxSizeCodec_decodeResponse() {
         int fileClientMessageIndex = 256;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        QueueDrainToMaxSizeCodec.ResponseParameters parameters = QueueDrainToMaxSizeCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        QueueDrainToMaxSizeCodec.ResponseParameters parameters = QueueDrainToMaxSizeCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2656,8 +2670,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ListGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 304;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListGetAllCodec.ResponseParameters parameters = ListGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListGetAllCodec.ResponseParameters parameters = ListGetAllCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2848,8 +2863,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ListSubCodec_decodeResponse() {
         int fileClientMessageIndex = 327;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListSubCodec.ResponseParameters parameters = ListSubCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListSubCodec.ResponseParameters parameters = ListSubCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2864,8 +2880,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ListIteratorCodec_decodeResponse() {
         int fileClientMessageIndex = 329;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListIteratorCodec.ResponseParameters parameters = ListIteratorCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListIteratorCodec.ResponseParameters parameters = ListIteratorCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -2880,8 +2897,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ListListIteratorCodec_decodeResponse() {
         int fileClientMessageIndex = 331;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ListListIteratorCodec.ResponseParameters parameters = ListListIteratorCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ListListIteratorCodec.ResponseParameters parameters = ListListIteratorCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -3039,8 +3057,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_SetGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 351;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        SetGetAllCodec.ResponseParameters parameters = SetGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        SetGetAllCodec.ResponseParameters parameters = SetGetAllCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -3971,8 +3990,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ReplicatedMapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 460;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ReplicatedMapKeySetCodec.ResponseParameters parameters = ReplicatedMapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ReplicatedMapKeySetCodec.ResponseParameters parameters = ReplicatedMapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -3987,8 +4007,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ReplicatedMapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 462;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ReplicatedMapValuesCodec.ResponseParameters parameters = ReplicatedMapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ReplicatedMapValuesCodec.ResponseParameters parameters = ReplicatedMapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4263,8 +4284,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_TransactionalMapKeySetCodec_decodeResponse() {
         int fileClientMessageIndex = 495;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapKeySetCodec.ResponseParameters parameters = TransactionalMapKeySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapKeySetCodec.ResponseParameters parameters = TransactionalMapKeySetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4279,8 +4301,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_TransactionalMapKeySetWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 497;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapKeySetWithPredicateCodec.ResponseParameters parameters = TransactionalMapKeySetWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapKeySetWithPredicateCodec.ResponseParameters parameters = TransactionalMapKeySetWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4295,8 +4318,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_TransactionalMapValuesCodec_decodeResponse() {
         int fileClientMessageIndex = 499;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapValuesCodec.ResponseParameters parameters = TransactionalMapValuesCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapValuesCodec.ResponseParameters parameters = TransactionalMapValuesCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4311,8 +4335,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_TransactionalMapValuesWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 501;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMapValuesWithPredicateCodec.ResponseParameters parameters = TransactionalMapValuesWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMapValuesWithPredicateCodec.ResponseParameters parameters = TransactionalMapValuesWithPredicateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4359,8 +4384,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_TransactionalMultiMapGetCodec_decodeResponse() {
         int fileClientMessageIndex = 507;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMultiMapGetCodec.ResponseParameters parameters = TransactionalMultiMapGetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMultiMapGetCodec.ResponseParameters parameters = TransactionalMultiMapGetCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4375,8 +4401,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_TransactionalMultiMapRemoveCodec_decodeResponse() {
         int fileClientMessageIndex = 509;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        TransactionalMultiMapRemoveCodec.ResponseParameters parameters = TransactionalMultiMapRemoveCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        TransactionalMultiMapRemoveCodec.ResponseParameters parameters = TransactionalMultiMapRemoveCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -4837,9 +4864,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_CacheIterateCodec_decodeResponse() {
         int fileClientMessageIndex = 566;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheIterateCodec.ResponseParameters parameters = CacheIterateCodec.decodeResponse(fromFile);
+        List<Data> keysList = new ArrayList<>();
+        CacheIterateCodec.ResponseParameters parameters = CacheIterateCodec.decodeResponse(fromFile, keysList::add);
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfData, parameters.keys));
+        assertTrue(isEqual(aListOfData, keysList));
     }
 
     @Test
@@ -5193,9 +5221,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_CacheEventJournalReadCodec_decodeResponse() {
         int fileClientMessageIndex = 607;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheEventJournalReadCodec.ResponseParameters parameters = CacheEventJournalReadCodec.decodeResponse(fromFile);
+        List<Data> itemsList = new ArrayList<>();
+        CacheEventJournalReadCodec.ResponseParameters parameters = CacheEventJournalReadCodec.decodeResponse(fromFile, itemsList::add);
         assertTrue(isEqual(anInt, parameters.readCount));
-        assertTrue(isEqual(aListOfData, parameters.items));
+        assertTrue(isEqual(aListOfData, itemsList));
         assertTrue(isEqual(aLongArray, parameters.itemSeqs));
         assertTrue(isEqual(aLong, parameters.nextSeq));
     }
@@ -5398,8 +5427,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ContinuousQueryPublisherCreateCodec_decodeResponse() {
         int fileClientMessageIndex = 633;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ContinuousQueryPublisherCreateCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfData, parameters.response));
+        List<Data> responseList = new ArrayList<>();
+        ContinuousQueryPublisherCreateCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateCodec.decodeResponse(fromFile, responseList::add);
+        assertTrue(isEqual(aListOfData, responseList));
     }
 
     @Test
@@ -5635,9 +5665,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_RingbufferReadManyCodec_decodeResponse() {
         int fileClientMessageIndex = 661;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        RingbufferReadManyCodec.ResponseParameters parameters = RingbufferReadManyCodec.decodeResponse(fromFile);
+        List<Data> itemsList = new ArrayList<>();
+        RingbufferReadManyCodec.ResponseParameters parameters = RingbufferReadManyCodec.decodeResponse(fromFile, itemsList::add);
         assertTrue(isEqual(anInt, parameters.readCount));
-        assertTrue(isEqual(aListOfData, parameters.items));
+        assertTrue(isEqual(aListOfData, itemsList));
         assertTrue(isEqual(aLongArray, parameters.itemSeqs));
         assertTrue(isEqual(aLong, parameters.nextSeq));
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,9 +33,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
@@ -1053,8 +1056,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 112;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapGetAllCodec.ResponseParameters parameters = MapGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapGetAllCodec.ResponseParameters parameters = MapGetAllCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1085,8 +1089,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapEntrySetCodec_decodeResponse() {
         int fileClientMessageIndex = 116;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEntrySetCodec.ResponseParameters parameters = MapEntrySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapEntrySetCodec.ResponseParameters parameters = MapEntrySetCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1133,8 +1138,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapEntriesWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 122;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEntriesWithPredicateCodec.ResponseParameters parameters = MapEntriesWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapEntriesWithPredicateCodec.ResponseParameters parameters = MapEntriesWithPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1258,8 +1264,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapExecuteOnAllKeysCodec_decodeResponse() {
         int fileClientMessageIndex = 138;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapExecuteOnAllKeysCodec.ResponseParameters parameters = MapExecuteOnAllKeysCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapExecuteOnAllKeysCodec.ResponseParameters parameters = MapExecuteOnAllKeysCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1274,8 +1281,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapExecuteWithPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 140;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapExecuteWithPredicateCodec.ResponseParameters parameters = MapExecuteWithPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapExecuteWithPredicateCodec.ResponseParameters parameters = MapExecuteWithPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1290,8 +1298,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapExecuteOnKeysCodec_decodeResponse() {
         int fileClientMessageIndex = 142;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapExecuteOnKeysCodec.ResponseParameters parameters = MapExecuteOnKeysCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapExecuteOnKeysCodec.ResponseParameters parameters = MapExecuteOnKeysCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1337,8 +1346,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapValuesWithPagingPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 148;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapValuesWithPagingPredicateCodec.ResponseParameters parameters = MapValuesWithPagingPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapValuesWithPagingPredicateCodec.ResponseParameters parameters = MapValuesWithPagingPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1353,8 +1363,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapEntriesWithPagingPredicateCodec_decodeResponse() {
         int fileClientMessageIndex = 150;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapEntriesWithPagingPredicateCodec.ResponseParameters parameters = MapEntriesWithPagingPredicateCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MapEntriesWithPagingPredicateCodec.ResponseParameters parameters = MapEntriesWithPagingPredicateCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -1401,9 +1412,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MapFetchEntriesCodec_decodeResponse() {
         int fileClientMessageIndex = 156;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MapFetchEntriesCodec.ResponseParameters parameters = MapFetchEntriesCodec.decodeResponse(fromFile);
+        List<Map.Entry<Data, Data>> entriesList = new ArrayList<>();
+        MapFetchEntriesCodec.ResponseParameters parameters = MapFetchEntriesCodec.decodeResponse(fromFile, (key, value) -> entriesList.add(new AbstractMap.SimpleEntry<>(key, value)));
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfDataToData, parameters.entries));
+        assertTrue(isEqual(aListOfDataToData, entriesList));
     }
 
     @Test
@@ -1792,8 +1804,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_MultiMapEntrySetCodec_decodeResponse() {
         int fileClientMessageIndex = 202;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        MultiMapEntrySetCodec.ResponseParameters parameters = MultiMapEntrySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        MultiMapEntrySetCodec.ResponseParameters parameters = MultiMapEntrySetCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -3990,8 +4003,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ReplicatedMapEntrySetCodec_decodeResponse() {
         int fileClientMessageIndex = 464;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ReplicatedMapEntrySetCodec.ResponseParameters parameters = ReplicatedMapEntrySetCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        ReplicatedMapEntrySetCodec.ResponseParameters parameters = ReplicatedMapEntrySetCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -4742,8 +4756,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_CacheGetAllCodec_decodeResponse() {
         int fileClientMessageIndex = 556;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheGetAllCodec.ResponseParameters parameters = CacheGetAllCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        CacheGetAllCodec.ResponseParameters parameters = CacheGetAllCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test
@@ -5059,9 +5074,10 @@ public class ClientCompatibilityTest_2_0 {
     public void test_CacheIterateEntriesCodec_decodeResponse() {
         int fileClientMessageIndex = 595;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        CacheIterateEntriesCodec.ResponseParameters parameters = CacheIterateEntriesCodec.decodeResponse(fromFile);
+        List<Map.Entry<Data, Data>> entriesList = new ArrayList<>();
+        CacheIterateEntriesCodec.ResponseParameters parameters = CacheIterateEntriesCodec.decodeResponse(fromFile, (key, value) -> entriesList.add(new AbstractMap.SimpleEntry<>(key, value)));
         assertTrue(isEqual(anInt, parameters.tableIndex));
-        assertTrue(isEqual(aListOfDataToData, parameters.entries));
+        assertTrue(isEqual(aListOfDataToData, entriesList));
     }
 
     @Test
@@ -5365,8 +5381,9 @@ public class ClientCompatibilityTest_2_0 {
     public void test_ContinuousQueryPublisherCreateWithValueCodec_decodeResponse() {
         int fileClientMessageIndex = 631;
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
-        ContinuousQueryPublisherCreateWithValueCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(fromFile);
-        assertTrue(isEqual(aListOfDataToData, parameters.response));
+        List<Map.Entry<Data, Data>> responseList = new ArrayList<>();
+        ContinuousQueryPublisherCreateWithValueCodec.ResponseParameters parameters = ContinuousQueryPublisherCreateWithValueCodec.decodeResponse(fromFile, (key, value) -> responseList.add(new AbstractMap.SimpleEntry<>(key, value)));
+        assertTrue(isEqual(aListOfDataToData, responseList));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;


### PR DESCRIPTION
This PR introduces consumers for responses that return `List<Data>` and bi-consumers for responses that return `List<Map.Entry<Data, Data>>` so that we would not iterate over the responses again to deserialize them. 

With this change, we call the consumer / bi-consumer on `EntryListCodec` / `ListMultiFrameCodec` when we get the data frame instead of adding it to a list directly. So, we get rid of 
- extra N `Map.Entry<Data, Data>` object creation for map-like responses of size N
- extra N iterations for responses that return  `List<Data>` / `List<Map.Entry<Data, Data>>` and size of N

in which we deserialize the response immediately.

There is one thing I am not very sure of. With the protocol 2.0, we don't know the list sizes beforehand. So, with the consumers, we are adding data or object to a list with the initial size of 0. With this setting, LinkedList looks like a logical choice. But, I did some local JMH tests in which I compared adding elements to a linked list vs. adding elements to an array list with the initial size of 0. Benchmarks showed that the array list was a better choice in terms of throughput and allocation rate. So, I choose array list but I am open to ideas about this. Here are the benchmark results.

```
Benchmark                                                         (N)   Mode  Cnt         Score         Error   Units
HzBenchmark.buildArrayList                                        100  thrpt    5   1701303.879 ±   98552.341   ops/s
HzBenchmark.buildArrayList:·gc.alloc.rate                         100  thrpt    5      2063.899 ±     120.154  MB/sec
HzBenchmark.buildArrayList:·gc.alloc.rate.norm                    100  thrpt    5      1400.000 ±       0.001    B/op
HzBenchmark.buildArrayList:·gc.churn.PS_Eden_Space                100  thrpt    5      2053.179 ±     264.741  MB/sec
HzBenchmark.buildArrayList:·gc.churn.PS_Eden_Space.norm           100  thrpt    5      1392.545 ±     128.532    B/op
HzBenchmark.buildArrayList:·gc.churn.PS_Survivor_Space            100  thrpt    5         0.026 ±       0.045  MB/sec
HzBenchmark.buildArrayList:·gc.churn.PS_Survivor_Space.norm       100  thrpt    5         0.018 ±       0.031    B/op
HzBenchmark.buildArrayList:·gc.count                              100  thrpt    5        83.000                counts
HzBenchmark.buildArrayList:·gc.time                               100  thrpt    5        37.000                    ms
HzBenchmark.buildArrayList                                      10000  thrpt    5     17290.374 ±    7305.500   ops/s
HzBenchmark.buildArrayList:·gc.alloc.rate                       10000  thrpt    5      2531.523 ±    1066.908  MB/sec
HzBenchmark.buildArrayList:·gc.alloc.rate.norm                  10000  thrpt    5    168968.005 ±       0.002    B/op
HzBenchmark.buildArrayList:·gc.churn.PS_Eden_Space              10000  thrpt    5      2524.560 ±    1241.708  MB/sec
HzBenchmark.buildArrayList:·gc.churn.PS_Eden_Space.norm         10000  thrpt    5    168295.540 ±   18382.529    B/op
HzBenchmark.buildArrayList:·gc.churn.PS_Survivor_Space          10000  thrpt    5         0.023 ±       0.041  MB/sec
HzBenchmark.buildArrayList:·gc.churn.PS_Survivor_Space.norm     10000  thrpt    5         1.530 ±       2.510    B/op
HzBenchmark.buildArrayList:·gc.count                            10000  thrpt    5       102.000                counts
HzBenchmark.buildArrayList:·gc.time                             10000  thrpt    5        47.000                    ms
HzBenchmark.buildArrayList                                    1000000  thrpt    5       179.400 ±       2.631   ops/s
HzBenchmark.buildArrayList:·gc.alloc.rate                     1000000  thrpt    5      2267.570 ±      34.935  MB/sec
HzBenchmark.buildArrayList:·gc.alloc.rate.norm                1000000  thrpt    5  14586416.532 ±       0.364    B/op
HzBenchmark.buildArrayList:·gc.churn.PS_Eden_Space            1000000  thrpt    5      2274.597 ±     254.791  MB/sec
HzBenchmark.buildArrayList:·gc.churn.PS_Eden_Space.norm       1000000  thrpt    5  14631390.255 ± 1585733.646    B/op
HzBenchmark.buildArrayList:·gc.churn.PS_Survivor_Space        1000000  thrpt    5         0.554 ±       2.522  MB/sec
HzBenchmark.buildArrayList:·gc.churn.PS_Survivor_Space.norm   1000000  thrpt    5      3562.310 ±   16212.157    B/op
HzBenchmark.buildArrayList:·gc.count                          1000000  thrpt    5        93.000                counts
HzBenchmark.buildArrayList:·gc.time                           1000000  thrpt    5       270.000                    ms
HzBenchmark.buildLinkedList                                       100  thrpt    5   1527042.216 ±   31960.771   ops/s
HzBenchmark.buildLinkedList:·gc.alloc.rate                        100  thrpt    5      3217.802 ±      64.944  MB/sec
HzBenchmark.buildLinkedList:·gc.alloc.rate.norm                   100  thrpt    5      2432.000 ±       0.001    B/op
HzBenchmark.buildLinkedList:·gc.churn.PS_Eden_Space               100  thrpt    5      3217.237 ±       5.895  MB/sec
HzBenchmark.buildLinkedList:·gc.churn.PS_Eden_Space.norm          100  thrpt    5      2431.628 ±      50.950    B/op
HzBenchmark.buildLinkedList:·gc.churn.PS_Survivor_Space           100  thrpt    5         0.056 ±       0.042  MB/sec
HzBenchmark.buildLinkedList:·gc.churn.PS_Survivor_Space.norm      100  thrpt    5         0.042 ±       0.033    B/op
HzBenchmark.buildLinkedList:·gc.count                             100  thrpt    5       130.000                counts
HzBenchmark.buildLinkedList:·gc.time                              100  thrpt    5        59.000                    ms
HzBenchmark.buildLinkedList                                     10000  thrpt    5     16523.765 ±     510.081   ops/s
HzBenchmark.buildLinkedList:·gc.alloc.rate                      10000  thrpt    5      3436.738 ±     104.193  MB/sec
HzBenchmark.buildLinkedList:·gc.alloc.rate.norm                 10000  thrpt    5    240032.005 ±       0.001    B/op
HzBenchmark.buildLinkedList:·gc.churn.PS_Eden_Space             10000  thrpt    5      3440.798 ±     209.956  MB/sec
HzBenchmark.buildLinkedList:·gc.churn.PS_Eden_Space.norm        10000  thrpt    5    240303.819 ±    7755.058    B/op
HzBenchmark.buildLinkedList:·gc.churn.PS_Survivor_Space         10000  thrpt    5         0.061 ±       0.036  MB/sec
HzBenchmark.buildLinkedList:·gc.churn.PS_Survivor_Space.norm    10000  thrpt    5         4.285 ±       2.631    B/op
HzBenchmark.buildLinkedList:·gc.count                           10000  thrpt    5       139.000                counts
HzBenchmark.buildLinkedList:·gc.time                            10000  thrpt    5        83.000                    ms
HzBenchmark.buildLinkedList                                   1000000  thrpt    5       174.288 ±       3.907   ops/s
HzBenchmark.buildLinkedList:·gc.alloc.rate                    1000000  thrpt    5      3625.252 ±      80.670  MB/sec
HzBenchmark.buildLinkedList:·gc.alloc.rate.norm               1000000  thrpt    5  24000032.555 ±       0.456    B/op
HzBenchmark.buildLinkedList:·gc.churn.PS_Eden_Space           1000000  thrpt    5      3606.537 ±     230.446  MB/sec
HzBenchmark.buildLinkedList:·gc.churn.PS_Eden_Space.norm      1000000  thrpt    5  23876137.365 ± 1434910.059    B/op
HzBenchmark.buildLinkedList:·gc.churn.PS_Survivor_Space       1000000  thrpt    5        32.887 ±       3.656  MB/sec
HzBenchmark.buildLinkedList:·gc.churn.PS_Survivor_Space.norm  1000000  thrpt    5    217705.736 ±   21883.559    B/op
HzBenchmark.buildLinkedList:·gc.count                         1000000  thrpt    5       158.000                counts
HzBenchmark.buildLinkedList:·gc.time                          1000000  thrpt    5      3375.000                    ms
```
fixes #13590 

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/270 