### PR TITLE
Prevent hitting max port count in mock tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -56,8 +56,8 @@ import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 
 class TestClientRegistry {
 
-    private static final AtomicInteger CLIENT_PORTS = new AtomicInteger(40000);
     private static final ILogger LOGGER = Logger.getLogger(HazelcastClient.class);
+    private final AtomicInteger CLIENT_PORTS = new AtomicInteger(40000);
 
     private final TestNodeRegistry nodeRegistry;
 


### PR DESCRIPTION
Since the counter is static we were hitting the max port count.
In this pr it is converted to start from beginning per
`TestHazelcastFactory`

fixes https://github.com/hazelcast/hazelcast/issues/16141
