### PR TITLE
Make StatisticsAwareServices self-registering as metrics providers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -54,6 +54,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
@@ -63,6 +64,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.QueueMergeTypes;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.transaction.impl.Transaction;
 
 import java.util.Collection;
@@ -141,6 +143,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -35,6 +35,7 @@ import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
@@ -99,6 +100,8 @@ public class DistributedExecutorService implements ManagedService, RemoteService
         this.nodeEngine = nodeEngine;
         this.executionService = nodeEngine.getExecutionService();
         this.logger = nodeEngine.getLogger(DistributedExecutorService.class);
+
+        ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -28,6 +28,8 @@ import com.hazelcast.internal.services.RemoteService;
 import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.ClusterProperty;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +56,11 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService,
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         this.nodeEngine = nodeEngine;
+
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/PNCounterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/PNCounterService.java
@@ -36,6 +36,8 @@ import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.Memoizer;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.ClusterProperty;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -134,6 +136,11 @@ public class PNCounterService implements ManagedService, RemoteService, CRDTRepl
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         this.nodeEngine = nodeEngine;
+
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -89,6 +89,7 @@ class MetricsCollectionCycle {
                 metricsSource.provideDynamicMetrics(descriptorSupplier.get(), metricsContext);
             } catch (Throwable t) {
                 logger.warning("Collecting metrics from source " + metricsSource.getClass().getName() + " failed", t);
+                assert false : "Collecting metrics from source " + metricsSource.getClass().getName() + " failed";
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -50,10 +50,12 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.spi.impl.CountingMigrationAwareService;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.wan.WanReplicationEvent;
@@ -116,6 +118,11 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         managedService.init(nodeEngine, properties);
+
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -53,6 +53,7 @@ import com.hazelcast.multimap.impl.operations.MultiMapReplicationOperation;
 import com.hazelcast.multimap.impl.txn.TransactionalMultiMapProxy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
@@ -60,6 +61,7 @@ import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MultiMapMergeTypes;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.transaction.TransactionalObject;
@@ -160,6 +162,11 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
                     }
                 };
             });
+        }
+
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -51,11 +51,13 @@ import com.hazelcast.replicatedmap.impl.operation.CheckReplicaVersionOperation;
 import com.hazelcast.replicatedmap.impl.operation.ReplicationOperation;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 
@@ -142,6 +144,11 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
         }
         antiEntropyFuture = nodeEngine.getExecutionService().getGlobalTaskScheduler()
                 .scheduleWithRepetition(antiEntropyTask, 0, SYNC_INTERVAL_SECONDS, TimeUnit.SECONDS);
+
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -16,20 +16,14 @@
 
 package com.hazelcast.spi.impl;
 
-import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MetricsConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.executor.impl.DistributedExecutorService;
-import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.crdt.pncounter.PNCounterService;
 import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.dynamicconfig.ClusterWideConfigurationService;
 import com.hazelcast.internal.dynamicconfig.DynamicConfigListener;
@@ -55,10 +49,7 @@ import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.impl.LoggingServiceImpl;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.ServiceNotFoundException;
 import com.hazelcast.spi.impl.eventservice.EventService;
@@ -79,8 +70,6 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.splitbrainprotection.impl.SplitBrainProtectionServiceImpl;
-import com.hazelcast.topic.impl.TopicService;
-import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.version.MemberVersion;
@@ -231,23 +220,6 @@ public class NodeEngineImpl implements NodeEngine {
         proxyService.init();
         operationService.start();
         splitBrainProtectionService.start();
-
-        MetricsConfig metricsConfig = node.getConfig().getMetricsConfig();
-        HazelcastProperties properties = new HazelcastProperties(node.getConfig().getProperties());
-        boolean dataStructureMetrics = properties.getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
-        if (metricsConfig.isEnabled() && dataStructureMetrics) {
-            metricsRegistry.registerDynamicMetricsProvider(getService(MapService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(ICacheService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(QueueService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(TopicService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(ReliableTopicService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(ReplicatedMapService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(MultiMapService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(PNCounterService.SERVICE_NAME));
-            metricsRegistry.registerDynamicMetricsProvider(getService(FlakeIdGeneratorService.SERVICE_NAME));
-        }
-        metricsRegistry.registerDynamicMetricsProvider(getService(DistributedExecutorService.SERVICE_NAME));
-        metricsRegistry.registerDynamicMetricsProvider(getService(WanReplicationService.SERVICE_NAME));
 
         diagnostics.start();
         node.getNodeExtension().registerPlugins(diagnostics);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -33,9 +33,11 @@ import com.hazelcast.internal.util.HashUtil;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.Message;
@@ -81,6 +83,11 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
             orderingLocks[i] = new ReentrantLock();
         }
         eventService = nodeEngine.getEventService();
+
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     // only for testing

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
@@ -29,6 +29,8 @@ import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.topic.LocalTopicStats;
 
 import java.util.Map;
@@ -89,6 +91,10 @@ public class ReliableTopicService implements ManagedService, RemoteService, Stat
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
+        boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
+        if (dsMetricsEnabled) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationService.java
@@ -20,11 +20,10 @@ import com.hazelcast.config.AbstractWanPublisherConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.WanBatchReplicationPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
-import com.hazelcast.internal.metrics.DynamicMetricsProvider;
-import com.hazelcast.internal.services.CoreService;
-import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.internal.monitor.LocalWanStats;
 import com.hazelcast.internal.monitor.WanSyncState;
+import com.hazelcast.internal.services.CoreService;
+import com.hazelcast.internal.services.StatisticsAwareService;
 import com.hazelcast.version.Version;
 import com.hazelcast.wan.DistributedServiceWanEventCounters;
 import com.hazelcast.wan.WanReplicationPublisher;
@@ -39,7 +38,7 @@ import java.util.UUID;
  * values to other clusters over the wide area network, so it has to deal
  * with long delays, slow uploads and higher latencies.
  */
-public interface WanReplicationService extends CoreService, StatisticsAwareService<LocalWanStats>, DynamicMetricsProvider {
+public interface WanReplicationService extends CoreService, StatisticsAwareService<LocalWanStats> {
 
     /**
      * Service name.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -25,8 +25,6 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.events.AddWanConfigIgnoredEvent;
 import com.hazelcast.internal.management.events.WanConsistencyCheckIgnoredEvent;
 import com.hazelcast.internal.management.events.WanSyncIgnoredEvent;
-import com.hazelcast.internal.metrics.MetricDescriptor;
-import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.monitor.LocalWanStats;
 import com.hazelcast.internal.monitor.WanSyncState;
 import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
@@ -410,10 +408,5 @@ public class WanReplicationServiceImpl implements WanReplicationService,
                 }
             }
         }
-    }
-
-    @Override
-    public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
-        // nop
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DynamicMetricsCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DynamicMetricsCollectionTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -171,6 +173,7 @@ public class DynamicMetricsCollectionTest extends HazelcastTestSupport {
         verify(collectorMock, never()).collectDouble(expectedDescriptor, 42.42D);
     }
 
+    @RequireAssertEnabled
     @Test
     public void testDynamicProviderExceptionsAreNotPropagated() {
         MetricsCollector collectorMock = mock(MetricsCollector.class);
@@ -184,6 +187,7 @@ public class DynamicMetricsCollectionTest extends HazelcastTestSupport {
         // which is for testing only
         try {
             metricsRegistry.collect(collectorMock);
+            fail("Should throw AssertionError");
         } catch (AssertionError ex) {
             // nop
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DynamicMetricsCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DynamicMetricsCollectionTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.logging.Logger;
@@ -180,8 +180,13 @@ public class DynamicMetricsCollectionTest extends HazelcastTestSupport {
 
         });
 
-        metricsRegistry.collect(collectorMock);
-        // we just expect there is no exception
+        // we just expect there is no exception apart from AssertionError,
+        // which is for testing only
+        try {
+            metricsRegistry.collect(collectorMock);
+        } catch (AssertionError ex) {
+            // nop
+        }
     }
 
     private static class SourceObject {


### PR DESCRIPTION
Recent change removed `StatisticsAwareMetricsSet` that was responsible for
providing metrics for `StatisticsAwareServices`. This changed to unconditionally
register the implementer services in `NodeEngineImpl`, which failed if the
cache was not initialized (if the `jcache.jar` is not present). Therefore,
all services made self-registering. They register themselves in `init()`
if the datastructure metrics are enabled. There are two exceptions: the
`DistributedExecutorService` and `(Enterprise)WanReplicationService` that
doesn't check the value of the datastructure flag.

Also, an `NPE` is fixed in `EnterpriseWanReplicationService`'s
provider method by checking if the distributed data structure counters are
present.

Additionally, an assertion is added to fail during the metrics
collection if the collection cycle encounters an exception AND the test
is testing metrics collection specifically by directly calling
`MetricRegistry.collect()` (otherwise the `AssertionError` is thrown on a
different thread). This means it is a best-effort assertion. In the
future, we might want to introduce a junit rule that reads out this info
from the metrics collection.

Fixes #16136 and hazelcast/hazelcast-enterprise#3391

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3393