### PR TITLE
Exclude serialization compatibility test blob from tests artifact

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -178,8 +178,12 @@
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
-                            <!--Need to add sources for this test jar to Maven central. partic TestHazelcastInstanceFactory. Brian request. -->
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*.serialization.compatibility.binary</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityTest.java
@@ -19,12 +19,12 @@ package com.hazelcast.nio.serialization.compatibility;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
@@ -51,7 +51,8 @@ import static com.hazelcast.nio.serialization.compatibility.ReferenceObjects.IDE
 import static com.hazelcast.nio.serialization.compatibility.ReferenceObjects.INNER_PORTABLE_CLASS_ID;
 import static com.hazelcast.nio.serialization.compatibility.ReferenceObjects.PORTABLE_FACTORY_ID;
 import static com.hazelcast.test.HazelcastTestSupport.assumeConfiguredByteOrder;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
@@ -95,6 +96,10 @@ public class BinaryCompatibilityTest {
     public static void init() throws IOException {
         for (byte version : versions) {
             InputStream input = BinaryCompatibilityTest.class.getResourceAsStream("/" + createFileName(version));
+            if (input == null) {
+                fail("Could not locate file " + createFileName(version) + ". Follow the instructions in "
+                        + "BinaryCompatibilityFileGenerator to generate the file.");
+            }
             DataInputStream inputStream = new DataInputStream(input);
             while (input.available() != 0) {
                 String objectKey = inputStream.readUTF();


### PR DESCRIPTION
Reasoning: the binary file is 67MB making the tests JAR artifact
very large. The serialization compatibility binary can
be regenerated by using BinaryCompatibilityFileGenerator.

Current size of tests JAR artifact is ~56MB, with this PR it is reduced to ~10MB.