### PR TITLE
Match Map.putAll with Map.put behavior upon map listener attribute type mismatch

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -54,6 +54,7 @@ public interface MapEventPublisher {
 
     /**
      * Publish an event to the event subsystem.
+     * Note: Exceptions during publications are caught and logged.
      *
      * @param caller    the address of the caller that caused the event
      * @param mapName   the map name
@@ -69,6 +70,7 @@ public interface MapEventPublisher {
      * Publish an event to the event subsystem. This method
      * can be used for a merge event since it also accepts
      * the value which was used in the merge process.
+     * Note: Exceptions during publications are caught and logged.
      *
      * @param caller           the address of the caller that caused the event
      * @param mapName          the map name

--- a/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.map.impl.MapListenerAdapter;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.event.MapPartitionEventData;
 import com.hazelcast.map.listener.EntryAddedListener;
@@ -35,6 +36,8 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.QueryConstants;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.test.AssertTask;
@@ -49,6 +52,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -595,6 +599,34 @@ public class ListenerTest extends HazelcastTestSupport {
                 });
         assertOpenEventually(latch, 10);
         SerializeCheckerObject.assertNotSerialized();
+    }
+
+    @Test
+    public void test_ListenerShouldNotThrowExceptions_whenAttributeTypeMismatches() {
+        IMap<Example, Example> map = createHazelcastInstance().getMap("map");
+        Predicate predicate = Predicates.in(QueryConstants.KEY_ATTRIBUTE_NAME.value(), Integer.MIN_VALUE);
+
+        Example example = new Example();
+        map.addLocalEntryListener(example, predicate, true);
+
+        HashMap<Example, Example> hashMap = new HashMap<>();
+        hashMap.put(example, example);
+        // Single put
+        map.put(example, example);
+        map.remove(example);
+
+        // PutAll
+        map.putAll(hashMap);
+    }
+
+    static class Example extends MapListenerAdapter<Object, Object>
+            implements Serializable, Comparable<Object> {
+
+        @Override
+        public int compareTo(Object o) {
+            return 0;
+        }
+
     }
 
     private static class EntryAddedLatch extends CountDownLatch implements EntryAddedListener {


### PR DESCRIPTION
`Map.putAll` differs from a plain `Map.put()`, because it triggers the listener events through the main `run()` block, which propagates exceptions to caller. `Map.put()`, does that as part of the `afterRun()` which only logs the error.

Fixes https://github.com/hazelcast/hazelcast/issues/15415