### PR TITLE
Fixes NPE in /rest/cluster when no client endpoint is defined

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -354,7 +354,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         NetworkingService ns = node.getNetworkingService();
         EndpointManager cem = ns.getEndpointManager(CLIENT);
         AggregateEndpointManager aem = ns.getAggregateEndpointManager();
-        res.append("ConnectionCount: ").append(cem.getActiveConnections().size());
+        res.append("ConnectionCount: ").append(cem == null ? "0" : cem.getActiveConnections().size());
         res.append("\n");
         res.append("AllConnectionCount: ").append(aem.getActiveConnections().size());
         res.append("\n");

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.ascii;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
@@ -97,6 +98,22 @@ public class RestClusterTest {
         } catch (IOException ignored) {
             // ignored
         }
+    }
+
+    @Test
+    public void testClusterInfo_whenAdvancedNetworkWithoutClientEndpoint() throws Exception {
+        // when advanced network config is enabled and no client endpoint is defined
+        // then client connections are reported as 0
+        Config config = createConfig();
+        config.getAdvancedNetworkConfig().setEnabled(true)
+              .setRestEndpointConfig(new RestServerEndpointConfig()
+                      .setPort(9999)
+                      .enableAllGroups());
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        String response = communicator.getClusterInfo();
+        assertThat(response, CoreMatchers.containsString("ConnectionCount: 0"));
     }
 
     @Test


### PR DESCRIPTION
When running Hazelcast with advanced network config, it is
possible no client endpoint is defined. In this case, no
client endpoint manager is registered and client connection
count is always 0.

Fixes #15635 