### PR TITLE
Collect client stats before sending response to server

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
@@ -41,12 +41,11 @@ public abstract class AbstractMapPutMessageTask<P> extends AbstractMapPartitionM
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(getDistributedObjectName());
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(getDistributedObjectName())
-                    .incrementPutLatencyNanos(latencyNanos);
+                    .incrementPutLatencyNanos(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapSetMessageTask.java
@@ -41,12 +41,11 @@ public abstract class AbstractMapSetMessageTask<P> extends AbstractMapPartitionM
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(getDistributedObjectName());
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(getDistributedObjectName())
-                    .incrementSetLatencyNanos(latencyNanos);
+                    .incrementSetLatencyNanos(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsKeyMessageTask.java
@@ -46,17 +46,14 @@ public class MapContainsKeyMessageTask
     }
 
     @Override
-    protected void afterSendingResponse(Object response, Throwable throwable) {
-        if (throwable != null) {
-            return;
-        }
-
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+    protected Object processResponseBeforeSending(Object response) {
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             LocalMapStatsProvider localMapStatsProvider = mapService.getMapServiceContext().getLocalMapStatsProvider();
             localMapStatsProvider.getLocalMapStatsImpl(parameters.name).incrementOtherOperations();
         }
+        return super.processResponseBeforeSending(response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDeleteMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDeleteMessageTask.java
@@ -54,12 +54,11 @@ public class MapDeleteMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementRemoveLatencyNanos(latencyNanos);
+                    .incrementRemoveLatencyNanos(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
@@ -62,12 +62,11 @@ public class MapGetAllMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementGetLatencyNanos(parameters.keys.size(), latencyNanos);
+                    .incrementGetLatencyNanos(parameters.keys.size(), System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
@@ -64,12 +64,11 @@ public class MapGetMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementGetLatencyNanos(latencyNanos);
+                    .incrementGetLatencyNanos(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -72,12 +72,11 @@ public class MapPutAllMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementPutLatencyNanos(parameters.entries.size(), latencyNanos);
+                    .incrementPutLatencyNanos(parameters.entries.size(), System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
@@ -46,12 +46,11 @@ public class MapRemoveMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        final long latencyNanos = System.nanoTime() - startTimeNanos;
-        final MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementRemoveLatencyNanos(latencyNanos);
+                    .incrementRemoveLatencyNanos(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ReplicatedMapGetCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.monitor.impl.LocalReplicatedMapStatsImpl;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.operation.GetOperation;
@@ -55,11 +56,10 @@ public class ReplicatedMapGetMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        long latencyNanos = System.nanoTime() - startTimeNanos;
         ReplicatedMapService replicatedMapService = getService(ReplicatedMapService.SERVICE_NAME);
-
         if (replicatedMapService.getReplicatedMapConfig(parameters.name).isStatisticsEnabled()) {
-            replicatedMapService.getLocalReplicatedMapStatsImpl(parameters.name).incrementGets(latencyNanos);
+            LocalReplicatedMapStatsImpl stats = replicatedMapService.getLocalReplicatedMapStatsImpl(parameters.name);
+            stats.incrementGets(System.nanoTime() - startTimeNanos);
         }
         return response;
     }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/16151

__Modifications :__

- Moved stats calculation from method `afterSendingResponse` to method `processResponseBeforeSending` for the task --> `MapContainsKeyMessageTask.java`(i assume this is the reason of test failure)
- Refactored latency calculations and calculated them only if map stats are enabled.