### PR TITLE
prevent multiple join config creation when discover strategy enabled

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestDiscoveryConfigApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestDiscoveryConfigApplicationContext.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.WanPublisherConfig;
+import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"discoveryConfig-applicationContext-hazelcast.xml"})
+@Category(QuickTest.class)
+@SuppressWarnings("unused")
+public class TestDiscoveryConfigApplicationContext {
+
+    private Config config;
+
+    @Resource(name = "instance")
+    private HazelcastInstance instance;
+
+    @BeforeClass
+    @AfterClass
+    public static void start() {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Before
+    public void before() {
+        config = instance.getConfig();
+    }
+
+    @Test
+    public void testNetworkDiscoveryConfig() {
+        NetworkConfig networkConfig = config.getNetworkConfig();
+
+        assertDiscoveryConfig(networkConfig.getJoin().getDiscoveryConfig());
+    }
+
+    @Test
+    public void testWanDiscoveryConfig() {
+        WanReplicationConfig wcfg = config.getWanReplicationConfig("testWan");
+        WanPublisherConfig publisherConfig = wcfg.getWanPublisherConfigs().get(0);
+
+        assertDiscoveryConfig(publisherConfig.getDiscoveryConfig());
+    }
+
+    private void assertDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+        assertTrue(discoveryConfig.getDiscoveryServiceProvider() instanceof DummyDiscoveryServiceProvider);
+        assertTrue(discoveryConfig.getNodeFilter() instanceof DummyNodeFilter);
+        List<DiscoveryStrategyConfig> discoveryStrategyConfigs
+                = (List<DiscoveryStrategyConfig>) discoveryConfig.getDiscoveryStrategyConfigs();
+        assertEquals(1, discoveryStrategyConfigs.size());
+        DiscoveryStrategyConfig discoveryStrategyConfig = discoveryStrategyConfigs.get(0);
+        assertTrue(discoveryStrategyConfig.getDiscoveryStrategyFactory() instanceof DummyDiscoveryStrategyFactory);
+        assertEquals(3, discoveryStrategyConfig.getProperties().size());
+        assertEquals("foo", discoveryStrategyConfig.getProperties().get("key-string"));
+        assertEquals("123", discoveryStrategyConfig.getProperties().get("key-int"));
+        assertEquals("true", discoveryStrategyConfig.getProperties().get("key-boolean"));
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -28,8 +28,6 @@ import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConsistencyCheckStrategy;
 import com.hazelcast.config.CountDownLatchConfig;
-import com.hazelcast.config.DiscoveryConfig;
-import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EurekaConfig;
@@ -834,8 +832,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         assertTrue("reuse-address", networkConfig.isReuseAddress());
 
-        assertDiscoveryConfig(networkConfig.getJoin().getDiscoveryConfig());
-
         MemberAddressProviderConfig memberAddressProviderConfig = networkConfig.getMemberAddressProviderConfig();
         assertFalse(memberAddressProviderConfig.isEnabled());
         assertEquals("com.hazelcast.spring.DummyMemberAddressProvider", memberAddressProviderConfig.getClassName());
@@ -892,25 +888,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertFalse(eureka.isEnabled());
         assertEquals("true", eureka.getProperty("self-registration"));
         assertEquals("hazelcast", eureka.getProperty("namespace"));
-    }
-
-    private void assertDiscoveryConfig(DiscoveryConfig discoveryConfig) {
-        assertTrue(discoveryConfig.getDiscoveryServiceProvider() instanceof DummyDiscoveryServiceProvider);
-        assertTrue(discoveryConfig.getNodeFilter() instanceof DummyNodeFilter);
-        List<DiscoveryStrategyConfig> discoveryStrategyConfigs
-                = (List<DiscoveryStrategyConfig>) discoveryConfig.getDiscoveryStrategyConfigs();
-        assertEquals(2, discoveryStrategyConfigs.size());
-        DiscoveryStrategyConfig discoveryStrategyConfig = discoveryStrategyConfigs.get(0);
-        assertTrue(discoveryStrategyConfig.getDiscoveryStrategyFactory() instanceof DummyDiscoveryStrategyFactory);
-        assertEquals(3, discoveryStrategyConfig.getProperties().size());
-        assertEquals("foo", discoveryStrategyConfig.getProperties().get("key-string"));
-        assertEquals("123", discoveryStrategyConfig.getProperties().get("key-int"));
-        assertEquals("true", discoveryStrategyConfig.getProperties().get("key-boolean"));
-
-        DiscoveryStrategyConfig discoveryStrategyConfig2 = discoveryStrategyConfigs.get(1);
-        assertEquals(DummyDiscoveryStrategy.class.getName(), discoveryStrategyConfig2.getClassName());
-        assertEquals(1, discoveryStrategyConfig2.getProperties().size());
-        assertEquals("foo2", discoveryStrategyConfig2.getProperties().get("key-string"));
     }
 
     @Test
@@ -996,22 +973,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("5000", publisherProps.get("response.timeout.millis"));
         assertEquals(WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE.name(), publisherProps.get("ack.type"));
         assertEquals("pass", publisherProps.get("group.password"));
-
-        WanPublisherConfig customPublisher = wcfg.getWanPublisherConfigs().get(1);
-        assertEquals("istanbul", customPublisher.getGroupName());
-        assertEquals("istanbulPublisherId", customPublisher.getPublisherId());
-        assertEquals("com.hazelcast.wan.custom.CustomPublisher", customPublisher.getClassName());
-        assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, customPublisher.getQueueFullBehavior());
-        Map<String, Comparable> customPublisherProps = customPublisher.getProperties();
-        assertEquals("prop.publisher", customPublisherProps.get("custom.prop.publisher"));
-        assertEquals("5", customPublisherProps.get("discovery.period"));
-        assertEquals("2", customPublisherProps.get("maxEndpoints"));
-        assertAwsConfig(customPublisher.getAwsConfig());
-        assertGcpConfig(customPublisher.getGcpConfig());
-        assertAzureConfig(customPublisher.getAzureConfig());
-        assertKubernetesConfig(customPublisher.getKubernetesConfig());
-        assertEurekaConfig(customPublisher.getEurekaConfig());
-        assertDiscoveryConfig(customPublisher.getDiscoveryConfig());
 
         WanPublisherConfig publisherPlaceHolderConfig = wcfg.getWanPublisherConfigs().get(2);
         assertEquals(5000, publisherPlaceHolderConfig.getQueueCapacity());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/discoveryConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/discoveryConfig-applicationContext-hazelcast.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:s="http://www.hazelcast.com/schema/sample"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/sample
+        hazelcast-sample-service.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+          p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
+        <property name="locations">
+            <list>
+                <value>classpath:/hazelcast-default.properties</value>
+            </list>
+        </property>
+    </bean>
+
+    <hz:hazelcast id="instance">
+        <hz:config>
+            <hz:instance-name>test-instance</hz:instance-name>
+            <hz:group
+                    name="${cluster.group.name}"
+                    password="${cluster.group.password}"/>
+            <hz:license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</hz:license-key>
+
+            <hz:wan-replication name="testWan">
+                <hz:wan-publisher group-name="istanbul"
+                                  publisher-id="istanbulPublisherId"
+                                  class-name="com.hazelcast.wan.custom.CustomPublisher">
+                    <hz:queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</hz:queue-full-behavior>
+                    <hz:discovery-strategies>
+                        <hz:node-filter implementation="dummyNodeFilter"/>
+                        <hz:discovery-strategy discovery-strategy-factory="dummyDiscoveryStrategyFactory">
+                            <hz:properties>
+                                <hz:property name="key-string">foo</hz:property>
+                                <hz:property name="key-int">123</hz:property>
+                                <hz:property name="key-boolean">true</hz:property>
+                            </hz:properties>
+                        </hz:discovery-strategy>
+                        <hz:discovery-service-provider implementation="dummyDiscoveryServiceProvider"/>
+                    </hz:discovery-strategies>
+                </hz:wan-publisher>
+            </hz:wan-replication>
+
+            <hz:network port="${cluster.port}" port-auto-increment="false" port-count="42">
+                <hz:join>
+                    <hz:multicast enabled="${boolean.false}" />
+                    <hz:discovery-strategies>
+                        <hz:node-filter implementation="dummyNodeFilter"/>
+                        <hz:discovery-strategy discovery-strategy-factory="dummyDiscoveryStrategyFactory">
+                            <hz:properties>
+                                <hz:property name="key-string">foo</hz:property>
+                                <hz:property name="key-int">123</hz:property>
+                                <hz:property name="key-boolean">true</hz:property>
+                            </hz:properties>
+                        </hz:discovery-strategy>
+                        <hz:discovery-service-provider implementation="dummyDiscoveryServiceProvider"/>
+                    </hz:discovery-strategies>
+                </hz:join>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <bean id="dummyNodeFilter" class="com.hazelcast.spring.DummyNodeFilter"/>
+    <bean id="dummyDiscoveryStrategyFactory" class="com.hazelcast.spring.DummyDiscoveryStrategyFactory"/>
+    <bean id="dummyDiscoveryServiceProvider" class="com.hazelcast.spring.DummyDiscoveryServiceProvider"/>
+    <bean id="dummyService" class="com.hazelcast.spring.MyService"/>
+
+</beans>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -105,22 +105,6 @@
                     <hz:eureka enabled="false"
                                self-registration="true"
                                namespace="hazelcast"/>
-                    <hz:discovery-strategies>
-                        <hz:node-filter implementation="dummyNodeFilter"/>
-                        <hz:discovery-strategy discovery-strategy-factory="dummyDiscoveryStrategyFactory">
-                            <hz:properties>
-                                <hz:property name="key-string">foo</hz:property>
-                                <hz:property name="key-int">123</hz:property>
-                                <hz:property name="key-boolean">true</hz:property>
-                            </hz:properties>
-                        </hz:discovery-strategy>
-                        <hz:discovery-strategy class-name="com.hazelcast.spring.DummyDiscoveryStrategy">
-                            <hz:properties>
-                                <hz:property name="key-string">foo2</hz:property>
-                            </hz:properties>
-                        </hz:discovery-strategy>
-                        <hz:discovery-service-provider implementation="dummyDiscoveryServiceProvider"/>
-                    </hz:discovery-strategies>
                     <hz:properties>
                         <hz:property name="custom.prop.publisher">prop.publisher</hz:property>
                         <hz:property name="discovery.period">5</hz:property>
@@ -192,22 +176,6 @@
                     <hz:eureka enabled="false"
                                self-registration="true"
                                namespace="hazelcast"/>
-                    <hz:discovery-strategies>
-                        <hz:node-filter implementation="dummyNodeFilter"/>
-                        <hz:discovery-strategy discovery-strategy-factory="dummyDiscoveryStrategyFactory">
-                            <hz:properties>
-                                <hz:property name="key-string">foo</hz:property>
-                                <hz:property name="key-int">123</hz:property>
-                                <hz:property name="key-boolean">true</hz:property>
-                            </hz:properties>
-                        </hz:discovery-strategy>
-                        <hz:discovery-strategy class-name="com.hazelcast.spring.DummyDiscoveryStrategy">
-                            <hz:properties>
-                                <hz:property name="key-string">foo2</hz:property>
-                            </hz:properties>
-                        </hz:discovery-strategy>
-                        <hz:discovery-service-provider implementation="dummyDiscoveryServiceProvider"/>
-                    </hz:discovery-strategies>
                 </hz:join>
                 <hz:interfaces enabled="false">
                     <hz:interface>10.10.1.*</hz:interface>

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -203,9 +203,7 @@ public class JoinConfig {
             countEnabled++;
         }
         Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryConfig.getDiscoveryStrategyConfigs();
-        if (discoveryStrategyConfigs.size() > 0) {
-            countEnabled++;
-        }
+        countEnabled += discoveryStrategyConfigs.size();
 
         if (countEnabled > 1) {
             throw new InvalidConfigurationException("Multiple join configuration cannot be enabled at the same time. Enable only "

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -176,7 +176,7 @@ public class JoinConfig {
     /**
      * Verifies this JoinConfig is valid. At most a single joiner should be active.
      *
-     * @throws IllegalStateException when the join config is not valid
+     * @throws InvalidConfigurationException when the join config is not valid
      */
     @SuppressWarnings("checkstyle:npathcomplexity")
     public void verify() {
@@ -202,28 +202,14 @@ public class JoinConfig {
         if (getEurekaConfig().isEnabled()) {
             countEnabled++;
         }
+        Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryConfig.getDiscoveryStrategyConfigs();
+        if (discoveryStrategyConfigs.size() > 0) {
+            countEnabled++;
+        }
 
         if (countEnabled > 1) {
             throw new InvalidConfigurationException("Multiple join configuration cannot be enabled at the same time. Enable only "
-                    + "one of: TCP/IP, Multicast, AWS, GCP, Azure, Kubernetes, or Eureka");
-        }
-
-        verifyDiscoveryProviderConfig();
-    }
-
-    /**
-     * Verifies this JoinConfig is valid. When Discovery SPI enabled other discovery
-     * methods should be disabled
-     *
-     * @throws IllegalStateException when the join config is not valid
-     */
-    private void verifyDiscoveryProviderConfig() {
-        Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryConfig.getDiscoveryStrategyConfigs();
-        if (discoveryStrategyConfigs.size() > 0) {
-            if (getMulticastConfig().isEnabled()) {
-                throw new InvalidConfigurationException(
-                        "Multicast and DiscoveryProviders join can't be enabled at the same time");
-            }
+                    + "one of: TCP/IP, Multicast, AWS, GCP, Azure, Kubernetes, Eureka or Discovery Strategy");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/JoinConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/JoinConfigTest.java
@@ -29,17 +29,30 @@ public class JoinConfigTest {
 
     @Test
     public void joinConfigTest() {
-        assertOk(false, false, false);
-        assertOk(true, false, false);
-        assertOk(false, true, false);
-        assertOk(false, false, true);
+        assertOk(false, false, false, false, false, false, false, false);
+        assertOk(true, false, false, false, false, false, false, false);
+        assertOk(false, true, false, false, false, false, false, false);
+        assertOk(false, false, true, false, false, false, false, false);
+        assertOk(false, false, false, true, false, false, false, false);
+        assertOk(false, false, false, false, true, false, false, false);
+        assertOk(false, false, false, false, false, true, false, false);
+        assertOk(false, false, false, false, false, false, true, false);
+        assertOk(false, false, false, false, false, false, false, true);
     }
 
-    private static void assertOk(boolean tcp, boolean multicast, boolean aws) {
+    private static void assertOk(boolean tcp, boolean multicast, boolean aws, boolean gcp, boolean azure,
+                                 boolean kubernetes, boolean eureka, boolean discoveryConfig) {
         JoinConfig config = new JoinConfig();
         config.getMulticastConfig().setEnabled(multicast);
         config.getTcpIpConfig().setEnabled(tcp);
         config.getAwsConfig().setEnabled(aws);
+        config.getGcpConfig().setEnabled(gcp);
+        config.getAzureConfig().setEnabled(azure);
+        config.getKubernetesConfig().setEnabled(kubernetes);
+        config.getEurekaConfig().setEnabled(eureka);
+        if (discoveryConfig) {
+            config.getDiscoveryConfig().getDiscoveryStrategyConfigs().add(new DiscoveryStrategyConfig());
+        }
 
         config.verify();
     }
@@ -56,9 +69,44 @@ public class JoinConfigTest {
     @Test(expected = InvalidConfigurationException.class)
     public void joinConfigTestWhenGcpAndAwsEnabled() {
         JoinConfig config = new JoinConfig();
+        // Multicast enabled by default
+        config.getMulticastConfig().setEnabled(false);
         config.getAwsConfig().setEnabled(true);
         config.getGcpConfig().setEnabled(true);
 
         config.verify();
     }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void joinConfigTestWhenMulticastAndDiscoveryStrategyEnabled() {
+        JoinConfig config = new JoinConfig();
+        config.getMulticastConfig().setEnabled(true);
+        config.getDiscoveryConfig().getDiscoveryStrategyConfigs().add(new DiscoveryStrategyConfig());
+
+        config.verify();
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void joinConfigTestWhenTcpIpAndDiscoveryStrategyEnabled() {
+        JoinConfig config = new JoinConfig();
+        // Multicast enabled by default
+        config.getMulticastConfig().setEnabled(false);
+        config.getTcpIpConfig().setEnabled(true);
+        config.getDiscoveryConfig().getDiscoveryStrategyConfigs().add(new DiscoveryStrategyConfig());
+
+        config.verify();
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void joinConfigTestWhenEurekaAndDiscoveryStrategyEnabled() {
+        JoinConfig config = new JoinConfig();
+        // Multicast enabled by default
+        config.getMulticastConfig().setEnabled(false);
+        config.getEurekaConfig().setEnabled(true);
+        config.getDiscoveryConfig().getDiscoveryStrategyConfigs().add(new DiscoveryStrategyConfig());
+
+        config.verify();
+    }
+
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -390,13 +390,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "            properties:\n"
                 + "              key-string: foo\n"
                 + "              key-int: 123\n"
-                + "              key-boolean: true\n"
-                + "          - class: DummyDiscoveryStrategy2\n"
-                + "            enabled: true\n"
-                + "            properties:\n"
-                + "              key-string: foobar\n"
-                + "              key-int: 321\n"
-                + "              key-boolean: false\n";
+                + "              key-boolean: true\n";
 
         Config config = buildConfig(yaml);
         DiscoveryConfig discoveryConfig = config.getNetworkConfig().getJoin().getDiscoveryConfig();
@@ -1825,12 +1819,6 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "                  key-string: foo\n"
                 + "                  key-int: 123\n"
                 + "                  key-boolean: true\n"
-                + "              - class: DummyDiscoveryStrategy2\n"
-                + "                enabled: true\n"
-                + "                properties:\n"
-                + "                  key-string: foobar\n"
-                + "                  key-int: 321\n"
-                + "                  key-boolean: false\n"
                 + "          properties:\n"
                 + "            custom.prop.publisher: prop.publisher\n"
                 + "            discovery.period: 5\n"
@@ -1891,7 +1879,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     private void assertDiscoveryConfig(DiscoveryConfig c) {
         assertEquals("DummyFilterClass", c.getNodeFilterClass());
-        assertEquals(2, c.getDiscoveryStrategyConfigs().size());
+        assertEquals(1, c.getDiscoveryStrategyConfigs().size());
 
         Iterator<DiscoveryStrategyConfig> iterator = c.getDiscoveryStrategyConfigs().iterator();
         DiscoveryStrategyConfig config = iterator.next();
@@ -1901,14 +1889,6 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals("foo", props.get("key-string"));
         assertEquals("123", props.get("key-int"));
         assertEquals("true", props.get("key-boolean"));
-
-        DiscoveryStrategyConfig config2 = iterator.next();
-        assertEquals("DummyDiscoveryStrategy2", config2.getClassName());
-
-        Map<String, Comparable> props2 = config2.getProperties();
-        assertEquals("foobar", props2.get("key-string"));
-        assertEquals("321", props2.get("key-int"));
-        assertEquals("false", props2.get("key-boolean"));
     }
 
     @Override


### PR DESCRIPTION
Current `verifyDiscoveryProviderConfig(`) method checks only `multicast & discovery strategy` config scenario. So when user configures `discovery strategy` and `tcp/ip` or `aliases(aws,eureka)` at the same time, `InvalidConfigurationException` is not thrown at JoinConfig.

Members use `discovery strategy` and ignore other one in that scenario, btw.