### PR TITLE
Remove old-style properties configuration support

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DomConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DomConfigHelper.java
@@ -52,14 +52,7 @@ public final class DomConfigHelper {
             if (n.getNodeType() == Node.TEXT_NODE || n.getNodeType() == Node.COMMENT_NODE) {
                 continue;
             }
-            final String name = cleanNodeName(n);
-            final String propertyName;
-            if ("property".equals(name)) {
-                propertyName = getTextContent(n.getAttributes().getNamedItem("name"), domLevel3).trim();
-            } else {
-                // old way - probably should be deprecated
-                propertyName = name;
-            }
+            final String propertyName = getTextContent(n.getAttributes().getNamedItem("name"), domLevel3).trim();
             final String value = getTextContent(n, domLevel3).trim();
             properties.put(propertyName, value);
         }
@@ -70,11 +63,7 @@ public final class DomConfigHelper {
             return;
         }
         for (Node n : childElements(node)) {
-            final String name = cleanNodeName(n);
-            final String propertyName = "property".equals(name)
-                    ? getTextContent(n.getAttributes().getNamedItem("name"), domLevel3).trim()
-                    // old way - probably should be deprecated
-                    : name;
+            final String propertyName = getTextContent(n.getAttributes().getNamedItem("name"), domLevel3).trim();
             final String value = getTextContent(n, domLevel3).trim();
             properties.setProperty(propertyName, value);
         }


### PR DESCRIPTION
Raw property names under properties tag are deprecated for a long time
and no longer accepted by XSD as valid.