### PR TITLE
Remove invalid deprecation suppressions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -207,7 +207,6 @@ public class ConfigXmlGenerator {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private static void replicatedMapConfigXmlGenerator(XmlGenerator gen, Config config) {
         for (ReplicatedMapConfig r : config.getReplicatedMapConfigs().values()) {
             MergePolicyConfig mergePolicyConfig = r.getMergePolicyConfig();
@@ -885,7 +884,6 @@ public class ConfigXmlGenerator {
         return "wan-endpoint-config";
     }
 
-    @SuppressWarnings("deprecation")
     private static void mapConfigXmlGenerator(XmlGenerator gen, Config config) {
         Collection<MapConfig> mapConfigs = config.getMapConfigs().values();
         for (MapConfig m : mapConfigs) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1673,7 +1673,6 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         }
     }
 
-    @SuppressWarnings("deprecation")
     protected void handleReplicatedMap(Node node) {
         Node attName = node.getAttributes().getNamedItem("name");
         String name = getTextContent(attName);
@@ -1707,7 +1706,6 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         config.addReplicatedMapConfig(replicatedMapConfig);
     }
 
-    @SuppressWarnings("deprecation")
     protected void handleMap(Node parentNode) throws Exception {
         String name = getAttribute(parentNode, "name");
         MapConfig mapConfig = new MapConfig();

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -1313,21 +1313,18 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    @SuppressWarnings("deprecation")
     public void testAddLocalEntryListener() {
         IMap<String, String> map = client.getMap(randomString());
         map.addLocalEntryListener(new EmptyEntryListener());
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    @SuppressWarnings("deprecation")
     public void testAddLocalEntryListener_WithPredicate() {
         IMap<String, String> map = client.getMap(randomString());
         map.addLocalEntryListener(new EmptyEntryListener(), Predicates.alwaysFalse(), true);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    @SuppressWarnings("deprecation")
     public void testAddLocalEntryListener_WithPredicateAndKey() {
         IMap<String, String> map = client.getMap(randomString());
         map.addLocalEntryListener(new EmptyEntryListener(), Predicates.alwaysFalse(), "Key", true);

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -114,7 +114,6 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testIssue537() {
         IMap<String, GenericEvent> map = createMap();
         AddAndExpiredListener listener = new AddAndExpiredListener();
@@ -286,7 +285,6 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testAsyncPutWithTtl() throws Exception {
         IMap<String, String> map = createMap();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -301,7 +299,6 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testAsyncPutWithMaxIdle() throws Exception {
         IMap<String, String> map = createMap();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -618,7 +615,6 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testListener() {
         IMap<String, String> map = createMap();
         final CountDownLatch latch1Add = new CountDownLatch(5);
@@ -670,7 +666,6 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testPredicateListenerWithPortableKey() throws Exception {
         IMap<Portable, Integer> tradeMap = createMap();
 
@@ -793,7 +788,6 @@ public class ClientMapTest extends HazelcastTestSupport {
      * Issue #996
      */
     @Test
-    @SuppressWarnings({"deprecation", "unchecked"})
     public void testEntryListener() throws Exception {
         CountDownLatch gateAdd = new CountDownLatch(3);
         CountDownLatch gateRemove = new CountDownLatch(1);
@@ -980,7 +974,6 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testEntryListenerWithPredicateOnDeleteOperation() {
         IMap<String, String> serverMap = server.getMap("A");
         IMap<String, String> clientMap = client.getMap("A");

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -715,7 +715,6 @@ public class ConfigCompatibilityChecker {
 
     public static class MapConfigChecker extends ConfigChecker<MapConfig> {
         @Override
-        @SuppressWarnings("deprecation")
         public boolean check(MapConfig c1, MapConfig c2) {
             if (c1 == c2) {
                 return true;
@@ -765,7 +764,6 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.isRepublishingEnabled(), c2.isRepublishingEnabled());
         }
 
-        @SuppressWarnings("deprecation")
         private static boolean isCompatible(NearCacheConfig c1, NearCacheConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getName(), c2.getName())
@@ -773,7 +771,6 @@ public class ConfigCompatibilityChecker {
                     && isCompatible(c1.getEvictionConfig(), c2.getEvictionConfig());
         }
 
-        @SuppressWarnings("deprecation")
         private static boolean isCompatible(EvictionConfig c1, EvictionConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getSize(), c2.getSize())

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -89,7 +89,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-@SuppressWarnings({"WeakerAccess", "deprecation"})
+@SuppressWarnings({"WeakerAccess"})
 public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.hazelcast.core.EntryEventType.LOADED;
 import static org.junit.Assert.assertEquals;
 
-@SuppressWarnings("deprecation")
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class EntryLoadedListenerTest extends HazelcastTestSupport {

--- a/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
@@ -72,7 +72,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@SuppressWarnings("deprecation")
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ListenerTest extends HazelcastTestSupport {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
@@ -654,7 +654,6 @@ public class MapLoaderTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testMapLoaderHittingEvictionOnInitialLoad() {
         String mapName = "testMapLoaderHittingEvictionOnInitialLoad";
         int sizePerPartition = 1;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -104,7 +104,6 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testQueryWithTTL() {
         Config config = getConfig();
         String mapName = "default";

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/NodeEngineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/NodeEngineTest.java
@@ -58,14 +58,12 @@ public class NodeEngineTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void getServiceOrNull_whenNonExistingService() {
         Object sharedService = nodeEngine.getServiceOrNull("notexist");
         assertNull(sharedService);
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void getServiceOrNull_whenExistingService() {
         Object sharedService = nodeEngine.getServiceOrNull(LockSupportService.SERVICE_NAME);
         assertNotNull(sharedService);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -169,7 +169,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
         }
     }
 
-    @SuppressWarnings({"deprecation", "NullableProblems"})
+    @SuppressWarnings({"deprecation"})
     private static final class ThreadLocalProperties extends Properties {
 
         private final Properties globalProperties;


### PR DESCRIPTION
A few suppressions left which are suppressing warnings in JUnit
and Java.