### PR TITLE
Remove done futures from recordstore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/FutureUtil.java
@@ -432,7 +432,7 @@ public final class FutureUtil {
     }
 
     /**
-     * Rethrow exeception of the fist future that completed with an exception
+     * Rethrow exception of the fist future that completed with an exception
      *
      * @param futures
      * @throws Exception

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperation.java
@@ -20,7 +20,8 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 
-public class IsPartitionLoadedOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
+public class IsPartitionLoadedOperation extends MapOperation
+        implements PartitionAwareOperation, ReadonlyOperation {
 
     private boolean isFinished;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -716,14 +716,16 @@ abstract class MapProxySupport<K, V>
 
     public void waitUntilLoaded() {
         try {
-            int mapNamePartition = partitionService.getPartitionId(name);
-            // first we have to check if key-load finished - otherwise the loading on other partitions might not have started.
-            // In this case we can't invoke IsPartitionLoadedOperation -> they will return "true", but it won't be correct
+            int mapNamesPartitionId = partitionService.getPartitionId(name);
+            // first we have to check if key-load finished - otherwise
+            // the loading on other partitions might not have started.
+            // In this case we can't invoke IsPartitionLoadedOperation
+            // -> they will return "true", but it won't be correct
 
             int sleepDurationMillis = INITIAL_WAIT_LOAD_SLEEP_MILLIS;
             while (true) {
                 Operation op = new IsKeyLoadFinishedOperation(name);
-                Future<Boolean> loadingFuture = operationService.invokeOnPartition(SERVICE_NAME, op, mapNamePartition);
+                Future<Boolean> loadingFuture = operationService.invokeOnPartition(SERVICE_NAME, op, mapNamesPartitionId);
                 if (loadingFuture.get()) {
                     break;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1101,7 +1101,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             return;
         }
 
-        if (isLoaded()) {
+        if (FutureUtil.allDone(loadingFutures)) {
             List<Future> doneFutures = null;
             try {
                 doneFutures = FutureUtil.getAllDone(loadingFutures);
@@ -1118,6 +1118,16 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             throw new RetryableHazelcastException("Map " + getName()
                     + " is still loading data from external store");
         }
+    }
+
+    @Override
+    public boolean isLoaded() {
+        boolean result = FutureUtil.allDone(loadingFutures);
+        if (result) {
+            loadingFutures.removeAll(loadingFutures);
+        }
+
+        return result;
     }
 
     @Override
@@ -1144,11 +1154,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public void setPreMigrationLoadedStatus(boolean loaded) {
         loadedOnPreMigration = loaded;
-    }
-
-    @Override
-    public boolean isLoaded() {
-        return FutureUtil.allDone(loadingFutures);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1124,10 +1124,15 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public boolean isLoaded() {
         boolean result = FutureUtil.allDone(loadingFutures);
         if (result) {
-            loadingFutures.removeAll(loadingFutures);
+            loadingFutures.removeAll(FutureUtil.getAllDone(loadingFutures));
         }
 
         return result;
+    }
+
+    // only used for testing purposes
+    public Collection<Future> getLoadingFutures() {
+        return loadingFutures;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFuturesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFuturesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.mapstore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MapLoaderFuturesTest extends HazelcastTestSupport {
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
+    @Test
+    public void zero_remaining_loading_future_after_multiple_loadAll() {
+        String mapName = "load-futures";
+        int keyCountToLoad = 10;
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setImplementation(new SimpleMapLoader(keyCountToLoad, false));
+
+        Config config = getConfig();
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        mapConfig.setMapStoreConfig(mapStoreConfig);
+
+        HazelcastInstance node = createHazelcastInstance(config);
+        IMap map = node.getMap(mapName);
+
+        for (int i = 0; i < 3; i++) {
+            map.loadAll(true);
+        }
+
+        assertEquals(keyCountToLoad, map.size());
+        assertEquals(0, loadingFutureCount(mapName, node));
+    }
+
+    private static int loadingFutureCount(String mapName, HazelcastInstance node) {
+        int count = 0;
+        NodeEngineImpl nodeEngine = getNode(node).getNodeEngine();
+        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
+        for (int i = 0; i < partitionCount; i++) {
+            RecordStore recordStore = mapServiceContext.getExistingRecordStore(i, mapName);
+            if (recordStore != null) {
+                count += ((DefaultRecordStore) recordStore).getLoadingFutures().size();
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/16096

Remove done futures of loading tasks otherwise repetitive calls to IMap#loadAll can cause memory leak.

- [ ] Backport?