### PR TITLE
Bitmap indexes

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -180,6 +180,7 @@
     <suppress checks="MethodLength|CyclomaticComplexity|NPathComplexity|ReturnCount"
               files="com[\\/]hazelcast[\\/]query[\\/]impl[\\/]getters[\\/]ReflectionHelper"/>
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]query[\\/]impl[\\/]predicates[\\/]BetweenVisitor"/>
+    <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]query[\\/]impl[\\/]bitmap[\\/]SparseIntArray"/>
 
     <!-- Instance -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]instance[\\/]"/>
@@ -304,6 +305,7 @@
     <suppress
             checks="MagicNumber|FileLength|DeclarationOrder|RedundantModifier|InnerAssignment|NPathComplexity|CyclomaticComplexity"
             files="com[\\/]hazelcast[\\/]util[\\/]ConcurrentReferenceHashMap"/>
+    <suppress checks="" files="com[\\/]hazelcast[\\/]util[\\/]collection[\\/]Object2LongHashMap"/>
 
     <!-- Exclude Clover instrumented sources -->
     <suppress checks="" files="[\\/]src-instrumented[\\/]"/>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -469,5 +469,12 @@
             <version>2.1.4</version>
             <scope>test</scope>
         </dependency>
+        <!-- Bitmap index benchmarking -->
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>0.8.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -32,11 +32,11 @@ public class QueryResultCollection<E> extends AbstractSet<E> {
     private final boolean binary;
 
     public QueryResultCollection(SerializationService serializationService, IterationType iterationType, boolean binary,
-                                 boolean unique, QueryResult queryResult) {
+                                 boolean distinct, QueryResult queryResult) {
         this.serializationService = serializationService;
         this.iterationType = iterationType;
         this.binary = binary;
-        if (unique) {
+        if (distinct) {
             // convert to a set
             this.rows = new HashSet<QueryResultRow>(queryResult.getRows());
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -38,8 +38,7 @@ public class QueryResultCollection<E> extends AbstractSet<E> {
         this.binary = binary;
         if (unique) {
             // convert to a set
-            this.rows = new HashSet<QueryResultRow>();
-            this.rows.addAll(queryResult.getRows());
+            this.rows = new HashSet<QueryResultRow>(queryResult.getRows());
         } else {
             // reuse the existing underlying list
             this.rows = queryResult.getRows();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -20,7 +20,6 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.IterationType;
 
 import java.util.AbstractSet;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -32,23 +31,19 @@ public class QueryResultCollection<E> extends AbstractSet<E> {
     private final IterationType iterationType;
     private final boolean binary;
 
-    public QueryResultCollection(SerializationService serializationService,
-                                 IterationType iterationType,
-                                 boolean binary,
-                                 boolean unique) {
+    public QueryResultCollection(SerializationService serializationService, IterationType iterationType, boolean binary,
+                                 boolean unique, QueryResult queryResult) {
         this.serializationService = serializationService;
         this.iterationType = iterationType;
         this.binary = binary;
-        this.rows = unique ? new HashSet<QueryResultRow>() : new ArrayList<QueryResultRow>();
-    }
-
-    public QueryResultCollection(SerializationService serializationService,
-                                 IterationType iterationType,
-                                 boolean binary,
-                                 boolean unique,
-                                 QueryResult queryResult) {
-        this(serializationService, iterationType, binary, unique);
-        addAllRows(queryResult.getRows());
+        if (unique) {
+            // convert to a set
+            this.rows = new HashSet<QueryResultRow>();
+            this.rows.addAll(queryResult.getRows());
+        } else {
+            // reuse the existing underlying list
+            this.rows = queryResult.getRows();
+        }
     }
 
     // just for testing
@@ -58,10 +53,6 @@ public class QueryResultCollection<E> extends AbstractSet<E> {
 
     public IterationType getIterationType() {
         return iterationType;
-    }
-
-    public void addAllRows(Collection<QueryResultRow> collection) {
-        rows.addAll(collection);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
@@ -23,6 +23,7 @@ import com.hazelcast.monitor.impl.PerIndexStats;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.getters.MultiResult;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
@@ -55,24 +56,26 @@ public abstract class AbstractIndex implements InternalIndex {
     private final String name;
     private final String[] components;
     private final boolean ordered;
+    private final String uniqueKey;
     private final PerIndexStats stats;
 
     private volatile TypeConverter converter;
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public AbstractIndex(String name, String[] components, boolean ordered, InternalSerializationService ss,
-                         Extractors extractors, IndexCopyBehavior copyBehavior, PerIndexStats stats) {
-        this.name = name;
-        this.components = components;
-        this.ordered = ordered;
+    public AbstractIndex(IndexDefinition definition, InternalSerializationService ss, Extractors extractors,
+                         IndexCopyBehavior copyBehavior, PerIndexStats stats) {
+        this.name = definition.getName();
+        this.components = definition.getComponents();
+        this.ordered = definition.isOrdered();
+        this.uniqueKey = definition.getUniqueKey();
         this.ss = ss;
         this.extractors = extractors;
         this.copyBehavior = copyBehavior;
-        this.indexStore = createIndexStore(ordered, stats);
+        this.indexStore = createIndexStore(definition, stats);
         this.stats = stats;
     }
 
-    protected abstract IndexStore createIndexStore(boolean ordered, PerIndexStats stats);
+    protected abstract IndexStore createIndexStore(IndexDefinition definition, PerIndexStats stats);
 
     @Override
     public String getName() {
@@ -88,6 +91,11 @@ public abstract class AbstractIndex implements InternalIndex {
     @Override
     public boolean isOrdered() {
         return ordered;
+    }
+
+    @Override
+    public String getUniqueKey() {
+        return uniqueKey;
     }
 
     @Override
@@ -128,8 +136,19 @@ public abstract class AbstractIndex implements InternalIndex {
         IndexOperationStats operationStats = stats.createOperationStats();
 
         Object attributeValue = extractAttributeValue(key, value);
-        indexStore.remove(attributeValue, key, operationStats);
+        indexStore.remove(attributeValue, key, value, operationStats);
         stats.onRemove(timestamp, operationStats, operationSource);
+    }
+
+    @Override
+    public boolean canEvaluate(Class<? extends Predicate> predicateClass) {
+        return indexStore.canEvaluate(predicateClass);
+    }
+
+    @Override
+    public Set<QueryableEntry> evaluate(Predicate predicate) {
+        assert converter != null;
+        return indexStore.evaluate(predicate, converter);
     }
 
     @Override
@@ -220,8 +239,8 @@ public abstract class AbstractIndex implements InternalIndex {
     }
 
     private Object extractAttributeValue(Data key, Object value) {
-        if (components == null) {
-            return QueryableEntry.extractAttributeValue(extractors, ss, name, key, value, null);
+        if (components.length == 1) {
+            return QueryableEntry.extractAttributeValue(extractors, ss, components[0], key, value, null);
         } else {
             Comparable[] valueComponents = new Comparable[components.length];
             for (int i = 0; i < components.length; ++i) {
@@ -254,8 +273,8 @@ public abstract class AbstractIndex implements InternalIndex {
     }
 
     private TypeConverter obtainConverter(QueryableEntry entry) {
-        if (components == null) {
-            return entry.getConverter(name);
+        if (components.length == 1) {
+            return entry.getConverter(components[0]);
         } else {
             CompositeConverter existingConverter = (CompositeConverter) converter;
             TypeConverter[] converters = new TypeConverter[components.length];

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
@@ -56,7 +56,6 @@ public abstract class AbstractIndex implements InternalIndex {
     private final String name;
     private final String[] components;
     private final boolean ordered;
-    private final String uniqueKey;
     private final PerIndexStats stats;
 
     private volatile TypeConverter converter;
@@ -67,7 +66,6 @@ public abstract class AbstractIndex implements InternalIndex {
         this.name = definition.getName();
         this.components = definition.getComponents();
         this.ordered = definition.isOrdered();
-        this.uniqueKey = definition.getUniqueKey();
         this.ss = ss;
         this.extractors = extractors;
         this.copyBehavior = copyBehavior;
@@ -91,11 +89,6 @@ public abstract class AbstractIndex implements InternalIndex {
     @Override
     public boolean isOrdered() {
         return ordered;
-    }
-
-    @Override
-    public String getUniqueKey() {
-        return uniqueKey;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
@@ -56,6 +56,7 @@ public abstract class AbstractIndex implements InternalIndex {
     private final String name;
     private final String[] components;
     private final boolean ordered;
+    private final String uniqueKey;
     private final PerIndexStats stats;
 
     private volatile TypeConverter converter;
@@ -66,6 +67,7 @@ public abstract class AbstractIndex implements InternalIndex {
         this.name = definition.getName();
         this.components = definition.getComponents();
         this.ordered = definition.isOrdered();
+        this.uniqueKey = definition.getUniqueKey();
         this.ss = ss;
         this.extractors = extractors;
         this.copyBehavior = copyBehavior;
@@ -89,6 +91,11 @@ public abstract class AbstractIndex implements InternalIndex {
     @Override
     public boolean isOrdered() {
         return ordered;
+    }
+
+    @Override
+    public String getUniqueKey() {
+        return uniqueKey;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -125,6 +125,12 @@ public class AttributeIndexRegistry {
 
         public boolean unorderedWorseThan(InternalIndex candidate) {
             assert !candidate.isOrdered();
+
+            if (candidate.getUniqueKey() != null) {
+                // if user adds a bitmap index, that is for a reason
+                return true;
+            }
+
             // we have no index and the unordered candidate is not composite
             return unordered == null && candidate.getComponents().length == 1;
         }
@@ -196,6 +202,11 @@ public class AttributeIndexRegistry {
         @Override
         public boolean isOrdered() {
             return delegate.isOrdered();
+        }
+
+        @Override
+        public String getUniqueKey() {
+            return delegate.getUniqueKey();
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -199,11 +199,6 @@ public class AttributeIndexRegistry {
         }
 
         @Override
-        public String getUniqueKey() {
-            return delegate.getUniqueKey();
-        }
-
-        @Override
         public TypeConverter getConverter() {
             CompositeConverter converter = (CompositeConverter) delegate.getConverter();
             return converter == null ? null : converter.getComponentConverter(0);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseSingleValueIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseSingleValueIndexStore.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.json.NonTerminalJsonValue;
+import com.hazelcast.monitor.impl.IndexOperationStats;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.getters.MultiResult;
+
+import java.util.List;
+
+/**
+ * The base store for indexes that are unable to work with multi-value
+ * attributes natively. For such indexes {@link MultiResult}s are split into
+ * individual values and each value is inserted/removed separately.
+ */
+public abstract class BaseSingleValueIndexStore extends BaseIndexStore {
+
+    private boolean multiResultHasToDetectDuplicates;
+
+    BaseSingleValueIndexStore(IndexCopyBehavior copyOn) {
+        super(copyOn);
+    }
+
+    /**
+     * Associates the given value in this index store with the given record.
+     * <p>
+     * Despite the name the given value acts as a key into this index store. In
+     * other words, it's a value of an attribute this index store is built for.
+     *
+     * @param value  the value of an attribute this index store is built for.
+     * @param record the record to associate with the given value.
+     * @return the record that was associated with the given value before the
+     * operation, if there was any, {@code null} otherwise.
+     */
+    abstract Object insertInternal(Comparable value, QueryableEntry record);
+
+    /**
+     * Removes the association between the given value and a record identified
+     * by the given record key.
+     * <p>
+     * Despite the name the given value acts as a key into this index store. In
+     * other words, it's a value of an attribute this index store is built for.
+     *
+     * @param value     the value of an attribute this index store is built for.
+     * @param recordKey the key of a record to dissociate from the given value.
+     * @return the record that was associated with the given value before the
+     * operation, if there was any, {@code null} otherwise.
+     */
+    abstract Object removeInternal(Comparable value, Data recordKey);
+
+    final MultiResultSet createMultiResultSet() {
+        return multiResultHasToDetectDuplicates ? new DuplicateDetectingMultiResult() : new FastMultiResultSet();
+    }
+
+    @Override
+    public final void insert(Object value, QueryableEntry record, IndexOperationStats operationStats) {
+        takeWriteLock();
+        try {
+            unwrapAndInsertToIndex(value, record, operationStats);
+        } finally {
+            releaseWriteLock();
+        }
+    }
+
+    @Override
+    public final void update(Object oldValue, Object newValue, QueryableEntry entry, IndexOperationStats operationStats) {
+        takeWriteLock();
+        try {
+            Data indexKey = entry.getKeyData();
+            unwrapAndRemoveFromIndex(oldValue, indexKey, operationStats);
+            unwrapAndInsertToIndex(newValue, entry, operationStats);
+        } finally {
+            releaseWriteLock();
+        }
+    }
+
+    @Override
+    public final void remove(Object value, Data entryKey, Object entryValue, IndexOperationStats operationStats) {
+        takeWriteLock();
+        try {
+            unwrapAndRemoveFromIndex(value, entryKey, operationStats);
+        } finally {
+            releaseWriteLock();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // nothing to destroy
+    }
+
+    @SuppressWarnings("unchecked")
+    private void unwrapAndInsertToIndex(Object newValue, QueryableEntry record, IndexOperationStats operationStats) {
+        if (newValue == NonTerminalJsonValue.INSTANCE) {
+            return;
+        }
+        if (newValue instanceof MultiResult) {
+            multiResultHasToDetectDuplicates = true;
+            List<Object> results = ((MultiResult) newValue).getResults();
+            for (Object o : results) {
+                Comparable sanitizedValue = sanitizeValue(o);
+                Object oldValue = insertInternal(sanitizedValue, record);
+                operationStats.onEntryAdded(oldValue, newValue);
+            }
+        } else {
+            Comparable sanitizedValue = sanitizeValue(newValue);
+            Object oldValue = insertInternal(sanitizedValue, record);
+            operationStats.onEntryAdded(oldValue, newValue);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void unwrapAndRemoveFromIndex(Object oldValue, Data indexKey, IndexOperationStats operationStats) {
+        if (oldValue == NonTerminalJsonValue.INSTANCE) {
+            return;
+        }
+        if (oldValue instanceof MultiResult) {
+            List<Object> results = ((MultiResult) oldValue).getResults();
+            for (Object o : results) {
+                Comparable sanitizedValue = sanitizeValue(o);
+                Object removedValue = removeInternal(sanitizedValue, indexKey);
+                operationStats.onEntryRemoved(removedValue);
+            }
+        } else {
+            Comparable sanitizedValue = sanitizeValue(oldValue);
+            Object removedValue = removeInternal(sanitizedValue, indexKey);
+            operationStats.onEntryRemoved(removedValue);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.monitor.impl.IndexOperationStats;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.bitmap.Bitmap;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.getters.MultiResult;
+import com.hazelcast.query.impl.predicates.AndPredicate;
+import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.query.impl.predicates.InPredicate;
+import com.hazelcast.query.impl.predicates.NotEqualPredicate;
+import com.hazelcast.query.impl.predicates.NotPredicate;
+import com.hazelcast.query.impl.predicates.OrPredicate;
+import com.hazelcast.util.collection.Long2LongHashMap;
+import com.hazelcast.util.collection.Object2LongHashMap;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The store of bitmap indexes.
+ * <p>
+ * Internally, manages a {@link Bitmap} instance along with key remapping
+ * structures used to establish the correspondence between long bitmap keys and
+ * actual user-provided keys.
+ */
+public final class BitmapIndexStore extends BaseIndexStore {
+
+    private static final long NO_KEY = -1;
+    private static final int INITIAL_CAPACITY = 8;
+    private static final float LOAD_FACTOR = 0.75F;
+
+    private static final Object CONSUMED = new Object();
+
+    private static final Set<Class<? extends Predicate>> EVALUABLE_PREDICATES = new HashSet<Class<? extends Predicate>>();
+
+    static {
+        EVALUABLE_PREDICATES.add(AndPredicate.class);
+        EVALUABLE_PREDICATES.add(OrPredicate.class);
+        EVALUABLE_PREDICATES.add(NotPredicate.class);
+
+        EVALUABLE_PREDICATES.add(EqualPredicate.class);
+        EVALUABLE_PREDICATES.add(NotEqualPredicate.class);
+        EVALUABLE_PREDICATES.add(InPredicate.class);
+    }
+
+    private final String keyAttribute;
+    private final InternalSerializationService serializationService;
+    private final Extractors extractors;
+
+    private final Bitmap<QueryableEntry> bitmap = new Bitmap<QueryableEntry>();
+    // maps user-provided long keys to long bitmap keys
+    private final Long2LongHashMap internalKeys;
+    // maps user-provided object keys to long bitmap keys
+    private final Object2LongHashMap internalObjectKeys;
+    private long internalKeyCounter;
+
+    public BitmapIndexStore(String keyAttribute, InternalSerializationService serializationService, Extractors extractors) {
+        super(IndexCopyBehavior.NEVER);
+        if (keyAttribute.endsWith("?")) {
+            // long-to-long remapping
+            this.keyAttribute = keyAttribute.substring(0, keyAttribute.length() - 1);
+            this.internalKeys = new Long2LongHashMap(INITIAL_CAPACITY, LOAD_FACTOR, NO_KEY);
+            this.internalObjectKeys = null;
+        } else if (keyAttribute.endsWith("!")) {
+            // no remapping, raw attribute values are used as long keys
+            this.keyAttribute = keyAttribute.substring(0, keyAttribute.length() - 1);
+            this.internalKeys = null;
+            this.internalObjectKeys = null;
+        } else {
+            // object-to-long remapping
+            this.keyAttribute = keyAttribute;
+            this.internalObjectKeys = new Object2LongHashMap(INITIAL_CAPACITY, LOAD_FACTOR, NO_KEY);
+            this.internalKeys = null;
+        }
+        this.serializationService = serializationService;
+        this.extractors = extractors;
+    }
+
+    @Override
+    public Comparable canonicalizeQueryArgumentScalar(Comparable value) {
+        // Using a storage representation for arguments here to save on
+        // conversions later.
+        return canonicalizeScalarForStorage(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void insert(Object value, QueryableEntry entry, IndexOperationStats operationStats) {
+        if (internalObjectKeys == null) {
+            // no remapping or long-to-long remapping
+
+            long key = extractLongKey(entry);
+            Iterator values = makeIterator(value);
+
+            takeWriteLock();
+            try {
+                if (internalKeys != null) {
+                    // long-to-long remapping
+
+                    long internalKey = internalKeyCounter++;
+                    long replaced = internalKeys.put(key, internalKey);
+                    assert replaced == NO_KEY;
+                    key = internalKey;
+                } else if (key < 0) {
+                    throw makeNegativeKeyException(key);
+                }
+
+                bitmap.insert(values, key, entry);
+            } finally {
+                releaseWriteLock();
+            }
+        } else {
+            // object-to-long remapping
+
+            Object key = extractObjectKey(entry);
+            Iterator values = makeIterator(value);
+
+            takeWriteLock();
+            try {
+                long internalKey = internalKeyCounter++;
+                long replaced = internalObjectKeys.put(key, internalKey);
+                assert replaced == NO_KEY;
+                bitmap.insert(values, internalKey, entry);
+            } finally {
+                releaseWriteLock();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void update(Object oldValue, Object newValue, QueryableEntry entry, IndexOperationStats operationStats) {
+        if (internalObjectKeys == null) {
+            // no remapping or long-to-long remapping
+
+            long key = extractLongKey(entry);
+            Iterator oldValues = makeIterator(oldValue);
+            Iterator newValues = makeIterator(newValue);
+
+            takeWriteLock();
+            try {
+                if (internalKeys != null) {
+                    // long-to-long remapping
+
+                    key = internalKeys.get(key);
+                    assert key != NO_KEY;
+                } else if (key < 0) {
+                    throw makeNegativeKeyException(key);
+                }
+                bitmap.update(oldValues, newValues, key, entry);
+            } finally {
+                releaseWriteLock();
+            }
+        } else {
+            // object-to-long remapping
+
+            Object key = extractObjectKey(entry);
+            Iterator oldValues = makeIterator(oldValue);
+            Iterator newValues = makeIterator(newValue);
+
+            takeWriteLock();
+            try {
+                long internalKey = internalObjectKeys.getValue(key);
+                assert internalKey != NO_KEY;
+                bitmap.update(oldValues, newValues, internalKey, entry);
+            } finally {
+                releaseWriteLock();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void remove(Object value, Data entryKey, Object entryValue, IndexOperationStats operationStats) {
+        if (internalObjectKeys == null) {
+            // no remapping or long-to-long remapping
+
+            long key = extractLongKey(entryKey, entryValue);
+            Iterator values = makeIterator(value);
+
+            takeWriteLock();
+            try {
+                if (internalKeys != null) {
+                    // long-to-long remapping
+
+                    key = internalKeys.remove(key);
+                    if (key != NO_KEY) {
+                        // XXX: see https://github.com/hazelcast/hazelcast/issues/15439
+                        bitmap.remove(values, key);
+                    }
+                } else {
+                    if (key < 0) {
+                        throw makeNegativeKeyException(key);
+                    }
+                    bitmap.remove(values, key);
+                }
+            } finally {
+                releaseWriteLock();
+            }
+        } else {
+            // object-to-long remapping
+
+            Object key = extractObjectKey(entryKey, entryValue);
+            Iterator values = makeIterator(value);
+
+            takeWriteLock();
+            try {
+                long internalKey = internalObjectKeys.removeKey(key);
+                if (internalKey != NO_KEY) {
+                    // XXX: see https://github.com/hazelcast/hazelcast/issues/15439
+                    bitmap.remove(values, internalKey);
+                }
+            } finally {
+                releaseWriteLock();
+            }
+        }
+    }
+
+    @Override
+    public void clear() {
+        takeWriteLock();
+        try {
+            bitmap.clear();
+            if (internalKeys != null) {
+                internalKeys.clear();
+                internalKeyCounter = 0;
+            }
+            if (internalObjectKeys != null) {
+                internalObjectKeys.clear();
+                internalKeyCounter = 0;
+            }
+        } finally {
+            releaseWriteLock();
+        }
+    }
+
+    @Override
+    public boolean canEvaluate(Class<? extends Predicate> predicateClass) {
+        return EVALUABLE_PREDICATES.contains(predicateClass);
+    }
+
+    @Override
+    public Set<QueryableEntry> evaluate(Predicate predicate, TypeConverter converter) {
+        takeReadLock();
+        try {
+            return toSingleResultSet(toMap(bitmap.evaluate(predicate, new CanonicalizingConverter(converter))));
+        } finally {
+            releaseReadLock();
+        }
+    }
+
+    @Override
+    public Set<QueryableEntry> getRecords(Comparable value) {
+        throw makeUnsupportedOperationException();
+    }
+
+    @Override
+    public Set<QueryableEntry> getRecords(Set<Comparable> values) {
+        throw makeUnsupportedOperationException();
+    }
+
+    @Override
+    public Set<QueryableEntry> getRecords(Comparison comparison, Comparable value) {
+        throw makeUnsupportedOperationException();
+    }
+
+    @Override
+    public Set<QueryableEntry> getRecords(Comparable from, boolean fromInclusive, Comparable to, boolean toInclusive) {
+        throw makeUnsupportedOperationException();
+    }
+
+    @Override
+    Comparable canonicalizeScalarForStorage(Comparable value) {
+        // Assuming on-heap overhead of 12 bytes for the object header and
+        // allocation granularity by modulo 8, there is no point in trying to
+        // represent a value in less than 4 bytes.
+
+        if (!(value instanceof Number)) {
+            return value;
+        }
+
+        Class clazz = value.getClass();
+        Number number = (Number) value;
+
+        if (clazz == Double.class) {
+            double doubleValue = number.doubleValue();
+
+            long longValue = number.longValue();
+            if (Numbers.equalDoubles(doubleValue, (double) longValue)) {
+                return canonicalizeLongRepresentable(longValue);
+            }
+
+            float floatValue = number.floatValue();
+            if (doubleValue == (double) floatValue) {
+                return floatValue;
+            }
+        } else if (clazz == Float.class) {
+            float floatValue = number.floatValue();
+
+            long longValue = number.longValue();
+            if (Numbers.equalFloats(floatValue, (float) longValue)) {
+                return canonicalizeLongRepresentable(longValue);
+            }
+        } else if (Numbers.isLongRepresentable(clazz)) {
+            return canonicalizeLongRepresentable(number.longValue());
+        }
+
+        return value;
+    }
+
+    private Map<Data, QueryableEntry> toMap(Iterator<QueryableEntry> iterator) {
+        Map<Data, QueryableEntry> map = new HashMap<Data, QueryableEntry>();
+        while (iterator.hasNext()) {
+            QueryableEntry entry = iterator.next();
+            map.put(entry.getKeyData(), entry);
+        }
+        return map;
+    }
+
+    private long extractLongKey(Data entryKey, Object entryValue) {
+        Object key =
+                QueryableEntry.extractAttributeValue(extractors, serializationService, keyAttribute, entryKey, entryValue, null);
+        if (key == null) {
+            throw new NullPointerException("non-null unique key value is required");
+        }
+        if (!Numbers.isLongRepresentable(key.getClass())) {
+            throw new NullPointerException("integer-valued unique key value is required");
+        }
+        return ((Number) key).longValue();
+    }
+
+    private long extractLongKey(QueryableEntry entry) {
+        Object key = entry.getAttributeValue(keyAttribute);
+        if (key == null) {
+            throw new NullPointerException("non-null unique key value is required");
+        }
+        if (!Numbers.isLongRepresentable(key.getClass())) {
+            throw new NullPointerException("integer-valued unique key value is required");
+        }
+        return ((Number) key).longValue();
+    }
+
+    private Object extractObjectKey(Data entryKey, Object entryValue) {
+        Object key =
+                QueryableEntry.extractAttributeValue(extractors, serializationService, keyAttribute, entryKey, entryValue, null);
+        if (key == null) {
+            throw new NullPointerException("non-null unique key value is required");
+        }
+        return key;
+    }
+
+    private Object extractObjectKey(QueryableEntry entry) {
+        Object key = entry.getAttributeValue(keyAttribute);
+        if (key == null) {
+            throw new NullPointerException("non-null unique key value is required");
+        }
+        return key;
+    }
+
+    private Iterator makeIterator(Object value) {
+        return value instanceof MultiResult ? new MultiValueIterator((MultiResult) value) : new SingleValueIterator(value);
+    }
+
+    private static Comparable canonicalizeLongRepresentable(long value) {
+        if (value == (long) (int) value) {
+            return (int) value;
+        } else {
+            return value;
+        }
+    }
+
+    private Comparable canonicalize(Comparable value) {
+        return canonicalizeScalarForStorage(value);
+    }
+
+    private static UnsupportedOperationException makeUnsupportedOperationException() {
+        return new UnsupportedOperationException("bitmap indexes support only direct predicate evaluation");
+    }
+
+    private IllegalArgumentException makeNegativeKeyException(long key) {
+        return new IllegalArgumentException("negative keys are not supported: " + keyAttribute + " = " + key);
+    }
+
+    private final class MultiValueIterator implements Iterator {
+
+        private final Iterator iterator;
+
+        MultiValueIterator(MultiResult multiResult) {
+            this.iterator = multiResult.getResults().iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            return sanitizeValue(iterator.next());
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    private final class SingleValueIterator implements Iterator {
+
+        private Object value;
+
+        SingleValueIterator(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return value != CONSUMED;
+        }
+
+        @Override
+        public Object next() {
+            Comparable value = sanitizeValue(this.value);
+            this.value = CONSUMED;
+            return value;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    /**
+     * Converts and at the same time canonicalizes the passed in values.
+     */
+    private final class CanonicalizingConverter implements TypeConverter {
+
+        private final TypeConverter converter;
+
+        CanonicalizingConverter(TypeConverter converter) {
+            this.converter = converter;
+        }
+
+        @Override
+        public Comparable convert(Comparable value) {
+            return canonicalize(converter.convert(value));
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
+import com.hazelcast.internal.json.NonTerminalJsonValue;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.monitor.impl.IndexOperationStats;
 import com.hazelcast.nio.serialization.Data;
@@ -109,6 +110,10 @@ public final class BitmapIndexStore extends BaseIndexStore {
     @SuppressWarnings("unchecked")
     @Override
     public void insert(Object value, QueryableEntry entry, IndexOperationStats operationStats) {
+        if (value == NonTerminalJsonValue.INSTANCE) {
+            return;
+        }
+
         if (internalObjectKeys == null) {
             // no remapping or long-to-long remapping
 
@@ -153,6 +158,11 @@ public final class BitmapIndexStore extends BaseIndexStore {
     @SuppressWarnings("unchecked")
     @Override
     public void update(Object oldValue, Object newValue, QueryableEntry entry, IndexOperationStats operationStats) {
+        if (oldValue == NonTerminalJsonValue.INSTANCE) {
+            insert(newValue, entry, operationStats);
+            return;
+        }
+
         if (internalObjectKeys == null) {
             // no remapping or long-to-long remapping
 
@@ -195,6 +205,10 @@ public final class BitmapIndexStore extends BaseIndexStore {
     @SuppressWarnings("unchecked")
     @Override
     public void remove(Object value, Data entryKey, Object entryValue, IndexOperationStats operationStats) {
+        if (value == NonTerminalJsonValue.INSTANCE) {
+            return;
+        }
+
         if (internalObjectKeys == null) {
             // no remapping or long-to-long remapping
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -271,12 +271,11 @@ public final class BitmapIndexStore extends BaseIndexStore {
             bitmap.clear();
             if (internalKeys != null) {
                 internalKeys.clear();
-                internalKeyCounter = 0;
             }
             if (internalObjectKeys != null) {
                 internalObjectKeys.clear();
-                internalKeyCounter = 0;
             }
+            internalKeyCounter = 0;
         } finally {
             releaseWriteLock();
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -40,6 +40,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.query.impl.QueryableEntry.extractAttributeValue;
+
 /**
  * The store of bitmap indexes.
  * <p>
@@ -365,43 +367,23 @@ public final class BitmapIndexStore extends BaseIndexStore {
     }
 
     private long extractLongKey(Data entryKey, Object entryValue) {
-        Object key =
-                QueryableEntry.extractAttributeValue(extractors, serializationService, keyAttribute, entryKey, entryValue, null);
-        if (key == null) {
-            throw new NullPointerException("non-null unique key value is required");
-        }
-        if (!Numbers.isLongRepresentable(key.getClass())) {
-            throw new NullPointerException("integer-valued unique key value is required");
-        }
-        return ((Number) key).longValue();
+        Object key = extractAttributeValue(extractors, serializationService, keyAttribute, entryKey, entryValue, null);
+        return extractLongKey(key);
     }
 
     private long extractLongKey(QueryableEntry entry) {
         Object key = entry.getAttributeValue(keyAttribute);
-        if (key == null) {
-            throw new NullPointerException("non-null unique key value is required");
-        }
-        if (!Numbers.isLongRepresentable(key.getClass())) {
-            throw new NullPointerException("integer-valued unique key value is required");
-        }
-        return ((Number) key).longValue();
+        return extractLongKey(key);
     }
 
     private Object extractObjectKey(Data entryKey, Object entryValue) {
-        Object key =
-                QueryableEntry.extractAttributeValue(extractors, serializationService, keyAttribute, entryKey, entryValue, null);
-        if (key == null) {
-            throw new NullPointerException("non-null unique key value is required");
-        }
-        return key;
+        Object key = extractAttributeValue(extractors, serializationService, keyAttribute, entryKey, entryValue, null);
+        return extractObjectKey(key);
     }
 
     private Object extractObjectKey(QueryableEntry entry) {
         Object key = entry.getAttributeValue(keyAttribute);
-        if (key == null) {
-            throw new NullPointerException("non-null unique key value is required");
-        }
-        return key;
+        return extractObjectKey(key);
     }
 
     private Iterator makeIterator(Object value) {
@@ -422,6 +404,23 @@ public final class BitmapIndexStore extends BaseIndexStore {
 
     private static UnsupportedOperationException makeUnsupportedOperationException() {
         return new UnsupportedOperationException("bitmap indexes support only direct predicate evaluation");
+    }
+
+    private static long extractLongKey(Object key) {
+        if (key == null) {
+            throw new NullPointerException("non-null unique key value is required");
+        }
+        if (!Numbers.isLongRepresentable(key.getClass())) {
+            throw new IllegalArgumentException("integer-valued unique key value is required");
+        }
+        return ((Number) key).longValue();
+    }
+
+    private static Object extractObjectKey(Object key) {
+        if (key == null) {
+            throw new NullPointerException("non-null unique key value is required");
+        }
+        return key;
     }
 
     private IllegalArgumentException makeNegativeKeyException(long key) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Comparison.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Comparison.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl;
 
 /**
  * Defines comparisons supported by {@link Index#getRecords(Comparison, Comparable)}
- * and {@link IndexStore#getRecords(Comparable)}.
+ * and {@link IndexStore#getRecords(Comparison, Comparable)}.
  */
 public enum Comparison {
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
@@ -66,8 +66,8 @@ public final class ConverterCache {
      */
     public void invalidate(InternalIndex index) {
         String[] components = index.getComponents();
-        if (components == null) {
-            cache.remove(index.getName());
+        if (components.length == 1) {
+            cache.remove(components[0]);
             return;
         }
 
@@ -111,7 +111,7 @@ public final class ConverterCache {
         }
 
         // try non-composite index first, if any
-        InternalIndex nonCompositeIndex = indexes.getIndex(attribute);
+        InternalIndex nonCompositeIndex = indexes.matchIndex(attribute, QueryContext.IndexMatchHint.NONE);
         if (nonCompositeIndex != null) {
             TypeConverter converter = nonCompositeIndex.getConverter();
             if (isNull(converter)) {
@@ -126,7 +126,7 @@ public final class ConverterCache {
         // scan composite indexes
         for (InternalIndex index : indexesSnapshot) {
             String[] components = index.getComponents();
-            if (components == null) {
+            if (components.length == 1) {
                 // not a composite index
                 continue;
             }
@@ -186,7 +186,7 @@ public final class ConverterCache {
 
             if (component == FULLY_UNRESOLVED) {
                 // we got a non-composite index with a null/transient converter
-                assert index.getComponents() == null;
+                assert index.getComponents().length == 1;
                 TypeConverter converter = index.getConverter();
                 return isNull(converter) ? null : converter;
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultIndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultIndexProvider.java
@@ -26,9 +26,9 @@ import com.hazelcast.query.impl.getters.Extractors;
 public class DefaultIndexProvider implements IndexProvider {
 
     @Override
-    public InternalIndex createIndex(String name, String[] components, boolean ordered, Extractors extractors,
-                                     InternalSerializationService ss, IndexCopyBehavior copyBehavior, PerIndexStats stats) {
-        return new IndexImpl(name, components, ordered, ss, extractors, copyBehavior, stats);
+    public InternalIndex createIndex(IndexDefinition definition, Extractors extractors, InternalSerializationService ss,
+                                     IndexCopyBehavior copyBehavior, PerIndexStats stats) {
+        return new IndexImpl(definition, ss, extractors, copyBehavior, stats);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -19,6 +19,7 @@ package com.hazelcast.query.impl;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.monitor.impl.PerIndexStats;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,6 +106,11 @@ public class GlobalQueryContextWithStats extends QueryContext {
         }
 
         @Override
+        public String getUniqueKey() {
+            return delegate.getUniqueKey();
+        }
+
+        @Override
         public TypeConverter getConverter() {
             return delegate.getConverter();
         }
@@ -117,6 +123,18 @@ public class GlobalQueryContextWithStats extends QueryContext {
         @Override
         public void removeEntry(Data key, Object value, OperationSource operationSource) {
             delegate.removeEntry(key, value, operationSource);
+        }
+
+        @Override
+        public boolean canEvaluate(Class<? extends Predicate> predicateClass) {
+            return delegate.canEvaluate(predicateClass);
+        }
+
+        @Override
+        public Set<QueryableEntry> evaluate(Predicate predicate) {
+            Set<QueryableEntry> result = delegate.evaluate(predicate);
+            hasQueries = true;
+            return result;
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -106,6 +106,11 @@ public class GlobalQueryContextWithStats extends QueryContext {
         }
 
         @Override
+        public String getUniqueKey() {
+            return delegate.getUniqueKey();
+        }
+
+        @Override
         public TypeConverter getConverter() {
             return delegate.getConverter();
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -106,11 +106,6 @@ public class GlobalQueryContextWithStats extends QueryContext {
         }
 
         @Override
-        public String getUniqueKey() {
-            return delegate.getUniqueKey();
-        }
-
-        @Override
         public TypeConverter getConverter() {
             return delegate.getConverter();
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.predicates.PredicateUtils;
 
@@ -40,8 +41,7 @@ public interface Index {
     String getName();
 
     /**
-     * @return the components of this index for composite indexes, {@code null}
-     * for single-attribute non-composite indexes.
+     * @return the components of this index.
      */
     String[] getComponents();
 
@@ -57,6 +57,12 @@ public interface Index {
      * @see #getRecords(Comparable, boolean, Comparable, boolean)
      */
     boolean isOrdered();
+
+    /**
+     * @return the unique key attribute configured for bitmap indexes, {@code
+     * null} if no unique key configured.
+     */
+    String getUniqueKey();
 
     /**
      * @return the converter associated with this index; or {@code null} if the
@@ -87,6 +93,22 @@ public interface Index {
      *                        attribute value from the entry.
      */
     void removeEntry(Data key, Object value, OperationSource operationSource);
+
+    /**
+     * @return {@code true} if this index can evaluate a predicate of the given
+     * predicate class, {@code false} otherwise.
+     */
+    boolean canEvaluate(Class<? extends Predicate> predicateClass);
+
+    /**
+     * Evaluates the given predicate using this index.
+     *
+     * @param predicate the predicate to evaluate. The predicate is guaranteed
+     *                  to be evaluable by this index ({@code canEvaluate}
+     *                  returned {@code true} for its class).
+     * @return a set containing entries matching the given predicate.
+     */
+    Set<QueryableEntry> evaluate(Predicate predicate);
 
     /**
      * Produces a result set containing entries whose attribute values are equal

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -59,6 +59,12 @@ public interface Index {
     boolean isOrdered();
 
     /**
+     * @return the unique key attribute for bitmap indexes, {@code null} if this
+     * index is not a bitmap one.
+     */
+    String getUniqueKey();
+
+    /**
      * @return the converter associated with this index; or {@code null} if the
      * converter is not known because there were no saves to this index and
      * the attribute type is not inferred yet.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -59,12 +59,6 @@ public interface Index {
     boolean isOrdered();
 
     /**
-     * @return the unique key attribute configured for bitmap indexes, {@code
-     * null} if no unique key configured.
-     */
-    String getUniqueKey();
-
-    /**
      * @return the converter associated with this index; or {@code null} if the
      * converter is not known because there were no saves to this index and
      * the attribute type is not inferred yet.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
@@ -221,7 +221,7 @@ public final class IndexDefinition {
     }
 
     /**
-     * @return {@code true} if this index ordered, {@code} if unordered.
+     * @return {@code true} if this index ordered, {@code false} if unordered.
      */
     public boolean isOrdered() {
         return ordered;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.query.impl.predicates.PredicateUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.hazelcast.query.impl.predicates.PredicateUtils.canonicalizeAttribute;
+import static com.hazelcast.query.impl.predicates.PredicateUtils.constructCanonicalCompositeIndexName;
+
+/**
+ * Defines an index.
+ */
+public final class IndexDefinition {
+
+    private static final int MAX_INDEX_COMPONENTS = 255;
+
+    private static final Pattern COMMA_PATTERN = Pattern.compile("\\s*,\\s*");
+
+    private static final Pattern ARROW_PATTERN = Pattern.compile("\\s*->\\s*");
+
+    private final String name;
+    private final boolean ordered;
+    private final String uniqueKey;
+    private final String[] components;
+
+    private IndexDefinition(String name, boolean ordered, String uniqueKey, String... components) {
+        this.name = name;
+        this.ordered = ordered;
+        this.uniqueKey = uniqueKey;
+        this.components = components;
+    }
+
+    /**
+     * Parses the given index definition. The following definitions are
+     * recognized:
+     * <ul>
+     * <li>Regular index definition: a single attribute path ({@code attr}).
+     * <li>Composite index definition: multiple attribute paths separated by
+     * commas ({@code attr1, attr2, attr3}).
+     * <li>Bitmap index definition: a single attribute path followed by a unique
+     * key path separated by "->" ({@code attr -> uniqueKeyAttr}).
+     * </ul>
+     *
+     * @param definition the definition to parse.
+     * @param ordered    {@code true} if the given definition should define an
+     *                   ordered index, {@code false} for unordered.
+     * @return the parsed out index definition.
+     * @throws IllegalArgumentException if the given definition is considered
+     *                                  invalid.
+     */
+    public static IndexDefinition parse(String definition, boolean ordered) {
+        IndexDefinition parsedDefinition = tryParseBitmap(definition, ordered);
+        if (parsedDefinition != null) {
+            return parsedDefinition;
+        }
+
+        parsedDefinition = tryParseComposite(definition, ordered);
+        if (parsedDefinition != null) {
+            return parsedDefinition;
+        }
+
+        String attribute = canonicalizeAttribute(definition);
+        return new IndexDefinition(attribute, ordered, null, attribute);
+    }
+
+    private static IndexDefinition tryParseBitmap(String definition, boolean ordered) {
+        String[] parts = ARROW_PATTERN.split(definition);
+
+        if (parts.length == 1) {
+            return null;
+        }
+
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid bitmap index definition: " + definition);
+        }
+
+        parts[0] = canonicalizeAttribute(parts[0]);
+        parts[1] = canonicalizeAttribute(parts[1]);
+
+        if (parts[0].isEmpty() || parts[1].isEmpty() || parts[0].equals(parts[1])) {
+            throw new IllegalArgumentException("Invalid bitmap index definition: " + definition);
+        }
+
+        if (parts[0].contains(",") || parts[1].contains(",")) {
+            throw new IllegalArgumentException("Composite bitmap indexes are not supported: " + definition);
+        }
+
+        return new IndexDefinition(parts[0] + " -> " + parts[1], ordered, parts[1], parts[0]);
+    }
+
+    private static IndexDefinition tryParseComposite(String definition, boolean ordered) {
+        String[] attributes = COMMA_PATTERN.split(definition, -1);
+
+        if (attributes.length == 1) {
+            return null;
+        }
+
+        if (attributes.length > MAX_INDEX_COMPONENTS) {
+            throw new IllegalArgumentException("Too many composite index attributes: " + definition);
+        }
+
+        Set<String> seenAttributes = new HashSet<String>(attributes.length);
+        for (int i = 0; i < attributes.length; ++i) {
+            String component = PredicateUtils.canonicalizeAttribute(attributes[i]);
+            attributes[i] = component;
+
+            if (component.isEmpty()) {
+                throw new IllegalArgumentException("Empty composite index attribute: " + definition);
+            }
+            if (!seenAttributes.add(component)) {
+                throw new IllegalArgumentException("Duplicate composite index attribute: " + definition);
+            }
+        }
+
+        return new IndexDefinition(constructCanonicalCompositeIndexName(attributes), ordered, null, attributes);
+    }
+
+    /**
+     * @return the canonical name of this index.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return {@code true} if this index ordered, {@code} if unordered.
+     */
+    public boolean isOrdered() {
+        return ordered;
+    }
+
+    /**
+     * @return the unique key attribute path, which may be used to extract
+     * a value that uniquely identifies an entry being indexed.
+     */
+    public String getUniqueKey() {
+        return uniqueKey;
+    }
+
+    /**
+     * @return the components of this index, which are attributes being indexed
+     * by it. Regular and bitmap indexes have just a single component, while
+     * composite indexes have multiple components.
+     */
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public String[] getComponents() {
+        return components;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
@@ -55,35 +55,35 @@ public final class IndexDefinition {
          * Extracted unique key value is interpreted as an object value.
          * Non-negative unique ID is assigned to every distinct object value.
          */
-        OBJECT("object"),
+        OBJECT("OBJECT"),
 
         /**
          * Extracted unique key value is interpreted as a whole integer value of
          * byte, short, int or long type. The extracted value is upcasted to
          * long and unique non-negative ID is assigned to every distinct value.
          */
-        LONG("long"),
+        LONG("LONG"),
 
         /**
          * Extracted unique key value is interpreted as a whole integer value of
          * byte, short, int or long type. The extracted value is upcasted to
          * long and the resulting value is used directly as an ID.
          */
-        RAW("raw");
+        RAW("RAW");
 
         private static UniqueKeyTransform parse(String text) {
             if (StringUtil.isNullOrEmpty(text)) {
                 throw new IllegalArgumentException("empty unique key transform");
             }
 
-            String lowerCasedText = text.toLowerCase();
-            if (lowerCasedText.equals(OBJECT.text)) {
+            String upperCasedText = text.toUpperCase();
+            if (upperCasedText.equals(OBJECT.text)) {
                 return OBJECT;
             }
-            if (lowerCasedText.equals(LONG.text)) {
+            if (upperCasedText.equals(LONG.text)) {
                 return LONG;
             }
-            if (lowerCasedText.equals(RAW.text)) {
+            if (upperCasedText.equals(RAW.text)) {
                 return RAW;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexDefinition.java
@@ -71,6 +71,12 @@ public final class IndexDefinition {
          */
         RAW("RAW");
 
+        private final String text;
+
+        UniqueKeyTransform(String text) {
+            this.text = text;
+        }
+
         private static UniqueKeyTransform parse(String text) {
             if (StringUtil.isNullOrEmpty(text)) {
                 throw new IllegalArgumentException("empty unique key transform");
@@ -88,12 +94,6 @@ public final class IndexDefinition {
             }
 
             throw new IllegalArgumentException("unexpected unique key transform: " + text);
-        }
-
-        private final String text;
-
-        UniqueKeyTransform(String text) {
-            this.text = text;
         }
 
         @Override
@@ -152,6 +152,7 @@ public final class IndexDefinition {
         return new IndexDefinition(attribute, ordered, attribute);
     }
 
+    @SuppressWarnings("checkstyle:npathcomplexity")
     private static IndexDefinition tryParseBitmap(String definition, boolean ordered) {
         if (definition == null || !definition.toUpperCase().startsWith(BITMAP_PREFIX)) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -32,14 +32,21 @@ public class IndexImpl extends AbstractIndex {
 
     private final Set<Integer> indexedPartitions = newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
 
-    public IndexImpl(String name, String[] components, boolean ordered, InternalSerializationService ss, Extractors extractors,
+    public IndexImpl(IndexDefinition definition, InternalSerializationService ss, Extractors extractors,
                      IndexCopyBehavior copyBehavior, PerIndexStats stats) {
-        super(name, components, ordered, ss, extractors, copyBehavior, stats);
+        super(definition, ss, extractors, copyBehavior, stats);
     }
 
     @Override
-    protected IndexStore createIndexStore(boolean ordered, PerIndexStats stats) {
-        return ordered ? new OrderedIndexStore(copyBehavior) : new UnorderedIndexStore(copyBehavior);
+    protected IndexStore createIndexStore(IndexDefinition definition, PerIndexStats stats) {
+        if (definition.getUniqueKey() == null) {
+            return definition.isOrdered() ? new OrderedIndexStore(copyBehavior) : new UnorderedIndexStore(copyBehavior);
+        } else {
+            if (definition.isOrdered()) {
+                throw new IllegalArgumentException("Ordered bitmap indexes are not supported");
+            }
+            return new BitmapIndexStore(definition.getUniqueKey(), ss, extractors);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -42,10 +42,7 @@ public class IndexImpl extends AbstractIndex {
         if (definition.getUniqueKey() == null) {
             return definition.isOrdered() ? new OrderedIndexStore(copyBehavior) : new UnorderedIndexStore(copyBehavior);
         } else {
-            if (definition.isOrdered()) {
-                throw new IllegalArgumentException("Ordered bitmap indexes are not supported");
-            }
-            return new BitmapIndexStore(definition.getUniqueKey(), ss, extractors);
+            return new BitmapIndexStore(definition, ss, extractors);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
@@ -29,12 +29,7 @@ public interface IndexProvider {
     /**
      * Creates a new index with the given name.
      *
-     * @param name         the name of the index to create or {@code null} if
-     *                     the index being created is not composite.
-     * @param components   the components of the index to create.
-     * @param ordered      {@code true} to create an ordered index supporting
-     *                     fast range queries, {@code false} to create an
-     *                     unordered index supporting fast point queries only.
+     * @param definition   the index definition to create the index from.
      * @param extractors   the extractors to extract values of the given
      *                     name.
      * @param ss           the serialization service to perform the
@@ -44,7 +39,7 @@ public interface IndexProvider {
      * @param stats        the index stats instance to report the statistics to.
      * @return the created index instance.
      */
-    InternalIndex createIndex(String name, String[] components, boolean ordered, Extractors extractors,
-                              InternalSerializationService ss, IndexCopyBehavior copyBehavior, PerIndexStats stats);
+    InternalIndex createIndex(IndexDefinition definition, Extractors extractors, InternalSerializationService ss,
+                              IndexCopyBehavior copyBehavior, PerIndexStats stats);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Numbers.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Numbers.java
@@ -245,7 +245,7 @@ public final class Numbers {
             }
         } else if (isDoubleRepresentable(clazz)) {
             int intValue = number.intValue();
-            if (equalDoubles(number.doubleValue(), (double) intValue)) {
+            if (equalDoubles(number.doubleValue(), intValue)) {
                 return intValue;
             }
         }
@@ -306,12 +306,15 @@ public final class Numbers {
         return l == (long) d;
     }
 
-    private static boolean isLongRepresentableExceptLong(Class clazz) {
-        return clazz == Integer.class || clazz == Short.class || clazz == Byte.class;
+    /**
+     * Compares two longs exactly as Java 7 Long.compare does.
+     */
+    public static int compareLongs(long lhs, long rhs) {
+        return lhs < rhs ? -1 : (lhs == rhs ? 0 : +1);
     }
 
-    private static int compareLongs(long lhs, long rhs) {
-        return lhs < rhs ? -1 : (lhs == rhs ? 0 : +1);
+    private static boolean isLongRepresentableExceptLong(Class clazz) {
+        return clazz == Integer.class || clazz == Short.class || clazz == Byte.class;
     }
 
     @SuppressWarnings("checkstyle:magicnumber")

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,7 +34,7 @@ import static java.util.Collections.emptySet;
 /**
  * Store indexes rankly.
  */
-public class OrderedIndexStore extends BaseIndexStore {
+public class OrderedIndexStore extends BaseSingleValueIndexStore {
 
     private final ConcurrentSkipListMap<Comparable, Map<Data, QueryableEntry>> recordMap =
             new ConcurrentSkipListMap<Comparable, Map<Data, QueryableEntry>>(Comparables.COMPARATOR);
@@ -90,6 +92,16 @@ public class OrderedIndexStore extends BaseIndexStore {
         } finally {
             releaseWriteLock();
         }
+    }
+
+    @Override
+    public boolean canEvaluate(Class<? extends Predicate> predicateClass) {
+        return false;
+    }
+
+    @Override
+    public Set<QueryableEntry> evaluate(Predicate predicate, TypeConverter converter) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +32,7 @@ import static com.hazelcast.query.impl.AbstractIndex.NULL;
 /**
  * Store indexes out of turn.
  */
-public class UnorderedIndexStore extends BaseIndexStore {
+public class UnorderedIndexStore extends BaseSingleValueIndexStore {
 
     private final ConcurrentMap<Comparable, Map<Data, QueryableEntry>> recordMap =
             new ConcurrentHashMap<Comparable, Map<Data, QueryableEntry>>(1000);
@@ -117,6 +119,16 @@ public class UnorderedIndexStore extends BaseIndexStore {
         } finally {
             releaseWriteLock();
         }
+    }
+
+    @Override
+    public boolean canEvaluate(Class<? extends Predicate> predicateClass) {
+        return false;
+    }
+
+    @Override
+    public Set<QueryableEntry> evaluate(Predicate predicate, TypeConverter converter) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/AscendingLongIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/AscendingLongIterator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+/**
+ * Iterates over a set of non-negative {@code long} values in ascending order.
+ */
+public interface AscendingLongIterator {
+
+    /**
+     * Identifies an iterator end.
+     * <p>
+     * Don't change this value, iteration logic relies on it being exactly -1L.
+     */
+    long END = -1L;
+
+    /**
+     * Denotes an empty ordered long iterator.
+     */
+    AscendingLongIterator EMPTY = new AscendingLongIterator() {
+        @Override
+        public long getIndex() {
+            return END;
+        }
+
+        @Override
+        public long advance() {
+            return END;
+        }
+
+        @Override
+        public long advanceAtLeastTo(long member) {
+            return END;
+        }
+    };
+
+    /**
+     * Returns a value at which this iterator is positioned currently or {@link
+     * #END} if this iterator has reached its end.
+     * <p>
+     * Just after the creation, iterators are positioned at their first value.
+     * <p>
+     * "Index" is used instead of "value" since {@link SparseArray.Iterator}
+     * interface extends this interface with {@link SparseArray.Iterator#getValue()}
+     * method.
+     */
+    long getIndex();
+
+    /**
+     * Advances this iterator to the next index.
+     * <p>
+     *
+     * @return an index at which this iterator was positioned before the
+     * advancement or {@link #END} if this iterator already was at its end.
+     * Once the end is reached, return value is always {@link #END} on any
+     * subsequent advancement attempts.
+     */
+    long advance();
+
+    /**
+     * Advances this iterator to the given member; or, if the member is not
+     * present in this iterator, to an index immediately following it and
+     * present in the iterator or {@link #END} if no such index exists.
+     *
+     * @param member the member to advance at least to.
+     * @return an index at which this iterator was advanced to or {@link #END}
+     * if this iterator reached its end. Once the end is reached, return value
+     * is always {@link #END} on any subsequent advancement attempts.
+     */
+    long advanceAtLeastTo(long member);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/Bitmap.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/Bitmap.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.predicates.AndPredicate;
+import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.query.impl.predicates.InPredicate;
+import com.hazelcast.query.impl.predicates.NotEqualPredicate;
+import com.hazelcast.query.impl.predicates.NotPredicate;
+import com.hazelcast.query.impl.predicates.OrPredicate;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Provides indexing and querying capabilities for a single attribute of entries
+ * of type {@code E}. Each indexed entry is uniquely identified by its unique
+ * {@code long} key provided externally.
+ * <p>
+ * Internally, each bitmap manages a set of sparse bit sets, one for each
+ * possible attribute value, and a sparse array to map from unique {@code long}
+ * entry keys back to entries.
+ *
+ * @param <E> the type of entries being indexed.
+ */
+@SuppressWarnings("rawtypes")
+public final class Bitmap<E> {
+
+    private final Map<Object, SparseBitSet> bitSets = new HashMap<Object, SparseBitSet>();
+
+    private final SparseArray<E> entries = new SparseArray<E>();
+
+    /**
+     * Inserts the given values associated with the given entry having the given
+     * unique key.
+     *
+     * @param values the values to insert.
+     * @param key    the unique key of the entry being inserted.
+     * @param entry  the entry to insert.
+     */
+    public void insert(Iterator values, long key, E entry) {
+        while (values.hasNext()) {
+            Object value = values.next();
+            assert value != null;
+
+            SparseBitSet bitSet = bitSets.get(value);
+            if (bitSet == null) {
+                bitSet = new SparseBitSet();
+                bitSets.put(value, bitSet);
+            }
+            bitSet.add(key);
+        }
+
+        entries.set(key, entry);
+    }
+
+    /**
+     * Updates the given old values to the given new values associated with the
+     * given entry having the given unique key.
+     *
+     * @param oldValues the old values to replace.
+     * @param newValues the new values to replace with.
+     * @param key       the unique key of the entry being updated.
+     * @param entry     the entry to update.
+     */
+    public void update(Iterator oldValues, Iterator newValues, long key, E entry) {
+        while (oldValues.hasNext()) {
+            Object value = oldValues.next();
+            assert value != null;
+
+            SparseBitSet bitSet = bitSets.get(value);
+            if (bitSet != null) {
+                bitSet.remove(key);
+            }
+        }
+
+        while (newValues.hasNext()) {
+            Object value = newValues.next();
+            assert value != null;
+
+            SparseBitSet bitSet = bitSets.get(value);
+            if (bitSet == null) {
+                bitSet = new SparseBitSet();
+                bitSets.put(value, bitSet);
+            }
+            bitSet.add(key);
+        }
+
+        entries.set(key, entry);
+    }
+
+    /**
+     * Removes the given values associated with an entry identified by the given
+     * unique key.
+     *
+     * @param values the values to remove.
+     * @param key    the unique key of an entry being removed.
+     */
+    public void remove(Iterator values, long key) {
+        while (values.hasNext()) {
+            Object value = values.next();
+            assert value != null;
+
+            SparseBitSet bitSet = bitSets.get(value);
+            if (bitSet != null) {
+                if (bitSet.remove(key)) {
+                    bitSets.remove(value);
+                }
+            }
+        }
+
+        entries.clear(key);
+    }
+
+    /**
+     * Clears this bitmap.
+     */
+    public void clear() {
+        bitSets.clear();
+        entries.clear();
+    }
+
+    /**
+     * Evaluates the given predicate while converting the predicate arguments
+     * using the given converter.
+     * <p>
+     * The following predicates (and combinations of them) are supported:
+     * {@link AndPredicate}, {@link OrPredicate}, {@link NotPredicate}, {@link
+     * NotEqualPredicate}, {@link EqualPredicate}, {@link InPredicate}.
+     *
+     * @param predicate the predicate to evaluate.
+     * @param converter the converter to use for the predicate arguments
+     *                  conversion.
+     * @return an iterator containing entries matching the given predicate.
+     */
+    public Iterator<E> evaluate(Predicate predicate, TypeConverter converter) {
+        return new EntryIterator<E>(predicateIterator(predicate, converter), entries.iterator());
+    }
+
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    private AscendingLongIterator predicateIterator(Predicate predicate, TypeConverter converter) {
+        if (predicate instanceof AndPredicate) {
+            Predicate[] predicates = ((AndPredicate) predicate).getPredicates();
+            assert predicates.length > 0;
+            if (predicates.length == 1) {
+                return predicateIterator(predicates[0], converter);
+            } else {
+                return BitmapAlgorithms.and(predicateIterators(predicates, converter));
+            }
+        }
+
+        if (predicate instanceof OrPredicate) {
+            Predicate[] predicates = ((OrPredicate) predicate).getPredicates();
+            assert predicates.length > 0;
+            if (predicates.length == 1) {
+                return predicateIterator(predicates[0], converter);
+            } else {
+                return BitmapAlgorithms.or(predicateIterators(predicates, converter));
+            }
+        }
+
+        if (predicate instanceof NotPredicate) {
+            Predicate subPredicate = ((NotPredicate) predicate).getPredicate();
+            return BitmapAlgorithms.not(predicateIterator(subPredicate, converter), entries);
+        }
+
+        if (predicate instanceof NotEqualPredicate) {
+            Comparable value = ((NotEqualPredicate) predicate).getFrom();
+            return BitmapAlgorithms.not(valueIterator(value, converter), entries);
+        }
+
+        if (predicate instanceof EqualPredicate) {
+            Comparable value = ((EqualPredicate) predicate).getFrom();
+            return valueIterator(value, converter);
+        }
+
+        if (predicate instanceof InPredicate) {
+            Comparable[] values = ((InPredicate) predicate).getValues();
+            return BitmapAlgorithms.or(valueIterators(values, converter));
+        }
+
+        throw new IllegalArgumentException("unexpected predicate: " + predicate);
+    }
+
+    private AscendingLongIterator[] predicateIterators(Predicate[] predicates, TypeConverter converter) {
+        AscendingLongIterator[] iterators = new AscendingLongIterator[predicates.length];
+        for (int i = 0; i < predicates.length; ++i) {
+            iterators[i] = predicateIterator(predicates[i], converter);
+        }
+        return iterators;
+    }
+
+    private AscendingLongIterator valueIterator(Comparable value, TypeConverter converter) {
+        SparseBitSet bitSet = bitSets.get(converter.convert(value));
+        return bitSet == null ? AscendingLongIterator.EMPTY : bitSet.iterator();
+    }
+
+    private AscendingLongIterator[] valueIterators(Comparable[] values, TypeConverter converter) {
+        AscendingLongIterator[] iterators = new AscendingLongIterator[values.length];
+        for (int i = 0; i < values.length; ++i) {
+            iterators[i] = valueIterator(values[i], converter);
+        }
+        return iterators;
+    }
+
+    /**
+     * Maps unique entry keys back to entries.
+     */
+    private static final class EntryIterator<E> implements Iterator<E> {
+
+        private final AscendingLongIterator iterator;
+        private final SparseArray.Iterator<E> universe;
+
+        EntryIterator(AscendingLongIterator iterator, SparseArray.Iterator<E> universe) {
+            this.iterator = iterator;
+            this.universe = universe;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.getIndex() != AscendingLongIterator.END;
+        }
+
+        @Override
+        public E next() {
+            long member = iterator.advance();
+            long advancedTo = universe.advanceAtLeastTo(member);
+            assert advancedTo == member;
+            return universe.getValue();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("bitmap iterators are read-only");
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithms.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithms.java
@@ -126,23 +126,9 @@ final class BitmapAlgorithms {
                 return index;
             }
 
-            long max = member;
-            for (Node node : nodes) {
-                long advancedTo = node.iterator.advanceAtLeastTo(max);
-                if (advancedTo == AscendingLongIterator.END) {
-                    // make it first just to detect the end in advance()
-                    first = node;
-                    index = AscendingLongIterator.END;
-                    return AscendingLongIterator.END;
-                }
-
-                if (advancedTo > max) {
-                    max = advancedTo;
-                }
-            }
-
-            orderAndLink();
+            last.iterator.advanceAtLeastTo(member);
             advance();
+
             return index;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithms.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithms.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl.bitmap;
 
 import com.hazelcast.query.impl.Numbers;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Arrays;
 
@@ -157,6 +158,7 @@ final class BitmapAlgorithms {
             last.next = null;
         }
 
+        @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
         private static final class Node implements Comparable<Node> {
 
             final AscendingLongIterator iterator;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithms.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithms.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+/**
+ * Provides algorithms crucial for set operations on ordered iterators provided
+ * by sparse bit sets.
+ */
+final class BitmapAlgorithms {
+
+    private BitmapAlgorithms() {
+    }
+
+    /**
+     * @return an iterator that represents a result of intersection of the given
+     * iterators.
+     */
+    public static AscendingLongIterator and(AscendingLongIterator[] iterators) {
+        return new AndIterator(iterators);
+    }
+
+    /**
+     * @return an iterator that represents a result of union over the given
+     * iterators.
+     */
+    public static AscendingLongIterator or(AscendingLongIterator[] iterators) {
+        return new OrIterator(iterators);
+    }
+
+    /**
+     * @return an iterator that represents a result of negation of the given
+     * iterator over the given universe (a set of known elements).
+     */
+    public static AscendingLongIterator not(AscendingLongIterator iterator, SparseArray<?> universe) {
+        return new NotIterator(iterator, universe);
+    }
+
+    private static final class AndIterator implements AscendingLongIterator {
+
+        // The idea: iteratively advance all iterators to the current
+        // maximum index among all iterators until all iterators are at the
+        // same index or the end is reached in at least one of the iterators.
+
+        private final AscendingLongIterator[] iterators;
+
+        private long index;
+
+        AndIterator(AscendingLongIterator[] iterators) {
+            this.iterators = iterators;
+            advance();
+        }
+
+        @Override
+        public long getIndex() {
+            return index;
+        }
+
+        @Override
+        public long advance() {
+            long current = index;
+
+            long currentMax = iterators[0].getIndex();
+            long max = AscendingLongIterator.END;
+            while (currentMax != max) {
+                max = currentMax;
+                for (AscendingLongIterator iterator : iterators) {
+                    currentMax = iterator.advanceAtLeastTo(currentMax);
+                    if (currentMax == AscendingLongIterator.END) {
+                        index = AscendingLongIterator.END;
+                        return current;
+                    }
+                }
+            }
+
+            // make a progress
+            iterators[0].advance();
+
+            index = max;
+            return current;
+        }
+
+        @Override
+        public long advanceAtLeastTo(long member) {
+            if (index >= member) {
+                return index;
+            }
+
+            for (AscendingLongIterator iterator : iterators) {
+                iterator.advanceAtLeastTo(member);
+            }
+            advance();
+            return index;
+        }
+
+    }
+
+    private static final class OrIterator implements AscendingLongIterator {
+
+        // The idea: build a min-heap that will order the iterators according
+        // to their current indexes. Luckily enough, we need only sift-down
+        // operation to accomplish that since heap creation and heap element
+        // removal/update can be expressed solely with sift-downs.
+
+        private final AscendingLongIterator[] iterators;
+
+        private int size;
+
+        OrIterator(AscendingLongIterator[] iterators) {
+            this.iterators = iterators;
+            this.size = iterators.length;
+
+            heapify();
+            removeEmptyIterators();
+        }
+
+        @Override
+        public long getIndex() {
+            return size == 0 ? AscendingLongIterator.END : iterators[0].getIndex();
+        }
+
+        @Override
+        public long advance() {
+            if (size == 0) {
+                return AscendingLongIterator.END;
+            }
+
+            long current = iterators[0].getIndex();
+            update();
+
+            // skip duplicates if any
+            while (size > 0 && iterators[0].getIndex() == current) {
+                update();
+            }
+
+            return current;
+        }
+
+        @Override
+        public long advanceAtLeastTo(long member) {
+            if (size == 0) {
+                return AscendingLongIterator.END;
+            }
+
+            long index;
+            while ((index = iterators[0].getIndex()) < member) {
+                update();
+                if (size == 0) {
+                    return AscendingLongIterator.END;
+                }
+            }
+            return index;
+        }
+
+        private void removeEmptyIterators() {
+            while (size > 0 && iterators[0].getIndex() == AscendingLongIterator.END) {
+                --size;
+                if (size != 0) {
+                    siftDown(0, iterators[size]);
+                }
+            }
+        }
+
+        private void update() {
+            assert size > 0;
+            AscendingLongIterator iterator = iterators[0];
+            long index = iterator.advance();
+            long newIndex = iterator.getIndex();
+
+            if (newIndex == AscendingLongIterator.END) {
+                --size;
+                if (size != 0) {
+                    siftDown(0, iterators[size]);
+                }
+            } else {
+                // Indexes are always increasing in each individual iterator,
+                // so we may just sift-down according to the index.
+
+                assert newIndex > index;
+                siftDown(0, iterator);
+            }
+        }
+
+        private void heapify() {
+            // A textbook implementation of heapify described in Wikipedia,
+            // java.util.PriorityQueue uses the same.
+
+            for (int i = (size >>> 1) - 1; i >= 0; i--) {
+                siftDown(i, iterators[i]);
+            }
+        }
+
+        private void siftDown(int index, AscendingLongIterator iterator) {
+            // A tail-call-eliminated implementation of sift-down described in
+            // Wikipedia, similar to the one used by java.util.PriorityQueue.
+
+            int firstLeafIndex = size >>> 1;
+            while (index < firstLeafIndex) {
+                int childIndex = (index << 1) + 1;
+                AscendingLongIterator child = iterators[childIndex];
+                int rightChildIndex = childIndex + 1;
+                if (rightChildIndex < size && child.getIndex() > iterators[rightChildIndex].getIndex()) {
+                    childIndex = rightChildIndex;
+                    child = iterators[childIndex];
+                }
+                if (iterator.getIndex() <= child.getIndex()) {
+                    break;
+                }
+                iterators[index] = child;
+                index = childIndex;
+            }
+            iterators[index] = iterator;
+        }
+
+    }
+
+    private static final class NotIterator implements AscendingLongIterator {
+
+        // The idea: find gaps in the base iterator and iterate indexes/members
+        // inside them using the universe iterator which contains all the known
+        // indexes.
+
+        private final AscendingLongIterator iterator;
+        private final AscendingLongIterator universe;
+
+        private long index;
+        private long gapEnd;
+
+        NotIterator(AscendingLongIterator iterator, SparseArray<?> universe) {
+            this.iterator = iterator;
+            this.universe = universe.iterator();
+            gapEnd = iterator.advance();
+            advance();
+        }
+
+        @Override
+        public long getIndex() {
+            return index;
+        }
+
+        @Override
+        public long advance() {
+            long current = index;
+
+            long newIndex = universe.advance();
+            if (newIndex != gapEnd) {
+                // We still not reached the gap end, fast exit.
+
+                index = newIndex;
+                return current;
+            }
+
+            // Try to find a new gap.
+
+            long newGapEnd = gapEnd;
+            while (newIndex == newGapEnd && newIndex != AscendingLongIterator.END) {
+                long newGapStart;
+                do {
+                    // We may overflow here to Long.MIN_VALUE, but we will exit
+                    // the loop anyway. In this case, after exiting the loop,
+                    // newGapEnd will be equal to BitSetIterator.END.
+                    newGapStart = newGapEnd + 1;
+                    newGapEnd = iterator.advance();
+                } while (newGapEnd == newGapStart);
+
+                if (newGapStart == Long.MIN_VALUE) {
+                    // If the overflow happened, nothing left for sure.
+                    assert newGapEnd == AscendingLongIterator.END;
+
+                    // Position the universe to Long.MAX_VALUE and consume it.
+                    universe.advanceAtLeastTo(Long.MAX_VALUE);
+                    universe.advance();
+                    break;
+                } else {
+                    newIndex = universe.advanceAtLeastTo(newGapStart);
+                }
+            }
+
+            index = universe.advance();
+            gapEnd = newGapEnd;
+            return current;
+        }
+
+        @Override
+        public long advanceAtLeastTo(long member) {
+            if (index >= member) {
+                // We are already at/beyond the member.
+                return index;
+            }
+
+            if (member > gapEnd) {
+                // Find out the new gap end and consume it.
+                gapEnd = iterator.advanceAtLeastTo(member);
+                iterator.advance();
+            }
+            // If existing/updated gap end is equal to the member, advance()
+            // will handle that. Gap end is either equal to the member or
+            // greater than it, since the gap end is part of the universe for
+            // sure.
+
+            universe.advanceAtLeastTo(member);
+            advance();
+            return index;
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/BitmapUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+/**
+ * Provides utilities shared among bitmap implementation classes.
+ */
+final class BitmapUtils {
+
+    private static final int SHORT_TO_INT_MASK = 0xFFFF;
+    private static final long SHORT_TO_LONG_MASK = 0xFFFFL;
+    private static final long INT_TO_LONG_MASK = 0xFFFFFFFFL;
+
+    private static final int INT_ARRAY_MIN_CAPACITY = 2;
+    private static final int SHORT_ARRAY_MIN_CAPACITY = 4;
+
+    /**
+     * Regulates the growth/shrink rate of the arrays. We are growing/shrinking
+     * by 1/4 of the current array size. The rate may seem as too low, but we
+     * are paying almost nothing for more frequent resizing while arrays are
+     * small and we don't waste as much memory for large arrays as with doubling.
+     */
+    private static final int CAPACITY_SHIFT = 2;
+
+    private BitmapUtils() {
+    }
+
+    /**
+     * Does exactly the same thing as Java 8 Short.toUnsignedInt.
+     */
+    public static int toUnsignedInt(short value) {
+        return ((int) value) & SHORT_TO_INT_MASK;
+    }
+
+    /**
+     * Does exactly the same thing as Java 8 Short.toUnsignedLong.
+     */
+    public static long toUnsignedLong(short value) {
+        return ((long) value) & SHORT_TO_LONG_MASK;
+    }
+
+    /**
+     * Does exactly the same thing as Java 8 Integer.toUnsignedLong.
+     */
+    public static long toUnsignedLong(int value) {
+        return ((long) value) & INT_TO_LONG_MASK;
+    }
+
+    /**
+     * Does binary search in a way similar to Arrays.binarySearch, but treats
+     * values as unsigned.
+     */
+    public static int unsignedBinarySearch(short[] array, int size, int unsignedValue) {
+        return unsignedBinarySearch(array, 0, size, unsignedValue);
+    }
+
+    /**
+     * Does binary search in a way similar to Arrays.binarySearch, but treats
+     * values as unsigned.
+     */
+    public static int unsignedBinarySearch(short[] array, int from, int size, int unsignedValue) {
+        int right = size - 1;
+        int lastValue = toUnsignedInt(array[right]);
+        if (unsignedValue > lastValue) {
+            // fast exit if we are beyond the last value
+            return -(size + 1);
+        } else if (lastValue == right) {
+            // The array is populated with contiguous values starting from 0 up
+            // to size - 1. The value we are searching for is less than or equal
+            // to size - 1 at this point, so we may just return the value itself
+            // as its index.
+            return unsignedValue;
+        }
+
+        int left = from;
+
+        while (left <= right) {
+            int middle = (left + right) >>> 1;
+            int candidate = toUnsignedInt(array[middle]);
+
+            if (candidate < unsignedValue) {
+                left = middle + 1;
+            } else if (candidate > unsignedValue) {
+                right = middle - 1;
+            } else {
+                return middle;
+            }
+        }
+        return -(left + 1);
+    }
+
+    /**
+     * Does binary search in a way similar to Arrays.binarySearch, but treats
+     * values as unsigned.
+     */
+    public static int unsignedBinarySearch(int[] array, int size, long unsignedValue) {
+        return unsignedBinarySearch(array, 0, size, unsignedValue);
+    }
+
+    /**
+     * Does binary search in a way similar to Arrays.binarySearch, but treats
+     * values as unsigned.
+     */
+    public static int unsignedBinarySearch(int[] array, int from, int size, long unsignedValue) {
+        int right = size - 1;
+        long lastValue = toUnsignedLong(array[right]);
+        if (unsignedValue > lastValue) {
+            // fast exit if we are beyond the last value
+            return -(size + 1);
+        } else if (lastValue == right) {
+            // The array is populated with contiguous values starting from 0 up
+            // to size - 1. The value we are searching for is less than or equal
+            // to size - 1 at this point, so we may just return the value itself
+            // as its index.
+            return (int) unsignedValue;
+        }
+
+        int left = from;
+
+        while (left <= right) {
+            int middle = (left + right) >>> 1;
+            long candidate = toUnsignedLong(array[middle]);
+
+            if (candidate < unsignedValue) {
+                left = middle + 1;
+            } else if (candidate > unsignedValue) {
+                right = middle - 1;
+            } else {
+                return middle;
+            }
+        }
+        return -(left + 1);
+    }
+
+    /**
+     * Computes capacity delta for sorted int arrays.
+     */
+    public static int capacityDeltaInt(int capacity) {
+        return Math.max(INT_ARRAY_MIN_CAPACITY, capacity >>> CAPACITY_SHIFT);
+    }
+
+    /**
+     * Computes capacity delta for sorted short arrays.
+     */
+    public static int capacityDeltaShort(int capacity) {
+        return Math.max(SHORT_ARRAY_MIN_CAPACITY, capacity >>> CAPACITY_SHIFT);
+    }
+
+    /**
+     * Computes capacity delta for dense directly indexable int arrays.
+     */
+    public static int denseCapacityDeltaInt(int size, int capacity) {
+        assert capacity > 0;
+        assert size <= capacity;
+        if (size == 0) {
+            return 0;
+        }
+
+        int delta = capacityDeltaInt(capacity);
+        int wasted = capacity - size;
+        return Math.max(0, delta - wasted);
+    }
+
+    /**
+     * Computes capacity delta for dense directly indexable short arrays.
+     */
+    public static int denseCapacityDeltaShort(int size, int capacity) {
+        assert capacity > 0;
+        assert size <= capacity;
+        if (size == 0) {
+            return 0;
+        }
+
+        int delta = capacityDeltaShort(capacity);
+        int wasted = capacity - size;
+        return Math.max(0, delta - wasted);
+    }
+
+    // for testing purposes, Java 8 Integer.compareUnsigned
+    public static int compareUnsigned(int x, int y) {
+        return compare(x + Integer.MIN_VALUE, y + Integer.MIN_VALUE);
+    }
+
+    // Java 7 Integer.compare
+    private static int compare(int x, int y) {
+        return x < y ? -1 : ((x == y) ? 0 : 1);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/SparseArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/SparseArray.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+/**
+ * Stores values of type {@code E} indexable by non-negative {@code long}
+ * indexes.
+ * <p>
+ * Internally, uses a {@link SparseIntArray} indexed by the high 32 bits (prefix)
+ * of an index to resolve another {@link SparseIntArray} indexed by the low 32
+ * bits (postfix).
+ *
+ * @param <E> the element type.
+ */
+final class SparseArray<E> {
+
+    private static final long INT_PREFIX_MASK = 0xFFFFFFFF00000000L;
+
+    /**
+     * Iterates over values of a sparse array in ascending index order.
+     */
+    public interface Iterator<T> extends AscendingLongIterator {
+
+        /**
+         * Returns a value this iterator is currently at. If this iterator is
+         * already reached its end, the return value is undefined.
+         * <p>
+         * Just after the creation, iterators are positioned at their first value.
+         */
+        T getValue();
+
+    }
+
+    private final SparseIntArray<SparseIntArray<E>> storages = new SparseIntArray<SparseIntArray<E>>();
+
+    // used for caching of the last resolved storage
+    private int lastPrefix = -1;
+    private SparseIntArray<E> lastStorage;
+
+    /**
+     * Sets or replaces a value at the given index in this sparse array to the
+     * new given value.
+     *
+     * @param index the index to set value at.
+     * @param value the value to set.
+     */
+    public void set(long index, E value) {
+        assert index >= 0;
+        assert value != null;
+        int prefix = (int) (index >>> Integer.SIZE);
+
+        if (prefix == lastPrefix) {
+            lastStorage.set((int) index, value);
+        } else {
+            lastPrefix = prefix;
+            SparseIntArray<E> storage = storages.get(prefix);
+            if (storage == null) {
+                SparseIntArray<E> createdStorage = new SparseIntArray<E>();
+                createdStorage.set((int) index, value);
+                lastStorage = createdStorage;
+                storages.set(prefix, createdStorage);
+            } else {
+                storage.set((int) index, value);
+                lastStorage = storage;
+            }
+        }
+    }
+
+    /**
+     * Clears the value at the given index in this sparse array.
+     *
+     * @param index the index to clear value at.
+     */
+    public void clear(long index) {
+        assert index >= 0;
+        int prefix = (int) (index >>> Integer.SIZE);
+
+        if (prefix == lastPrefix) {
+            if (lastStorage.clear((int) index)) {
+                lastPrefix = -1;
+                lastStorage = null;
+                // cleanup the empty storage
+                storages.clear(prefix);
+            }
+        } else {
+            SparseIntArray<E> storage = storages.get(prefix);
+            if (storage != null) {
+                if (storage.clear((int) index)) {
+                    // cleanup the empty storage
+                    storages.clear(prefix);
+                } else {
+                    lastPrefix = prefix;
+                    lastStorage = storage;
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears this sparse array entirely.
+     */
+    public void clear() {
+        lastPrefix = -1;
+        lastStorage = null;
+        storages.clear();
+    }
+
+    /**
+     * @return an iterator that iterates over all the values stored in this
+     * sparse array.
+     */
+    public Iterator<E> iterator() {
+        return new IteratorImpl<E>(storages);
+    }
+
+    private static final class IteratorImpl<T> extends SparseIntArray.Iterator<T> implements Iterator<T> {
+
+        private final SparseIntArray<SparseIntArray<T>> storages;
+        private final SparseIntArray.Iterator<SparseIntArray<T>> storageIterator;
+
+        private SparseIntArray<T> storage;
+        private long index;
+
+        IteratorImpl(SparseIntArray<SparseIntArray<T>> storages) {
+            this.storages = storages;
+            this.storageIterator = new SparseIntArray.Iterator<SparseIntArray<T>>();
+
+            long prefix = storages.iterate(storageIterator);
+            if (prefix != SparseIntArray.Iterator.END) {
+                storage = storageIterator.getValue();
+                long postfix = storage.iterate(this);
+                assert postfix != SparseIntArray.Iterator.END;
+                index = prefix << Integer.SIZE | postfix;
+            } else {
+                index = Iterator.END;
+            }
+        }
+
+        @Override
+        public long getIndex() {
+            return index;
+        }
+
+        @Override
+        public long advance() {
+            long current = index;
+            if (current == Iterator.END) {
+                return Iterator.END;
+            }
+
+            // Try to advance the current storage.
+
+            long postfix = storage.advance((int) current, this);
+            if (postfix != SparseIntArray.Iterator.END) {
+                index = current & INT_PREFIX_MASK | postfix;
+                return current;
+            }
+
+            // Try to advance to the next storage.
+
+            long prefix = storages.advance((int) (current >>> Integer.SIZE), storageIterator);
+            if (prefix != SparseIntArray.Iterator.END) {
+                storage = storageIterator.getValue();
+                postfix = storage.iterate(this);
+                if (postfix != SparseIntArray.Iterator.END) {
+                    index = prefix << Integer.SIZE | postfix;
+                    return current;
+                }
+            }
+
+            // The end.
+
+            index = Iterator.END;
+            return current;
+        }
+
+        @SuppressWarnings("checkstyle:nestedifdepth")
+        @Override
+        public long advanceAtLeastTo(long member) {
+            assert member >= 0;
+            long current = index;
+            if (current == Iterator.END) {
+                return Iterator.END;
+            }
+
+            if (current >= member) {
+                // Already at or beyond the requested member.
+
+                return current;
+            }
+
+            int memberPrefix = (int) (member >>> Integer.SIZE);
+            int currentPrefix = (int) (current >>> Integer.SIZE);
+
+            if (memberPrefix == currentPrefix) {
+                // Try to advance the current storage.
+
+                long postfix = storage.advanceAtLeastTo((int) member, (int) current, this);
+                if (postfix != SparseIntArray.Iterator.END) {
+                    index = current & INT_PREFIX_MASK | postfix;
+                    return index;
+                } else {
+                    // Try to advance to the next storage.
+
+                    long prefix = storages.advance(currentPrefix, storageIterator);
+                    if (prefix != SparseIntArray.Iterator.END) {
+                        storage = storageIterator.getValue();
+                        postfix = storage.iterate(this);
+                        assert postfix != SparseIntArray.Iterator.END;
+                        index = prefix << Integer.SIZE | postfix;
+                        return index;
+                    }
+                }
+            } else {
+                // Try to advance to the requested storage.
+
+                long prefix = storages.advanceAtLeastTo(memberPrefix, currentPrefix, storageIterator);
+                if (prefix != SparseIntArray.Iterator.END) {
+                    storage = storageIterator.getValue();
+                    if (prefix == memberPrefix) {
+                        // We got the storage we have requested.
+
+                        long postfix = storage.iterateAtLeastFrom((int) member, this);
+                        if (postfix != SparseIntArray.Iterator.END) {
+                            index = prefix << Integer.SIZE | postfix;
+                            return index;
+                        } else {
+                            // The storage we got doesn't contain the requested
+                            // postfix or any postfix beyond it: try to advance
+                            // to the next storage (storages are guaranteed to
+                            // be non-empty).
+
+                            prefix = storages.advance((int) prefix, storageIterator);
+                            if (prefix != SparseIntArray.Iterator.END) {
+                                storage = storageIterator.getValue();
+                                postfix = storage.iterate(this);
+                                assert postfix != SparseIntArray.Iterator.END;
+                                index = prefix << Integer.SIZE | postfix;
+                                return index;
+                            }
+                        }
+                    } else {
+                        // We got a storage corresponding to some other prefix
+                        // beyond the requested one: just iterate the storage
+                        // (storages are guaranteed to be non-empty).
+
+                        long postfix = storage.iterate(this);
+                        assert postfix != SparseIntArray.Iterator.END;
+                        index = prefix << Integer.SIZE | postfix;
+                        return index;
+                    }
+                }
+            }
+
+            // The end.
+
+            index = AscendingLongIterator.END;
+            return index;
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/SparseBitSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/SparseBitSet.java
@@ -1,0 +1,1251 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.capacityDeltaInt;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.capacityDeltaShort;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.toUnsignedInt;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.toUnsignedLong;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.unsignedBinarySearch;
+import static java.lang.Long.numberOfTrailingZeros;
+import static java.lang.System.arraycopy;
+import static java.util.Arrays.copyOf;
+
+/**
+ * Stores a set of bits indexable by non-negative {@code long} indexes.
+ * <p>
+ * Internally, uses a {@link SparseIntArray} indexed by the high 32 bits (32-bit
+ * prefix) to resolve a storage ({@link Storage32 Storage32}) for the low 32
+ * bits (32-bit postfix).
+ * <p>
+ * {@link Storage32 Storage32} goes in two flavors:
+ * <ul>
+ * <li>{@link ArrayStorage32 ArrayStorage32} which manages sorted int array of
+ * 32-bit postfixes.
+ * <li>{@link PrefixStorage32 PrefixStorage32} which splits 32-bit postfixes
+ * into 16-bit prefixes and 16-bit postfixes. The high 16 bits are stored in
+ * sorted array and used to lookup a storage ({@link Storage16 Storage16}) for
+ * the low 16 bits.
+ * </ul>
+ * <p>
+ * {@link Storage16 Storage16} also goes in two flavors:
+ * <ul>
+ * <li>{@link ArrayStorage16 ArrayStorage16} which manages sorted short array of
+ * 16-bit postfixes.
+ * <li>{@link BitSetStorage16 BitSetStorage16} which manages directly indexable
+ * long array of bits.
+ * </ul>
+ * <p>
+ * The implementation (which was inspired by Roaring Bitmap) switches between
+ * various storage flavors once certain thresholds on storage size are reached.
+ * <p>
+ * Empty storages are never stored by the implementation.
+ */
+final class SparseBitSet {
+
+    /**
+     * The size at which ArrayStorage32 is converted to PrefixStorage32.
+     * Inferred empirically: at this size we are not penalized too much for
+     * doing binary searches.
+     */
+    public static final int ARRAY_STORAGE_32_MAX_SIZE = 513;
+
+    /**
+     * The size at which ArrayStorage16 is converted to BitSetStorage16. At
+     * this size the memory cost of having sorted short array is equal to the
+     * cost of having directly indexable long array of bits.
+     */
+    public static final int ARRAY_STORAGE_16_MAX_SIZE = 4096;
+
+    private static final long INT_PREFIX_MASK = 0xFFFFFFFF00000000L;
+    private static final long INT_POSTFIX_MASK = 0x00000000FFFFFFFFL;
+    private static final long SHORT_PREFIX_MASK = 0x00000000FFFF0000L;
+    private static final long INT_PREFIX_SHORT_POSTFIX_MASK = 0xFFFFFFFF0000FFFFL;
+    private static final long INT_PREFIX_SHORT_PREFIX_MASK = 0xFFFFFFFFFFFF0000L;
+    private static final long SHORT_POSTFIX_MASK = 0x000000000000FFFFL;
+
+    private final SparseIntArray<Storage32> storages = new SparseIntArray<Storage32>();
+
+    // used for caching of the last resolved 32-bit storage
+    private int lastPrefix = -1;
+    private Storage32 lastStorage;
+
+    /**
+     * Adds the given member to this bit set.
+     *
+     * @param member the member to add.
+     */
+    public void add(long member) {
+        assert member >= 0;
+        int prefix = (int) (member >>> Integer.SIZE);
+
+        if (prefix == lastPrefix) {
+            Storage32 newStorage = lastStorage.add((int) member);
+            if (newStorage != lastStorage) {
+                // storage was upgraded
+                lastStorage = newStorage;
+                storages.set(prefix, newStorage);
+            }
+        } else {
+            lastPrefix = prefix;
+            Storage32 storage = storages.get(prefix);
+            if (storage == null) {
+                Storage32 createdStorage = new ArrayStorage32((int) member);
+                lastStorage = createdStorage;
+                storages.set(prefix, createdStorage);
+            } else {
+                Storage32 newStorage = storage.add((int) member);
+                if (newStorage == storage) {
+                    lastStorage = storage;
+                } else {
+                    // storage was upgraded
+                    lastStorage = newStorage;
+                    storages.set(prefix, newStorage);
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes the given member from this bit set.
+     *
+     * @param member the member to remove.
+     * @return {@code true} if this storage became empty as a result of the
+     * member removal, {@code false} otherwise.
+     */
+    public boolean remove(long member) {
+        assert member >= 0;
+        int prefix = (int) (member >>> Integer.SIZE);
+
+        if (prefix == lastPrefix) {
+            if (lastStorage.remove((int) member)) {
+                lastPrefix = -1;
+                lastStorage = null;
+                return storages.clear(prefix);
+            } else {
+                return false;
+            }
+        } else {
+            Storage32 storage = storages.get(prefix);
+            if (storage == null) {
+                return false;
+            }
+            if (storage.remove((int) member)) {
+                lastPrefix = -1;
+                lastStorage = null;
+                return storages.clear(prefix);
+            } else {
+                lastPrefix = prefix;
+                lastStorage = storage;
+                return false;
+            }
+        }
+    }
+
+    /**
+     * @return an iterator that iterates over all the indexes of bits set in
+     * this sparse bit set.
+     */
+    public AscendingLongIterator iterator() {
+        return new IteratorImpl(storages);
+    }
+
+    /**
+     * Defines internal contract of storages responsible for storing of 32-bit
+     * postfixes.
+     */
+    private interface Storage32 {
+
+        /**
+         * Adds the given member to this storage.
+         *
+         * @param member the member to add.
+         * @return a new storage instance if this storage was converted to
+         * another storage flavor; this storage otherwise.
+         */
+        Storage32 add(int member);
+
+        /**
+         * Removes the given member from this storage.
+         *
+         * @param member the member to remove.
+         * @return {@code true} if this storage became empty as a result of the
+         * member removal, {@code false} otherwise.
+         */
+        boolean remove(int member);
+
+        /**
+         * Starts iteration on this storage using the given iterator.
+         * <p>
+         * Always succeeds since we never keep empty storages.
+         *
+         * @param iterator the iterator to iterate with.
+         */
+        void iterate(IteratorImpl iterator);
+
+        /**
+         * Advances the given iterator on this storage.
+         *
+         * @param iterator the iterator to advance.
+         * @return {@code true} if the iterator is advanced to the next member,
+         * {@code false} if no members to iterate are left in this storage.
+         */
+        boolean advance(IteratorImpl iterator);
+
+        /**
+         * Starts iteration on this storage starting from the given member using
+         * the given iterator.
+         *
+         * @param member   the member to start the iteration from.
+         * @param iterator the iterator to iterate with.
+         * @return {@code true} if the iterator is positioned to the given
+         * member; or, if the member is not present in this storage, to a member
+         * immediately following it and present in this storage or {@code false}
+         * if no such member exists in this storage.
+         */
+        boolean iterateAtLeastFrom(int member, IteratorImpl iterator);
+
+        /**
+         * Advances the given iterator to the given member; or, if the member is
+         * not present in this storage, to a member immediately following it
+         * and present in this storage.
+         *
+         * @param member   the member to advance at least to. The member must be
+         *                 greater than the member this iterator is currently at.
+         * @param iterator the iterator to advance.
+         * @return {@code true} if the iterator is advanced to the given
+         * member; or, if the member is not present in this storage, to a member
+         * immediately following it and present in this storage or {@code false}
+         * if no such member exists in this storage.
+         */
+        boolean advanceAtLeastTo(int member, IteratorImpl iterator);
+
+    }
+
+    /**
+     * Manages sorted int array of indexes of set bits.
+     */
+    private static final class ArrayStorage32 implements Storage32 {
+
+        private static final int MIN_CAPACITY = 1;
+
+        private int size;
+        private int[] members;
+
+        ArrayStorage32(int member) {
+            this.size = 1;
+            this.members = new int[MIN_CAPACITY];
+            members[0] = member;
+        }
+
+        @Override
+        public Storage32 add(int member) {
+            int index = unsignedBinarySearch(members, size, toUnsignedLong(member));
+            if (index >= 0) {
+                // already in the array
+                return this;
+            }
+            index = -(index + 1);
+
+            if (size == members.length) {
+                // No space left: try to grow members array.
+
+                if (size == ARRAY_STORAGE_32_MAX_SIZE) {
+                    return new PrefixStorage32(members, member, index);
+                }
+
+                int newCapacity = Math.min(ARRAY_STORAGE_32_MAX_SIZE, size + capacityDeltaInt(members.length));
+                int[] newMembers = new int[newCapacity];
+                arraycopy(members, 0, newMembers, 0, index);
+                arraycopy(members, index, newMembers, index + 1, size - index);
+                members = newMembers;
+            } else {
+                // shift members right to free a slot for the new member
+                arraycopy(members, index, members, index + 1, size - index);
+            }
+            members[index] = member;
+            ++size;
+            return this;
+        }
+
+        @Override
+        public boolean remove(int member) {
+            int index = unsignedBinarySearch(members, size, toUnsignedLong(member));
+            if (index < 0) {
+                // not a member
+                return false;
+            }
+
+            --size;
+            if (size == 0) {
+                // emptied
+                return true;
+            }
+
+            int delta = capacityDeltaInt(members.length);
+            int wasted = members.length - size;
+            int newCapacity = members.length - delta;
+            if (wasted >= delta && newCapacity >= MIN_CAPACITY) {
+                // We are wasting too much: shrink the array.
+
+                int[] newMembers = new int[newCapacity];
+                arraycopy(members, 0, newMembers, 0, index);
+                arraycopy(members, index + 1, newMembers, index, size - index);
+                members = newMembers;
+            } else {
+                // shift members left to fill the gap
+                arraycopy(members, index + 1, members, index, size - index);
+            }
+            return false;
+        }
+
+        @Override
+        public void iterate(IteratorImpl iterator) {
+            assert size > 0;
+            iterator.position32 = 1;
+            iterator.index = iterator.index & INT_PREFIX_MASK | toUnsignedLong(members[0]);
+        }
+
+        @Override
+        public boolean advance(IteratorImpl iterator) {
+            int position = iterator.position32;
+            if (position < size) {
+                iterator.index = iterator.index & INT_PREFIX_MASK | toUnsignedLong(members[position]);
+                iterator.position32 = position + 1;
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean iterateAtLeastFrom(int member, IteratorImpl iterator) {
+            long unsignedMember = toUnsignedLong(member);
+            int position = unsignedBinarySearch(members, size, unsignedMember);
+
+            if (position < 0) {
+                position = -(position + 1);
+                if (position == size) {
+                    return false;
+                }
+                unsignedMember = toUnsignedLong(members[position]);
+            }
+
+            iterator.index = iterator.index & INT_PREFIX_MASK | unsignedMember;
+            iterator.position32 = position + 1;
+            return true;
+        }
+
+        @Override
+        public boolean advanceAtLeastTo(int member, IteratorImpl iterator) {
+            long unsignedMember = toUnsignedLong(member);
+            long current = iterator.index;
+            assert (current & INT_POSTFIX_MASK) < unsignedMember;
+
+            int position = iterator.position32;
+            if (position == size) {
+                return false;
+            }
+
+            position = unsignedBinarySearch(members, position, size, unsignedMember);
+
+            if (position < 0) {
+                position = -(position + 1);
+                if (position == size) {
+                    return false;
+                }
+                unsignedMember = toUnsignedLong(members[position]);
+            }
+
+            iterator.index = current & INT_PREFIX_MASK | unsignedMember;
+            iterator.position32 = position + 1;
+            return true;
+        }
+
+    }
+
+    /**
+     * Manages sorted array of 16-bit prefixes to lookup storages for 16-bit
+     * postfixes.
+     */
+    private static final class PrefixStorage32 implements Storage32 {
+
+        private static final int MIN_CAPACITY = 2;
+        private static final int MAX_CAPACITY = 64 * 1024;
+
+        private int size;
+        private short[] prefixes;
+        private Storage16[] storages;
+
+        // used for caching of the last resolved 16-bit storage
+        private int lastPrefix = -1;
+        private Storage16 lastStorage;
+
+        /**
+         * Constructs a new prefix storage for the given sorted members array
+         * and the given member to insert at the given index.
+         */
+        PrefixStorage32(int[] members, int member, int index) {
+            this.prefixes = new short[MIN_CAPACITY];
+            this.storages = new Storage16[MIN_CAPACITY];
+
+            for (int i = 0; i < index; ++i) {
+                append(members[i]);
+            }
+            append(member);
+            for (int i = index; i < members.length; ++i) {
+                append(members[i]);
+            }
+        }
+
+        @Override
+        public Storage32 add(int member) {
+            short prefix = (short) (member >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+
+            // Try to resolve the corresponding 16-bit postfix storage by its
+            // 16-bit prefix.
+
+            if (unsignedPrefix == lastPrefix) {
+                // We are lucky: just add the member to the cached storage.
+
+                Storage16 newStorage = lastStorage.add((short) member);
+                // handle potential storage upgrade
+                if (newStorage != lastStorage) {
+                    int index = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+                    assert index >= 0;
+                    storages[index] = newStorage;
+                    lastStorage = newStorage;
+                }
+                return this;
+            }
+
+            int index = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+            if (index >= 0) {
+                // The storage already exists: just add the member to it.
+
+                Storage16 storage = storages[index];
+                Storage16 newStorage = storage.add((short) member);
+                // handle potential storage upgrade
+                if (newStorage != storage) {
+                    storages[index] = newStorage;
+                }
+                lastPrefix = unsignedPrefix;
+                lastStorage = newStorage;
+                return this;
+            }
+            index = -(index + 1);
+
+            // No storage exists yet: we need to allocate a new postfix storage
+            // and insert it into this prefix storage.
+
+            if (size == prefixes.length) {
+                // Grow the arrays.
+
+                int newCapacity = Math.min(MAX_CAPACITY, size + capacityDeltaShort(prefixes.length));
+
+                short[] newPrefixes = new short[newCapacity];
+                arraycopy(prefixes, 0, newPrefixes, 0, index);
+                arraycopy(prefixes, index, newPrefixes, index + 1, size - index);
+                prefixes = newPrefixes;
+
+                Storage16[] newStorages = new Storage16[newCapacity];
+                arraycopy(storages, 0, newStorages, 0, index);
+                arraycopy(storages, index, newStorages, index + 1, size - index);
+                storages = newStorages;
+            } else {
+                // Shift the arrays right to free a slot.
+
+                arraycopy(prefixes, index, prefixes, index + 1, size - index);
+                arraycopy(storages, index, storages, index + 1, size - index);
+            }
+
+            ArrayStorage16 createdStorage = new ArrayStorage16((short) member);
+            prefixes[index] = prefix;
+            storages[index] = createdStorage;
+            lastPrefix = unsignedPrefix;
+            lastStorage = createdStorage;
+            ++size;
+            return this;
+        }
+
+        @Override
+        public boolean remove(int member) {
+            short prefix = (short) (member >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+
+            // Try to resolve the corresponding 16-bit postfix storage by its
+            // 16-bit prefix.
+
+            Storage16 newStorage;
+            int index;
+
+            if (unsignedPrefix == lastPrefix) {
+                // We are lucky: just remove the member from the cached storage.
+
+                Storage16 storage = lastStorage;
+                newStorage = storage.remove((short) member);
+                if (newStorage == storage) {
+                    return false;
+                }
+                // To handle the storage downgrade or removal we need to know
+                // its prefix index.
+                index = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+                assert index >= 0;
+            } else {
+                index = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+                if (index < 0) {
+                    // no storage, no problems
+                    return false;
+                }
+
+                Storage16 storage = storages[index];
+                newStorage = storage.remove((short) member);
+                if (newStorage == storage) {
+                    lastStorage = storage;
+                    lastPrefix = unsignedPrefix;
+                    return false;
+                }
+            }
+
+            // The 16-bit postfix storage is either emptied or downgraded at
+            // this point.
+
+            if (newStorage == null) {
+                // The postfix storage is emptied: remove it from this prefix
+                // storage.
+
+                --size;
+                lastStorage = null;
+                lastPrefix = -1;
+                if (size == 0) {
+                    // this prefix storage is also emptied
+                    return true;
+                }
+
+                int delta = capacityDeltaShort(prefixes.length);
+                int wasted = prefixes.length - size;
+                int newCapacity = prefixes.length - delta;
+                if (wasted >= delta && newCapacity >= MIN_CAPACITY) {
+                    // Wasting too much: shrink the arrays.
+
+                    short[] newPrefixes = new short[newCapacity];
+                    arraycopy(prefixes, 0, newPrefixes, 0, index);
+                    arraycopy(prefixes, index + 1, newPrefixes, index, size - index);
+                    prefixes = newPrefixes;
+
+                    Storage16[] newStorages = new Storage16[newCapacity];
+                    arraycopy(storages, 0, newStorages, 0, index);
+                    arraycopy(storages, index + 1, newStorages, index, size - index);
+                    storages = newStorages;
+                } else {
+                    // Shift the arrays left to fill the gap.
+
+                    arraycopy(prefixes, index + 1, prefixes, index, size - index);
+                    arraycopy(storages, index + 1, storages, index, size - index);
+                }
+            } else {
+                // The postfix storage is downgraded: update the records.
+
+                lastStorage = newStorage;
+                lastPrefix = unsignedPrefix;
+                storages[index] = newStorage;
+            }
+            return false;
+        }
+
+        @Override
+        public void iterate(IteratorImpl iterator) {
+            assert size > 0;
+            iterator.position32 = 1;
+            Storage16 storage = storages[0];
+            iterator.storage16 = storage;
+            iterator.index = iterator.index & INT_PREFIX_MASK | toUnsignedLong(prefixes[0]) << Short.SIZE;
+            storage.iterate(iterator);
+        }
+
+        @Override
+        public boolean advance(IteratorImpl iterator) {
+            // Try advance the current postfix storage.
+
+            if (iterator.storage16.advance(iterator)) {
+                return true;
+            }
+
+            // Try to advance to the next postfix storage and iterate it.
+
+            int position = iterator.position32;
+            if (position < size) {
+                Storage16 storage = storages[position];
+                iterator.storage16 = storage;
+                iterator.index = iterator.index & INT_PREFIX_MASK | toUnsignedLong(prefixes[position]) << Short.SIZE;
+                iterator.position32 = position + 1;
+                storage.iterate(iterator);
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean iterateAtLeastFrom(int member, IteratorImpl iterator) {
+            return iterateAtLeastFrom(member, 0, iterator);
+        }
+
+        @Override
+        public boolean advanceAtLeastTo(int member, IteratorImpl iterator) {
+            short prefix = (short) (member >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+            long current = iterator.index;
+            int currentUnsignedPrefix = (int) (current & SHORT_PREFIX_MASK) >>> Short.SIZE;
+            assert currentUnsignedPrefix <= unsignedPrefix;
+
+            if (unsignedPrefix == currentUnsignedPrefix) {
+                // The requested member is within the current 16-bit postfix
+                // storage.
+
+                if (iterator.storage16.advanceAtLeastTo((short) member, iterator)) {
+                    // found in the current postfix storage
+                    return true;
+                }
+
+                int position = iterator.position32;
+                if (position == size) {
+                    // the end
+                    return false;
+                }
+
+                // Iterate the next prefix.
+
+                Storage16 storage = storages[position];
+                iterator.storage16 = storage;
+                iterator.index = current & INT_PREFIX_MASK | toUnsignedLong(prefixes[position]) << Short.SIZE;
+                iterator.position32 = position + 1;
+                storage.iterate(iterator);
+                return true;
+            }
+
+            // Resolve and iterate the requested prefix.
+
+            int position = iterator.position32;
+            if (position == size) {
+                return false;
+            }
+            return iterateAtLeastFrom(member, position, iterator);
+        }
+
+        private void append(int member) {
+            short prefix = (short) (member >>> Short.SIZE);
+
+            if (size != 0 && prefix == prefixes[size - 1]) {
+                ((ArrayStorage16) storages[size - 1]).append((short) member);
+                return;
+            }
+
+            if (size == prefixes.length) {
+                int newCapacity = Math.min(MAX_CAPACITY, size + capacityDeltaShort(prefixes.length));
+                prefixes = copyOf(prefixes, newCapacity);
+                storages = copyOf(storages, newCapacity);
+            }
+
+            prefixes[size] = prefix;
+            storages[size] = new ArrayStorage16((short) member);
+            ++size;
+        }
+
+        private boolean iterateAtLeastFrom(int member, int fromPosition, IteratorImpl iterator) {
+            short prefix = (short) (member >>> Short.SIZE);
+            int position = unsignedBinarySearch(prefixes, fromPosition, size, toUnsignedInt(prefix));
+
+            if (position < 0) {
+                position = -(position + 1);
+                if (position == size) {
+                    // no such member
+                    return false;
+                }
+            }
+
+            Storage16 storage = storages[position];
+            if (storage.iterateAtLeastFrom((short) member, iterator)) {
+                // The postfix storage corresponding to the requested member is
+                // successfully advanced at least to the requested member.
+
+                iterator.storage16 = storage;
+                iterator.index =
+                        iterator.index & INT_PREFIX_SHORT_POSTFIX_MASK | toUnsignedLong(prefixes[position]) << Short.SIZE;
+                iterator.position32 = position + 1;
+            } else {
+                // The postfix storage corresponding to the requested member
+                // doesn't contain the requested member or any members greater
+                // than it: try to iterate from the next prefix storage.
+
+                ++position;
+                if (position == size) {
+                    return false;
+                }
+
+                storage = storages[position];
+                iterator.storage16 = storage;
+                iterator.index = iterator.index & INT_PREFIX_MASK | toUnsignedLong(prefixes[position]) << Short.SIZE;
+                iterator.position32 = position + 1;
+                storage.iterate(iterator);
+            }
+            return true;
+        }
+
+    }
+
+    /**
+     * Defines internal contract of storages responsible for storing of 16-bit
+     * postfixes.
+     */
+    private interface Storage16 {
+
+        /**
+         * Adds the given member to this storage.
+         *
+         * @param member the member to add.
+         * @return a new storage instance if this storage was converted to
+         * another storage flavor; this storage otherwise.
+         */
+        Storage16 add(short member);
+
+        /**
+         * Removes the given member from this storage.
+         *
+         * @param member the member to remove.
+         * @return {@code null} if this storage became empty as a result of the
+         * member removal; a new storage instance if this storage was converted
+         * to another storage flavor; this storage otherwise.
+         */
+        Storage16 remove(short member);
+
+        /**
+         * Starts iteration on this storage using the given iterator.
+         * <p>
+         * Always succeeds since we never keep empty storages.
+         *
+         * @param iterator the iterator to iterate with.
+         */
+        void iterate(IteratorImpl iterator);
+
+        /**
+         * Advances the given iterator on this storage.
+         *
+         * @param iterator the iterator to advance.
+         * @return {@code true} if the iterator is advanced to the next member,
+         * {@code false} if no members to iterate are left in this storage.
+         */
+        boolean advance(IteratorImpl iterator);
+
+        /**
+         * Starts iteration on this storage starting at least from the given
+         * member using the given iterator.
+         *
+         * @param member   the member to start the iteration from.
+         * @param iterator the iterator to iterate with.
+         * @return {@code true} if the iterator is positioned to the given
+         * member; or, if the member is not present in this storage, to a member
+         * immediately following it and present in this storage or {@code false}
+         * if no such member exists in this storage.
+         */
+        boolean iterateAtLeastFrom(short member, IteratorImpl iterator);
+
+        /**
+         * Advances the given iterator to the given member; or, if the member is
+         * not present in this storage, to a member immediately following it and
+         * present in this storage.
+         *
+         * @param member   the member to advance at least to. The member must be
+         *                 greater than the member this iterator is currently at.
+         * @param iterator the iterator to advance.
+         * @return {@code true} if the iterator is advanced to the given
+         * member; or, if the member is not present in this storage, to a member
+         * immediately following it and present in this storage or {@code false}
+         * if no such member exists in this storage.
+         */
+        boolean advanceAtLeastTo(short member, IteratorImpl iterator);
+
+    }
+
+    /**
+     * Manages sorted short array of indexes of set bits.
+     */
+    private static final class ArrayStorage16 implements Storage16 {
+
+        private static final int MIN_CAPACITY = 2;
+
+        private int size;
+        private short[] members;
+
+        ArrayStorage16(short member) {
+            this.size = 1;
+            this.members = new short[MIN_CAPACITY];
+            members[0] = member;
+        }
+
+        /**
+         * Constructs a new storage by downgrading from the given {@link
+         * BitSetStorage16} data.
+         */
+        ArrayStorage16(long[] bits, int size) {
+            assert size == BitSetStorage16.MIN_SIZE;
+            this.size = size;
+
+            short[] members = new short[ARRAY_STORAGE_16_MAX_SIZE];
+            int index = 0;
+            for (int i = 0; i < bits.length; ++i) {
+                long value = bits[i];
+                int base = i << BitSetStorage16.BIT_SET_LONG_SHIFT;
+                while (value != 0) {
+                    int offset = numberOfTrailingZeros(value);
+                    members[index++] = (short) (base + offset);
+                    // zero out the consumed bit
+                    value &= value - 1;
+                }
+            }
+            assert index == size;
+
+            this.members = members;
+        }
+
+        @Override
+        public Storage16 add(short member) {
+            int index = unsignedBinarySearch(members, size, toUnsignedInt(member));
+            if (index >= 0) {
+                // already in the array
+                return this;
+            }
+            index = -(index + 1);
+
+            if (size == members.length) {
+                // No space left: try to grow members array.
+
+                if (size == ARRAY_STORAGE_16_MAX_SIZE) {
+                    return new BitSetStorage16(members, member, index);
+                }
+
+                int newCapacity = Math.min(ARRAY_STORAGE_16_MAX_SIZE, size + capacityDeltaShort(members.length));
+                short[] newMembers = new short[newCapacity];
+                arraycopy(members, 0, newMembers, 0, index);
+                arraycopy(members, index, newMembers, index + 1, size - index);
+                members = newMembers;
+            } else {
+                // shift members right to free a slot for the new member
+                arraycopy(members, index, members, index + 1, size - index);
+            }
+            members[index] = member;
+            ++size;
+            return this;
+        }
+
+        @Override
+        public Storage16 remove(short member) {
+            int index = unsignedBinarySearch(members, size, toUnsignedInt(member));
+            if (index < 0) {
+                // not a member
+                return this;
+            }
+
+            --size;
+            if (size == 0) {
+                // emptied
+                return null;
+            }
+
+            int delta = capacityDeltaShort(members.length);
+            int wasted = members.length - size;
+            int newCapacity = members.length - delta;
+            if (wasted >= delta && newCapacity >= MIN_CAPACITY) {
+                // We are wasting too much: shrink the array.
+
+                short[] newMembers = new short[newCapacity];
+                arraycopy(members, 0, newMembers, 0, index);
+                arraycopy(members, index + 1, newMembers, index, size - index);
+                members = newMembers;
+            } else {
+                // shift members left to fill the gap
+                arraycopy(members, index + 1, members, index, size - index);
+            }
+            return this;
+        }
+
+        @Override
+        public void iterate(IteratorImpl iterator) {
+            assert size > 0;
+            iterator.position16 = 1;
+            iterator.index = iterator.index & INT_PREFIX_SHORT_PREFIX_MASK | toUnsignedInt(members[0]);
+        }
+
+        @Override
+        public boolean advance(IteratorImpl iterator) {
+            int index = iterator.position16;
+            if (index < size) {
+                iterator.index = iterator.index & INT_PREFIX_SHORT_PREFIX_MASK | toUnsignedInt(members[index]);
+                iterator.position16 = index + 1;
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean iterateAtLeastFrom(short member, IteratorImpl iterator) {
+            int unsignedMember = toUnsignedInt(member);
+            int index = unsignedBinarySearch(members, size, unsignedMember);
+
+            if (index < 0) {
+                index = -(index + 1);
+                if (index == size) {
+                    return false;
+                }
+                unsignedMember = toUnsignedInt(members[index]);
+            }
+
+            iterator.index = iterator.index & INT_PREFIX_SHORT_PREFIX_MASK | unsignedMember;
+            iterator.position16 = index + 1;
+            return true;
+        }
+
+        @Override
+        public boolean advanceAtLeastTo(short member, IteratorImpl iterator) {
+            int unsignedMember = toUnsignedInt(member);
+            long current = iterator.index;
+            assert (current & SHORT_POSTFIX_MASK) < unsignedMember;
+
+            int position = iterator.position16;
+            if (position == size) {
+                return false;
+            }
+            position = unsignedBinarySearch(members, position, size, unsignedMember);
+
+            if (position < 0) {
+                position = -(position + 1);
+                if (position == size) {
+                    return false;
+                }
+                unsignedMember = toUnsignedInt(members[position]);
+            }
+
+            iterator.index = current & INT_PREFIX_SHORT_PREFIX_MASK | unsignedMember;
+            iterator.position16 = position + 1;
+            return true;
+        }
+
+        /**
+         * Appends the given member to this storage. The given member must be
+         * greater than any member already known by this storage.
+         */
+        public void append(short member) {
+            if (size == members.length) {
+                int newCapacity = size + capacityDeltaShort(members.length);
+                assert newCapacity <= ARRAY_STORAGE_16_MAX_SIZE;
+                members = copyOf(members, newCapacity);
+            }
+            members[size] = member;
+            ++size;
+        }
+
+    }
+
+    /**
+     * Manages directly indexable long array of bits.
+     */
+    private static final class BitSetStorage16 implements Storage16 {
+
+        // 2^6 = 64 = number of bits a long can store
+        public static final int BIT_SET_LONG_SHIFT = 6;
+
+        private static final int MIN_SIZE = ARRAY_STORAGE_16_MAX_SIZE - 1;
+        private static final int SIZE = 1024;
+
+        // masks lower 6 bits
+        private static final long POSTFIX_MASK = 0xFFFFFFFFFFFFFFC0L;
+
+        private final long[] members = new long[SIZE];
+        private int size;
+
+        /**
+         * Constructs a new bit set storage for the given sorted members array
+         * and the given member to insert at the given index.
+         */
+        BitSetStorage16(short[] members, short member, int index) {
+            for (int i = 0; i < index; ++i) {
+                append(members[i]);
+            }
+            append(member);
+            for (int i = index; i < members.length; ++i) {
+                append(members[i]);
+            }
+            this.size = members.length + 1;
+        }
+
+        @Override
+        public Storage16 add(short member) {
+            int bitIndex = toUnsignedInt(member);
+            int longIndex = bitIndex >>> BIT_SET_LONG_SHIFT;
+
+            long bitSet = members[longIndex];
+            long newBitSet = bitSet | 1L << bitIndex;
+            members[longIndex] = newBitSet;
+
+            if (newBitSet != bitSet) {
+                ++size;
+            }
+            return this;
+        }
+
+        @Override
+        public Storage16 remove(short member) {
+            int bitIndex = toUnsignedInt(member);
+            int longIndex = bitIndex >>> BIT_SET_LONG_SHIFT;
+
+            long bitSet = members[longIndex];
+            long newBitSet = bitSet & ~(1L << bitIndex);
+            members[longIndex] = newBitSet;
+
+            if (newBitSet != bitSet) {
+                --size;
+                if (size == MIN_SIZE) {
+                    return new ArrayStorage16(members, size);
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public void iterate(IteratorImpl iterator) {
+            assert size > 0;
+            iterator.position16 = 0;
+            iterator.bitSet16 = members[0];
+            iterator.index = iterator.index & INT_PREFIX_SHORT_PREFIX_MASK;
+            boolean advanced = advance(iterator);
+            assert advanced;
+        }
+
+        @Override
+        public boolean advance(IteratorImpl iterator) {
+            // Consume bits from the current long until it's empty.
+
+            long bitSet = iterator.bitSet16;
+            if (bitSet != 0) {
+                iterator.index = iterator.index & POSTFIX_MASK | numberOfTrailingZeros(bitSet);
+                // zero out the consumed bit
+                iterator.bitSet16 = bitSet & bitSet - 1;
+                return true;
+            }
+
+            // Try to find the next non-zero long.
+
+            int index = iterator.position16;
+            do {
+                ++index;
+                if (index == members.length) {
+                    // nothing left
+                    return false;
+                }
+                bitSet = members[index];
+            } while (bitSet == 0);
+
+            iterator.index =
+                    iterator.index & INT_PREFIX_SHORT_PREFIX_MASK | index << BIT_SET_LONG_SHIFT | numberOfTrailingZeros(bitSet);
+            iterator.bitSet16 = bitSet & bitSet - 1;
+            iterator.position16 = index;
+            return true;
+        }
+
+        @Override
+        public boolean iterateAtLeastFrom(short member, IteratorImpl iterator) {
+            int bitIndex = toUnsignedInt(member);
+            int longIndex = bitIndex >>> BIT_SET_LONG_SHIFT;
+
+            iterator.position16 = longIndex;
+            // consume all preceding bits by zeroing them out
+            iterator.bitSet16 = members[longIndex] & -(1L << bitIndex);
+            iterator.index = iterator.index & INT_PREFIX_SHORT_PREFIX_MASK | longIndex << BIT_SET_LONG_SHIFT;
+            return advance(iterator);
+        }
+
+        @Override
+        public boolean advanceAtLeastTo(short member, IteratorImpl iterator) {
+            long current = iterator.index;
+            int bitIndex = toUnsignedInt(member);
+            assert (current & SHORT_POSTFIX_MASK) < bitIndex;
+
+            int longIndex = bitIndex >>> BIT_SET_LONG_SHIFT;
+
+            iterator.position16 = longIndex;
+            // consume all preceding bits by zeroing them out
+            iterator.bitSet16 = members[longIndex] & -(1L << bitIndex);
+            iterator.index = current & INT_PREFIX_SHORT_PREFIX_MASK | longIndex << BIT_SET_LONG_SHIFT;
+            return advance(iterator);
+        }
+
+        private void append(short member) {
+            int bitIndex = toUnsignedInt(member);
+            members[bitIndex >>> BIT_SET_LONG_SHIFT] |= 1L << bitIndex;
+        }
+
+    }
+
+    /**
+     * Iterates over sparse bit sets.
+     */
+    private static final class IteratorImpl extends SparseIntArray.Iterator<Storage32> implements AscendingLongIterator {
+
+        // The idea: use a single iterator instance to iterate over the entire
+        // bit set including all its internal storages. This way we are avoiding
+        // frequent sub iterators allocation, producing no heap litter and
+        // keeping the iteration state just in a few cache lines.
+
+        // the root storage mapping 32-bit prefixes to 32-bit postfix storages
+        private final SparseIntArray<Storage32> storage64;
+
+        // the current position of the current Storage32
+        private int position32;
+
+        // the current Storage16
+        private Storage16 storage16;
+        // its position
+        private int position16;
+        // the current bit set of BitSetStorage16
+        private long bitSet16;
+
+        // the current index (member), constructed cooperatively by all storages
+        private long index;
+
+        IteratorImpl(SparseIntArray<Storage32> storage64) {
+            this.storage64 = storage64;
+            long prefix = storage64.iterate(this);
+            if (prefix != SparseIntArray.Iterator.END) {
+                index = prefix << Integer.SIZE;
+                getStorage32().iterate(this);
+            } else {
+                index = AscendingLongIterator.END;
+            }
+        }
+
+        @Override
+        public long getIndex() {
+            return index;
+        }
+
+        @Override
+        public long advance() {
+            long current = index;
+            if (current == AscendingLongIterator.END) {
+                return AscendingLongIterator.END;
+            }
+
+            if (getStorage32().advance(this)) {
+                return current;
+            }
+
+            long prefix = storage64.advance((int) (current >>> Integer.SIZE), this);
+            if (prefix != SparseIntArray.Iterator.END) {
+                index = prefix << Integer.SIZE;
+                getStorage32().iterate(this);
+                return current;
+            }
+
+            index = AscendingLongIterator.END;
+            return current;
+        }
+
+        @SuppressWarnings("checkstyle:nestedifdepth")
+        @Override
+        public long advanceAtLeastTo(long member) {
+            assert member >= 0;
+            long current = index;
+            if (current == AscendingLongIterator.END) {
+                return AscendingLongIterator.END;
+            }
+
+            if (current >= member) {
+                // Already at or beyond the requested member.
+
+                return current;
+            }
+
+            int memberPrefix = (int) (member >>> Integer.SIZE);
+            int currentPrefix = (int) (current >>> Integer.SIZE);
+
+            if (memberPrefix == currentPrefix) {
+                // Try to advance the current storage.
+
+                if (getStorage32().advanceAtLeastTo((int) member, this)) {
+                    return index;
+                } else {
+                    // Try to advance to the next storage.
+
+                    long prefix = storage64.advance(currentPrefix, this);
+                    if (prefix != SparseIntArray.Iterator.END) {
+                        index = prefix << Integer.SIZE;
+                        getStorage32().iterate(this);
+                        return index;
+                    }
+                }
+            } else {
+                // Try to advance to the requested storage.
+
+                long prefix = storage64.advanceAtLeastTo(memberPrefix, currentPrefix, this);
+                if (prefix != SparseIntArray.Iterator.END) {
+                    if (prefix == memberPrefix) {
+                        // We got the storage we have requested.
+
+                        index = prefix << Integer.SIZE;
+                        if (getStorage32().iterateAtLeastFrom((int) member, this)) {
+                            return index;
+                        } else {
+                            // The storage we got doesn't contain the requested
+                            // postfix or any postfix beyond it: try to advance
+                            // to the next storage (storages are guaranteed to
+                            // be non-empty).
+
+                            prefix = storage64.advance((int) prefix, this);
+                            if (prefix != SparseIntArray.Iterator.END) {
+                                index = prefix << Integer.SIZE;
+                                getStorage32().iterate(this);
+                                return index;
+                            }
+                        }
+                    } else {
+                        // We got a storage corresponding to some other prefix
+                        // beyond the requested one: just iterate the storage
+                        // (storages are guaranteed to be non-empty).
+
+                        index = prefix << Integer.SIZE;
+                        getStorage32().iterate(this);
+                        return index;
+                    }
+                }
+            }
+
+            // The end.
+
+            index = AscendingLongIterator.END;
+            return AscendingLongIterator.END;
+        }
+
+        // just an alias for getValue
+        private Storage32 getStorage32() {
+            return getValue();
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/SparseIntArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/bitmap/SparseIntArray.java
@@ -1,0 +1,1598 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.capacityDeltaInt;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.capacityDeltaShort;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.denseCapacityDeltaInt;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.denseCapacityDeltaShort;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.toUnsignedInt;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.toUnsignedLong;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.unsignedBinarySearch;
+import static java.lang.System.arraycopy;
+import static java.util.Arrays.copyOf;
+
+/**
+ * Stores values of type {@code E} indexable by {@code int} indexes interpreted
+ * as unsigned.
+ * <p>
+ * Internally, uses top-level storage ({@link Storage32 Storage32}) which goes
+ * in two flavors:
+ * <ul>
+ * <li>{@link ArrayStorage32 ArrayStorage32} which manages arrays of index-value
+ * pairs and can operate in two modes: dense mode with directly indexable values
+ * array and sparse mode with sorted indexes and values arrays.
+ * <li>{@link PrefixStorage32 PrefixStorage32} which splits 32-bit indexes
+ * into 16-bit prefixes and 16-bit postfixes. The high 16 bits are stored in
+ * sorted array and used to lookup a storage ({@link Storage16 Storage16}) for
+ * the low 16 bits.
+ * </ul>
+ * <p>
+ * {@link Storage16 Storage16} also manages arrays of index-value pairs and can
+ * operate in two modes: dense and sparse.
+ * <p>
+ * The implementation switches between various storage flavors once certain
+ * thresholds on storage size are reached.
+ * <p>
+ * Empty storages are never stored by the implementation.
+ */
+class SparseIntArray<E> {
+
+    /**
+     * The size at which ArrayStorage32 is converted to PrefixStorage32.
+     * Inferred empirically: at this size we are not penalized too much for
+     * doing binary searches.
+     */
+    public static final int ARRAY_STORAGE_32_MAX_SPARSE_SIZE = 513;
+
+    /**
+     * Sets a limit on maximum dense ArrayStorage32 size to avoid stressing GC
+     * too much.
+     */
+    private static final int ARRAY_STORAGE_32_MAX_DENSE_SIZE = 262145;
+
+    private static final int STORAGE_16_MAX_DENSE_SIZE = 64 * 1024;
+    private static final int STORAGE_16_MAX_SPARSE_SIZE = 64 * 1024;
+
+    private static final long SHORT_PREFIX_MASK_LONG = 0xFFFF0000L;
+    private static final int SHORT_PREFIX_MASK_INT = 0xFFFF0000;
+
+    private Storage32 storage = new ArrayStorage32();
+
+    /**
+     * Iterates over values of a sparse array in ascending index order.
+     */
+    public static class Iterator<T> {
+
+        /**
+         * Identifies an iterator end.
+         */
+        public static final long END = -1;
+
+        // the current position of Storage32
+        private int position32;
+
+        // the current Storage16
+        private Storage16 storage16;
+        // its position
+        private int position16;
+
+        private T value;
+
+        /**
+         * Returns a value this iterator is currently at. If this iterator is
+         * already reached its end, the return value is undefined.
+         * <p>
+         * Just after the creation, iterators are positioned at their first value.
+         */
+        public final T getValue() {
+            return value;
+        }
+
+    }
+
+    /**
+     * @return the value stored inside this sparse array at the given index or
+     * {@code null} if nothing stored at it.
+     */
+    @SuppressWarnings("unchecked")
+    public E get(int index) {
+        return (E) storage.get(index);
+    }
+
+    /**
+     * Sets or replaces a value at the given index in this sparse array to the
+     * new given value.
+     *
+     * @param index the index to set value at.
+     * @param value the value to set.
+     */
+    public void set(int index, E value) {
+        assert value != null;
+        Storage32 newStorage = storage.set(index, value);
+        if (newStorage != storage) {
+            storage = newStorage;
+        }
+    }
+
+    /**
+     * Clears a value stored at the given index in this sparse array.
+     *
+     * @param index the index to clear a value at.
+     * @return {@code true} if this sparse array is emptied, {@code false} if
+     * this sparse array still contains some values.
+     */
+    public boolean clear(int index) {
+        Storage32 newStorage = storage.clear(index);
+        if (newStorage == null) {
+            return true;
+        }
+
+        if (newStorage != storage) {
+            storage = newStorage;
+        }
+        return false;
+    }
+
+    /**
+     * Clears this sparse array entirely.
+     */
+    public void clear() {
+        storage = new ArrayStorage32();
+    }
+
+    /**
+     * Starts iteration on this sparse array using the given iterator.
+     *
+     * @param iterator the iterator to iterate with.
+     * @return an index at which the iterator is currently at or {@link
+     * Iterator#END END} if this sparse array is empty.
+     */
+    public long iterate(Iterator<E> iterator) {
+        return storage.iterate(iterator);
+    }
+
+    /**
+     * Advances the given iterator on this sparse array.
+     *
+     * @param iterator the iterator to advance.
+     * @return an index at which this iterator was positioned before the
+     * advancement or {@link Iterator#END END} if this iterator already was at
+     * its end.
+     */
+    public long advance(int current, Iterator<E> iterator) {
+        return storage.advance(current, iterator);
+    }
+
+    /**
+     * Starts iteration on this sparse array starting at least from the given
+     * index using the given iterator.
+     *
+     * @param index    the index to start the iteration from.
+     * @param iterator the iterator to iterate with.
+     * @return an index at which the iterator is currently at; or {@link
+     * Iterator#END END} if no index greater than or equal to the given index
+     * exists in this array.
+     */
+    public long iterateAtLeastFrom(int index, Iterator<E> iterator) {
+        return storage.iterateAtLeastFrom(index, iterator);
+    }
+
+    /**
+     * Advances the given iterator to the given index; or, if the index is
+     * not present in this sparse array, to an index immediately following it
+     * and present in this array.
+     *
+     * @param index    the index to advance at least to. The index must be
+     *                 greater than the index this iterator is currently at.
+     * @param iterator the iterator to advance.
+     * @return an index at which this iterator was advanced to or {@link
+     * Iterator#END END} if this iterator reached its end.
+     */
+    public long advanceAtLeastTo(int index, int current, Iterator<E> iterator) {
+        return storage.advanceAtLeastTo(index, current, iterator);
+    }
+
+    /**
+     * Defines internal contract of storages responsible for working on full
+     * 32-bit indexes.
+     */
+    private interface Storage32 {
+
+        /**
+         * Sets or replaces a value at the given index to the new given value.
+         *
+         * @param index the index to set value at.
+         * @param value the value to set.
+         * @return a new storage instance if this storage was converted to
+         * another storage flavor; this storage otherwise.
+         */
+        Storage32 set(int index, Object value);
+
+        /**
+         * Clears a value stored at the given index in this storage.
+         *
+         * @param index the index to clear a value at.
+         * @return {@code null} if this storage array is emptied, a new storage
+         * instance if this storage was converted to another storage flavor;
+         * this storage otherwise.
+         */
+        Storage32 clear(int index);
+
+        /**
+         * @return the value stored inside this storage at the given index or
+         * {@code null} if nothing stored at it.
+         */
+        Object get(int index);
+
+        /**
+         * Starts iteration on this storage using the given iterator.
+         *
+         * @param iterator the iterator to iterate with.
+         * @return an index at which the iterator is currently at or {@link
+         * Iterator#END END} if this storage is empty.
+         */
+        long iterate(Iterator iterator);
+
+        /**
+         * Advances the given iterator on this storage.
+         *
+         * @param iterator the iterator to advance.
+         * @return an index at which this iterator was positioned before the
+         * advancement or {@link Iterator#END END} if this iterator already was
+         * at its end.
+         */
+        long advance(int current, Iterator iterator);
+
+        /**
+         * Starts iteration on this storage starting at least from the given
+         * index using the given iterator.
+         *
+         * @param index    the index to start the iteration from.
+         * @param iterator the iterator to iterate with.
+         * @return an index at which the iterator is currently at; or {@link
+         * Iterator#END END} if no index greater than or equal to the given
+         * index exists in this storage.
+         */
+        long iterateAtLeastFrom(int index, Iterator iterator);
+
+        /**
+         * Advances the given iterator to the given index; or, if the index is
+         * not present in this storage, to an index immediately following it
+         * and present in this storage.
+         *
+         * @param index    the index to advance at least to. The index must be
+         *                 greater than the index this iterator is currently at.
+         * @param iterator the iterator to advance.
+         * @return an index at which thee iterator was advanced to or {@link
+         * Iterator#END END} if the iterator reached its end.
+         */
+        long advanceAtLeastTo(int index, int current, Iterator iterator);
+
+    }
+
+    /**
+     * Manages ordered arrays of index-value pairs for 32-bit indexes.
+     * <p>
+     * Works in two modes:
+     * <ul>
+     * <li>Dense mode with directly indexable values array.
+     * <li>Sparse mode with sorted indexes and values arrays.
+     * </ul>
+     */
+    private static final class ArrayStorage32 implements Storage32 {
+
+        private static final int MIN_CAPACITY = 1;
+
+        private int size;
+        private int[] indexes;
+        private Object[] values = new Object[MIN_CAPACITY];
+
+        @Override
+        public Storage32 set(int index, Object value) {
+            if (indexes == null) {
+                return setDense(index, value);
+            } else {
+                return setSparse(index, value);
+            }
+        }
+
+        @SuppressWarnings("checkstyle:npathcomplexity")
+        private Storage32 setDense(int index, Object value) {
+            long unsignedIndex = toUnsignedLong(index);
+
+            if (unsignedIndex < values.length) {
+                // The index is inside the bounds: just set the corresponding
+                // array slot.
+
+                if (values[index] == null) {
+                    ++size;
+                }
+                values[index] = value;
+                return this;
+            }
+
+            // We need to grow the array.
+
+            int delta = denseCapacityDeltaInt(size, values.length);
+            int newCapacity = Math.min(ARRAY_STORAGE_32_MAX_DENSE_SIZE, size + delta);
+            if (unsignedIndex < newCapacity) {
+                // We are good: just grow the array and store the value.
+
+                values = copyOf(values, newCapacity);
+                values[index] = value;
+                ++size;
+                return this;
+            }
+
+            // We would be wasting too much space on dense representation:
+            // convert to sparse representation.
+
+            if (size >= ARRAY_STORAGE_32_MAX_SPARSE_SIZE) {
+                // Too big: convert to prefix storage.
+                return new PrefixStorage32(values, size, index, value);
+            }
+
+            Object[] oldValues = values;
+            if (size == values.length) {
+                // No space left: reallocate the values and allocate the
+                // indexes array.
+
+                indexes = new int[newCapacity];
+                values = new Object[newCapacity];
+            } else {
+                // Some space left, its size is bellow the sparse
+                // representation threshold (we adjusted for it in
+                // denseCapacityDeltaInt call): reuse the values array and
+                // allocate indexes array.
+
+                indexes = new int[values.length];
+            }
+
+            // Iterate dense records one-by-one and represent them as sparse
+            // ones.
+            int count = 0;
+            for (int i = 0; i < values.length; ++i) {
+                Object storedValue = oldValues[i];
+                if (storedValue != null) {
+                    indexes[count] = i;
+                    values[count] = storedValue;
+                    ++count;
+                    if (count == size) {
+                        // Everything converted: stop.
+                        break;
+                    }
+                }
+            }
+
+            // Store the original value being inserted and grow the size.
+            indexes[size] = index;
+            values[size] = value;
+            ++size;
+            return this;
+        }
+
+        private Storage32 setSparse(int index, Object value) {
+            assert size > 0;
+            long unsignedIndex = toUnsignedLong(index);
+
+            int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+            if (position >= 0) {
+                // Already there: just overwrite it.
+
+                values[position] = value;
+                return this;
+            }
+            position = -(position + 1);
+
+            if (size == indexes.length) {
+                // We are full: either grow the array or try to convert to
+                // dense representation.
+
+                int delta = capacityDeltaInt(indexes.length);
+                long lastIndex = toUnsignedLong(indexes[indexes.length - 1]);
+                long denseCapacity = Math.max(unsignedIndex, lastIndex) + 1;
+                if (denseCapacity <= size + delta) {
+                    // The wasted space is bellow the threshold: convert to
+                    // dense representation.
+
+                    Object[] newValues = new Object[(int) denseCapacity];
+                    for (int i = 0; i < indexes.length; ++i) {
+                        newValues[indexes[i]] = values[i];
+                    }
+                    newValues[index] = value;
+
+                    indexes = null;
+                    values = newValues;
+                    ++size;
+                    return this;
+                }
+
+                // We were unable to convert to dense representation.
+
+                if (size >= ARRAY_STORAGE_32_MAX_SPARSE_SIZE) {
+                    // Too big: convert to prefix storage.
+                    return new PrefixStorage32(indexes, values, position, index, value);
+                }
+
+                // Reallocate the arrays to gain the space for the new value.
+
+                int newCapacity = Math.min(ARRAY_STORAGE_32_MAX_SPARSE_SIZE, size + delta);
+
+                int[] newIndexes = new int[newCapacity];
+                arraycopy(indexes, 0, newIndexes, 0, position);
+                arraycopy(indexes, position, newIndexes, position + 1, size - position);
+                indexes = newIndexes;
+
+                Object[] newValues = new Object[newCapacity];
+                arraycopy(values, 0, newValues, 0, position);
+                arraycopy(values, position, newValues, position + 1, size - position);
+                values = newValues;
+            } else {
+                // There is some space left: just shift the values to the right.
+                arraycopy(indexes, position, indexes, position + 1, size - position);
+                arraycopy(values, position, values, position + 1, size - position);
+            }
+
+            // Finally insert the value.
+            indexes[position] = index;
+            values[position] = value;
+            ++size;
+            return this;
+        }
+
+        @Override
+        public Storage32 clear(int index) {
+            if (indexes == null) {
+                return clearDense(index);
+            } else {
+                return clearSparse(index);
+            }
+        }
+
+        @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+        private Storage32 clearDense(int index) {
+            long unsignedIndex = toUnsignedLong(index);
+
+            if (unsignedIndex >= values.length) {
+                // Out of bounds.
+                return this;
+            }
+            if (values[index] == null) {
+                // No such record.
+                return this;
+            }
+
+            values[index] = null;
+            --size;
+            if (size == 0) {
+                // Emptied: just report the storage is empty by returning null.
+                return null;
+            }
+
+            int delta = capacityDeltaInt(values.length);
+            int wasted = values.length - size;
+            if (wasted < delta) {
+                return this;
+            }
+            int newCapacity = values.length - delta;
+            if (newCapacity < MIN_CAPACITY) {
+                // never reached with the default MIN_CAPACITY of 1
+                return this;
+            }
+            assert wasted == delta;
+            assert newCapacity == size;
+
+            // Shrink the capacity while trying to keep the representation dense.
+
+            Object[] newValues = new Object[newCapacity];
+            int left = size;
+            for (int i = values.length - 1; i >= 0; --i) {
+                Object value = values[i];
+                if (value != null) {
+                    if (i >= newCapacity && indexes == null) {
+                        // The index-value pair is outside of the dense
+                        // representation bounds: convert to sparse by
+                        // allocating indexes array.
+
+                        if (size > ARRAY_STORAGE_32_MAX_SPARSE_SIZE) {
+                            return new PrefixStorage32(values, size);
+                        }
+                        indexes = new int[newCapacity];
+                    }
+
+                    --left;
+                    if (indexes != null) {
+                        // store sparse representation index
+                        indexes[left] = i;
+                    }
+                    newValues[left] = value;
+
+                    if (left == 0) {
+                        break;
+                    }
+                }
+            }
+            assert left == 0;
+            values = newValues;
+            return this;
+        }
+
+        private Storage32 clearSparse(int index) {
+            assert size > 0;
+            long unsignedIndex = toUnsignedLong(index);
+
+            int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+            if (position < 0) {
+                return this;
+            }
+
+            --size;
+            if (size == 0) {
+                // Emptied: just null out the value and convert to dense
+                // representation by setting indexes to null.
+                values[position] = null;
+                indexes = null;
+                return null;
+            }
+
+            int delta = capacityDeltaInt(indexes.length);
+            int wasted = indexes.length - size;
+            int newCapacity = indexes.length - delta;
+            if (wasted >= delta && newCapacity >= MIN_CAPACITY) {
+                // We are wasting too much: shrink the arrays.
+
+                int[] newIndexes = new int[newCapacity];
+                arraycopy(indexes, 0, newIndexes, 0, position);
+                arraycopy(indexes, position + 1, newIndexes, position, size - position);
+                indexes = newIndexes;
+
+                Object[] newValues = new Object[newCapacity];
+                arraycopy(values, 0, newValues, 0, position);
+                arraycopy(values, position + 1, newValues, position, size - position);
+                values = newValues;
+            } else {
+                // shift left to fill the gap
+                arraycopy(indexes, position + 1, indexes, position, size - position);
+                arraycopy(values, position + 1, values, position, size - position);
+                values[size] = null;
+            }
+            return this;
+        }
+
+        @Override
+        public Object get(int index) {
+            long unsignedIndex = toUnsignedLong(index);
+
+            if (indexes == null) {
+                // Dense representation.
+
+                return unsignedIndex < values.length ? values[index] : null;
+            } else {
+                // Sparse representation. Size is always greater than zero since
+                // empty arrays are represented as dense ones.
+                assert size > 0;
+
+                int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+                return position >= 0 ? values[position] : null;
+            }
+        }
+
+        @Override
+        public long iterate(Iterator iterator) {
+            if (size > 0) {
+                iterator.position32 = 0;
+                long index = advance(0, iterator);
+                assert index != Iterator.END;
+                return index;
+            } else {
+                return Iterator.END;
+            }
+        }
+
+        @Override
+        public long advance(int current, Iterator iterator) {
+            int position = iterator.position32;
+
+            if (indexes == null) {
+                // Dense representation.
+
+                while (position < values.length) {
+                    Object value = values[position];
+                    if (value != null) {
+                        iterator.value = value;
+                        iterator.position32 = position + 1;
+                        return position;
+                    }
+
+                    ++position;
+                }
+
+                return Iterator.END;
+            } else {
+                // Sparse representation. Size is always greater than zero since
+                // empty arrays are represented as dense ones.
+                assert size > 0;
+
+                if (position < size) {
+                    iterator.value = values[position];
+                    iterator.position32 = position + 1;
+                    return toUnsignedLong(indexes[position]);
+                } else {
+                    return Iterator.END;
+                }
+            }
+        }
+
+        @Override
+        public long iterateAtLeastFrom(int index, Iterator iterator) {
+            long unsignedIndex = toUnsignedLong(index);
+
+            if (indexes == null) {
+                // Dense representation.
+
+                long position = unsignedIndex;
+
+                while (position < values.length) {
+                    Object value = values[(int) position];
+                    if (value != null) {
+                        iterator.value = value;
+                        iterator.position32 = (int) position + 1;
+                        return position;
+                    }
+
+                    ++position;
+                }
+
+                return Iterator.END;
+            } else {
+                // Sparse representation. Size is always greater than zero since
+                // empty arrays are represented as dense ones.
+                assert size > 0;
+
+                int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+
+                if (position < 0) {
+                    position = -(position + 1);
+                    if (position == size) {
+                        return Iterator.END;
+                    }
+                    unsignedIndex = toUnsignedLong(indexes[position]);
+                }
+
+                iterator.position32 = position + 1;
+                iterator.value = values[position];
+                return unsignedIndex;
+            }
+        }
+
+        @Override
+        public long advanceAtLeastTo(int index, int current, Iterator iterator) {
+            long unsignedIndex = toUnsignedLong(index);
+            assert toUnsignedLong(current) < unsignedIndex;
+
+            if (indexes == null) {
+                // Dense representation.
+
+                long position = unsignedIndex;
+
+                while (position < values.length) {
+                    Object value = values[(int) position];
+                    if (value != null) {
+                        iterator.value = value;
+                        iterator.position32 = (int) position + 1;
+                        return position;
+                    }
+
+                    ++position;
+                }
+
+                return Iterator.END;
+            } else {
+                // Sparse representation. Size is always greater than zero since
+                // empty arrays are represented as dense ones.
+                assert size > 0;
+
+                int position = iterator.position32;
+                if (position == size) {
+                    return Iterator.END;
+                }
+                position = unsignedBinarySearch(indexes, position, size, unsignedIndex);
+
+                if (position < 0) {
+                    position = -(position + 1);
+                    if (position == size) {
+                        return Iterator.END;
+                    }
+                    unsignedIndex = toUnsignedLong(indexes[position]);
+                }
+
+                iterator.value = values[position];
+                iterator.position32 = position + 1;
+                return unsignedIndex;
+            }
+        }
+
+    }
+
+    /**
+     * Manages sorted array of 16-bit prefixes to lookup storages for 16-bit
+     * postfixes.
+     */
+    private static final class PrefixStorage32 implements Storage32 {
+
+        private static final int MIN_CAPACITY = 2;
+        private static final int MAX_CAPACITY = 64 * 1024;
+
+        private int size;
+        private short[] prefixes;
+        private Storage16[] storages;
+
+        // used for caching of the last resolved 16-bit storage
+        private int lastPrefix = -1;
+        private Storage16 lastStorage;
+
+        /**
+         * Constructs a new prefix storage by converting from the given dense
+         * values and inserting the new given index-value pair.
+         */
+        PrefixStorage32(Object[] values, int size, int index, Object value) {
+            assert size <= values.length;
+            assert index >= values.length;
+
+            this.prefixes = new short[MIN_CAPACITY];
+            this.storages = new Storage16[MIN_CAPACITY];
+
+            int count = 0;
+            for (int i = 0; i < values.length; ++i) {
+                Object storedValue = values[i];
+                if (storedValue != null) {
+                    append(i, storedValue);
+                    ++count;
+                    if (count == size) {
+                        break;
+                    }
+                }
+            }
+            append(index, value);
+        }
+
+        /**
+         * Constructs a new prefix storage by converting from the given dense
+         * values.
+         */
+        PrefixStorage32(Object[] values, int size) {
+            assert size <= values.length;
+
+            this.prefixes = new short[MIN_CAPACITY];
+            this.storages = new Storage16[MIN_CAPACITY];
+
+            int count = 0;
+            for (int i = 0; i < values.length; ++i) {
+                Object storedValue = values[i];
+                if (storedValue != null) {
+                    append(i, storedValue);
+                    ++count;
+                    if (count == size) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Constructs a new prefix storage by converting from the given sparse
+         * index-value pairs and inserting the new given index-value pair at the
+         * given position.
+         */
+        PrefixStorage32(int[] indexes, Object[] values, int position, int index, Object value) {
+            this.prefixes = new short[MIN_CAPACITY];
+            this.storages = new Storage16[MIN_CAPACITY];
+
+            for (int i = 0; i < position; ++i) {
+                append(indexes[i], values[i]);
+            }
+            append(index, value);
+            for (int i = position; i < indexes.length; ++i) {
+                append(indexes[i], values[i]);
+            }
+        }
+
+        @Override
+        public Storage32 set(int index, Object value) {
+            short prefix = (short) (index >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+
+            // Try to resolve the corresponding 16-bit postfix storage by its
+            // 16-bit prefix.
+
+            if (unsignedPrefix == lastPrefix) {
+                // We are lucky: just set the index-value pair in the cached
+                // storage.
+
+                lastStorage.set((short) index, value);
+                return this;
+            }
+
+            int position = size == 0 ? -1 : unsignedBinarySearch(prefixes, size, unsignedPrefix);
+            if (position >= 0) {
+                // The storage already exists: just add the index-value pair to
+                // it.
+
+                Storage16 storage = storages[position];
+                storage.set((short) index, value);
+                lastPrefix = unsignedPrefix;
+                lastStorage = storage;
+                return this;
+            }
+            position = -(position + 1);
+
+            // No storage exists yet: we need to allocate a new postfix storage
+            // and insert it into this prefix storage.
+
+            if (size == prefixes.length) {
+                // Grow the arrays.
+
+                int newCapacity = Math.min(MAX_CAPACITY, size + capacityDeltaShort(prefixes.length));
+
+                short[] newPrefixes = new short[newCapacity];
+                arraycopy(prefixes, 0, newPrefixes, 0, position);
+                arraycopy(prefixes, position, newPrefixes, position + 1, size - position);
+                prefixes = newPrefixes;
+
+                Storage16[] newStorages = new Storage16[newCapacity];
+                arraycopy(storages, 0, newStorages, 0, position);
+                arraycopy(storages, position, newStorages, position + 1, size - position);
+                storages = newStorages;
+            } else {
+                // Shift the arrays right to free a slot.
+
+                arraycopy(prefixes, position, prefixes, position + 1, size - position);
+                arraycopy(storages, position, storages, position + 1, size - position);
+            }
+
+            Storage16 createdStorage = new Storage16((short) index, value);
+            prefixes[position] = prefix;
+            storages[position] = createdStorage;
+            lastPrefix = unsignedPrefix;
+            lastStorage = createdStorage;
+            ++size;
+            return this;
+        }
+
+        @Override
+        public Storage32 clear(int index) {
+            short prefix = (short) (index >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+
+            // Try to resolve the corresponding 16-bit postfix storage by its
+            // 16-bit prefix.
+
+            int position;
+
+            if (unsignedPrefix == lastPrefix) {
+                // We are lucky: just remove the index-value pair from the
+                // cached storage.
+
+                Storage16 storage = lastStorage;
+                if (!storage.clear((short) index)) {
+                    return this;
+                }
+                // To handle the storage removal we need to know its prefix index.
+                position = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+                assert position >= 0;
+            } else {
+                if (size == 0) {
+                    // no storages, no problems
+                    return this;
+                }
+                position = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+                if (position < 0) {
+                    // no storage, no problems
+                    return this;
+                }
+
+                Storage16 storage = storages[position];
+                if (!storage.clear((short) index)) {
+                    lastStorage = storage;
+                    lastPrefix = unsignedPrefix;
+                    return this;
+                }
+            }
+
+            // The 16-bit postfix storage is emptied this point: remove it from
+            // this prefix storage.
+
+            --size;
+            lastStorage = null;
+            lastPrefix = -1;
+            if (size == 0) {
+                // this prefix storage is also emptied
+                storages[position] = null;
+                return null;
+            }
+
+            int delta = capacityDeltaShort(prefixes.length);
+            int wasted = prefixes.length - size;
+            int newCapacity = prefixes.length - delta;
+            if (wasted >= delta && newCapacity >= MIN_CAPACITY) {
+                // Wasting too much: shrink the arrays.
+
+                short[] newPrefixes = new short[newCapacity];
+                arraycopy(prefixes, 0, newPrefixes, 0, position);
+                arraycopy(prefixes, position + 1, newPrefixes, position, size - position);
+                prefixes = newPrefixes;
+
+                Storage16[] newStorages = new Storage16[newCapacity];
+                arraycopy(storages, 0, newStorages, 0, position);
+                arraycopy(storages, position + 1, newStorages, position, size - position);
+                storages = newStorages;
+            } else {
+                // Shift the arrays left to fill the gap.
+
+                arraycopy(prefixes, position + 1, prefixes, position, size - position);
+                arraycopy(storages, position + 1, storages, position, size - position);
+                storages[size] = null;
+            }
+            return this;
+        }
+
+        @Override
+        public Object get(int index) {
+            short prefix = (short) (index >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+
+            // Try to resolve the corresponding 16-bit postfix storage by its
+            // 16-bit prefix.
+
+            if (unsignedPrefix == lastPrefix) {
+                // We are lucky: just consult the cached postfix storage.
+                return lastStorage.get((short) index);
+            }
+
+            if (size == 0) {
+                // no storages, no problems
+                return null;
+            }
+            int position = unsignedBinarySearch(prefixes, size, unsignedPrefix);
+            if (position < 0) {
+                // no storage, no problems
+                return null;
+            }
+
+            Storage16 storage = storages[position];
+            lastPrefix = unsignedPrefix;
+            lastStorage = storage;
+            return storage.get((short) index);
+        }
+
+        @Override
+        public long iterate(Iterator iterator) {
+            if (size > 0) {
+                iterator.position32 = 1;
+                iterator.storage16 = storages[0];
+                return toUnsignedLong(prefixes[0]) << Short.SIZE | iterator.storage16.iterate(iterator);
+            } else {
+                return Iterator.END;
+            }
+        }
+
+        @Override
+        public long advance(int current, Iterator iterator) {
+            // Try advance the current postfix storage.
+
+            int postfix = iterator.storage16.advance(iterator);
+            if (postfix != Storage16.END) {
+                return toUnsignedLong(current) & SHORT_PREFIX_MASK_LONG | postfix;
+            }
+
+            // Try to advance to the next postfix storage and iterate it.
+
+            int index = iterator.position32;
+            if (index < size) {
+                iterator.storage16 = storages[index];
+                iterator.position32 = index + 1;
+                postfix = iterator.storage16.iterate(iterator);
+                return toUnsignedLong(prefixes[index]) << Short.SIZE | postfix;
+            } else {
+                return Iterator.END;
+            }
+        }
+
+        @Override
+        public long iterateAtLeastFrom(int index, Iterator iterator) {
+            if (size == 0) {
+                return Iterator.END;
+            }
+            return iterateAtLeastFrom(index, 0, iterator);
+        }
+
+        @Override
+        public long advanceAtLeastTo(int index, int current, Iterator iterator) {
+            short prefix = (short) (index >>> Short.SIZE);
+            int unsignedPrefix = toUnsignedInt(prefix);
+            int currentUnsignedPrefix = (current & SHORT_PREFIX_MASK_INT) >>> Short.SIZE;
+            assert currentUnsignedPrefix <= unsignedPrefix;
+
+            if (unsignedPrefix == currentUnsignedPrefix) {
+                // The requested index is within the current 16-bit postfix
+                // storage.
+
+                int postfix = iterator.storage16.advanceAtLeastTo((short) index, (short) current, iterator);
+                if (postfix != Storage16.END) {
+                    // found in the current postfix storage
+                    return toUnsignedLong(prefix) << Short.SIZE | postfix;
+                }
+
+                int position = iterator.position32;
+                if (position == size) {
+                    // the end
+                    return Iterator.END;
+                }
+
+                // Iterate the next prefix.
+
+                Storage16 storage = storages[position];
+                iterator.storage16 = storage;
+                iterator.position32 = position + 1;
+                postfix = storage.iterate(iterator);
+                assert postfix != Storage16.END;
+                return toUnsignedLong(prefixes[position]) << Short.SIZE | postfix;
+            }
+
+            // Resolve and iterate the requested prefix.
+
+            int position = iterator.position32;
+            if (position == size) {
+                return Iterator.END;
+            }
+            return iterateAtLeastFrom(index, position, iterator);
+        }
+
+        private void append(int index, Object value) {
+            short prefix = (short) (index >>> Short.SIZE);
+
+            if (size != 0 && prefix == prefixes[size - 1]) {
+                storages[size - 1].set((short) index, value);
+                return;
+            }
+
+            if (size == prefixes.length) {
+                int newCapacity = Math.min(MAX_CAPACITY, size + capacityDeltaShort(prefixes.length));
+                prefixes = copyOf(prefixes, newCapacity);
+                storages = copyOf(storages, newCapacity);
+            }
+
+            prefixes[size] = prefix;
+            storages[size] = new Storage16((short) index, value);
+            ++size;
+        }
+
+        private long iterateAtLeastFrom(int index, int startFrom, Iterator iterator) {
+            short prefix = (short) (index >>> Short.SIZE);
+            int position = unsignedBinarySearch(prefixes, startFrom, size, toUnsignedInt(prefix));
+
+            Storage16 storage;
+            int postfix;
+            if (position < 0) {
+                position = -(position + 1);
+                if (position == size) {
+                    // no such index
+                    return Iterator.END;
+                }
+
+                storage = storages[position];
+                prefix = prefixes[position];
+                postfix = storage.iterate(iterator);
+                assert postfix != Storage16.END;
+            } else {
+                storage = storages[position];
+                postfix = storage.iterateAtLeastFrom((short) index, iterator);
+            }
+
+            if (postfix != Storage16.END) {
+                // The postfix storage corresponding to the requested index is
+                // successfully advanced at least to the requested index.
+
+                iterator.storage16 = storage;
+                iterator.position32 = position + 1;
+                return toUnsignedLong(prefix) << Short.SIZE | postfix;
+            } else {
+                // The postfix storage corresponding to the requested index
+                // doesn't contain the requested index or any indexes greater
+                // than it: try to iterate from the next prefix storage.
+
+                ++position;
+                if (position == size) {
+                    return Iterator.END;
+                }
+
+                storage = storages[position];
+                iterator.storage16 = storage;
+                iterator.position32 = position + 1;
+                postfix = storage.iterate(iterator);
+                assert postfix != Storage16.END;
+                return toUnsignedLong(prefixes[position]) << Short.SIZE | postfix;
+            }
+        }
+
+    }
+
+    /**
+     * Manages ordered arrays of index-value pairs for 16-bit indexes (postfixes).
+     * <p>
+     * Works in two modes:
+     * <ul>
+     * <li>Dense mode with directly indexable values array.
+     * <li>Sparse mode with sorted indexes and values arrays.
+     * </ul>
+     */
+    private static final class Storage16 {
+
+        /**
+         * Identifies an iterator end.
+         */
+        public static final int END = -1;
+
+        private static final int MIN_CAPACITY = 2;
+
+        private int size;
+        private short[] indexes;
+        private Object[] values = new Object[MIN_CAPACITY];
+
+        Storage16(short index, Object value) {
+            set(index, value);
+        }
+
+        /**
+         * Sets or replaces a value at the given index to the new given value.
+         *
+         * @param index the index to set value at.
+         * @param value the value to set.
+         */
+        public void set(short index, Object value) {
+            if (indexes == null) {
+                setDense(index, value);
+            } else {
+                setSparse(index, value);
+            }
+        }
+
+        private void setDense(short index, Object value) {
+            int unsignedIndex = toUnsignedInt(index);
+
+            if (unsignedIndex < values.length) {
+                // The index is inside the bounds: just set the corresponding
+                // array slot.
+
+                if (values[unsignedIndex] == null) {
+                    ++size;
+                }
+                values[unsignedIndex] = value;
+                return;
+            }
+
+            // We need to grow the array.
+
+            int delta = denseCapacityDeltaShort(size, values.length);
+            int newCapacity = Math.min(STORAGE_16_MAX_DENSE_SIZE, size + delta);
+            if (unsignedIndex < newCapacity) {
+                // We are good: just grow the array and store the value.
+
+                values = copyOf(values, newCapacity);
+                values[unsignedIndex] = value;
+                ++size;
+                return;
+            }
+
+            // We would be wasting too much space on dense representation:
+            // convert to sparse representation.
+
+            Object[] oldValues = values;
+            if (size == values.length) {
+                // No space left: reallocate the values and allocate the
+                // indexes array.
+
+                indexes = new short[newCapacity];
+                values = new Object[newCapacity];
+            } else {
+                // Some space left, its size is bellow the sparse
+                // representation threshold (we adjusted for it in
+                // denseCapacityDeltaShort call): reuse the values array and
+                // allocate indexes array.
+
+                indexes = new short[values.length];
+            }
+
+            // Iterate dense records one-by-one and represent them as sparse
+            // ones.
+            int count = 0;
+            for (int i = 0; i < values.length; ++i) {
+                Object storedValue = oldValues[i];
+                if (storedValue != null) {
+                    indexes[count] = (short) i;
+                    values[count] = storedValue;
+                    ++count;
+                    if (count == size) {
+                        break;
+                    }
+                }
+            }
+
+            // Store the original value being inserted and grow the size.
+            indexes[size] = index;
+            values[size] = value;
+            ++size;
+        }
+
+        private void setSparse(short index, Object value) {
+            int unsignedIndex = toUnsignedInt(index);
+
+            int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+            if (position >= 0) {
+                // Already there: just overwrite it.
+
+                values[position] = value;
+                return;
+            }
+            position = -(position + 1);
+
+            if (size == indexes.length) {
+                // We are full: either grow the array or try to convert to
+                // dense representation.
+
+                int delta = capacityDeltaShort(indexes.length);
+                int lastIndex = toUnsignedInt(indexes[indexes.length - 1]);
+                int denseCapacity = Math.max(unsignedIndex, lastIndex) + 1;
+                if (denseCapacity <= size + delta) {
+                    // The wasted space is bellow the threshold: convert to
+                    // dense representation.
+
+                    Object[] newValues = new Object[denseCapacity];
+                    for (int i = 0; i < indexes.length; ++i) {
+                        newValues[toUnsignedInt(indexes[i])] = values[i];
+                    }
+                    newValues[unsignedIndex] = value;
+
+                    indexes = null;
+                    values = newValues;
+                    ++size;
+                    return;
+                }
+
+                // We were unable to convert to dense representation: reallocate
+                // the arrays to gain the space for the new value.
+
+                int newCapacity = Math.min(STORAGE_16_MAX_SPARSE_SIZE, size + capacityDeltaShort(indexes.length));
+
+                short[] newIndexes = new short[newCapacity];
+                arraycopy(indexes, 0, newIndexes, 0, position);
+                arraycopy(indexes, position, newIndexes, position + 1, size - position);
+                indexes = newIndexes;
+
+                Object[] newValues = new Object[newCapacity];
+                arraycopy(values, 0, newValues, 0, position);
+                arraycopy(values, position, newValues, position + 1, size - position);
+                values = newValues;
+            } else {
+                // There is some space left: just shift the values to the right.
+                arraycopy(indexes, position, indexes, position + 1, size - position);
+                arraycopy(values, position, values, position + 1, size - position);
+            }
+
+            // Finally insert the value.
+            indexes[position] = index;
+            values[position] = value;
+            ++size;
+        }
+
+        /**
+         * Clears a value stored at the given index in this storage.
+         *
+         * @param index the index to clear a value at.
+         * @return {@code true} if this storage array is emptied, {@code false}
+         * otherwise.
+         */
+        public boolean clear(short index) {
+            if (indexes == null) {
+                return clearDense(index);
+            } else {
+                return clearSparse(index);
+            }
+        }
+
+        @SuppressWarnings("checkstyle:npathcomplexity")
+        private boolean clearDense(short index) {
+            int unsignedIndex = toUnsignedInt(index);
+
+            if (unsignedIndex >= values.length) {
+                // Out of bounds.
+                return false;
+            }
+            if (values[unsignedIndex] == null) {
+                // No such record.
+                return false;
+            }
+
+            --size;
+            if (size == 0) {
+                // Emptied: just report the storage is empty by returning null.
+                return true;
+            }
+            values[unsignedIndex] = null;
+
+            int delta = capacityDeltaShort(values.length);
+            int wasted = values.length - size;
+            if (wasted < delta) {
+                return false;
+            }
+            int newCapacity = values.length - delta;
+            if (newCapacity < MIN_CAPACITY) {
+                // never reached with the default MIN_CAPACITY of 2
+                return false;
+            }
+            assert wasted == delta;
+            assert newCapacity == size;
+
+            // Shrink the capacity while trying to keep the representation dense.
+
+            Object[] newValues = new Object[newCapacity];
+            int left = size;
+            for (int i = values.length - 1; i >= 0; --i) {
+                Object value = values[i];
+                if (value != null) {
+                    if (i >= newCapacity && indexes == null) {
+                        // The index-value pair is outside of the dense
+                        // representation bounds: convert to sparse by
+                        // allocating indexes array.
+
+                        indexes = new short[newCapacity];
+                    }
+
+                    --left;
+                    if (indexes != null) {
+                        // store sparse representation index
+                        indexes[left] = (short) i;
+                    }
+                    newValues[left] = value;
+
+                    if (left == 0) {
+                        break;
+                    }
+                }
+            }
+            values = newValues;
+            return false;
+        }
+
+        private boolean clearSparse(short index) {
+            int unsignedIndex = toUnsignedInt(index);
+
+            int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+            if (position < 0) {
+                return false;
+            }
+
+            --size;
+            if (size == 0) {
+                // Emptied.
+                return true;
+            }
+
+            int delta = capacityDeltaShort(indexes.length);
+            int wasted = indexes.length - size;
+            int newCapacity = indexes.length - delta;
+            if (wasted >= delta && newCapacity >= MIN_CAPACITY) {
+                // We are wasting too much: shrink the arrays.
+
+                short[] newIndexes = new short[newCapacity];
+                arraycopy(indexes, 0, newIndexes, 0, position);
+                arraycopy(indexes, position + 1, newIndexes, position, size - position);
+                indexes = newIndexes;
+
+                Object[] newValues = new Object[newCapacity];
+                arraycopy(values, 0, newValues, 0, position);
+                arraycopy(values, position + 1, newValues, position, size - position);
+                values = newValues;
+            } else {
+                // shift left to fill the gap
+
+                arraycopy(indexes, position + 1, indexes, position, size - position);
+                arraycopy(values, position + 1, values, position, size - position);
+                values[size] = null;
+            }
+
+            return false;
+        }
+
+        /**
+         * @return the value stored inside this storage at the given index or
+         * {@code null} if nothing stored at it.
+         */
+        public Object get(short index) {
+            int unsignedIndex = toUnsignedInt(index);
+
+            if (indexes == null) {
+                return unsignedIndex < values.length ? values[unsignedIndex] : null;
+            } else {
+                int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+                return position >= 0 ? values[position] : null;
+            }
+        }
+
+        /**
+         * Starts iteration on this storage using the given iterator.
+         *
+         * @param iterator the iterator to iterate with.
+         * @return an index at which the iterator is currently at or {@link
+         * #END} if this storage is empty.
+         */
+        public int iterate(Iterator iterator) {
+            assert size > 0;
+            iterator.position16 = 0;
+            int index = advance(iterator);
+            assert index != Storage16.END;
+            return index;
+        }
+
+        /**
+         * Advances the given iterator on this storage.
+         *
+         * @param iterator the iterator to advance.
+         * @return an index at which this iterator was positioned before the
+         * advancement or {@link #END} if this iterator already was at its end.
+         */
+        public int advance(Iterator iterator) {
+            assert size > 0;
+            int position = iterator.position16;
+
+            if (indexes == null) {
+                // Dense representation.
+
+                while (position < values.length) {
+                    Object value = values[position];
+                    if (value != null) {
+                        iterator.value = value;
+                        iterator.position16 = position + 1;
+                        return position;
+                    }
+
+                    ++position;
+                }
+
+                return Storage16.END;
+            } else {
+                // Sparse representation.
+
+                if (position < size) {
+                    iterator.value = values[position];
+                    iterator.position16 = position + 1;
+                    return toUnsignedInt(indexes[position]);
+                } else {
+                    return Storage16.END;
+                }
+            }
+        }
+
+        /**
+         * Starts iteration on this storage starting at least from the given
+         * index using the given iterator.
+         *
+         * @param index    the index to start the iteration from.
+         * @param iterator the iterator to iterate with.
+         * @return an index at which the iterator is currently at; or {@link
+         * #END} if no index greater than or equal to the given index exists in
+         * this storage.
+         */
+        public int iterateAtLeastFrom(short index, Iterator iterator) {
+            assert size > 0;
+            int unsignedIndex = toUnsignedInt(index);
+
+            if (indexes == null) {
+                // Dense representation.
+
+                int position = unsignedIndex;
+                while (position < values.length) {
+                    Object value = values[position];
+                    if (value != null) {
+                        iterator.value = value;
+                        iterator.position16 = position + 1;
+                        return position;
+                    }
+
+                    ++position;
+                }
+
+                return Storage16.END;
+            } else {
+                // Sparse representation.
+
+                int position = unsignedBinarySearch(indexes, size, unsignedIndex);
+
+                if (position < 0) {
+                    position = -(position + 1);
+                    if (position == size) {
+                        return Storage16.END;
+                    }
+                    unsignedIndex = toUnsignedInt(indexes[position]);
+                }
+
+                iterator.value = values[position];
+                iterator.position16 = position + 1;
+                return unsignedIndex;
+            }
+        }
+
+        /**
+         * Advances the given iterator to the given index; or, if the index is
+         * not present in this storage, to an index immediately following it
+         * and present in this storage.
+         *
+         * @param index    the index to advance at least to. The index must be
+         *                 greater than the index this iterator is currently at.
+         * @param iterator the iterator to advance.
+         * @return an index at which thee iterator was advanced to or {@link
+         * #END} if the iterator reached its end.
+         */
+        public int advanceAtLeastTo(short index, short current, Iterator iterator) {
+            assert size > 0;
+            int unsignedIndex = toUnsignedInt(index);
+            assert toUnsignedInt(current) < unsignedIndex;
+
+            if (indexes == null) {
+                // Dense representation.
+
+                int position = unsignedIndex;
+
+                while (position < values.length) {
+                    Object value = values[position];
+                    if (value != null) {
+                        iterator.value = value;
+                        iterator.position16 = position + 1;
+                        return position;
+                    }
+
+                    ++position;
+                }
+
+                return Storage16.END;
+            } else {
+                // Sparse representation.
+
+                int position = iterator.position16;
+                if (position == size) {
+                    return Storage16.END;
+                }
+                position = unsignedBinarySearch(indexes, position, size, unsignedIndex);
+
+                if (position < 0) {
+                    position = -(position + 1);
+                    if (position == size) {
+                        return Storage16.END;
+                    }
+                    unsignedIndex = toUnsignedInt(indexes[position]);
+                }
+
+                iterator.value = values[position];
+                iterator.position16 = position + 1;
+                return unsignedIndex;
+            }
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
@@ -24,8 +24,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.util.Collection;
 
-
 public abstract class AbstractMultiValueGetter extends Getter {
+
     public static final String REDUCER_ANY_TOKEN = "any";
 
     public static final int DO_NOT_REDUCE = -1;
@@ -140,7 +140,6 @@ public abstract class AbstractMultiValueGetter extends Getter {
         return parseModifier(modifierSuffix);
     }
 
-
     private Object getItemAtPositionOrNull(Object object, int position) {
         if (object == null) {
             return null;
@@ -154,7 +153,6 @@ public abstract class AbstractMultiValueGetter extends Getter {
         throw new IllegalArgumentException("Cannot extract an element from class of type" + object.getClass()
                 + " Collections and Arrays are supported only");
     }
-
 
     private Object getParentObject(Object obj) throws Exception {
         return parent != null ? parent.getValue(obj) : obj;
@@ -171,14 +169,88 @@ public abstract class AbstractMultiValueGetter extends Getter {
         }
     }
 
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:methodlength", "unchecked"})
     private void reducePrimitiveArrayInto(MultiResult collector, Object primitiveArray) {
-        int length = Array.getLength(primitiveArray);
-        if (length == 0) {
-            collector.addNullOrEmptyTarget();
-        } else {
-            for (int i = 0; i < length; i++) {
-                collector.add(Array.get(primitiveArray, i));
+        // XXX: Standard Array.get has really bad performance, see
+        // https://bugs.openjdk.java.net/browse/JDK-8051447. For large arrays
+        // it may consume significant amount of time, so we are doing the
+        // reduction manually for each primitive type.
+
+        if (primitiveArray instanceof long[]) {
+            long[] array = (long[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (long value : array) {
+                    collector.add(value);
+                }
             }
+        } else if (primitiveArray instanceof int[]) {
+            int[] array = (int[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (int value : array) {
+                    collector.add(value);
+                }
+            }
+        } else if (primitiveArray instanceof short[]) {
+            short[] array = (short[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (short value : array) {
+                    collector.add(value);
+                }
+            }
+        } else if (primitiveArray instanceof byte[]) {
+            byte[] array = (byte[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (byte value : array) {
+                    collector.add(value);
+                }
+            }
+        } else if (primitiveArray instanceof char[]) {
+            char[] array = (char[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (char value : array) {
+                    collector.add(value);
+                }
+            }
+        } else if (primitiveArray instanceof boolean[]) {
+            boolean[] array = (boolean[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (boolean value : array) {
+                    collector.add(value);
+                }
+            }
+        } else if (primitiveArray instanceof double[]) {
+            double[] array = (double[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (double value : array) {
+                    collector.add(value);
+                }
+            }
+
+        } else if (primitiveArray instanceof float[]) {
+            float[] array = (float[]) primitiveArray;
+            if (array.length == 0) {
+                collector.addNullOrEmptyTarget();
+            } else {
+                for (float value : array) {
+                    collector.add(value);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("unexpected primitive array: " + primitiveArray);
         }
     }
 
@@ -213,7 +285,6 @@ public abstract class AbstractMultiValueGetter extends Getter {
                     + " Only Collections and Arrays are supported.");
         }
     }
-
 
     private static int parseModifier(String modifier) {
         String stringValue = modifier.substring(1, modifier.length() - 1);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
@@ -26,6 +26,16 @@ import com.hazelcast.query.impl.Indexes;
 public abstract class AbstractVisitor implements Visitor {
 
     @Override
+    public Predicate visit(EqualPredicate predicate, Indexes indexes) {
+        return predicate;
+    }
+
+    @Override
+    public Predicate visit(NotEqualPredicate predicate, Indexes indexes) {
+        return predicate;
+    }
+
+    @Override
     public Predicate visit(AndPredicate predicate, Indexes indexes) {
         return predicate;
     }
@@ -37,6 +47,11 @@ public abstract class AbstractVisitor implements Visitor {
 
     @Override
     public Predicate visit(NotPredicate predicate, Indexes indexes) {
+        return predicate;
+    }
+
+    @Override
+    public Predicate visit(InPredicate predicate, Indexes indexes) {
         return predicate;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -20,8 +20,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.VisitablePredicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -34,7 +36,8 @@ import static com.hazelcast.query.impl.predicates.PredicateUtils.isNull;
  * Equal Predicate
  */
 @BinaryInterface
-public class EqualPredicate extends AbstractIndexAwarePredicate implements NegatablePredicate, RangePredicate {
+public class EqualPredicate extends AbstractIndexAwarePredicate
+        implements NegatablePredicate, RangePredicate, VisitablePredicate {
 
     private static final long serialVersionUID = 1L;
 
@@ -50,6 +53,11 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
     public EqualPredicate(String attribute, Comparable value) {
         super(attribute);
         this.value = value;
+    }
+
+    @Override
+    public Predicate accept(Visitor visitor, Indexes indexes) {
+        return visitor.visit(this, indexes);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluatePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluatePredicate.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.IndexAwarePredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.QueryContext;
+import com.hazelcast.query.impl.QueryableEntry;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wraps a predicate for which {@link Index#canEvaluate} returned {@code true}.
+ * <p>
+ * Used during predicate tree optimization done by {@link EvaluateVisitor}.
+ * Never transferred over the wire.
+ */
+public final class EvaluatePredicate implements Predicate, IndexAwarePredicate {
+
+    private final Predicate predicate;
+    private final String indexName;
+
+    /**
+     * Constructs {@link EvaluatePredicate} instance for the given predicate
+     * which can be evaluated by the given index identified by its name.
+     *
+     * @param predicate the evaluable predicate to wrap.
+     * @param indexName the index which can evaluate the given predicate.
+     */
+    public EvaluatePredicate(Predicate predicate, String indexName) {
+        this.predicate = predicate;
+        this.indexName = indexName;
+    }
+
+    /**
+     * @return the original evaluable predicate.
+     */
+    public Predicate getPredicate() {
+        return predicate;
+    }
+
+    /**
+     * @return the index name of the index which can evaluate the predicate
+     * wrapped by this predicate instance.
+     */
+    public String getIndexName() {
+        return indexName;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean apply(Map.Entry mapEntry) {
+        return predicate.apply(mapEntry);
+    }
+
+    @Override
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        return index.evaluate(predicate);
+    }
+
+    @Override
+    public boolean isIndexed(QueryContext queryContext) {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "eval(" + predicate.toString() + ")";
+    }
+
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        throw new UnsupportedOperationException("can't be serialized");
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.QueryContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tries to divide the predicate tree into isolated subtrees every of which can
+ * be evaluated by {@link Index#evaluate} method in a single go.
+ */
+public class EvaluateVisitor extends AbstractVisitor {
+
+    private static final Predicate[] EMPTY_PREDICATES = new Predicate[0];
+
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
+    @Override
+    public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
+        Predicate[] predicates = andPredicate.predicates;
+
+        // Try to group evaluable predicates by their indexes.
+
+        Map<String, List<EvaluatePredicate>> evaluable = null;
+        boolean requiresGeneration = false;
+        for (Predicate subPredicate : predicates) {
+            if (!(subPredicate instanceof EvaluatePredicate)) {
+                continue;
+            }
+
+            EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
+            String indexName = evaluatePredicate.getIndexName();
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            if (!index.canEvaluate(andPredicate.getClass())) {
+                continue;
+            }
+
+            if (evaluable == null) {
+                evaluable = new HashMap<String, List<EvaluatePredicate>>(predicates.length);
+            }
+            List<EvaluatePredicate> group = evaluable.get(indexName);
+            if (group == null) {
+                group = new ArrayList<EvaluatePredicate>(predicates.length);
+                evaluable.put(indexName, group);
+            } else {
+                requiresGeneration = true;
+            }
+            group.add(evaluatePredicate);
+        }
+
+        if (!requiresGeneration) {
+            // no changes to the predicates required
+            return andPredicate;
+        }
+
+        // Add non-evaluable predicates to the output.
+
+        List<Predicate> output = new ArrayList<Predicate>();
+        for (Predicate subPredicate : predicates) {
+            if (!(subPredicate instanceof EvaluatePredicate)) {
+                output.add(subPredicate);
+                continue;
+            }
+
+            EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
+            String indexName = evaluatePredicate.getIndexName();
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            if (!index.canEvaluate(andPredicate.getClass())) {
+                output.add(subPredicate);
+            }
+        }
+
+        // Add evaluable predicates to the output.
+
+        for (Map.Entry<String, List<EvaluatePredicate>> groupEntry : evaluable.entrySet()) {
+            String indexName = groupEntry.getKey();
+            List<EvaluatePredicate> group = groupEntry.getValue();
+
+            if (group.size() == 1) {
+                output.add(group.get(0));
+                continue;
+            }
+
+            Predicate[] groupPredicates = new Predicate[group.size()];
+            for (int i = 0; i < groupPredicates.length; ++i) {
+                groupPredicates[i] = group.get(i).getPredicate();
+            }
+            output.add(new EvaluatePredicate(new AndPredicate(groupPredicates), indexName));
+        }
+
+        return output.size() == 1 ? output.get(0) : new AndPredicate(output.toArray(EMPTY_PREDICATES));
+    }
+
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
+    @Override
+    public Predicate visit(OrPredicate orPredicate, Indexes indexes) {
+        Predicate[] predicates = orPredicate.predicates;
+
+        // Try to group evaluable predicates by their indexes.
+
+        Map<String, List<EvaluatePredicate>> evaluable = null;
+        boolean requiresGeneration = false;
+        for (Predicate subPredicate : predicates) {
+            if (!(subPredicate instanceof EvaluatePredicate)) {
+                continue;
+            }
+
+            EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
+            String indexName = evaluatePredicate.getIndexName();
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            if (!index.canEvaluate(orPredicate.getClass())) {
+                continue;
+            }
+
+            if (evaluable == null) {
+                evaluable = new HashMap<String, List<EvaluatePredicate>>(predicates.length);
+            }
+            List<EvaluatePredicate> group = evaluable.get(indexName);
+            if (group == null) {
+                group = new ArrayList<EvaluatePredicate>(predicates.length);
+                evaluable.put(indexName, group);
+            } else {
+                requiresGeneration = true;
+            }
+            group.add(evaluatePredicate);
+        }
+
+        if (!requiresGeneration) {
+            // no changes to the predicates required
+            return orPredicate;
+        }
+
+        // Add non-evaluable predicates to the output.
+
+        List<Predicate> output = new ArrayList<Predicate>();
+        for (Predicate subPredicate : predicates) {
+            if (!(subPredicate instanceof EvaluatePredicate)) {
+                output.add(subPredicate);
+                continue;
+            }
+
+            EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
+            String indexName = evaluatePredicate.getIndexName();
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            if (!index.canEvaluate(orPredicate.getClass())) {
+                output.add(subPredicate);
+            }
+        }
+
+        // Add evaluable predicates to the output.
+
+        for (Map.Entry<String, List<EvaluatePredicate>> groupEntry : evaluable.entrySet()) {
+            String indexName = groupEntry.getKey();
+            List<EvaluatePredicate> group = groupEntry.getValue();
+
+            if (group.size() == 1) {
+                output.add(group.get(0));
+                continue;
+            }
+
+            Predicate[] groupPredicates = new Predicate[group.size()];
+            for (int i = 0; i < groupPredicates.length; ++i) {
+                groupPredicates[i] = group.get(i).getPredicate();
+            }
+            output.add(new EvaluatePredicate(new OrPredicate(groupPredicates), indexName));
+        }
+
+        return output.size() == 1 ? output.get(0) : new OrPredicate(output.toArray(EMPTY_PREDICATES));
+    }
+
+    @Override
+    public Predicate visit(NotPredicate notPredicate, Indexes indexes) {
+        Predicate subPredicate = notPredicate.getPredicate();
+        if (!(subPredicate instanceof EvaluatePredicate)) {
+            return notPredicate;
+        }
+
+        EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
+        String indexName = evaluatePredicate.getIndexName();
+        Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (!index.canEvaluate(notPredicate.getClass())) {
+            return notPredicate;
+        }
+
+        return new EvaluatePredicate(new NotPredicate(evaluatePredicate.getPredicate()), indexName);
+    }
+
+    @Override
+    public Predicate visit(EqualPredicate predicate, Indexes indexes) {
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        if (index == null) {
+            return predicate;
+        }
+
+        if (!index.canEvaluate(predicate.getClass())) {
+            return predicate;
+        }
+
+        TypeConverter converter = index.getConverter();
+        if (converter == null) {
+            return predicate;
+        }
+
+        return new EvaluatePredicate(predicate, index.getName());
+    }
+
+    @Override
+    public Predicate visit(NotEqualPredicate predicate, Indexes indexes) {
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        if (index == null) {
+            return predicate;
+        }
+
+        if (!index.canEvaluate(predicate.getClass())) {
+            return predicate;
+        }
+
+        TypeConverter converter = index.getConverter();
+        if (converter == null) {
+            return predicate;
+        }
+
+        return new EvaluatePredicate(predicate, index.getName());
+    }
+
+    @Override
+    public Predicate visit(InPredicate predicate, Indexes indexes) {
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        if (index == null) {
+            return predicate;
+        }
+
+        if (!index.canEvaluate(predicate.getClass())) {
+            return predicate;
+        }
+
+        TypeConverter converter = index.getConverter();
+        if (converter == null) {
+            return predicate;
+        }
+
+        return new EvaluatePredicate(predicate, index.getName());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -19,10 +19,14 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.BinaryInterface;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.VisitablePredicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,7 +38,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
  * In Predicate
  */
 @BinaryInterface
-public class InPredicate extends AbstractIndexAwarePredicate {
+public class InPredicate extends AbstractIndexAwarePredicate implements VisitablePredicate {
 
     private static final long serialVersionUID = 1L;
 
@@ -51,6 +55,17 @@ public class InPredicate extends AbstractIndexAwarePredicate {
             throw new NullPointerException("Array can't be null");
         }
         this.values = values;
+    }
+
+
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public Comparable[] getValues() {
+        return values;
+    }
+
+    @Override
+    public Predicate accept(Visitor visitor, Indexes indexes) {
+        return visitor.visit(this, indexes);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -37,6 +38,11 @@ public final class NotEqualPredicate extends EqualPredicate {
 
     public NotEqualPredicate(String attribute, Comparable value) {
         super(attribute, value);
+    }
+
+    @Override
+    public Predicate accept(Visitor visitor, Indexes indexes) {
+        return visitor.visit(this, indexes);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
@@ -47,6 +47,10 @@ public final class NotPredicate
     public NotPredicate() {
     }
 
+    public Predicate getPredicate() {
+        return predicate;
+    }
+
     @Override
     public boolean apply(Map.Entry mapEntry) {
         return !predicate.apply(mapEntry);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -22,9 +22,6 @@ import com.hazelcast.query.impl.OrResultSet;
 import com.hazelcast.query.impl.QueryableEntry;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.regex.Pattern;
 
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 
@@ -32,15 +29,11 @@ public final class PredicateUtils {
 
     private static final int EXPECTED_AVERAGE_COMPONENT_NAME_LENGTH = 16;
 
-    private static final int MAX_INDEX_COMPONENTS = 255;
-
     private static final String THIS_DOT = "this.";
 
     private static final String KEY_HASH = "__key#";
 
     private static final String KEY_DOT = "__key.";
-
-    private static final Pattern COMMA_PATTERN = Pattern.compile("\\s*,\\s*");
 
     private PredicateUtils() {
     }
@@ -109,48 +102,6 @@ public final class PredicateUtils {
             return KEY_DOT + attribute.substring(KEY_HASH.length());
         }
         return attribute;
-    }
-
-    /**
-     * Parses the given index name into components.
-     *
-     * @param name the index name to parse.
-     * @return the parsed components or {@code null} if the given index name
-     * doesn't describe a composite index components.
-     * @throws IllegalArgumentException if the given index name is empty.
-     * @throws IllegalArgumentException if the given index name contains empty
-     *                                  components.
-     * @throws IllegalArgumentException if the given index name contains
-     *                                  duplicate components.
-     * @throws IllegalArgumentException if the given index name has more than
-     *                                  255 components.
-     * @see #constructCanonicalCompositeIndexName
-     */
-    public static String[] parseOutCompositeIndexComponents(String name) {
-        String[] components = COMMA_PATTERN.split(name, -1);
-
-        if (components.length == 1) {
-            return null;
-        }
-
-        if (components.length > MAX_INDEX_COMPONENTS) {
-            throw new IllegalArgumentException("Too many composite index attributes: " + name);
-        }
-
-        Set<String> seenComponents = new HashSet<String>(components.length);
-        for (int i = 0; i < components.length; ++i) {
-            String component = PredicateUtils.canonicalizeAttribute(components[i]);
-            components[i] = component;
-
-            if (component.isEmpty()) {
-                throw new IllegalArgumentException("Empty composite index attribute: " + name);
-            }
-            if (!seenComponents.add(component)) {
-                throw new IllegalArgumentException("Duplicate composite index attribute: " + name);
-            }
-        }
-
-        return components;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
@@ -29,6 +29,7 @@ public final class RuleBasedQueryOptimizer implements QueryOptimizer {
     private final Visitor rangeVisitor = new RangeVisitor();
     private final Visitor orToInVisitor = new OrToInVisitor();
     private final Visitor compositeIndexVisitor = new CompositeIndexVisitor();
+    private final Visitor evaluateVisitor = new EvaluateVisitor();
 
     @SuppressWarnings("unchecked")
     public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes) {
@@ -44,6 +45,9 @@ public final class RuleBasedQueryOptimizer implements QueryOptimizer {
         }
         if (optimized instanceof VisitablePredicate) {
             optimized = ((VisitablePredicate) optimized).accept(compositeIndexVisitor, indexes);
+        }
+        if (optimized instanceof VisitablePredicate) {
+            optimized = ((VisitablePredicate) optimized).accept(evaluateVisitor, indexes);
         }
         return optimized;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
@@ -28,11 +28,17 @@ import com.hazelcast.query.impl.Indexes;
  */
 public interface Visitor {
 
+    Predicate visit(EqualPredicate predicate, Indexes indexes);
+
+    Predicate visit(NotEqualPredicate predicate, Indexes indexes);
+
     Predicate visit(AndPredicate predicate, Indexes indexes);
 
     Predicate visit(OrPredicate predicate, Indexes indexes);
 
     Predicate visit(NotPredicate predicate, Indexes indexes);
+
+    Predicate visit(InPredicate predicate, Indexes indexes);
 
     Predicate visit(BetweenPredicate predicate, Indexes indexes);
 

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
@@ -38,4 +38,15 @@ public final class Hashing {
         final int h = (int) fastLongMix(value);
         return h & mask & ~1;
     }
+
+    static int hash(Object value, int mask) {
+        return fastIntMix(value.hashCode()) & mask;
+    }
+
+    static int hashCode(long value) {
+        // Used only for nominal Object.hashCode implementations, no mixing
+        // required.
+        return (int) (value ^ (value >>> Integer.SIZE));
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Object2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Object2LongHashMap.java
@@ -19,7 +19,6 @@ package com.hazelcast.util.collection;
 import com.hazelcast.util.QuickMath;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -30,7 +29,7 @@ import java.util.*;
  * @param <K> type of keys stored in the {@link Map}
  */
 public class Object2LongHashMap<K>
-    implements Map<K, Long>, Serializable
+    implements Map<K, Long>
 {
     private static final float DEFAULT_LOAD_FACTOR = 0.6F;
     private static final int MIN_CAPACITY = 8;
@@ -637,8 +636,7 @@ public class Object2LongHashMap<K>
     // Sets and Collections
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    @SuppressFBWarnings(value = "SE_INNER_CLASS")
-    public final class KeySet extends AbstractSet<K> implements Serializable
+    public final class KeySet extends AbstractSet<K>
     {
         private final KeyIterator keyIterator = shouldAvoidAllocation ? new KeyIterator() : null;
 
@@ -679,8 +677,7 @@ public class Object2LongHashMap<K>
         }
     }
 
-    @SuppressFBWarnings(value = "SE_INNER_CLASS")
-    public final class ValueCollection extends AbstractCollection<Long> implements Serializable
+    public final class ValueCollection extends AbstractCollection<Long>
     {
         private final ValueIterator valueIterator = shouldAvoidAllocation ? new ValueIterator() : null;
 
@@ -715,8 +712,7 @@ public class Object2LongHashMap<K>
         }
     }
 
-    @SuppressFBWarnings(value = "SE_INNER_CLASS")
-    public final class EntrySet extends AbstractSet<Entry<K, Long>> implements Serializable
+    public final class EntrySet extends AbstractSet<Entry<K, Long>>
     {
         private final EntryIterator entryIterator = shouldAvoidAllocation ? new EntryIterator() : null;
 
@@ -760,7 +756,7 @@ public class Object2LongHashMap<K>
     // Iterators
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    abstract class AbstractIterator<T> implements Iterator<T>, Serializable
+    abstract class AbstractIterator<T> implements Iterator<T>
     {
         private int posCounter;
         private int stopCounter;

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Object2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Object2LongHashMap.java
@@ -1,0 +1,974 @@
+/*
+ * Original work Copyright 2014-2019 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.QuickMath;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * {@link Map} implementation specialised for long values using open addressing and
+ * linear probing for cache efficient access. The implementation is mirror copy of {@link Long2ObjectHashMap}
+ * and it also relies on missing value concept from {@link Long2LongHashMap}
+ *
+ * @param <K> type of keys stored in the {@link Map}
+ */
+public class Object2LongHashMap<K>
+    implements Map<K, Long>, Serializable
+{
+    private static final float DEFAULT_LOAD_FACTOR = 0.6F;
+    private static final int MIN_CAPACITY = 8;
+
+    private final float loadFactor;
+    private final long missingValue;
+    private int resizeThreshold;
+    private int size;
+    private final boolean shouldAvoidAllocation;
+
+    private K[] keys;
+    private long[] values;
+
+    private ValueCollection valueCollection;
+    private KeySet keySet;
+    private EntrySet entrySet;
+
+    /**
+     * Construct a map with default capacity and load factor.
+     *
+     * @param missingValue value to be used as a null maker in the map
+     */
+    public Object2LongHashMap(final long missingValue)
+    {
+        this(MIN_CAPACITY, DEFAULT_LOAD_FACTOR, missingValue);
+    }
+
+    /**
+     * Construct a new map allowing a configuration for initial capacity and load factor.
+     *
+     * @param initialCapacity for the backing array
+     * @param loadFactor      limit for resizing on puts
+     * @param missingValue    value to be used as a null marker in the map
+     */
+    public Object2LongHashMap(
+        final int initialCapacity,
+        final float loadFactor,
+        final long missingValue)
+    {
+        this(initialCapacity, loadFactor, missingValue, true);
+    }
+
+    /**
+     * Construct a new map allowing a configuration for initial capacity and load factor.
+     * @param initialCapacity       for the backing array
+     * @param loadFactor            limit for resizing on puts
+     * @param missingValue          value to be used as a null marker in the map
+     * @param shouldAvoidAllocation should allocation be avoided by caching iterators and map entries.
+     */
+    @SuppressWarnings("unchecked")
+    public Object2LongHashMap(
+        final int initialCapacity,
+        final float loadFactor,
+        final long missingValue,
+        final boolean shouldAvoidAllocation)
+    {
+        this.loadFactor = loadFactor;
+        final int capacity = QuickMath.nextPowerOfTwo(Math.max(MIN_CAPACITY, initialCapacity));
+        resizeThreshold = (int)(capacity * loadFactor);
+
+        this.missingValue = missingValue;
+        this.shouldAvoidAllocation = shouldAvoidAllocation;
+        keys = (K[])new Object[capacity];
+        values = new long[capacity];
+        Arrays.fill(values, missingValue);
+    }
+
+    /**
+     * Copy construct a new map from an existing one.
+     *
+     * @param mapToCopy for construction.
+     */
+    public Object2LongHashMap(final Object2LongHashMap<K> mapToCopy)
+    {
+        this.loadFactor = mapToCopy.loadFactor;
+        this.resizeThreshold = mapToCopy.resizeThreshold;
+        this.size = mapToCopy.size;
+        this.missingValue = mapToCopy.missingValue;
+        this.shouldAvoidAllocation = mapToCopy.shouldAvoidAllocation;
+
+        keys = mapToCopy.keys.clone();
+        values = mapToCopy.values.clone();
+    }
+
+    /**
+     * The value to be used as a null marker in the map.
+     *
+     * @return value to be used as a null marker in the map.
+     */
+    public long missingValue()
+    {
+        return missingValue;
+    }
+
+    /**
+     * Get the load factor beyond which the map will increase size.
+     *
+     * @return load factor for when the map should increase size.
+     */
+    public float loadFactor()
+    {
+        return loadFactor;
+    }
+
+    /**
+     * Get the total capacity for the map to which the load factor will be a fraction of.
+     *
+     * @return the total capacity for the map.
+     */
+    public int capacity()
+    {
+        return values.length;
+    }
+
+    /**
+     * Get the actual threshold which when reached the map will resize.
+     * This is a function of the current capacity and load factor.
+     *
+     * @return the threshold when the map will resize.
+     */
+    public int resizeThreshold()
+    {
+        return resizeThreshold;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size()
+    {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty()
+    {
+        return 0 == size;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Overloaded version of {@link Map#containsKey(Object)} that takes a primitive long key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return true if the key is found otherwise false.
+     */
+    public boolean containsKey(final Object key)
+    {
+        final int mask = values.length - 1;
+        int index = Hashing.hash(key, mask);
+
+        boolean found = false;
+        while (missingValue != values[index])
+        {
+            if (key.equals(keys[index]))
+            {
+                found = true;
+                break;
+            }
+
+            index = ++index & mask;
+        }
+
+        return found;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsValue(final Object value)
+    {
+        return containsValue(((Long)value).longValue());
+    }
+
+    public boolean containsValue(final long value)
+    {
+        if (value == missingValue)
+        {
+            return false;
+        }
+
+        boolean found = false;
+        for (final long v : values)
+        {
+            if (value == v)
+            {
+                found = true;
+                break;
+            }
+        }
+
+        return found;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public Long get(final Object key)
+    {
+        return valOrNull(getValue((K)key));
+    }
+
+    /**
+     * Overloaded version of {@link Map#get(Object)} that takes a primitive long key.
+     * Due to type erasure have to rename the method
+     *
+     * @param key for indexing the {@link Map}
+     * @return the value if found otherwise missingValue
+     */
+    public long getValue(final K key)
+    {
+        final int mask = values.length - 1;
+        int index = Hashing.hash(key, mask);
+
+        long value;
+        while (missingValue != (value = values[index]))
+        {
+            if (key.equals(keys[index]))
+            {
+                break;
+            }
+
+            index = ++index & mask;
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long put(final K key, final Long value)
+    {
+        return valOrNull(put(key, value.longValue()));
+    }
+
+    /**
+     * Overloaded version of {@link Map#put(Object, Object)} that takes a primitive long key.
+     *
+     * @param key   for indexing the {@link Map}
+     * @param value to be inserted in the {@link Map}
+     * @return the previous value if found otherwise missingValue
+     */
+    public long put(final K key, final long value)
+    {
+        if (value == missingValue)
+        {
+            throw new IllegalArgumentException("cannot accept missingValue");
+        }
+
+        long oldValue = missingValue;
+        final int mask = values.length - 1;
+        int index = Hashing.hash(key, mask);
+
+        while (missingValue != values[index])
+        {
+            if (key.equals(keys[index]))
+            {
+                oldValue = values[index];
+                break;
+            }
+
+            index = ++index & mask;
+        }
+
+        if (missingValue == oldValue)
+        {
+            ++size;
+            keys[index] = key;
+        }
+
+        values[index] = value;
+
+        if (size > resizeThreshold)
+        {
+            increaseCapacity();
+        }
+
+        return oldValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public Long remove(final Object key)
+    {
+        return valOrNull(removeKey(((K)key)));
+    }
+
+    /**
+     * Overloaded version of {@link Map#remove(Object)} that takes a primitive long key.
+     * Due to type erasure have to rename the method
+     *
+     * @param key for indexing the {@link Map}
+     * @return the value if found otherwise missingValue
+     */
+    public long removeKey(final K key)
+    {
+        final int mask = values.length - 1;
+        int index = Hashing.hash(key, mask);
+
+        long value;
+        while (missingValue != (value = values[index]))
+        {
+            if (key.equals(keys[index]))
+            {
+                keys[index] = null;
+                values[index] = missingValue;
+                --size;
+
+                compactChain(index);
+                break;
+            }
+
+            index = ++index & mask;
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear()
+    {
+        if (size > 0)
+        {
+            Arrays.fill(keys, null);
+            Arrays.fill(values, missingValue);
+            size = 0;
+        }
+    }
+
+    /**
+     * Compact the {@link Map} backing arrays by rehashing with a capacity just larger than current size
+     * and giving consideration to the load factor.
+     */
+    public void compact()
+    {
+        final int idealCapacity = (int)Math.round(size() * (1.0d / loadFactor));
+        rehash(QuickMath.nextPowerOfTwo(Math.max(MIN_CAPACITY, idealCapacity)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void putAll(final Map<? extends K, ? extends Long> map)
+    {
+        for (final Entry<? extends K, ? extends Long> entry : map.entrySet())
+        {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public KeySet keySet()
+    {
+        if (null == keySet)
+        {
+            keySet = new KeySet();
+        }
+
+        return keySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ValueCollection values()
+    {
+        if (null == valueCollection)
+        {
+            valueCollection = new ValueCollection();
+        }
+
+        return valueCollection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public EntrySet entrySet()
+    {
+        if (null == entrySet)
+        {
+            entrySet = new EntrySet();
+        }
+
+        return entrySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString()
+    {
+        if (isEmpty())
+        {
+            return "{}";
+        }
+
+        final EntryIterator entryIterator = new EntryIterator();
+        entryIterator.reset();
+
+        final StringBuilder sb = new StringBuilder().append('{');
+        while (true)
+        {
+            entryIterator.next();
+            sb.append(entryIterator.getKey()).append('=').append(entryIterator.getLongValue());
+            if (!entryIterator.hasNext())
+            {
+                return sb.append('}').toString();
+            }
+            sb.append(',').append(' ');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+
+        if (!(o instanceof Map))
+        {
+            return false;
+        }
+
+        final Map<?, ?> that = (Map<?, ?>)o;
+
+        if (size != that.size())
+        {
+            return false;
+        }
+
+        for (int i = 0, length = values.length; i < length; i++)
+        {
+            final long thisValue = values[i];
+            if (missingValue != thisValue)
+            {
+                final Object thatValueObject = that.get(keys[i]);
+                if (!(thatValueObject instanceof Long))
+                {
+                    return false;
+                }
+
+                final long thatValue = (Long)thatValueObject;
+                if (missingValue == thatValue || thisValue != thatValue)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int hashCode()
+    {
+        int result = 0;
+
+        for (int i = 0, length = values.length; i < length; i++)
+        {
+            final long value = values[i];
+            if (missingValue != value)
+            {
+                result += (keys[i].hashCode() ^ Hashing.hashCode(value));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Primitive specialised version of {@link #replace(Object, Object)}
+     *
+     * @param key   key with which the specified value is associated
+     * @param value value to be associated with the specified key
+     * @return the previous value associated with the specified key, or
+     * {@code null} if there was no mapping for the key.
+     */
+    public long replace(final K key, final long value)
+    {
+        long curValue = getValue(key);
+        if (curValue != missingValue)
+        {
+            curValue = put(key, value);
+        }
+
+        return curValue;
+    }
+
+    /**
+     * Primitive specialised version of {@link #replace(Object, Object, Object)}
+     *
+     * @param key      key with which the specified value is associated
+     * @param oldValue value expected to be associated with the specified key
+     * @param newValue value to be associated with the specified key
+     * @return {@code true} if the value was replaced
+     */
+    public boolean replace(final K key, final long oldValue, final long newValue)
+    {
+        final long curValue = getValue(key);
+        if (curValue == missingValue || curValue != oldValue)
+        {
+            return false;
+        }
+
+        put(key, newValue);
+
+        return true;
+    }
+
+    private void increaseCapacity()
+    {
+        final int newCapacity = values.length << 1;
+        if (newCapacity < 0)
+        {
+            throw new IllegalStateException("max capacity reached at size=" + size);
+        }
+
+        rehash(newCapacity);
+    }
+
+    private void rehash(final int newCapacity)
+    {
+        final int mask = newCapacity - 1;
+        resizeThreshold = (int)(newCapacity * loadFactor);
+
+        @SuppressWarnings("unchecked")
+        final K[] tempKeys = (K[])new Object[newCapacity];
+        final long[] tempValues = new long[newCapacity];
+        Arrays.fill(tempValues, missingValue);
+
+        for (int i = 0, size = values.length; i < size; i++)
+        {
+            final long value = values[i];
+            if (missingValue != value)
+            {
+                final K key = keys[i];
+                int index = Hashing.hash(key, mask);
+                while (missingValue != tempValues[index])
+                {
+                    index = ++index & mask;
+                }
+
+                tempKeys[index] = key;
+                tempValues[index] = value;
+            }
+        }
+
+        keys = tempKeys;
+        values = tempValues;
+    }
+
+    @SuppressWarnings("FinalParameters")
+    private void compactChain(int deleteIndex)
+    {
+        final int mask = values.length - 1;
+        int index = deleteIndex;
+
+        while (true)
+        {
+            index = ++index & mask;
+            if (missingValue == values[index])
+            {
+                break;
+            }
+
+            final int hash = Hashing.hash(keys[index], mask);
+
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index)) ||
+                (hash <= deleteIndex && deleteIndex <= index))
+            {
+                keys[deleteIndex] = keys[index];
+                values[deleteIndex] = values[index];
+
+                keys[index] = null;
+                values[index] = missingValue;
+                deleteIndex = index;
+            }
+        }
+    }
+
+    private Long valOrNull(final long value)
+    {
+        return value == missingValue ? null : value;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Sets and Collections
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    @SuppressFBWarnings(value = "SE_INNER_CLASS")
+    public final class KeySet extends AbstractSet<K> implements Serializable
+    {
+        private final KeyIterator keyIterator = shouldAvoidAllocation ? new KeyIterator() : null;
+
+        /**
+         * {@inheritDoc}
+         */
+        public KeyIterator iterator()
+        {
+            KeyIterator keyIterator = this.keyIterator;
+            if (null == keyIterator)
+            {
+                keyIterator = new KeyIterator();
+            }
+
+            keyIterator.reset();
+            return keyIterator;
+        }
+
+        public int size()
+        {
+            return Object2LongHashMap.this.size();
+        }
+
+        public boolean contains(final Object o)
+        {
+            return Object2LongHashMap.this.containsKey(o);
+        }
+
+        @SuppressWarnings("unchecked")
+        public boolean remove(final Object o)
+        {
+            return missingValue != Object2LongHashMap.this.removeKey((K)o);
+        }
+
+        public void clear()
+        {
+            Object2LongHashMap.this.clear();
+        }
+    }
+
+    @SuppressFBWarnings(value = "SE_INNER_CLASS")
+    public final class ValueCollection extends AbstractCollection<Long> implements Serializable
+    {
+        private final ValueIterator valueIterator = shouldAvoidAllocation ? new ValueIterator() : null;
+
+        /**
+         * {@inheritDoc}
+         */
+        public ValueIterator iterator()
+        {
+            ValueIterator valueIterator = this.valueIterator;
+            if (null == valueIterator)
+            {
+                valueIterator = new ValueIterator();
+            }
+
+            valueIterator.reset();
+            return valueIterator;
+        }
+
+        public int size()
+        {
+            return Object2LongHashMap.this.size();
+        }
+
+        public boolean contains(final Object o)
+        {
+            return Object2LongHashMap.this.containsValue(o);
+        }
+
+        public void clear()
+        {
+            Object2LongHashMap.this.clear();
+        }
+    }
+
+    @SuppressFBWarnings(value = "SE_INNER_CLASS")
+    public final class EntrySet extends AbstractSet<Entry<K, Long>> implements Serializable
+    {
+        private final EntryIterator entryIterator = shouldAvoidAllocation ? new EntryIterator() : null;
+
+        /**
+         * {@inheritDoc}
+         */
+        public EntryIterator iterator()
+        {
+            EntryIterator entryIterator = this.entryIterator;
+            if (null == entryIterator)
+            {
+                entryIterator = new EntryIterator();
+            }
+
+            entryIterator.reset();
+            return entryIterator;
+        }
+
+        public int size()
+        {
+            return Object2LongHashMap.this.size();
+        }
+
+        public void clear()
+        {
+            Object2LongHashMap.this.clear();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean contains(final Object o)
+        {
+            final Entry entry = (Entry)o;
+            final Long value = get(entry.getKey());
+            return value != null && value.equals(entry.getValue());
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Iterators
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    abstract class AbstractIterator<T> implements Iterator<T>, Serializable
+    {
+        private int posCounter;
+        private int stopCounter;
+        private int remaining;
+        private boolean isPositionValid = false;
+
+        protected final int position()
+        {
+            return posCounter & (values.length - 1);
+        }
+
+        public boolean hasNext()
+        {
+            return remaining > 0;
+        }
+
+        protected final void findNext()
+        {
+            if (!hasNext())
+            {
+                throw new NoSuchElementException();
+            }
+
+            final long[] values = Object2LongHashMap.this.values;
+            final int mask = values.length - 1;
+
+            for (int i = posCounter - 1; i >= stopCounter; i--)
+            {
+                final int index = i & mask;
+                if (missingValue != values[index])
+                {
+                    posCounter = i;
+                    isPositionValid = true;
+                    --remaining;
+
+                    return;
+                }
+            }
+
+            isPositionValid = false;
+            throw new IllegalStateException();
+        }
+
+        public abstract T next();
+
+        public void remove()
+        {
+            if (isPositionValid)
+            {
+                final int position = position();
+                values[position] = missingValue;
+                keys[position] = null;
+                --size;
+
+                compactChain(position);
+
+                isPositionValid = false;
+            }
+            else
+            {
+                throw new IllegalStateException();
+            }
+        }
+
+        final void reset()
+        {
+            remaining = Object2LongHashMap.this.size;
+            final long[] values = Object2LongHashMap.this.values;
+            final int capacity = values.length;
+
+            int i = capacity;
+            if (missingValue != values[capacity - 1])
+            {
+                for (i = 0; i < capacity; i++)
+                {
+                    if (missingValue == values[i])
+                    {
+                        break;
+                    }
+                }
+            }
+
+            stopCounter = i;
+            posCounter = i + capacity;
+            isPositionValid = false;
+        }
+    }
+
+    public final class ValueIterator extends AbstractIterator<Long>
+    {
+        public Long next()
+        {
+            return nextLong();
+        }
+
+        public long nextLong()
+        {
+            findNext();
+
+            return values[position()];
+        }
+    }
+
+    public final class KeyIterator extends AbstractIterator<K>
+    {
+        public K next()
+        {
+            findNext();
+
+            return keys[position()];
+        }
+    }
+
+    @SuppressFBWarnings(value = "PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS")
+    public final class EntryIterator
+        extends AbstractIterator<Entry<K, Long>>
+        implements Entry<K, Long>
+    {
+        public Entry<K, Long> next()
+        {
+            findNext();
+            if (shouldAvoidAllocation)
+            {
+                return this;
+            }
+
+            return allocateDuplicateEntry();
+        }
+
+        private Entry<K, Long> allocateDuplicateEntry()
+        {
+            final K k = getKey();
+            final long v = getLongValue();
+
+            return new Entry<K, Long>()
+            {
+                public K getKey()
+                {
+                    return k;
+                }
+
+                public Long getValue()
+                {
+                    return v;
+                }
+
+                public Long setValue(final Long value)
+                {
+                    return Object2LongHashMap.this.put(k, value);
+                }
+
+                public int hashCode()
+                {
+                    return getKey().hashCode() ^ Hashing.hashCode(getLongValue());
+                }
+
+                public boolean equals(final Object o)
+                {
+                    if (!(o instanceof Entry))
+                    {
+                        return false;
+                    }
+
+                    final Entry e = (Entry)o;
+
+                    return (e.getKey() != null && e.getValue() != null) &&
+                        (e.getKey().equals(k) && e.getValue().equals(v));
+                }
+
+                public String toString()
+                {
+                    return k + "=" + v;
+                }
+            };
+        }
+
+        public K getKey()
+        {
+            return keys[position()];
+        }
+
+        public long getLongValue()
+        {
+            return values[position()];
+        }
+
+        public Long getValue()
+        {
+            return getLongValue();
+        }
+
+        public Long setValue(final Long value)
+        {
+            return setValue(value.longValue());
+        }
+
+        public long setValue(final long value)
+        {
+            if (value == missingValue)
+            {
+                throw new IllegalArgumentException("cannot accept missingValue");
+            }
+
+            final int pos = position();
+            final long oldValue = values[pos];
+            values[pos] = value;
+
+            return oldValue;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.query.impl.SkipIndexPredicate;
 import com.hazelcast.query.impl.predicates.BoundedRangePredicate;
 import com.hazelcast.query.impl.predicates.CompositeEqualPredicate;
 import com.hazelcast.query.impl.predicates.CompositeRangePredicate;
+import com.hazelcast.query.impl.predicates.EvaluatePredicate;
 import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -348,6 +349,7 @@ public class DataSerializableConventionsTest {
         whiteList.add(CompositeRangePredicate.class);
         whiteList.add(CompositeEqualPredicate.class);
         whiteList.add(AddIndexBackupOperation.class);
+        whiteList.add(EvaluatePredicate.class);
         try {
             // these can't be accessed through the meta class since they are private
             whiteList.add(Class.forName("com.hazelcast.query.impl.predicates.CompositeIndexVisitor$Output"));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
@@ -70,10 +70,11 @@ public class MultiValueBitmapIndexTest extends HazelcastTestSupport {
     public static Collection<Object[]> parameters() {
         // @formatter:off
         return asList(new Object[][]{
-                {"habits[any] -> __key"},
-                {"habits[any] -> stringId"},
-                {"habits[any] -> __key!"},
-                {"habits[any] -> __key?"}
+                {"BITMAP(habits[any])"},
+                {"BITMAP(habits[any], stringId)"},
+                {"BITMAP(habits[any], stringId, OBJECT)"},
+                {"BITMAP(habits[any], __key, RAW)"},
+                {"BITMAP(habits[any], __key, LONG)"}
         });
         // @formatter:on
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.in;
+import static com.hazelcast.query.Predicates.not;
+import static com.hazelcast.query.Predicates.notEqual;
+import static com.hazelcast.query.Predicates.or;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MultiValueBitmapIndexTest extends HazelcastTestSupport {
+
+    private static final int BATCH_SIZE = 1000;
+    private static final int BATCH_COUNT = 10;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> parameters() {
+        // @formatter:off
+        return asList(new Object[][]{
+                {"habits[any] -> __key"},
+                {"habits[any] -> stringId"},
+                {"habits[any] -> __key!"},
+                {"habits[any] -> __key?"}
+        });
+        // @formatter:on
+    }
+
+    private static final Predicate[] actualQueries;
+
+    static {
+        actualQueries = new Predicate[9];
+        actualQueries[0] = notEqual("habits[any]", "0");
+        actualQueries[1] = equal("habits[any]", 1L);
+        actualQueries[2] = equal("habits[any]", 2);
+        actualQueries[3] = or(equal("habits[any]", 1L), equal("habits[any]", 2));
+        actualQueries[4] = in("habits[any]", 3, 4);
+        actualQueries[5] = not(in("habits[any]", 3, "4"));
+
+        // all together
+        actualQueries[6] = and(equal("habits[any]", 1L), or(notEqual("habits[any]", "0"), equal("habits[any]", 2)),
+                not(in("habits[any]", 3, "4")));
+
+        // negate the previous one
+        actualQueries[7] = not(and(equal("habits[any]", 1L), or(notEqual("habits[any]", "0"), equal("habits[any]", 2)),
+                not(in("habits[any]", 3, "4"))));
+
+        // try really dense query (returns all entries)
+        actualQueries[8] = equal("habits[any]", "0");
+    }
+
+    private final ExpectedQuery[] expectedQueries;
+
+    {
+        expectedQueries = new ExpectedQuery[9];
+        expectedQueries[0] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !bit(0, value);
+            }
+        });
+        expectedQueries[1] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value);
+            }
+        });
+        expectedQueries[2] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(2, value);
+            }
+        });
+        expectedQueries[3] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value) || bit(2, value);
+            }
+        });
+        expectedQueries[4] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(3, value) || bit(4, value);
+            }
+        });
+        expectedQueries[5] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !(bit(3, value) || bit(4, value));
+            }
+        });
+        expectedQueries[6] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value) && (!bit(0, value) || bit(2, value)) && !(bit(3, value) || bit(4, value));
+            }
+        });
+        expectedQueries[7] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !(bit(1, value) && (!bit(0, value) || bit(2, value)) && !(bit(3, value) || bit(4, value)));
+            }
+        });
+        expectedQueries[8] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(0, value);
+            }
+        });
+    }
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Parameter
+    public String indexDefinition;
+
+    private IMap<Long, Person> persons;
+
+    @Before
+    public void before() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
+        persons = instance.getMap("persons");
+        factory.newHazelcastInstance(getConfig());
+    }
+
+    @Test
+    public void testConsecutiveQueries() {
+        for (int i = BATCH_COUNT - 1; i >= 0; --i) {
+            for (long j = 0; j < BATCH_SIZE; ++j) {
+                long id = i * BATCH_SIZE + j;
+                put(id, habits(id));
+            }
+            verifyQueries();
+        }
+
+        for (int i = 0; i < BATCH_COUNT; ++i) {
+            for (long j = 0; j < BATCH_SIZE; ++j) {
+                long id = i * BATCH_SIZE + j;
+                if (i % 2 == 0) {
+                    put(id, habits(id + 1));
+                } else {
+                    remove(id);
+                }
+            }
+            verifyQueries();
+        }
+
+        clear();
+        verifyQueries();
+    }
+
+    @Test
+    public void testRandomQueries() {
+        long seed = System.nanoTime();
+        System.out.println(testName.getMethodName() + " seed: " + seed);
+        Random random = new Random(seed);
+
+        for (int i = 0; i < BATCH_COUNT; ++i) {
+            for (int j = 0; j < BATCH_SIZE; ++j) {
+                long id = random.nextInt(i * BATCH_SIZE + j + 1);
+                put(id, habits(id));
+            }
+            verifyQueries();
+        }
+
+        random = new Random(seed);
+        for (int i = 0; i < BATCH_COUNT; ++i) {
+            for (int j = 0; j < BATCH_SIZE; ++j) {
+                long id = random.nextInt(i * BATCH_SIZE + j + 1);
+                if (i % 2 == 0) {
+                    put(id, habits(id + 1));
+                } else {
+                    remove(id);
+                }
+            }
+            verifyQueries();
+        }
+
+        clear();
+        verifyQueries();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = HazelcastTestSupport.smallInstanceConfig();
+        MapConfig mapConfig = config.getMapConfig("persons");
+        mapConfig.addMapIndexConfig(new MapIndexConfig(indexDefinition, false));
+        return config;
+    }
+
+    private static long habits(long id) {
+        return id << 1 | 1;
+    }
+
+    private void put(long id, long habits) {
+        Person person = new Person(id, habits);
+        persons.put(id, person);
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.put(id, person, habits);
+        }
+    }
+
+    private void remove(long id) {
+        persons.remove(id);
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.remove(id);
+        }
+    }
+
+    private void clear() {
+        persons.clear();
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.clear();
+        }
+    }
+
+    private void verifyQueries() {
+        for (int i = 0; i < actualQueries.length; ++i) {
+            Predicate actualQuery = actualQueries[i];
+            ExpectedQuery expectedQuery = expectedQueries[i];
+
+            Set<Map.Entry<Long, Person>> entries = persons.entrySet(actualQuery);
+            expectedQuery.verify(entries);
+        }
+    }
+
+    public static class Person implements DataSerializable {
+
+        public long id;
+
+        public long[] habits;
+
+        public String stringId;
+
+        public Person(long id, long habitsLong) {
+            this.id = id;
+            this.stringId = Long.toString(id);
+
+            long[] habits = new long[Long.bitCount(habitsLong)];
+            int count = 0;
+            for (int i = 0; i < Long.SIZE; ++i) {
+                if ((habitsLong & 1L << i) != 0) {
+                    habits[count] = i;
+                    ++count;
+                }
+            }
+            assert count == Long.bitCount(habitsLong);
+            this.habits = habits;
+        }
+
+        public Person() {
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeLong(id);
+            out.writeUTF(stringId);
+            out.writeLongArray(habits);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            id = in.readLong();
+            stringId = in.readUTF();
+            habits = in.readLongArray();
+        }
+
+        @Override
+        public String toString() {
+            return "Person{id=" + id + "}";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Person person = (Person) o;
+
+            if (id != person.id) {
+                return false;
+            }
+            if (!Arrays.equals(habits, person.habits)) {
+                return false;
+            }
+            return stringId.equals(person.stringId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (id ^ (id >>> 32));
+            result = 31 * result + Arrays.hashCode(habits);
+            result = 31 * result + stringId.hashCode();
+            return result;
+        }
+
+    }
+
+    private static boolean bit(int bit, long value) {
+        return (value & 1L << bit) != 0;
+    }
+
+    private interface LongPredicate {
+
+        boolean test(long value);
+
+    }
+
+    private static class ExpectedQuery {
+
+        private final LongPredicate predicate;
+        private final Map<Long, Person> result = new HashMap<Long, Person>();
+
+        ExpectedQuery(LongPredicate predicate) {
+            this.predicate = predicate;
+        }
+
+        public void put(long id, Person person, long habits) {
+            result.remove(id);
+            if (predicate.test(habits)) {
+                result.put(id, person);
+            }
+        }
+
+        public void remove(long id) {
+            result.remove(id);
+        }
+
+        public void verify(Set<Map.Entry<Long, Person>> actual) {
+            assertEquals(result.size(), actual.size());
+            for (Map.Entry<Long, Person> actualEntry : actual) {
+                Person person = result.get(actualEntry.getKey());
+                assertEquals(person, actualEntry.getValue());
+            }
+        }
+
+        public void clear() {
+            result.clear();
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
@@ -274,7 +274,10 @@ public class MultiValueBitmapIndexTest extends HazelcastTestSupport {
             Predicate actualQuery = actualQueries[i];
             ExpectedQuery expectedQuery = expectedQueries[i];
 
+            long before = persons.getLocalMapStats().getIndexStats().values().iterator().next().getQueryCount();
             Set<Map.Entry<Long, Person>> entries = persons.entrySet(actualQuery);
+            long after = persons.getLocalMapStats().getIndexStats().values().iterator().next().getQueryCount();
+            assertEquals(1, after - before);
             expectedQuery.verify(entries);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
@@ -257,7 +257,10 @@ public class SingleValueBitmapIndexTest extends HazelcastTestSupport {
             Predicate actualQuery = actualQueries[i];
             ExpectedQuery expectedQuery = expectedQueries[i];
 
+            long before = persons.getLocalMapStats().getIndexStats().values().iterator().next().getQueryCount();
             Set<Map.Entry<Long, Person>> entries = persons.entrySet(actualQuery);
+            long after = persons.getLocalMapStats().getIndexStats().values().iterator().next().getQueryCount();
+            assertEquals(1, after - before);
             expectedQuery.verify(entries);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.in;
+import static com.hazelcast.query.Predicates.notEqual;
+import static com.hazelcast.query.Predicates.or;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SingleValueBitmapIndexTest extends HazelcastTestSupport {
+
+    private static final int BATCH_SIZE = 1000;
+    private static final int BATCH_COUNT = 10;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> parameters() {
+        // @formatter:off
+        return asList(new Object[][]{
+                {"age -> __key"},
+                {"age -> stringId"},
+                {"age -> __key!"},
+                {"age -> __key?"}
+        });
+        // @formatter:on
+    }
+
+    private static final Predicate[] actualQueries;
+
+    static {
+        actualQueries = new Predicate[8];
+        actualQueries[0] = equal("age", new Age(0));
+        actualQueries[1] = equal("age", null);
+        actualQueries[2] = notEqual("age", null);
+        actualQueries[3] = notEqual("age", new Age(1));
+        actualQueries[4] = equal("age", new Age(50));
+        actualQueries[5] = and(equal("age", new Age(50)), notEqual("age", new Age(99)));
+        actualQueries[6] = or(equal("age", new Age(50)), equal("age", new Age(99)));
+        actualQueries[7] = or(equal("age", new Age(5)), in("age", new Age(10), null));
+    }
+
+    private final ExpectedQuery[] expectedQueries;
+
+    {
+        expectedQueries = new ExpectedQuery[8];
+        expectedQueries[0] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                // no zero values at all, they are all nulls
+                return false;
+            }
+        });
+        expectedQueries[1] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                return value == 0;
+            }
+        });
+        expectedQueries[2] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                return value != 0;
+            }
+        });
+        expectedQueries[3] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                return value != 1;
+            }
+        });
+        expectedQueries[4] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                return value == 50;
+            }
+        });
+        expectedQueries[5] = new ExpectedQuery(new IntPredicate() {
+            @SuppressWarnings({"ExcessiveRangeCheck", "ConstantConditions"})
+            @Override
+            public boolean test(int value) {
+                return value == 50 && value != 99;
+            }
+        });
+        expectedQueries[6] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                return value == 50 || value == 99;
+            }
+        });
+        expectedQueries[7] = new ExpectedQuery(new IntPredicate() {
+            @Override
+            public boolean test(int value) {
+                return value == 5 || value == 10 || value == 0;
+            }
+        });
+    }
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Parameter
+    public String indexDefinition;
+
+    private IMap<Long, Person> persons;
+
+    @Before
+    public void before() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
+        persons = instance.getMap("persons");
+        factory.newHazelcastInstance(getConfig());
+    }
+
+    @Test
+    public void testConsecutiveQueries() {
+        for (int i = BATCH_COUNT - 1; i >= 0; --i) {
+            for (long j = 0; j < BATCH_SIZE; ++j) {
+                long id = i * BATCH_SIZE + j;
+                put(id, (int) id);
+            }
+            verifyQueries();
+        }
+
+        for (int i = 0; i < BATCH_COUNT; ++i) {
+            for (long j = 0; j < BATCH_SIZE; ++j) {
+                long id = i * BATCH_SIZE + j;
+                if (i % 2 == 0) {
+                    put(id, (int) id + 1);
+                } else {
+                    remove(id);
+                }
+            }
+            verifyQueries();
+        }
+
+        clear();
+        verifyQueries();
+    }
+
+    @Test
+    public void testRandomQueries() {
+        long seed = System.nanoTime();
+        System.out.println(testName.getMethodName() + " seed: " + seed);
+        Random random = new Random(seed);
+
+        for (int i = 0; i < BATCH_COUNT; ++i) {
+            for (int j = 0; j < BATCH_SIZE; ++j) {
+                long id = random.nextInt(i * BATCH_SIZE + j + 1);
+                put(id, (int) id);
+            }
+            verifyQueries();
+        }
+
+        random = new Random(seed);
+        for (int i = 0; i < BATCH_COUNT; ++i) {
+            for (int j = 0; j < BATCH_SIZE; ++j) {
+                long id = random.nextInt(i * BATCH_SIZE + j + 1);
+                if (i % 2 == 0) {
+                    put(id, (int) id + 1);
+                } else {
+                    remove(id);
+                }
+            }
+            verifyQueries();
+        }
+
+        clear();
+        verifyQueries();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = HazelcastTestSupport.smallInstanceConfig();
+        MapConfig mapConfig = config.getMapConfig("persons");
+        mapConfig.addMapIndexConfig(new MapIndexConfig(indexDefinition, false));
+        return config;
+    }
+
+    private void put(long id, int age) {
+        age = age % 100;
+        Person person = new Person(id, age == 0 ? null : age);
+        persons.put(id, person);
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.put(id, person, age);
+        }
+    }
+
+    private void remove(long id) {
+        persons.remove(id);
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.remove(id);
+        }
+    }
+
+    private void clear() {
+        persons.clear();
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.clear();
+        }
+    }
+
+    private void verifyQueries() {
+        for (int i = 0; i < actualQueries.length; ++i) {
+            Predicate actualQuery = actualQueries[i];
+            ExpectedQuery expectedQuery = expectedQueries[i];
+
+            Set<Map.Entry<Long, Person>> entries = persons.entrySet(actualQuery);
+            expectedQuery.verify(entries);
+        }
+    }
+
+    public static class Person implements DataSerializable {
+
+        public long id;
+
+        public Age age;
+
+        public String stringId;
+
+        public Person(long id, Integer age) {
+            this.id = id;
+            this.age = age == null ? null : new Age(age);
+            this.stringId = Long.toString(id);
+        }
+
+        public Person() {
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Person person = (Person) o;
+
+            if (id != person.id) {
+                return false;
+            }
+            if (age != null ? !age.equals(person.age) : person.age != null) {
+                return false;
+            }
+            return stringId.equals(person.stringId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (id ^ (id >>> 32));
+            result = 31 * result + (age != null ? age.hashCode() : 0);
+            result = 31 * result + stringId.hashCode();
+            return result;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeLong(id);
+            out.writeUTF(stringId);
+            out.writeObject(age);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            id = in.readLong();
+            stringId = in.readUTF();
+            age = in.readObject();
+        }
+
+        @Override
+        public String toString() {
+            return "Person{id=" + id + "}";
+        }
+
+    }
+
+    private interface IntPredicate {
+
+        boolean test(int value);
+
+    }
+
+    private static class ExpectedQuery {
+
+        private final IntPredicate predicate;
+        private final Map<Long, Person> result = new HashMap<Long, Person>();
+
+        ExpectedQuery(IntPredicate predicate) {
+            this.predicate = predicate;
+        }
+
+        public void put(long id, Person person, int age) {
+            result.remove(id);
+            if (predicate.test(age)) {
+                result.put(id, person);
+            }
+        }
+
+        public void remove(long id) {
+            result.remove(id);
+        }
+
+        public void verify(Set<Map.Entry<Long, Person>> actual) {
+            assertEquals(result.size(), actual.size());
+            for (Map.Entry<Long, Person> actualEntry : actual) {
+                Person person = result.get(actualEntry.getKey());
+                assertEquals(person, actualEntry.getValue());
+            }
+        }
+
+        public void clear() {
+            result.clear();
+        }
+
+    }
+
+    public static class Age implements Serializable, Comparable<Age> {
+
+        private final int age;
+
+        public Age(int age) {
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Age that = (Age) o;
+
+            return age == that.age;
+        }
+
+        @Override
+        public int hashCode() {
+            return age;
+        }
+
+        @Override
+        public String toString() {
+            return "Age{" + "age=" + age + '}';
+        }
+
+        @Override
+        public int compareTo(Age o) {
+            return age - o.age;
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
@@ -69,10 +69,11 @@ public class SingleValueBitmapIndexTest extends HazelcastTestSupport {
     public static Collection<Object[]> parameters() {
         // @formatter:off
         return asList(new Object[][]{
-                {"age -> __key"},
-                {"age -> stringId"},
-                {"age -> __key!"},
-                {"age -> __key?"}
+                {"BITMAP(age)"},
+                {"BITMAP(age, stringId)"},
+                {"BITMAP(age, stringId, OBJECT)"},
+                {"BITMAP(age, __key, RAW)"},
+                {"BITMAP(age, __key, LONG)"}
         });
         // @formatter:on
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AttributeIndexRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AttributeIndexRegistryTest.java
@@ -193,7 +193,7 @@ public class AttributeIndexRegistryTest {
         InternalIndex index = Mockito.mock(InternalIndex.class);
         if (components.length == 1) {
             when(index.getName()).thenReturn(components[0]);
-            when(index.getComponents()).thenReturn(null);
+            when(index.getComponents()).thenReturn(components);
         } else {
             when(index.getName()).thenReturn(PredicateUtils.constructCanonicalCompositeIndexName(components));
             when(index.getComponents()).thenReturn(components);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
@@ -43,11 +43,10 @@ public class IndexFirstComponentDecoratorTest {
     public void before() {
         serializationService = new DefaultSerializationServiceBuilder().build();
         Extractors extractors = Extractors.newBuilder(serializationService).build();
-        expected = new IndexImpl("this", null, true, serializationService, extractors, IndexCopyBehavior.COPY_ON_READ,
-                PerIndexStats.EMPTY);
-        InternalIndex compositeIndex =
-                new IndexImpl("this, __key", new String[]{"this", "__key"}, true, serializationService, extractors,
-                        IndexCopyBehavior.COPY_ON_READ, PerIndexStats.EMPTY);
+        expected = new IndexImpl(IndexDefinition.parse("this", true), serializationService, extractors,
+                IndexCopyBehavior.COPY_ON_READ, PerIndexStats.EMPTY);
+        InternalIndex compositeIndex = new IndexImpl(IndexDefinition.parse("this, __key", true), serializationService, extractors,
+                IndexCopyBehavior.COPY_ON_READ, PerIndexStats.EMPTY);
         actual = new AttributeIndexRegistry.FirstComponentDecorator(compositeIndex);
 
         for (int i = 0; i < 100; ++i) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -45,7 +45,7 @@ public class IndexImplTest {
     public void setUp() {
         InternalSerializationService mockSerializationService = mock(InternalSerializationService.class);
         Extractors mockExtractors = Extractors.newBuilder(mockSerializationService).build();
-        index = new IndexImpl(ATTRIBUTE_NAME, null, false, mockSerializationService, mockExtractors,
+        index = new IndexImpl(IndexDefinition.parse(ATTRIBUTE_NAME, false), mockSerializationService, mockExtractors,
                 IndexCopyBehavior.COPY_ON_READ, PerIndexStats.EMPTY);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -465,8 +465,8 @@ public class IndexTest {
 
     private void testIt(boolean ordered) {
         IndexImpl index =
-                new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), null, ordered, ss, newExtractor(), copyBehavior,
-                        PerIndexStats.EMPTY);
+                new IndexImpl(IndexDefinition.parse(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered), ss, newExtractor(),
+                        copyBehavior, PerIndexStats.EMPTY);
         assertEquals(0, index.getRecords(0L).size());
         assertEquals(0, index.getRecords(0L, true, 1000L, true).size());
         QueryRecord record5 = newRecord(5L, 55L);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithmsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapAlgorithmsTest.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BitmapAlgorithmsTest {
+
+    private final List<SparseBitSet> actual = new ArrayList<SparseBitSet>();
+    private final List<TreeSet<Long>> expected = new ArrayList<TreeSet<Long>>();
+
+    private final SparseArray<Long> actualUniverse = new SparseArray<Long>();
+    private final TreeSet<Long> expectedUniverse = new TreeSet<Long>();
+
+    @Test
+    public void testAnd() {
+        long seed = System.nanoTime();
+        System.out.println(getClass().getSimpleName() + ".testAnd seed: " + seed);
+
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyAnd();
+        actual.clear();
+        expected.clear();
+
+        generate(0, 100, 1);
+        verifyAnd();
+
+        generate(100, 100, 1);
+        verifyAnd();
+
+        generate(0, 75000, 1);
+        verifyAnd();
+
+        generate(100, 40000, 2);
+        verifyAnd();
+
+        generate(200, 30000, 3);
+        verifyAnd();
+
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyAnd();
+        actual.remove(actual.size() - 1);
+        expected.remove(expected.size() - 1);
+
+        generate(2000000, 30000, 3);
+        verifyAnd();
+        actual.remove(actual.size() - 1);
+        expected.remove(expected.size() - 1);
+
+        generateRandom(seed, 10000, 50000);
+        verifyAnd();
+
+        generateRandom(seed, 500000, -1);
+        verifyAnd();
+    }
+
+    @Test
+    public void testOr() {
+        long seed = System.nanoTime();
+        System.out.println(getClass().getSimpleName() + ".testOr seed: " + seed);
+
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyOr();
+        actual.clear();
+        expected.clear();
+
+        generate(0, 75000, 1);
+        verifyOr();
+
+        generate(100, 40000, 2);
+        verifyOr();
+
+        generate(200, 30000, 3);
+        verifyOr();
+
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyOr();
+        actual.remove(actual.size() - 1);
+        expected.remove(expected.size() - 1);
+
+        generate(2000000, 30000, 3);
+        verifyOr();
+        actual.remove(actual.size() - 1);
+        expected.remove(expected.size() - 1);
+
+        generateRandom(seed, 10000, 50000);
+        verifyOr();
+
+        generateRandom(seed, 20000, -1);
+        verifyOr();
+
+        actual.clear();
+        expected.clear();
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyOr();
+
+        generateRandom(seed, 40000, 100000);
+        verifyOr();
+
+        generateRandom(seed, 40000, 100000);
+        verifyOr();
+
+        generateRandom(seed, 500000, -1);
+        verifyOr();
+    }
+
+    @Test
+    public void testNot() {
+        long seed = System.nanoTime();
+        System.out.println(getClass().getSimpleName() + ".testNot seed: " + seed);
+
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyNotAndThenClear();
+
+        generateUniverse(0, 75000, 1);
+        actual.add(new SparseBitSet());
+        expected.add(new TreeSet<Long>());
+        verifyNotAndThenClear();
+
+        generateUniverse(0, 70000, 1);
+        generate(0, 70000, 1);
+        verifyNotAndThenClear();
+
+        generateUniverse(0, 70000, 2);
+        generate(0, 70000, 1);
+        verifyNotAndThenClear();
+
+        generateUniverse(100, 75000, 1);
+        generateRandom(seed, 50000, 100000);
+        verifyNotAndThenClear();
+
+        generateUniverse(100, 75000, 2);
+        generateRandom(seed, 50000, 100000);
+        verifyNotAndThenClear();
+
+        generateRandomUniverse(seed, 60000, 100000);
+        generateRandom(seed, 60000, 100000);
+        verifyNotAndThenClear();
+
+        generateRandomUniverse(seed, 40000, 100000);
+        generateRandom(seed, 40000, -1);
+        verifyNotAndThenClear();
+
+        generateRandomUniverse(seed, 75000, -1);
+        generateRandom(seed, 75000, -1);
+        verifyNotAndThenClear();
+
+        generateRandomUniverse(seed, 1000, -1);
+        generateRandom(seed, 1000, -1);
+        actual.get(0).add(Long.MAX_VALUE);
+        expected.get(0).add(Long.MAX_VALUE);
+        verifyNotAndThenClear();
+
+        generateRandomUniverse(seed, 2000, -1);
+        generateRandom(seed, 2000, -1);
+        actual.get(0).add(Long.MAX_VALUE - 1);
+        actual.get(0).add(Long.MAX_VALUE);
+        expected.get(0).add(Long.MAX_VALUE - 1);
+        expected.get(0).add(Long.MAX_VALUE);
+        verifyNotAndThenClear();
+
+        generateRandomUniverse(seed, 500000, -1);
+        generateRandom(seed, 500000, -1);
+        actual.get(0).add(Long.MAX_VALUE - 2);
+        actual.get(0).add(Long.MAX_VALUE - 1);
+        actual.get(0).add(Long.MAX_VALUE);
+        expected.get(0).add(Long.MAX_VALUE - 2);
+        expected.get(0).add(Long.MAX_VALUE - 1);
+        expected.get(0).add(Long.MAX_VALUE);
+        verifyNotAndThenClear();
+    }
+
+    private void verifyAnd() {
+        assert !actual.isEmpty();
+        assert !expected.isEmpty();
+
+        TreeSet<Long> expectedResult = null;
+        for (TreeSet<Long> expectedSet : expected) {
+            if (expectedResult == null) {
+                expectedResult = new TreeSet<Long>(expectedSet);
+            } else {
+                expectedResult.retainAll(expectedSet);
+            }
+        }
+
+        verify(BitmapAlgorithms.and(actualIterators()), expectedResult);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, 1);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, 2);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, 5);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.and(actualIterators()), expectedResult, Long.MAX_VALUE);
+    }
+
+    private void verifyOr() {
+        assert !actual.isEmpty();
+        assert !expected.isEmpty();
+
+        TreeSet<Long> expectedResult = null;
+        for (TreeSet<Long> expectedSet : expected) {
+            if (expectedResult == null) {
+                expectedResult = new TreeSet<Long>(expectedSet);
+            } else {
+                expectedResult.addAll(expectedSet);
+            }
+        }
+
+        verify(BitmapAlgorithms.or(actualIterators()), expectedResult);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, 1);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, 2);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, 5);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.or(actualIterators()), expectedResult, Long.MAX_VALUE);
+    }
+
+    private void verifyNotAndThenClear() {
+        assert actual.size() == 1;
+        assert expected.size() == 1;
+
+        SparseBitSet actual = this.actual.get(0);
+        TreeSet<Long> expected = this.expected.get(0);
+
+        AscendingLongIterator actualIterator = actual.iterator();
+        for (long i = actualIterator.advance(); i != AscendingLongIterator.END; i = actualIterator.advance()) {
+            actualUniverse.set(i, i);
+        }
+        expectedUniverse.addAll(expected);
+
+        TreeSet<Long> expectedResult = new TreeSet<Long>(expectedUniverse);
+        expectedResult.removeAll(expected);
+
+        verify(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, 1);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, 2);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, 5);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(BitmapAlgorithms.not(actual.iterator(), actualUniverse), expectedResult, Long.MAX_VALUE);
+
+        this.actual.clear();
+        this.expected.clear();
+        actualUniverse.clear();
+        expectedUniverse.clear();
+    }
+
+    private AscendingLongIterator[] actualIterators() {
+        AscendingLongIterator[] actualIterators = new AscendingLongIterator[actual.size()];
+        for (int i = 0; i < actual.size(); ++i) {
+            actualIterators[i] = actual.get(i).iterator();
+        }
+        return actualIterators;
+    }
+
+    private void generate(long offset, long count, long step) {
+        SparseBitSet actual = new SparseBitSet();
+        TreeSet<Long> expected = new TreeSet<Long>();
+        for (long i = 0; i < count; ++i) {
+            long index = offset + i * step;
+            actual.add(index);
+            expected.add(index);
+        }
+
+        verify(actual.iterator(), expected);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, 1);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, 5);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Long.MAX_VALUE);
+
+        this.actual.add(actual);
+        this.expected.add(expected);
+    }
+
+    private void generateRandom(long seed, int count, long range) {
+        Random random = new Random(seed);
+        if (range == -1) {
+            range = random.nextLong() & Long.MAX_VALUE;
+        }
+
+        SparseBitSet actual = new SparseBitSet();
+        TreeSet<Long> expected = new TreeSet<Long>();
+        if (range != 0) {
+            for (int i = 0; i < count; ++i) {
+                long member = (random.nextLong() & Long.MAX_VALUE) % range;
+                actual.add(member);
+                expected.add(member);
+            }
+        }
+
+        verify(actual.iterator(), expected);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, 1);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, 5);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), expected, Long.MAX_VALUE);
+
+        this.actual.add(actual);
+        this.expected.add(expected);
+    }
+
+    private void generateUniverse(long offset, long count, long step) {
+        for (long i = 0; i < count; ++i) {
+            long index = offset + i * step;
+            actualUniverse.set(index, index);
+            expectedUniverse.add(index);
+        }
+
+        verify(actualUniverse.iterator(), expectedUniverse);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, 1);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, 2);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, 5);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Long.MAX_VALUE);
+    }
+
+    private void generateRandomUniverse(long seed, int count, long range) {
+        Random random = new Random(seed);
+        if (range == -1) {
+            range = random.nextLong() & Long.MAX_VALUE;
+        }
+
+        if (range != 0) {
+            for (int i = 0; i < count; ++i) {
+                long member = (random.nextLong() & Long.MAX_VALUE) % range;
+                actualUniverse.set(member, member);
+                expectedUniverse.add(member);
+            }
+        }
+
+        verify(actualUniverse.iterator(), expectedUniverse);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, 1);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, 2);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, 5);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(actualUniverse.iterator(), expectedUniverse, Long.MAX_VALUE);
+    }
+
+    private void verify(AscendingLongIterator actual, SortedSet<Long> expected) {
+        long actualIndex = actual.getIndex();
+        long actualCurrent = actual.advance();
+        for (Long expectedIndex : expected) {
+            assertEquals(actualCurrent, actualIndex);
+            assertEquals((long) expectedIndex, actualCurrent);
+            actualIndex = actual.getIndex();
+            actualCurrent = actual.advance();
+        }
+        assertEquals(actualCurrent, actualIndex);
+        assertEquals(AscendingLongIterator.END, actualCurrent);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void verifyAdvanceAtLeastTo(AscendingLongIterator actual, TreeSet<Long> expected, long step) {
+        long actualPrevious = AscendingLongIterator.END;
+        long actualCurrent = actual.advanceAtLeastTo(step);
+        long actualIndex = actual.getIndex();
+
+        while (actualCurrent != AscendingLongIterator.END) {
+            long expectedIndex;
+            if (actualPrevious == AscendingLongIterator.END) {
+                expectedIndex = expected.ceiling(step);
+            } else {
+                expectedIndex = expected.ceiling(actualPrevious + step);
+            }
+            assertEquals(actualCurrent, actualIndex);
+            assertEquals(expectedIndex, actualIndex);
+
+            actualPrevious = actualCurrent;
+            if (actualCurrent <= Long.MAX_VALUE - step) {
+                actualCurrent = actual.advanceAtLeastTo(actualCurrent + step);
+                actualIndex = actual.getIndex();
+            } else {
+                break;
+            }
+        }
+
+        assertEquals(actualCurrent, actualIndex);
+        if (actualPrevious == AscendingLongIterator.END) {
+            assertNull(expected.ceiling(step));
+        } else if (actualCurrent == AscendingLongIterator.END) {
+            assertNull(expected.ceiling(actualPrevious + step));
+        } else {
+            verify(actual, expected.tailSet(actualCurrent));
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexInsertBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexInsertBenchmark.java
@@ -58,7 +58,7 @@ public class BitmapIndexInsertBenchmark {
 
         MapConfig personsBitmapConfig = config.getMapConfig("personsBitmap");
         personsBitmapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
-        personsBitmapConfig.addMapIndexConfig(new MapIndexConfig("habits[any] -> __key!", false));
+        personsBitmapConfig.addMapIndexConfig(new MapIndexConfig("BITMAP(habits[any], __key, RAW)", false));
 
         MapConfig personsHashConfig = config.getMapConfig("personsHash");
         personsHashConfig.setInMemoryFormat(InMemoryFormat.OBJECT);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexInsertBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexInsertBenchmark.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.io.Serializable;
+import java.util.Random;
+
+@State(Scope.Benchmark)
+public class BitmapIndexInsertBenchmark {
+
+    private static final int HABITS = 2500;
+    private static final int DOMAIN = 25000;
+
+    private final Random random = new Random(303);
+
+    private HazelcastInstance instance;
+    private IMap<Integer, Person> personsBitmap;
+    private IMap<Integer, Person> personsHash;
+
+    private int index;
+
+    @Setup
+    public void setup() {
+        Config config = new Config();
+
+        MapConfig personsBitmapConfig = config.getMapConfig("personsBitmap");
+        personsBitmapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        personsBitmapConfig.addMapIndexConfig(new MapIndexConfig("habits[any] -> __key!", false));
+
+        MapConfig personsHashConfig = config.getMapConfig("personsHash");
+        personsHashConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        personsHashConfig.addMapIndexConfig(new MapIndexConfig("habits[any]", false));
+
+        instance = Hazelcast.newHazelcastInstance(config);
+
+        personsBitmap = instance.getMap("personsBitmap");
+        personsHash = instance.getMap("personsHash");
+    }
+
+    @TearDown
+    public void tearDown() {
+        instance.shutdown();
+    }
+
+    @Benchmark
+    public void bitmapInsert() {
+        int[] habits = new int[HABITS];
+        for (int j = 0; j < HABITS; ++j) {
+            habits[j] = random.nextInt(DOMAIN);
+        }
+        Person person = new Person(habits);
+        personsBitmap.put(index, person);
+        ++index;
+    }
+
+    @Benchmark
+    public void hashInsert() {
+        int[] habits = new int[HABITS];
+        for (int j = 0; j < HABITS; ++j) {
+            habits[j] = random.nextInt(DOMAIN);
+        }
+        Person person = new Person(habits);
+        personsHash.put(index, person);
+        ++index;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        // @formatter:off
+        Options opt = new OptionsBuilder()
+                .include(BitmapIndexInsertBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(20)
+                .measurementTime(TimeValue.seconds(1))
+                .forks(1)
+                .threads(1)
+                .addProfiler(GCProfiler.class)
+                .jvmArgsAppend("-Xmx16g")
+                .build();
+        // @formatter:on
+
+        new Runner(opt).run();
+    }
+
+    public static class Person implements Serializable {
+
+        private final int[] habits;
+
+        public Person(int[] habits) {
+            this.habits = habits;
+        }
+
+        @SuppressWarnings("unused")
+        public int[] getHabits() {
+            return habits;
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexQueriesBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexQueriesBenchmark.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicates;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.io.Serializable;
+import java.util.Random;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.not;
+import static com.hazelcast.query.Predicates.or;
+
+@State(Scope.Benchmark)
+public class BitmapIndexQueriesBenchmark {
+
+    private static final int SIZE = 1000;
+    private static final int HABITS = 5000;
+    private static final int DOMAIN = 25000;
+
+    private final Random random = new Random(303);
+    private HazelcastInstance instance;
+    private IMap<Integer, Person> personsBitmap;
+    private IMap<Integer, Person> personsHash;
+
+    @Setup
+    public void setup() {
+        Config config = new Config();
+
+        MapConfig personsBitmapConfig = config.getMapConfig("personsBitmap");
+        personsBitmapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        personsBitmapConfig.addMapIndexConfig(new MapIndexConfig("habits[any] -> __key!", false));
+
+        MapConfig personsHashConfig = config.getMapConfig("personsHash");
+        personsHashConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        personsHashConfig.addMapIndexConfig(new MapIndexConfig("habits[any]", false));
+
+        instance = Hazelcast.newHazelcastInstance(config);
+
+        personsBitmap = instance.getMap("personsBitmap");
+        personsHash = instance.getMap("personsHash");
+
+        for (int i = 0; i < SIZE; ++i) {
+            int[] habits = new int[HABITS];
+            for (int j = 0; j < HABITS; ++j) {
+                habits[j] = random.nextInt(DOMAIN);
+            }
+            Person person = new Person(habits);
+            personsBitmap.put(i, person);
+            personsHash.put(i, person);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        instance.shutdown();
+    }
+
+    @Benchmark
+    public void bitmapQueriesEqual() {
+        personsBitmap.entrySet(equal("habits[any]", random.nextInt(DOMAIN)));
+    }
+
+    @Benchmark
+    public void hashQueriesEqual() {
+        personsHash.entrySet(Predicates.equal("habits[any]", random.nextInt(DOMAIN)));
+    }
+
+    @Benchmark
+    public void bitmapQueriesAnd() {
+        personsBitmap.entrySet(and(equal("habits[any]", random.nextInt(DOMAIN)), equal("habits[any]", random.nextInt(DOMAIN))));
+    }
+
+    @Benchmark
+    public void hashQueriesAnd() {
+        personsHash.entrySet(and(equal("habits[any]", random.nextInt(DOMAIN)), equal("habits[any]", random.nextInt(DOMAIN))));
+    }
+
+    @Benchmark
+    public void bitmapQueriesOr() {
+        personsBitmap.entrySet(or(equal("habits[any]", random.nextInt(DOMAIN)), equal("habits[any]", random.nextInt(DOMAIN))));
+    }
+
+    @Benchmark
+    public void hashQueriesOr() {
+        personsHash.entrySet(or(equal("habits[any]", random.nextInt(DOMAIN)), equal("habits[any]", random.nextInt(DOMAIN))));
+    }
+
+    @Benchmark
+    public void bitmapQueriesNot() {
+        personsBitmap.entrySet(not(equal("habits[any]", random.nextInt(DOMAIN))));
+    }
+
+    @Benchmark
+    public void hashQueriesNot() {
+        personsHash.entrySet(not(equal("habits[any]", random.nextInt(DOMAIN))));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        // @formatter:off
+        Options opt = new OptionsBuilder()
+                .include(BitmapIndexQueriesBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(10)
+                .measurementTime(TimeValue.seconds(1))
+                .forks(1)
+                .threads(1)
+                .jvmArgsAppend("-Xmx16g")
+                .build();
+        // @formatter:on
+
+        new Runner(opt).run();
+    }
+
+    public static class Person implements Serializable {
+
+        private final int[] habits;
+
+        public Person(int[] habits) {
+            this.habits = habits;
+        }
+
+        @SuppressWarnings("unused")
+        public int[] getHabits() {
+            return habits;
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexQueriesBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapIndexQueriesBenchmark.java
@@ -61,7 +61,7 @@ public class BitmapIndexQueriesBenchmark {
 
         MapConfig personsBitmapConfig = config.getMapConfig("personsBitmap");
         personsBitmapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
-        personsBitmapConfig.addMapIndexConfig(new MapIndexConfig("habits[any] -> __key!", false));
+        personsBitmapConfig.addMapIndexConfig(new MapIndexConfig("BITMAP(habits[any], __key, RAW)", false));
 
         MapConfig personsHashConfig = config.getMapConfig("personsHash");
         personsHashConfig.setInMemoryFormat(InMemoryFormat.OBJECT);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/BitmapTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.in;
+import static com.hazelcast.query.Predicates.not;
+import static com.hazelcast.query.Predicates.notEqual;
+import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BitmapTest {
+
+    private static final long COUNT = 1000;
+
+    private static final Predicate[] actualQueries;
+
+    static {
+        actualQueries = new Predicate[10];
+        actualQueries[0] = notEqual("a", "0");
+        actualQueries[1] = equal("a", 1L);
+        actualQueries[2] = equal("a", 2);
+        actualQueries[3] = or(equal("a", 1L), equal("a", 2));
+        actualQueries[4] = in("a", 3, 4);
+        actualQueries[5] = not(in("a", 3, "4"));
+
+        // all together
+        actualQueries[6] = and(notEqual("a", "0"), or(equal("a", 1L), equal("a", 2)), not(in("a", 3, "4")));
+
+        // negate the previous one
+        actualQueries[7] = not(and(notEqual("a", "0"), or(equal("a", 1L), equal("a", 2)), not(in("a", 3, "4"))));
+
+        // single-predicate and/or
+        actualQueries[8] = or(equal("a", 1.0D));
+        actualQueries[9] = and(equal("a", 1.0F));
+    }
+
+    private final ExpectedQuery[] expectedQueries;
+
+    {
+        expectedQueries = new ExpectedQuery[10];
+        expectedQueries[0] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !bit(0, value);
+            }
+        });
+        expectedQueries[1] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value);
+            }
+        });
+        expectedQueries[2] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(2, value);
+            }
+        });
+        expectedQueries[3] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value) || bit(2, value);
+            }
+        });
+        expectedQueries[4] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(3, value) || bit(4, value);
+            }
+        });
+        expectedQueries[5] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !(bit(3, value) || bit(4, value));
+            }
+        });
+        expectedQueries[6] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !bit(0, value) && (bit(1, value) || bit(2, value)) && !(bit(3, value) || bit(4, value));
+            }
+        });
+        expectedQueries[7] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return !(!bit(0, value) && (bit(1, value) || bit(2, value)) && !(bit(3, value) || bit(4, value)));
+            }
+        });
+        expectedQueries[8] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value);
+            }
+        });
+        expectedQueries[9] = new ExpectedQuery(new LongPredicate() {
+            @Override
+            public boolean test(long value) {
+                return bit(1, value);
+            }
+        });
+    }
+
+    private final Bitmap<String> bitmap = new Bitmap<String>();
+
+    @Test
+    public void testInsertUpdateRemove() {
+        // insert
+        for (long i = 0; i < COUNT; ++i) {
+            insert(i, i);
+            verify();
+        }
+        // update inserted
+        for (long i = 0; i < COUNT; ++i) {
+            update(i, i, i + 1);
+            verify();
+        }
+        // update some nonexistent records
+        for (long i = COUNT; i < COUNT * 2; ++i) {
+            update(i, i, i + 1);
+            verify();
+        }
+        // remove existed updated records
+        for (long i = 0; i < COUNT; ++i) {
+            remove(i, i + 1);
+            verify();
+        }
+        // remove some nonexistent records
+        for (long i = COUNT * 3; i < COUNT * 4; ++i) {
+            remove(i, i);
+            verify();
+        }
+        // remove nonexistent "updated" records
+        for (long i = COUNT; i < COUNT * 2; ++i) {
+            remove(i, i + 1);
+            verify();
+        }
+    }
+
+    @Test
+    public void testClear() {
+        // insert
+        for (long i = 0; i < COUNT; ++i) {
+            insert(i, i);
+            verify();
+        }
+        clear();
+        verify();
+
+        // reinsert
+        for (long i = 0; i < COUNT; ++i) {
+            insert(i, i);
+            verify();
+        }
+        clear();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnexpectedPredicate() {
+        bitmap.evaluate(Predicates.like("a", "b"), INTEGER_CONVERTER);
+    }
+
+    private void insert(long key, long value) {
+        bitmap.insert(values(value), key, Long.toString(key));
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.insert(key, value);
+        }
+    }
+
+    private void update(long key, long oldValue, long newValue) {
+        bitmap.update(values(oldValue), values(newValue), key, Long.toString(key));
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.update(key, oldValue, newValue);
+        }
+    }
+
+    private void remove(long key, long value) {
+        bitmap.remove(values(value), key);
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.remove(key, value);
+        }
+    }
+
+    private void clear() {
+        bitmap.clear();
+        for (ExpectedQuery expectedQuery : expectedQueries) {
+            expectedQuery.clear();
+        }
+    }
+
+    private void verify() {
+        for (int i = 0; i < actualQueries.length; ++i) {
+            Predicate actualQuery = actualQueries[i];
+            ExpectedQuery expectedQuery = expectedQueries[i];
+
+            Iterator<String> actualResult = bitmap.evaluate(actualQuery, INTEGER_CONVERTER);
+            expectedQuery.verify(actualResult);
+        }
+    }
+
+    private static Iterator<Integer> values(long key) {
+        List<Integer> values = new ArrayList<Integer>(Long.SIZE);
+        for (int i = 0; i < Long.SIZE; ++i) {
+            if ((key & 1L << i) != 0) {
+                values.add(i);
+            }
+        }
+        return values.iterator();
+    }
+
+    private static boolean bit(int bit, long value) {
+        return (value & 1L << bit) != 0;
+    }
+
+    private interface LongPredicate {
+
+        boolean test(long value);
+
+    }
+
+    private static class ExpectedQuery {
+
+        private final LongPredicate predicate;
+        private final SortedSet<Long> result = new TreeSet<Long>();
+
+        public ExpectedQuery(LongPredicate predicate) {
+            this.predicate = predicate;
+        }
+
+        public void insert(long key, long value) {
+            if (predicate.test(value)) {
+                result.add(key);
+            }
+        }
+
+        public void update(long key, long oldValue, long newValue) {
+            // not really needed, just to harden the test
+            if (predicate.test(oldValue)) {
+                result.remove(key);
+            }
+
+            if (predicate.test(newValue)) {
+                result.add(key);
+            }
+        }
+
+        public void remove(long key, long value) {
+            // not really needed, just to harden the test
+            if (predicate.test(value)) {
+                result.remove(key);
+            }
+        }
+
+        public void clear() {
+            result.clear();
+        }
+
+        public void verify(Iterator<String> actualResult) {
+            Iterator<Long> expectedResult = result.iterator();
+            while (actualResult.hasNext()) {
+                long expected = expectedResult.next();
+                long actual = Long.parseLong(actualResult.next());
+                assertEquals(expected, actual);
+            }
+            assertFalse(expectedResult.hasNext());
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseArrayTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseArrayTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SparseArrayTest {
+
+    private final NavigableMap<Long, Long> expected = new TreeMap<Long, Long>();
+    private final SparseArray<Long> actual = new SparseArray<Long>();
+
+    @Test
+    public void testSet() {
+        // try empty array
+        verify();
+
+        // at the beginning
+        for (long i = 0; i < 1000; ++i) {
+            set(i);
+            verify();
+            set(i, 100 + i);
+            verify();
+        }
+
+        // offset
+        for (long i = 1000000; i < 1000000 + 1000; ++i) {
+            set(i);
+            verify();
+            set(i, 100 + i);
+            verify();
+        }
+
+        // clear everything we have added
+        for (long i = 0; i < 1000; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = 1000000; i < 1000000 + 1000; ++i) {
+            clear(i);
+            verify();
+        }
+
+        // test empty again
+        verify();
+
+        // try gaps
+        for (long i = 0; i < 1000; ++i) {
+            set(i * i);
+            verify();
+            set(i * i, 100 + i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+            verify();
+            set(i * i, 100 + i * i);
+            verify();
+        }
+
+        // try some edge cases
+        for (long i = 0; i <= 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testClear() {
+        // try to clear empty array
+        actual.clear();
+        verify();
+
+        // at the beginning
+        for (long i = 0; i < 1000; ++i) {
+            set(i);
+        }
+        for (long i = 0; i < 1000 + 100; ++i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+
+        // offset
+        for (long i = 1000000; i < 1000000 + 1000; ++i) {
+            set(i);
+        }
+        for (long i = 1000000 + 1000 + 100; i >= 1000000; --i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+
+        // test empty again
+        actual.clear();
+        verify();
+
+        // try gaps
+        for (long i = 0; i < 1000; ++i) {
+            set(i * i);
+        }
+        for (long i = 0; i < 1000; ++i) {
+            clear(i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+        }
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            clear(i * i);
+            verify();
+        }
+
+        // try larger 2-element gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+            set(i * i - 1);
+        }
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            clear(i * i);
+            verify();
+            clear(i * i - 1);
+            verify();
+        }
+
+        // try some edge cases
+        for (long i = 0; i <= 2; ++i) {
+            set(i);
+        }
+        for (long i = 0; i <= 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set(i);
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            set(i);
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            clear(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testIteratorAdvanceAtLeastTo() {
+        // try empty array
+        verifyAdvanceAtLeastTo();
+
+        // at the beginning
+        for (long i = 0; i < 1000; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+            set(i, 100 + i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // offset
+        for (long i = 1000000; i < 1000000 + 1000; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+            set(i, 100 + i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // clear everything we have added
+        for (long i = 0; i < 1000; ++i) {
+            clear(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = 1000000; i < 1000000 + 1000; ++i) {
+            clear(i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // test empty again
+        verifyAdvanceAtLeastTo();
+
+        // try gaps
+        for (long i = 0; i < 1000; ++i) {
+            set(i * i);
+            verifyAdvanceAtLeastTo();
+            set(i * i, 100 + i * i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // try larger gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+            verifyAdvanceAtLeastTo();
+            set(i * i, 100 + i * i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // try some edge cases
+        for (long i = 0; i <= 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+    }
+
+    @Test
+    public void testIteratorAdvanceAtLeastToDistinctPrefixes() {
+        long prefix = ((long) Integer.MAX_VALUE * 2 + 1);
+
+        set(0);
+        verifyAdvanceAtLeastTo();
+        set(prefix + 1);
+        verifyAdvanceAtLeastTo();
+        set(prefix * 3 + 1);
+        verifyAdvanceAtLeastTo();
+        set(prefix * 4 + 1);
+        verifyAdvanceAtLeastTo();
+        set(prefix * 5 + 1);
+        verifyAdvanceAtLeastTo();
+
+        SparseArray.Iterator<Long> iterator = actual.iterator();
+        // try advance to the gap
+        iterator.advanceAtLeastTo(prefix * 2 + 1);
+        verify(iterator, expected.tailMap(prefix * 2 + 1));
+    }
+
+    private void verify() {
+        SparseArray.Iterator<Long> iterator = actual.iterator();
+        verify(iterator, expected);
+    }
+
+    private void verify(SparseArray.Iterator<Long> actual, SortedMap<Long, Long> expected) {
+        long currentIndex = actual.getIndex();
+        Long currentValue = actual.getValue();
+        long current = actual.advance();
+        for (Map.Entry<Long, Long> expectedEntry : expected.entrySet()) {
+            assertEquals(current, currentIndex);
+            assertEquals((long) expectedEntry.getKey(), current);
+            assertEquals(expectedEntry.getValue(), currentValue);
+            currentIndex = actual.getIndex();
+            currentValue = actual.getValue();
+            current = actual.advance();
+        }
+        assertEquals(current, currentIndex);
+        assertEquals(AscendingLongIterator.END, current);
+    }
+
+    private void verifyAdvanceAtLeastTo() {
+        verifyAdvanceAtLeastTo(actual.iterator(), 1);
+        verifyAdvanceAtLeastTo(actual.iterator(), 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), 5);
+        verifyAdvanceAtLeastTo(actual.iterator(), Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), Long.MAX_VALUE / 2);
+    }
+
+    private void verifyAdvanceAtLeastTo(SparseArray.Iterator<Long> actual, long step) {
+        long previous = SparseArray.Iterator.END;
+        long current = actual.advanceAtLeastTo(step);
+        long currentIndex = actual.getIndex();
+        Long currentValue = actual.getValue();
+
+        while (current != SparseArray.Iterator.END) {
+            Map.Entry<Long, Long> expectedEntry;
+            if (previous == SparseArray.Iterator.END) {
+                expectedEntry = expected.ceilingEntry(step);
+            } else {
+                expectedEntry = expected.ceilingEntry(previous + step);
+            }
+            assertEquals(current, currentIndex);
+            assertEquals((long) expectedEntry.getKey(), currentIndex);
+            assertEquals((long) expectedEntry.getValue(), (long) currentValue);
+
+            previous = current;
+            if (current <= Long.MAX_VALUE - step) {
+                current = actual.advanceAtLeastTo(current + step);
+                currentIndex = actual.getIndex();
+                currentValue = actual.getValue();
+            } else {
+                break;
+            }
+        }
+
+        assertEquals(current, currentIndex);
+        if (previous == SparseArray.Iterator.END) {
+            assertNull(expected.ceilingEntry(step));
+        } else if (current == SparseArray.Iterator.END) {
+            assertNull(expected.ceilingEntry(previous + step));
+        } else {
+            verify(actual, expected.tailMap(current));
+        }
+    }
+
+    private void set(long index) {
+        expected.put(index, index + 1);
+        actual.set(index, index + 1);
+    }
+
+    private void set(long index, long value) {
+        expected.put(index, value);
+        actual.set(index, value);
+    }
+
+    private void clear(long index) {
+        expected.remove(index);
+        actual.clear(index);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseBitSetAddBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseBitSetAddBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import java.util.Random;
+
+@State(Scope.Benchmark)
+public class SparseBitSetAddBenchmark {
+
+    private static final long MEMBER_MASK = 0x000000FFFFFFFFFFL;
+
+    private final SparseBitSet bitSet = new SparseBitSet();
+    private final Roaring64NavigableMap roaringBitmap = new Roaring64NavigableMap();
+
+    private final Random random = new Random(404);
+    private long index = 0;
+
+    @Benchmark
+    public void sequentialAdd() {
+        bitSet.add(index);
+        index += 1;
+    }
+
+    @Benchmark
+    public void sequentialAdd_Roaring() {
+        roaringBitmap.addLong(index);
+        index += 1;
+    }
+
+    @Benchmark
+    public void randomAdd() {
+        bitSet.add(random.nextLong() & MEMBER_MASK);
+    }
+
+    @Benchmark
+    public void randomAdd_Roaring() {
+        roaringBitmap.addLong(random.nextLong() & MEMBER_MASK);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        // @formatter:off
+        Options opt = new OptionsBuilder()
+                .include(SparseBitSetAddBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(5)
+                .measurementTime(TimeValue.seconds(1))
+                .addProfiler(GCProfiler.class)
+                .forks(1)
+                .threads(1)
+                .build();
+        // @formatter:on
+
+        new Runner(opt).run();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseBitSetIterateBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseBitSetIterateBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.roaringbitmap.longlong.LongIterator;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import java.util.Random;
+
+@State(Scope.Benchmark)
+public class SparseBitSetIterateBenchmark {
+
+    private static final int SIZE = 1000000;
+    private static final long MEMBER_MASK = 0x00000000000FFFFFL;
+
+    private final SparseBitSet bitSet = new SparseBitSet();
+    private final Roaring64NavigableMap roaringBitmap = new Roaring64NavigableMap();
+
+    private AscendingLongIterator iterator;
+    private LongIterator iteratorRoaring;
+
+    @Setup
+    public void setup() {
+        Random random = new Random(404);
+        for (int i = 0; i < SIZE; ++i) {
+            long v = random.nextLong() & MEMBER_MASK;
+            bitSet.add(v);
+        }
+        iterator = bitSet.iterator();
+
+        random = new Random(404);
+        for (int i = 0; i < SIZE; ++i) {
+            long v = random.nextLong() & MEMBER_MASK;
+            roaringBitmap.addLong(v);
+        }
+
+        iteratorRoaring = roaringBitmap.getLongIterator();
+
+        System.gc();
+    }
+
+    @Benchmark
+    public long iterate() {
+        long member = iterator.advance();
+        if (member == AscendingLongIterator.END) {
+            iterator = bitSet.iterator();
+            member = iterator.advance();
+        }
+        return member;
+    }
+
+    @Benchmark
+    public long iterateRoaring() {
+        if (!iteratorRoaring.hasNext()) {
+            iteratorRoaring = roaringBitmap.getLongIterator();
+        }
+        return iteratorRoaring.next();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        // @formatter:off
+        Options opt = new OptionsBuilder()
+                .include(SparseBitSetIterateBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(5)
+                .measurementTime(TimeValue.seconds(1))
+                .addProfiler(GCProfiler.class)
+                .forks(1)
+                .threads(1)
+                .build();
+        // @formatter:on
+
+        new Runner(opt).run();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseBitSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseBitSetTest.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.NavigableSet;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static com.hazelcast.query.impl.bitmap.SparseBitSet.ARRAY_STORAGE_16_MAX_SIZE;
+import static com.hazelcast.query.impl.bitmap.SparseBitSet.ARRAY_STORAGE_32_MAX_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SparseBitSetTest {
+
+    private final NavigableSet<Long> expected = new TreeSet<Long>();
+    private final SparseBitSet actual = new SparseBitSet();
+
+    @Test
+    public void testAdd() {
+        // try empty set
+        verify();
+
+        // at the beginning
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2; ++i) {
+            set(i);
+            verify();
+            set(i);
+            verify();
+        }
+
+        // offset
+        for (long i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SIZE; ++i) {
+            set(i);
+            verify();
+            set(i);
+            verify();
+        }
+
+        // clear everything we have added
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SIZE; ++i) {
+            clear(i);
+            verify();
+        }
+
+        // test empty again
+        verify();
+
+        // try gaps
+        for (long i = 0; i < 1000; ++i) {
+            set(i * i);
+            verify();
+            set(i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+            verify();
+            set(i * i);
+            verify();
+        }
+
+        // try some edge cases
+        for (long i = 0; i <= 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testAddWithGapAndStorage32Upgrade() {
+        for (long i = 555; i < 555 + ARRAY_STORAGE_32_MAX_SIZE + 1; ++i) {
+            if (i != 560) {
+                set(i);
+            }
+            verify();
+        }
+        set(560);
+        verify();
+    }
+
+    @Test
+    public void testAddWithStorage32Switching() {
+        long prefix = ((long) Integer.MAX_VALUE * 2 + 1);
+
+        for (long i = 100; i < 100 + ARRAY_STORAGE_32_MAX_SIZE + 10; ++i) {
+            set(prefix + i);
+            verify();
+            set(prefix * 2 + i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testAddWithStorage16Upgrade() {
+        for (long i = 555; i < 555 + ARRAY_STORAGE_16_MAX_SIZE + 10; ++i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testAddWithStorage16UpgradeAndSwitching() {
+        long prefix = ((long) Short.MAX_VALUE * 2 + 1);
+
+        for (long i = 0; i < ARRAY_STORAGE_16_MAX_SIZE + 10; ++i) {
+            set(i);
+            verify();
+            set(prefix + i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testRemove() {
+        // try to clear empty set
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2; ++i) {
+            clear(i);
+            verify();
+        }
+
+        // at the beginning
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2; ++i) {
+            set(i);
+        }
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2 + 100; ++i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+
+        // offset
+        for (long i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SIZE; ++i) {
+            set(i);
+        }
+        for (long i = 1000000 + ARRAY_STORAGE_32_MAX_SIZE + 100; i >= 1000000; --i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+
+        // test empty again
+        for (long i = 111; i < 1111; ++i) {
+            clear(i);
+            verify();
+        }
+
+        // try gaps
+        for (long i = 0; i < 1000; ++i) {
+            set(i * i);
+        }
+        for (long i = 0; i < 1000; ++i) {
+            clear(i * i);
+            verify();
+            clear(i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+        }
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            clear(i * i);
+            verify();
+        }
+
+        // try larger 2-element gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+            set(i * i - 1);
+        }
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            clear(i * i);
+            verify();
+            clear(i * i - 1);
+            verify();
+        }
+
+        // try some edge cases
+        for (long i = 0; i <= 2; ++i) {
+            set(i);
+        }
+        for (long i = 0; i <= 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set(i);
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            set(i);
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            clear(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testRemoveWithStorage16Downgrade() {
+        for (long i = 555; i < 555 + ARRAY_STORAGE_16_MAX_SIZE + 10; ++i) {
+            set(i);
+        }
+        for (long i = 555; i < 555 + ARRAY_STORAGE_16_MAX_SIZE + 10; ++i) {
+            clear(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testIteratorAdvanceAtLeastTo() {
+        // try empty set
+        verifyAdvanceAtLeastTo();
+
+        // at the beginning
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // offset
+        for (long i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SIZE; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // clear everything we have added
+        for (long i = 0; i < ARRAY_STORAGE_32_MAX_SIZE / 2; ++i) {
+            clear(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SIZE; ++i) {
+            clear(i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // test empty again
+        verifyAdvanceAtLeastTo();
+
+        // try gaps
+        for (long i = 0; i < 1000; ++i) {
+            set(i * i);
+            verifyAdvanceAtLeastTo();
+            set(i * i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // try larger gaps
+        for (long i = (long) Math.sqrt(Long.MAX_VALUE) - 1000; i < (long) Math.sqrt(Long.MAX_VALUE); ++i) {
+            set(i * i);
+            verifyAdvanceAtLeastTo();
+            set(i * i);
+            verifyAdvanceAtLeastTo();
+        }
+
+        // try some edge cases
+        for (long i = 0; i <= 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+        for (long i = Long.MAX_VALUE; i >= Long.MAX_VALUE - 2; --i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+        }
+    }
+
+    @Test
+    public void testIteratorAdvanceAtLeastToDistinctPrefixes() {
+        long prefix = ((long) Integer.MAX_VALUE * 2 + 1);
+
+        set(0);
+        verifyAdvanceAtLeastTo();
+        set(prefix + 1);
+        verifyAdvanceAtLeastTo();
+        set(prefix * 3 + 1);
+        verifyAdvanceAtLeastTo();
+        set(prefix * 4 + 1);
+        verifyAdvanceAtLeastTo();
+        set(prefix * 5 + 1);
+        verifyAdvanceAtLeastTo();
+
+        AscendingLongIterator iterator = actual.iterator();
+        // try advance to the gap
+        iterator.advanceAtLeastTo(prefix * 2 + 1);
+        verify(iterator, expected.tailSet(prefix * 2 + 1));
+    }
+
+    @Test
+    public void testPrefixIteration() {
+        long prefix32 = ((long) Integer.MAX_VALUE * 2 + 1);
+        long prefix16 = ((long) Short.MAX_VALUE * 2 + 1);
+
+        // create a few top-level 32-bit prefix storages
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SIZE + 10; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo();
+            set(prefix32 + i);
+            verifyAdvanceAtLeastTo();
+            set(2 * prefix32 + i);
+            verifyAdvanceAtLeastTo();
+            set(4 * prefix32 + i);
+            verifyAdvanceAtLeastTo();
+
+            verify();
+        }
+
+        // force creation of 16-bit array storages on lower level
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SIZE + 10; ++i) {
+            set(i + prefix16);
+            verifyAdvanceAtLeastTo();
+            set(prefix32 + prefix16 + i);
+            verifyAdvanceAtLeastTo();
+            set(2 * prefix32 + prefix16 + i);
+            verifyAdvanceAtLeastTo();
+            set(4 * prefix32 + prefix16 + i);
+            verifyAdvanceAtLeastTo();
+
+            verify();
+        }
+
+        // force upgrade of 16-bit array storage to 16-bit bit storage
+        for (int i = 0; i < ARRAY_STORAGE_16_MAX_SIZE + 10; ++i) {
+            set(2 * prefix32 + prefix16 + i);
+            verifyAdvanceAtLeastTo();
+            verify();
+        }
+    }
+
+    private void verify() {
+        AscendingLongIterator iterator = actual.iterator();
+        verify(iterator, expected);
+    }
+
+    private void verify(AscendingLongIterator actual, SortedSet<Long> expected) {
+        long currentIndex = actual.getIndex();
+        long current = actual.advance();
+        for (Long expectedIndex : expected) {
+            assertEquals(current, currentIndex);
+            assertEquals((long) expectedIndex, current);
+            currentIndex = actual.getIndex();
+            current = actual.advance();
+        }
+        assertEquals(current, currentIndex);
+        assertEquals(AscendingLongIterator.END, current);
+    }
+
+    private void verifyAdvanceAtLeastTo() {
+        verifyAdvanceAtLeastTo(actual.iterator(), 1);
+        verifyAdvanceAtLeastTo(actual.iterator(), 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), 5);
+        verifyAdvanceAtLeastTo(actual.iterator(), Short.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), Integer.MAX_VALUE);
+        verifyAdvanceAtLeastTo(actual.iterator(), Long.MAX_VALUE / 2);
+        verifyAdvanceAtLeastTo(actual.iterator(), Long.MAX_VALUE);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void verifyAdvanceAtLeastTo(AscendingLongIterator actual, long step) {
+        long previous = AscendingLongIterator.END;
+        long current = actual.advanceAtLeastTo(step);
+        long currentIndex = actual.getIndex();
+
+        while (current != AscendingLongIterator.END) {
+            long expectedIndex;
+            if (previous == AscendingLongIterator.END) {
+                expectedIndex = expected.ceiling(step);
+            } else {
+                expectedIndex = expected.ceiling(previous + step);
+            }
+            assertEquals(current, currentIndex);
+            assertEquals(expectedIndex, currentIndex);
+
+            previous = current;
+            if (current <= Long.MAX_VALUE - step) {
+                current = actual.advanceAtLeastTo(current + step);
+                currentIndex = actual.getIndex();
+            } else {
+                break;
+            }
+        }
+
+        assertEquals(current, currentIndex);
+        if (previous == AscendingLongIterator.END) {
+            assertNull(expected.ceiling(step));
+        } else if (current == AscendingLongIterator.END) {
+            assertNull(expected.ceiling(previous + step));
+        } else {
+            verify(actual, expected.tailSet(current));
+        }
+    }
+
+    private void set(long index) {
+        expected.add(index);
+        actual.add(index);
+    }
+
+    private void clear(long index) {
+        expected.remove(index);
+        actual.remove(index);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseIntArrayTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/bitmap/SparseIntArrayTest.java
@@ -1,0 +1,752 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.bitmap;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.capacityDeltaInt;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.compareUnsigned;
+import static com.hazelcast.query.impl.bitmap.BitmapUtils.denseCapacityDeltaShort;
+import static com.hazelcast.query.impl.bitmap.SparseIntArray.ARRAY_STORAGE_32_MAX_SPARSE_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SparseIntArrayTest {
+
+    private final NavigableMap<Integer, Integer> expected = new TreeMap<Integer, Integer>(new Comparator<Integer>() {
+        @Override
+        public int compare(Integer o1, Integer o2) {
+            return compareUnsigned(o1, o2);
+        }
+    });
+    private final SparseIntArray<Integer> actual = new SparseIntArray<Integer>();
+
+    @Test
+    public void testSet() {
+        // try empty array
+        verify();
+
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+            verify();
+            set(i, 100 + i);
+            verify();
+        }
+
+        // go sparse
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verify();
+            set(i, 100 + i);
+            verify();
+        }
+
+        // clear everything we have added
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            clear(i);
+            verify();
+        }
+
+        // test empty again
+        verify();
+
+        // try gaps
+        for (int i = 0; i < 1000; ++i) {
+            set(i * i);
+            verify();
+            set(i * i, 100 + i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            set(i * i);
+            verify();
+            set(i * i, 100 + i * i);
+            verify();
+        }
+
+        // try some edge cases
+        for (int i = -2; i <= 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            set(i);
+            verify();
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set((int) i);
+            verify();
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            set((int) i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testSetDenseToSparse32WithMaxExceeded() {
+        // add some dense entries
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verify();
+        }
+
+        // go far beyond the last index to trigger dense to sparse conversion
+        set(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 1000);
+        verify();
+
+        // make sure we are still good
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 5; ++i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testSetDenseToSparse32WithCapacityEqualToSize() {
+        // add some dense entries
+        for (int i = 0; i < capacityDeltaInt(0) + 1; ++i) {
+            set(i);
+            verify();
+        }
+        // at this point capacity is equal to size
+
+        // go far beyond the last index to trigger dense to sparse conversion
+        set(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 1000);
+        verify();
+
+        // make sure we are still good
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 5; ++i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testSetSparseToDense32() {
+        // add some sparse entries
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i * 2);
+            verify();
+        }
+
+        // restore density
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i * 2 + 1);
+            verify();
+        }
+
+        // make sure we still can insert something
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 5; ++i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testSetSparse16WithCapacityEqualToSize() {
+        // add some dense entries
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verify();
+        }
+
+        // go far beyond the last index to trigger dense to sparse conversion
+        set(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 1000);
+        verify();
+
+        // keep adding entries to trigger prefix storage creation
+        int threshold = computeCapacityAfterInsertion(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 2);
+        for (int i = 0; i < threshold; ++i) {
+            set(i);
+            verify();
+        }
+
+        // trigger dense to sparse conversion in 16-bit storage
+        set(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 4);
+        verify();
+
+        // add more to the prefix eventually restoring the density
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 4; ++i) {
+            set(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testClear() {
+        // try to clear empty array
+        actual.clear();
+        verify();
+
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+        }
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2 + 100; ++i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+
+        // go sparse
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+        }
+        for (int i = 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE + 100; i >= 1000000; --i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+
+        // test empty again
+        actual.clear();
+        verify();
+
+        // try gaps
+        for (int i = 0; i < 1000; ++i) {
+            set(i * i);
+        }
+        for (int i = 0; i < 1000; ++i) {
+            clear(i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            set(i * i);
+        }
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            clear(i * i);
+            verify();
+        }
+
+        // try some edge cases
+        for (int i = -2; i <= 2; ++i) {
+            set(i);
+        }
+        for (int i = -2; i <= 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            set(i);
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            clear(i);
+            verify();
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set((int) i);
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            clear((int) i);
+            verify();
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            set((int) i);
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            clear((int) i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testClearDenseCleanup() {
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+        }
+        for (int i = ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2 + 100; i >= 0; --i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testClearDenseCleanupWithGap() {
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 2; ++i) {
+            set(i);
+        }
+
+        // make a gap
+        clear(ARRAY_STORAGE_32_MAX_SPARSE_SIZE);
+        verify();
+
+        // continue removing
+        for (int i = ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 2; i >= 0; --i) {
+            clear(i);
+            verify();
+            // try nonexistent
+            clear(i);
+            verify();
+            // try cleaning nonexistent with offset in the same prefix
+            clear(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 3 + i);
+            verify();
+            // try cleaning some really faraway entry
+            clear(ARRAY_STORAGE_32_MAX_SPARSE_SIZE * 1000 + i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testGet() {
+        // try empty array
+        verify(0);
+        verify(1000);
+        verify(-1);
+        verify();
+
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+            verify(i);
+            verify();
+            set(i, 100 + i);
+            verify(i);
+            verify();
+        }
+
+        // go sparse
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verify(i);
+            verify();
+            set(i, 100 + i);
+            verify(i);
+            verify();
+        }
+
+        // clear everything we have added
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            clear(i);
+            verify(i);
+            verify();
+        }
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            clear(i);
+            verify(i);
+            verify();
+        }
+
+        // test empty again
+        verify(0);
+        verify(1000);
+        verify(-1);
+        verify();
+
+        // try gaps
+        for (int i = 0; i < 1000; ++i) {
+            set(i * i);
+            verify(i * i);
+            verify();
+            set(i * i, 100 + i * i);
+            verify(i * i);
+            verify();
+        }
+
+        // try larger gaps
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            set(i * i);
+            verify(i * i);
+            verify();
+            set(i * i, 100 + i * i);
+            verify(i * i);
+            verify();
+        }
+
+        // try some edge cases
+        for (int i = -2; i <= 2; ++i) {
+            set(i);
+            verify(i);
+            verify();
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verify(i);
+            verify();
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            set(i);
+            verify(i);
+            verify();
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set((int) i);
+            verify((int) i);
+            verify();
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            set((int) i);
+            verify((int) i);
+            verify();
+        }
+    }
+
+    @Test
+    public void testIterate() {
+        SparseIntArray.Iterator<Integer> iterator = new SparseIntArray.Iterator<Integer>();
+
+        // test empty array
+        verifyIterate(iterator);
+
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+            verifyIterate(iterator);
+        }
+
+        // go sparse
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verifyIterate(iterator);
+        }
+
+        // clear everything we have added
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            clear(i);
+            verifyIterate(iterator);
+        }
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            clear(i);
+            verifyIterate(iterator);
+        }
+
+        // test empty again
+        verifyIterate(iterator);
+
+        // try gaps
+        for (int i = 0; i < 1000; ++i) {
+            set(i * i);
+            verifyIterate(iterator);
+        }
+
+        // try larger gaps
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            set(i * i);
+            verifyIterate(iterator);
+        }
+
+        // try some edge cases
+        for (int i = -2; i <= 2; ++i) {
+            set(i);
+            verifyIterate(iterator);
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyIterate(iterator);
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            set(i);
+            verifyIterate(iterator);
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set((int) i);
+            verifyIterate(iterator);
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            set((int) i);
+            verifyIterate(iterator);
+        }
+    }
+
+    @Test
+    public void testIterateAtLeastFrom() {
+        SparseIntArray.Iterator<Integer> iterator = new SparseIntArray.Iterator<Integer>();
+
+        // test empty array
+        verifyIterateAtLeastFrom(0, iterator);
+
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+
+        // go sparse
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+
+        // clear everything we have added
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            clear(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            clear(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+
+        // test empty again
+        verifyIterateAtLeastFrom(100, iterator);
+
+        // try gaps
+        for (int i = 0; i < 1000; ++i) {
+            set(i * i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+
+        // try larger gaps
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            set(i * i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+
+        // try some edge cases
+        for (int i = -2; i <= 2; ++i) {
+            set(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            set(i);
+            verifyIterateAtLeastFrom(i, iterator);
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set((int) i);
+            verifyIterateAtLeastFrom((int) i, iterator);
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            set((int) i);
+            verifyIterateAtLeastFrom((int) i, iterator);
+        }
+    }
+
+    @Test
+    public void testAdvanceAtLeastTo() {
+        SparseIntArray.Iterator<Integer> iterator = new SparseIntArray.Iterator<Integer>();
+
+        // test empty array
+        verifyAdvanceAtLeastTo(iterator);
+
+        // try dense
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+
+        // go sparse
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+
+        // clear everything we have added
+        for (int i = 0; i < ARRAY_STORAGE_32_MAX_SPARSE_SIZE / 2; ++i) {
+            clear(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+        for (int i = 1000000; i < 1000000 + ARRAY_STORAGE_32_MAX_SPARSE_SIZE; ++i) {
+            clear(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+
+        // test empty again
+        verifyAdvanceAtLeastTo(iterator);
+
+        // try gaps
+        for (int i = 0; i < 1000; ++i) {
+            set(i * i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+
+        // try larger gaps
+        for (int i = (int) Math.sqrt(Integer.MAX_VALUE) - 1000; i < (int) Math.sqrt(Integer.MAX_VALUE); ++i) {
+            set(i * i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+
+        // try some edge cases
+        for (int i = -2; i <= 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+        for (int i = Short.MAX_VALUE - 2; i <= Short.MAX_VALUE + 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+        for (int i = Short.MIN_VALUE - 2; i <= Short.MIN_VALUE + 2; ++i) {
+            set(i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+        for (long i = (long) Integer.MAX_VALUE - 2; i <= (long) Integer.MAX_VALUE + 2; ++i) {
+            set((int) i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+        for (long i = (long) Integer.MIN_VALUE - 2; i <= (long) Integer.MIN_VALUE + 2; ++i) {
+            set((int) i);
+            verifyAdvanceAtLeastTo(iterator);
+        }
+    }
+
+    private void set(int index, int value) {
+        expected.put(index, value);
+        actual.set(index, value);
+    }
+
+    private void set(int index) {
+        expected.put(index, index + 1);
+        actual.set(index, index + 1);
+    }
+
+    private void clear(int index) {
+        expected.remove(index);
+        actual.clear(index);
+    }
+
+    private void verify(int index) {
+        assertEquals(expected.get(index), actual.get(index));
+    }
+
+    private void verify() {
+        SparseIntArray.Iterator<Integer> actualIterator = new SparseIntArray.Iterator<Integer>();
+        long actualCurrent = actual.iterate(actualIterator);
+        verify(actualCurrent, actualIterator, expected);
+    }
+
+    private void verifyIterate(SparseIntArray.Iterator<Integer> actualIterator) {
+        long actualCurrent = actual.iterate(actualIterator);
+        verify(actualCurrent, actualIterator, expected);
+    }
+
+    private void verifyIterateAtLeastFrom(int from, SparseIntArray.Iterator<Integer> iterator) {
+        long current = actual.iterateAtLeastFrom(from - 10, iterator);
+        verify(current, iterator, expected.tailMap(from - 10));
+
+        current = actual.iterateAtLeastFrom(from - 1, iterator);
+        verify(current, iterator, expected.tailMap(from - 1));
+
+        current = actual.iterateAtLeastFrom(from, iterator);
+        verify(current, iterator, expected.tailMap(from));
+
+        current = actual.iterateAtLeastFrom(from + 1, iterator);
+        verify(current, iterator, expected.tailMap(from + 1));
+
+        current = actual.iterateAtLeastFrom(from + 10, iterator);
+        verify(current, iterator, expected.tailMap(from + 10));
+    }
+
+    private void verifyAdvanceAtLeastTo(SparseIntArray.Iterator<Integer> iterator) {
+        verifyAdvanceAtLeastTo(iterator, 1);
+        verifyAdvanceAtLeastTo(iterator, 2);
+        verifyAdvanceAtLeastTo(iterator, 5);
+        verifyAdvanceAtLeastTo(iterator, 1000);
+    }
+
+    private void verifyAdvanceAtLeastTo(SparseIntArray.Iterator<Integer> iterator, int step) {
+        long previous = SparseIntArray.Iterator.END;
+        long current = actual.iterate(iterator);
+
+        while (current != SparseIntArray.Iterator.END) {
+            Map.Entry<Integer, Integer> expectedEntry;
+            if (previous == SparseIntArray.Iterator.END) {
+                expectedEntry = expected.firstEntry();
+            } else {
+                expectedEntry = expected.ceilingEntry((int) (previous + step));
+            }
+            assertEquals((int) expectedEntry.getKey(), (int) current);
+            assertEquals((int) expectedEntry.getValue(), (int) iterator.getValue());
+
+            if (current <= 0xFFFFFFFFL - step) {
+                previous = current;
+                current = actual.advanceAtLeastTo((int) (current + step), (int) current, iterator);
+            } else {
+                break;
+            }
+        }
+
+        if (previous == SparseIntArray.Iterator.END) {
+            assertTrue(expected.isEmpty());
+        } else if (current == SparseIntArray.Iterator.END) {
+            assertNull(expected.ceilingEntry((int) (previous + step)));
+        } else {
+            verify(current, iterator, expected.tailMap((int) current));
+        }
+    }
+
+    private void verify(long actualCurrent, SparseIntArray.Iterator<Integer> actualIterator,
+                        SortedMap<Integer, Integer> expected) {
+        long current = actualCurrent;
+        for (Map.Entry<Integer, Integer> expectedEntry : expected.entrySet()) {
+            assertEquals((int) expectedEntry.getKey(), (int) current);
+            assertEquals(expectedEntry.getValue(), actualIterator.getValue());
+            current = actual.advance((int) current, actualIterator);
+        }
+        assertEquals(SparseIntArray.Iterator.END, current);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static int computeCapacityAfterInsertion(int count) {
+        int size = 0;
+        int capacity = capacityDeltaInt(0);
+        while (size < count) {
+            if (capacity <= size) {
+                capacity += denseCapacityDeltaShort(size, capacity);
+            }
+            ++size;
+        }
+        return capacity;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.impl.IndexCopyBehavior;
+import com.hazelcast.query.impl.IndexDefinition;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -28,7 +29,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.query.impl.predicates.PredicateUtils.canonicalizeAttribute;
-import static com.hazelcast.query.impl.predicates.PredicateUtils.parseOutCompositeIndexComponents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -39,12 +39,12 @@ public class AttributeCanonicalizationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testEmptyComponentIsNotAllowed() {
-        parseOutCompositeIndexComponents("a,");
+        IndexDefinition.parse("a,", false);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testDuplicateComponentsAreNotAllowed() {
-        parseOutCompositeIndexComponents("a,b,a");
+        IndexDefinition.parse("a,b,a", false);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BitmapIndexDefinitionParsingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BitmapIndexDefinitionParsingTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.impl.IndexDefinition;
+import com.hazelcast.query.impl.IndexDefinition.UniqueKeyTransform;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BitmapIndexDefinitionParsingTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnMissingParenthesis() {
+        IndexDefinition.parse("BITMAP(", false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnEmpty() {
+        IndexDefinition.parse("BITMAP()", false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnTooManyParts() {
+        IndexDefinition.parse("BITMAP(a, b, RAW, extra)", false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnEmptyAttribute() {
+        IndexDefinition.parse("BITMAP(, b)", false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnEmptyKey() {
+        IndexDefinition.parse("BITMAP(a,)", false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnSameAttributeAndKey() {
+        IndexDefinition.parse("BITMAP(a, a)", false);
+    }
+
+    @Test
+    public void testValidDefinitions() {
+        verify("BITMAP(a)", "a", "__key", UniqueKeyTransform.OBJECT);
+        verify("BITMAP(y, z)", "y", "z", UniqueKeyTransform.OBJECT);
+        verify("BITMAP(a, b, OBJECT)", "a", "b", UniqueKeyTransform.OBJECT);
+        verify("BITMAP(a, b, LONG)", "a", "b", UniqueKeyTransform.LONG);
+        verify("BITMAP(a, b, RAW)", "a", "b", UniqueKeyTransform.RAW);
+        verify("BITMAP(this.a)", "a", "__key", UniqueKeyTransform.OBJECT);
+        verify("BITMAP(this.a, __key#b, RAW)", "a", "__key.b", UniqueKeyTransform.RAW);
+    }
+
+    private static void verify(String text, String expectedAttribute, String expectedKey, UniqueKeyTransform expectedTransform) {
+        IndexDefinition definition = IndexDefinition.parse(text, false);
+
+        assertEquals(1, definition.getComponents().length);
+        assertEquals(expectedAttribute, definition.getComponents()[0]);
+        assertEquals(expectedKey, definition.getUniqueKey());
+        assertEquals(expectedTransform, definition.getUniqueKeyTransform());
+        assertEquals("BITMAP(" + expectedAttribute + ", " + expectedKey + ", " + expectedTransform + ")", definition.getName());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.VisitablePredicate;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
+import com.hazelcast.query.impl.QueryContext;
+import com.hazelcast.query.impl.TypeConverters;
+import com.hazelcast.query.impl.predicates.VisitorTestSupport.CustomPredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.query.Predicates.alwaysFalse;
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.in;
+import static com.hazelcast.query.Predicates.like;
+import static com.hazelcast.query.Predicates.not;
+import static com.hazelcast.query.Predicates.notEqual;
+import static com.hazelcast.query.Predicates.or;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EvaluateVisitorTest {
+
+    private static final Set<Class<? extends Predicate>> EVALUABLE_PREDICATES = new HashSet<Class<? extends Predicate>>();
+
+    static {
+        EVALUABLE_PREDICATES.add(AndPredicate.class);
+        EVALUABLE_PREDICATES.add(OrPredicate.class);
+        EVALUABLE_PREDICATES.add(NotPredicate.class);
+
+        EVALUABLE_PREDICATES.add(EqualPredicate.class);
+        EVALUABLE_PREDICATES.add(NotEqualPredicate.class);
+        EVALUABLE_PREDICATES.add(InPredicate.class);
+    }
+
+    private EvaluateVisitor visitor = new EvaluateVisitor();
+    private Indexes indexes;
+
+    @SuppressWarnings({"unchecked", "SuspiciousMethodCalls"})
+    @Before
+    public void before() {
+        indexes = mock(Indexes.class);
+
+        InternalIndex bitmapA = mock(InternalIndex.class);
+        when(bitmapA.canEvaluate((Class<? extends Predicate>) any())).then(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) {
+                return EVALUABLE_PREDICATES.contains(invocation.getArgument(0));
+            }
+        });
+        when(bitmapA.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
+        when(bitmapA.getName()).thenReturn("a");
+        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapA);
+        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapA);
+
+        InternalIndex bitmapB = mock(InternalIndex.class);
+        when(bitmapB.canEvaluate((Class<? extends Predicate>) any())).then(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) {
+                return EVALUABLE_PREDICATES.contains(invocation.getArgument(0));
+            }
+        });
+        when(bitmapB.getConverter()).thenReturn(TypeConverters.STRING_CONVERTER);
+        when(bitmapB.getName()).thenReturn("b");
+        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapB);
+        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapB);
+
+        InternalIndex regular = mock(InternalIndex.class);
+        when(regular.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
+        when(regular.canEvaluate((Class<? extends Predicate>) any())).thenReturn(false);
+        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(regular);
+        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(regular);
+
+        InternalIndex bitmapNoConverter = mock(InternalIndex.class);
+        when(bitmapNoConverter.getName()).thenReturn("nc");
+        when(bitmapNoConverter.getConverter()).thenReturn(null);
+        when(bitmapNoConverter.canEvaluate((Class<? extends Predicate>) any())).then(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) {
+                return EVALUABLE_PREDICATES.contains(invocation.getArgument(0));
+            }
+        });
+        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapNoConverter);
+        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapNoConverter);
+
+        InternalIndex bitmapNoSubPredicates = mock(InternalIndex.class);
+        when(bitmapNoSubPredicates.getName()).thenReturn("ns");
+        when(bitmapNoSubPredicates.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
+        when(bitmapNoSubPredicates.canEvaluate((Class<? extends Predicate>) any())).then(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) {
+                Object clazz = invocation.getArgument(0);
+                return !(clazz == AndPredicate.class || clazz == OrPredicate.class || clazz == NotPredicate.class);
+            }
+        });
+        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapNoSubPredicates);
+        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapNoSubPredicates);
+
+        visitor = new EvaluateVisitor();
+    }
+
+    @Test
+    public void testUnoptimizablePredicates() {
+        assertNoOptimization(alwaysFalse());
+        assertNoOptimization(new CustomPredicate());
+        assertNoOptimization(equal("r", 1));
+        assertNoOptimization(equal("nc", 1));
+        assertNoOptimization(notEqual("r", 1));
+        assertNoOptimization(notEqual("nc", 1));
+        assertNoOptimization(in("r", 1, 2, 3));
+        assertNoOptimization(in("nc", 1, 2, 3));
+        assertNoOptimization(and());
+        assertNoOptimization(or());
+        assertNoOptimization(and(equal("r", 1)));
+        assertNoOptimization(and(equal("nc", 1)));
+        assertNoOptimization(and(new CustomPredicate()));
+        assertNoOptimization(or(equal("noIndex", 1)));
+        assertNoOptimization(or(in("noIndex", 1, 2, 5)));
+        assertNoOptimization(or(equal("r", 1)));
+        assertNoOptimization(or(equal("nc", 1)));
+        assertNoOptimization(or(new CustomPredicate(), new CustomPredicate()));
+        assertNoOptimization(and(equal("r", 1), equal("noIndex", 1)));
+        assertNoOptimization(or(equal("r", 1), equal("noIndex", 1)));
+        assertNoOptimization(not(equal("r", 1)));
+        assertNoOptimization(not(equal("nc", 1)));
+        assertNoOptimization(notEqual("noIndex", 1));
+    }
+
+    @Test
+    public void testOptimizablePredicates() {
+        assertOptimization(and(equal("a", 1)), and(eval(equal("a", 1), "a")));
+        assertOptimization(and(equal("a", 1), equal("a", 2)), eval(and(equal("a", 1), equal("a", 2)), "a"));
+        assertOptimization(and(equal("a", 1), notEqual("b", 0)), and(eval(equal("a", 1), "a"), eval(notEqual("b", 0), "b")));
+        assertOptimization(and(equal("a", 1), notEqual("ns", 0)), and(eval(equal("a", 1), "a"), eval(notEqual("ns", 0), "ns")));
+        assertOptimization(and(equal("a", 1), in("ns", 1, 2, 3), notEqual("ns", 0)),
+                and(eval(equal("a", 1), "a"), eval(notEqual("ns", 0), "ns"), eval(in("ns", 1, 2, 3), "ns")));
+        assertOptimization(and(equal("a", 1), equal("a", 2), like("r", ".*")),
+                and(eval(and(equal("a", 1), equal("a", 2)), "a"), like("r", ".*")));
+        assertOptimization(and(equal("a", 1), equal("a", 2), equal("ns", 5)),
+                and(eval(and(equal("a", 1), equal("a", 2)), "a"), eval(equal("ns", 5), "ns")));
+        assertOptimization(and(equal("a", 1), equal("a", 2), equal("b", 5)),
+                and(eval(and(equal("a", 1), equal("a", 2)), "a"), eval(equal("b", 5), "b")));
+
+        assertOptimization(or(equal("a", 1)), or(eval(equal("a", 1), "a")));
+        assertOptimization(or(equal("a", 1), equal("a", 2)), eval(or(equal("a", 1), equal("a", 2)), "a"));
+        assertOptimization(or(equal("a", 1), notEqual("b", 0)), or(eval(equal("a", 1), "a"), eval(notEqual("b", 0), "b")));
+        assertOptimization(or(equal("a", 1), notEqual("ns", 0)), or(eval(equal("a", 1), "a"), eval(notEqual("ns", 0), "ns")));
+        assertOptimization(or(equal("a", 1), in("ns", 1, 2, 3), notEqual("ns", 0)),
+                or(eval(equal("a", 1), "a"), eval(notEqual("ns", 0), "ns"), eval(in("ns", 1, 2, 3), "ns")));
+        assertOptimization(or(equal("a", 1), equal("a", 2), like("r", ".*")),
+                or(eval(or(equal("a", 1), equal("a", 2)), "a"), like("r", ".*")));
+        assertOptimization(or(equal("a", 1), equal("a", 2), equal("ns", 5)),
+                or(eval(or(equal("a", 1), equal("a", 2)), "a"), eval(equal("ns", 5), "ns")));
+        assertOptimization(or(equal("a", 1), equal("a", 2), equal("b", 5)),
+                or(eval(or(equal("a", 1), equal("a", 2)), "a"), eval(equal("b", 5), "b")));
+
+        assertOptimization(not(equal("a", 1)), eval(not(equal("a", 1)), "a"));
+        assertOptimization(not(equal("ns", 1)), not(eval(equal("ns", 1), "ns")));
+
+        assertOptimization(and(or(equal("a", 1), equal("b", 2)), equal("a", 3), equal("a", 4)),
+                and(or(eval(equal("a", 1), "a"), eval(equal("b", 2), "b")), eval(and(equal("a", 3), equal("a", 4)), "a")));
+    }
+
+    private void assertNoOptimization(Predicate original) {
+        Predicate actual = optimize(original);
+        assertSame(original, actual);
+    }
+
+    private void assertOptimization(Predicate original, Predicate expected) {
+        Predicate actual = optimize(original);
+        assertTrue(original.toString() + " vs " + expected.toString(), homomorphic(original, expected, true));
+        assertTrue(original.toString() + " vs " + actual.toString(), homomorphic(original, actual, false));
+        assertTrue(expected.toString() + " vs " + actual.toString(), same(expected, actual));
+    }
+
+    private static boolean same(Predicate expected, Predicate actual) {
+        if (expected.equals(actual)) {
+            return true;
+        }
+
+        if (expected instanceof EvaluatePredicate && actual instanceof EvaluatePredicate) {
+            return same(((EvaluatePredicate) expected).getPredicate(), ((EvaluatePredicate) actual).getPredicate());
+        }
+
+        if (expected instanceof AndPredicate && actual instanceof AndPredicate) {
+            List<Predicate> expectedSubPredicates = new ArrayList<Predicate>(asList(((AndPredicate) expected).predicates));
+            List<Predicate> actualSubPredicates = new ArrayList<Predicate>(asList(((AndPredicate) actual).predicates));
+
+            for (int i = expectedSubPredicates.size() - 1; i >= 0; --i) {
+                for (int j = actualSubPredicates.size() - 1; j >= 0; --j) {
+                    if (same(expectedSubPredicates.get(i), actualSubPredicates.get(j))) {
+                        expectedSubPredicates.remove(i);
+                        actualSubPredicates.remove(j);
+                        break;
+                    }
+                }
+            }
+
+            return expectedSubPredicates.isEmpty() && actualSubPredicates.isEmpty();
+        }
+
+        if (expected instanceof OrPredicate && actual instanceof OrPredicate) {
+            List<Predicate> expectedSubPredicates = new ArrayList<Predicate>(asList(((OrPredicate) expected).predicates));
+            List<Predicate> actualSubPredicates = new ArrayList<Predicate>(asList(((OrPredicate) actual).predicates));
+
+            for (int i = expectedSubPredicates.size() - 1; i >= 0; --i) {
+                for (int j = actualSubPredicates.size() - 1; j >= 0; --j) {
+                    if (same(expectedSubPredicates.get(i), actualSubPredicates.get(j))) {
+                        expectedSubPredicates.remove(i);
+                        actualSubPredicates.remove(j);
+                        break;
+                    }
+                }
+            }
+
+            return expectedSubPredicates.isEmpty() && actualSubPredicates.isEmpty();
+        }
+
+        if (expected instanceof NotPredicate && actual instanceof NotPredicate) {
+            return same(((NotPredicate) expected).getPredicate(), ((NotPredicate) actual).getPredicate());
+        }
+
+        return false;
+    }
+
+    private static boolean homomorphic(Predicate expected, Predicate actual, boolean useEquals) {
+        if (expected == actual) {
+            return true;
+        }
+
+        if (useEquals && expected.equals(actual)) {
+            return true;
+        }
+
+        if (actual instanceof EvaluatePredicate) {
+            return homomorphic(expected, ((EvaluatePredicate) actual).getPredicate(), useEquals);
+        }
+
+        if (expected instanceof AndPredicate && actual instanceof AndPredicate) {
+            List<Predicate> expectedSubPredicates = new ArrayList<Predicate>(asList(((AndPredicate) expected).predicates));
+            List<Predicate> actualSubPredicates = new ArrayList<Predicate>(asList(((AndPredicate) actual).predicates));
+
+            // First comparison pass.
+
+            for (int i = expectedSubPredicates.size() - 1; i >= 0; --i) {
+                for (int j = actualSubPredicates.size() - 1; j >= 0; --j) {
+                    if (homomorphic(expectedSubPredicates.get(i), actualSubPredicates.get(j), useEquals)) {
+                        expectedSubPredicates.remove(i);
+                        actualSubPredicates.remove(j);
+                        break;
+                    }
+                }
+            }
+            if (expectedSubPredicates.isEmpty() && actualSubPredicates.isEmpty()) {
+                return true;
+            }
+
+            // Pull up predicates from the nested evaluable "and" predicates.
+
+            for (int i = actualSubPredicates.size() - 1; i >= 0; --i) {
+                Predicate actualSubPredicate = actualSubPredicates.get(i);
+                if (actualSubPredicate instanceof EvaluatePredicate) {
+                    EvaluatePredicate actualEvaluatePredicate = (EvaluatePredicate) actualSubPredicate;
+                    if (actualEvaluatePredicate.getPredicate() instanceof AndPredicate) {
+                        AndPredicate actualAndPredicate = (AndPredicate) actualEvaluatePredicate.getPredicate();
+                        actualSubPredicates.remove(i);
+                        actualSubPredicates.addAll(asList(actualAndPredicate.predicates));
+                    }
+                }
+            }
+
+            // Second comparison pass.
+
+            for (int i = expectedSubPredicates.size() - 1; i >= 0; --i) {
+                for (int j = actualSubPredicates.size() - 1; j >= 0; --j) {
+                    if (homomorphic(expectedSubPredicates.get(i), actualSubPredicates.get(j), useEquals)) {
+                        expectedSubPredicates.remove(i);
+                        actualSubPredicates.remove(j);
+                        break;
+                    }
+                }
+            }
+            return expectedSubPredicates.isEmpty() && actualSubPredicates.isEmpty();
+        }
+
+        if (expected instanceof OrPredicate && actual instanceof OrPredicate) {
+            List<Predicate> expectedSubPredicates = new ArrayList<Predicate>(asList(((OrPredicate) expected).predicates));
+            List<Predicate> actualSubPredicates = new ArrayList<Predicate>(asList(((OrPredicate) actual).predicates));
+
+            // First comparison pass.
+
+            for (int i = expectedSubPredicates.size() - 1; i >= 0; --i) {
+                for (int j = actualSubPredicates.size() - 1; j >= 0; --j) {
+                    if (homomorphic(expectedSubPredicates.get(i), actualSubPredicates.get(j), useEquals)) {
+                        expectedSubPredicates.remove(i);
+                        actualSubPredicates.remove(j);
+                        break;
+                    }
+                }
+            }
+            if (expectedSubPredicates.isEmpty() && actualSubPredicates.isEmpty()) {
+                return true;
+            }
+
+            // Pull up predicates from the nested evaluable "or" predicates.
+
+            for (int i = actualSubPredicates.size() - 1; i >= 0; --i) {
+                Predicate actualSubPredicate = actualSubPredicates.get(i);
+                if (actualSubPredicate instanceof EvaluatePredicate) {
+                    EvaluatePredicate actualEvaluatePredicate = (EvaluatePredicate) actualSubPredicate;
+                    if (actualEvaluatePredicate.getPredicate() instanceof OrPredicate) {
+                        OrPredicate actualAndPredicate = (OrPredicate) actualEvaluatePredicate.getPredicate();
+                        actualSubPredicates.remove(i);
+                        actualSubPredicates.addAll(asList(actualAndPredicate.predicates));
+                    }
+                }
+            }
+
+            // Second comparison pass.
+
+            for (int i = expectedSubPredicates.size() - 1; i >= 0; --i) {
+                for (int j = actualSubPredicates.size() - 1; j >= 0; --j) {
+                    if (homomorphic(expectedSubPredicates.get(i), actualSubPredicates.get(j), useEquals)) {
+                        expectedSubPredicates.remove(i);
+                        actualSubPredicates.remove(j);
+                        break;
+                    }
+                }
+            }
+            return expectedSubPredicates.isEmpty() && actualSubPredicates.isEmpty();
+        }
+
+        if (expected instanceof NotPredicate && actual instanceof NotPredicate) {
+            return homomorphic(((NotPredicate) expected).getPredicate(), ((NotPredicate) actual).getPredicate(), useEquals);
+        }
+
+        return false;
+    }
+
+    private Predicate optimize(Predicate input) {
+        if (input instanceof VisitablePredicate) {
+            return ((VisitablePredicate) input).accept(visitor, indexes);
+        } else {
+            return input;
+        }
+    }
+
+    private Predicate eval(Predicate subPredicate, String index) {
+        return new EvaluatePredicate(subPredicate, index);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.query.QueryException;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
 import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexDefinition;
 import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryEntry;
@@ -313,8 +314,8 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     @Test
     public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex =
-                new IndexImpl("foo", null, false, ss, Extractors.newBuilder(ss).build(), COPY_ON_READ, PerIndexStats.EMPTY);
+        Index dummyIndex = new IndexImpl(IndexDefinition.parse("foo", false), ss, Extractors.newBuilder(ss).build(), COPY_ON_READ,
+                PerIndexStats.EMPTY);
         QueryContext mockQueryContext = mock(QueryContext.class);
         when(mockQueryContext.getIndex(anyString())).thenReturn(dummyIndex);
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorTestSupport.java
@@ -271,7 +271,7 @@ public abstract class VisitorTestSupport {
 
     }
 
-    protected static class CustomPredicate implements Predicate {
+    public static class CustomPredicate implements Predicate {
 
         @Override
         public boolean apply(Map.Entry mapEntry) {

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Object2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Object2LongHashMapTest.java
@@ -1,0 +1,271 @@
+/*
+ * Original work Copyright 2015 Real Logic Ltd.
+ * Modified work Copyright (c) 2015-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Object2LongHashMapTest {
+
+    public static final long MISSING_VALUE = -1L;
+
+    private Object2LongHashMap<String> map = new Object2LongHashMap<String>(MISSING_VALUE);
+
+    @Test
+    public void shouldInitiallyBeEmpty() {
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void getShouldReturnMissingValueWhenEmpty() {
+        assertEquals(MISSING_VALUE, map.getValue("1"));
+    }
+
+    @Test
+    public void getShouldReturnMissingValueWhenThereIsNoElement() {
+        map.put("1", 1L);
+
+        assertEquals(MISSING_VALUE, map.getValue("2"));
+    }
+
+    @Test
+    public void getShouldReturnPutValues() {
+        map.put("1", 1L);
+
+        assertEquals(1L, map.getValue("1"));
+    }
+
+    @Test
+    public void putShouldReturnOldValue() {
+        map.put("1", 1L);
+
+        assertEquals(1L, map.put("1", 2L));
+    }
+
+    @Test
+    public void clearShouldResetSize() {
+        map.put("1", 1L);
+        map.put("100", 100L);
+
+        map.clear();
+
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void clearShouldRemoveValues() {
+        map.put("1", 1L);
+        map.put("100", 100L);
+
+        map.clear();
+
+        assertEquals(MISSING_VALUE, map.getValue("1"));
+        assertEquals(MISSING_VALUE, map.getValue("100"));
+    }
+
+    @Test
+    public void shouldNotContainKeyOfAMissingKey() {
+        assertFalse(map.containsKey("1"));
+    }
+
+    @Test
+    public void shouldContainKeyOfAPresentKey() {
+        map.put("1", 1L);
+
+        assertTrue(map.containsKey("1"));
+    }
+
+    @Test
+    public void shouldNotContainValueForAMissingEntry() {
+        assertFalse(map.containsValue(1L));
+    }
+
+    @Test
+    public void shouldContainValueForAPresentEntry() {
+        map.put("1", 1L);
+
+        assertTrue(map.containsValue(1L));
+    }
+
+    @Test
+    public void shouldExposeValidKeySet() {
+        map.put("1", 1L);
+        map.put("2", 2L);
+
+        assertKeysContainsElements(map.keySet());
+    }
+
+    @Test
+    public void shouldExposeValidValueSet() {
+        map.put("1", 1L);
+        map.put("2", 2L);
+
+        assertValuesContainsElements(map.values());
+    }
+
+    @Test
+    public void shouldPutAllMembersOfAnotherHashMap() {
+        map.put("1", 1L);
+        map.put("2", 3L);
+
+        final Map<String, Long> other = new HashMap<String, Long>();
+        other.put("1", 2L);
+        other.put("3", 4L);
+
+        map.putAll(other);
+
+        assertEquals(3, map.size());
+
+        assertEquals(2, map.getValue("1"));
+        assertEquals(3, map.getValue("2"));
+        assertEquals(4, map.getValue("3"));
+    }
+
+    @Test
+    public void entrySetShouldContainEntries() {
+        map.put("1", 1L);
+        map.put("2", 3L);
+
+        final Set<Entry<String, Long>> entrySet = map.entrySet();
+        assertEquals(2, entrySet.size());
+        assertFalse(entrySet.isEmpty());
+
+        final Iterator<Entry<String, Long>> it = entrySet.iterator();
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), "2", 3L);
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), "1", 1L);
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void removeShouldReturnMissing() {
+        assertEquals(MISSING_VALUE, map.removeKey("1"));
+    }
+
+    @Test
+    public void removeShouldReturnValueRemoved() {
+        map.put("1", 2L);
+
+        assertEquals(2L, map.removeKey("1"));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void removeShouldRemoveEntry() {
+        map.put("1", 2L);
+
+        map.remove("1");
+
+        assertTrue(map.isEmpty());
+        assertFalse(map.containsKey("1"));
+        assertFalse(map.containsValue(2L));
+    }
+
+    @Test
+    public void shouldOnlyRemoveTheSpecifiedEntry() {
+        for (int i = 0; i < 8; i++) {
+            map.put(Integer.toString(i), i * 2);
+        }
+
+        map.remove("5");
+
+        for (int i = 0; i < 8; i++) {
+            if (i != 5) {
+                assertTrue(map.containsKey(Integer.toString(i)));
+                assertTrue(map.containsValue(2 * i));
+            }
+        }
+    }
+
+    @Test
+    public void shouldResizeWhenMoreElementsAreAdded() {
+        for (int key = 0; key < 100; key++) {
+            final int value = key * 2;
+            assertEquals(MISSING_VALUE, map.put(Integer.toString(key), value));
+            assertEquals(value, map.getValue(Integer.toString(key)));
+        }
+    }
+
+    @Test
+    public void toStringShouldReportAllEntries() {
+        map.put("1", 2);
+        map.put("3", 4);
+        String string = map.toString();
+        assertTrue(string.equals("{1=2, 3=4}") || string.equals("{3=4, 1=2}"));
+    }
+
+    private static void assertEntryIs(final Entry<String, Long> entry, final String expectedKey, final long expectedValue) {
+        assertEquals(expectedKey, entry.getKey());
+        assertEquals(expectedValue, entry.getValue().longValue());
+    }
+
+    private static void assertKeysContainsElements(final Collection<String> keys) {
+        assertEquals(2, keys.size());
+        assertFalse(keys.isEmpty());
+        assertTrue(keys.contains("1"));
+        assertTrue(keys.contains("2"));
+        assertFalse(keys.contains("3"));
+        assertThat(keys, hasItems("1", "2"));
+
+        assertThat("iterator has failed to be reset", keys, hasItems("1", "2"));
+    }
+
+    private static void assertValuesContainsElements(final Collection<Long> values) {
+        assertEquals(2, values.size());
+        assertFalse(values.isEmpty());
+        assertTrue(values.contains(1L));
+        assertTrue(values.contains(2L));
+        assertFalse(values.contains(3L));
+        assertThat(values, hasItems(1L, 2L));
+
+        assertThat("iterator has failed to be reset", values, hasItems(1L, 2L));
+    }
+
+    @Test
+    public void sizeShouldReturnNumberOfEntries() {
+        final int count = 100;
+        for (int key = 0; key < count; key++) {
+            map.put(Integer.toString(key), 1);
+        }
+
+        assertEquals(count, map.size());
+    }
+
+}


### PR DESCRIPTION
EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3430

A quick walk-through over the implementation:

1. User adds a bitmap index using one of the following syntaxes:

    1. The implicit unique key syntax: `BITMAP(a)`, adds a bitmap index on attribute `a`, IMap key is used to assign a unique monotonically increasing long key to each indexed IMap entry.

    2. The explicit unique key syntax: `BITMAP(a, b)`, adds a bitmap index on attribute `a` and uses values of unique attribute `b` to assign a unique monotonically increasing long key to each indexed IMap entry.

    3. The explicit unique key and transform syntax: `BITMAP(a, b, transform)`, where `transform` can be:

         - `OBJECT`: the default used implicitly and the least efficient one, interprets values of unique key as objects. Internally an object-to-long hash table is used to establish the mapping between map entry unique key values and long unique keys used by bitmap index.
         - `LONG`: more efficient than the previous one, interprets values of unique key as long values (upcasts byte, short, int if needed). Internally a more efficient long-to-long hash table is used to establish the mapping. Good for sparse unique keys since we are remapping/renumbering them into more dense ones to raise the bitmap memory efficiency.
         - `RAW`: the most efficient one, interprets values of the specified unique key as long values and uses them as internal bitmap unique long keys directly. No hash table maintained to establish the mapping. Good for dense unique integer-valued keys.
    
    Both the attribute and the unique key parts support the regular doted attribute path syntax along with the regular array/collection subscript syntax.

2. `BitmapIndexStore` is created for every bitmap index. The store manages the indexed attribute value extraction, the unique key extraction and its (re)mapping. Index updates and queries are forwarded to the associated `Bitmap` instance.

3. The `Bitmap` manages a hash map of `SparseBitSet` instances, one for each possible attribute value, and a `SparseArray` to map unique `long` IDs back to `QueryableEntry` instances.

4. Each `SparseBitSet` manages a set of bits and provides iteration facilities. A bit is set in a sparse bit set if a `QueryableEntry` corresponding to a long unique key (which is used as a bit index) has an indexed attribute value equal to the value indexed by that sparse bit set. Iteration on bit set members is performed in ascending order: bits with lower indexes are provided before bits with with higher indexes.

5. `SparseArray` behaves similarly to a regular `Map<Long, QueryableEntry>` with following important differences:

    - It allows iteration in ascending key order. That is important for achieving good performance while evaluating `not` and `notEqual` predicates.

    - It allows to save on memory cost significantly. In the best case we are spending just 4 or 8 bytes per every element inserted depending on the JVM memory pointer size.

    -  Since sparse bit sets are also iterated in ascending bit index order, the process of mapping back to `QueryableEntry` can be performed sequentially avoiding random jumps over memory addresses as hash maps do while resolving values by keys.

6. User performs queries using the usual `IMap` querying methods. `EvaluateVisitor` optimizes a predicate tree by offloading the evaluation of the predicate (sub)tree(s) to bitmap indexes. The evaluation and its possibility is handled by the new pair of `Index` methods: `evaluate` and `canEvaluate`.

7. The predicate (sub)tree is forwarded to `Bitmap.evaluate` by bitmap index store. `Bitmap` creates iterators for terminal predicates acting on values directly and evaluates non-terminal ones (`and`, `or`, `not`) using the facilities provided by `BitmapAlgorithms`. `Bitmap` maps `long` unique keys back to `QueryableEntry` instances using the associated `SparseArray`, the result set is returned to the user.