### PR TITLE
Checks for existing static config when adding config from client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -112,6 +112,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddFlakeIdGenerator
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddListConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMultiMapConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddPNCounterConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddQueueConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableTopicConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReplicatedMapConfigCodec;
@@ -464,6 +465,7 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddFlakeIdGenerator
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddListConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMultiMapConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddPNCounterConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddQueueConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableTopicConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReplicatedMapConfigMessageTask;
@@ -1542,6 +1544,8 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 (cm, con) -> new AddCacheConfigMessageTask(cm, node, con));
         factories.put(DynamicConfigAddFlakeIdGeneratorConfigCodec.REQUEST_MESSAGE_TYPE,
                 (cm, con) -> new AddFlakeIdGeneratorConfigMessageTask(cm, node, con));
+        factories.put(DynamicConfigAddPNCounterConfigCodec.REQUEST_MESSAGE_TYPE,
+                (cm, con) -> new AddPNCounterConfigMessageTask(cm, node, con));
 //endregion
 // region ----------- REGISTRATION FOR flake id generator
         factories.put(FlakeIdGeneratorNewIdBatchCodec.REQUEST_MESSAGE_TYPE,

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AbstractAddConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AbstractAddConfigMessageTask.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.dynamicconfig.ClusterWideConfigurationService;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.security.permission.ConfigPermission;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.security.Permission;
 import java.util.ArrayList;
@@ -70,8 +69,12 @@ public abstract class AbstractAddConfigMessageTask<P> extends AbstractMessageTas
     public final void processMessage() {
         IdentifiedDataSerializable config = getConfig();
         ClusterWideConfigurationService service = getService(ClusterWideConfigurationService.SERVICE_NAME);
-        InternalCompletableFuture<Object> future = service.broadcastConfigAsync(config);
-        future.whenCompleteAsync(this);
+        if (checkStaticConfigDoesNotExist(config)) {
+            service.broadcastConfigAsync(config)
+                   .whenCompleteAsync(this);
+        } else {
+            sendResponse(null);
+        }
     }
 
     @Override
@@ -100,4 +103,6 @@ public abstract class AbstractAddConfigMessageTask<P> extends AbstractMessageTas
     }
 
     protected abstract IdentifiedDataSerializable getConfig();
+
+    protected abstract boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -90,5 +91,13 @@ public class AddCacheConfigMessageTask
     @Override
     public String getMethodName() {
         return "addCacheConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        CacheSimpleConfig cacheConfig = (CacheSimpleConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getCacheConfigs(),
+                cacheConfig.getName(), cacheConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
@@ -66,6 +66,7 @@ public class AddCacheConfigMessageTask
                     new ExpiryPolicyFactoryConfig(parameters.timedExpiryPolicyFactoryConfig);
             config.setExpiryPolicyFactoryConfig(expiryPolicyFactoryConfig);
         }
+        config.setEventJournalConfig(parameters.eventJournalConfig);
         config.setHotRestartConfig(parameters.hotRestartConfig);
         config.setInMemoryFormat(InMemoryFormat.valueOf(parameters.inMemoryFormat));
         config.setKeyType(parameters.keyType);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCardinalityEstimatorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCardinalityEstimatorConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddCardinalityEstim
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -53,5 +54,13 @@ public class AddCardinalityEstimatorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addCardinalityEstimatorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        CardinalityEstimatorConfig cardinalityEstimatorConfig = (CardinalityEstimatorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getCardinalityEstimatorConfigs(),
+                cardinalityEstimatorConfig.getName(), cardinalityEstimatorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddDurableExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddDurableExecutorConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddDurableExecutorConfigCodec;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -50,5 +51,13 @@ public class AddDurableExecutorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addDurableExecutorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        DurableExecutorConfig durableExecutorConfig = (DurableExecutorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getDurableExecutorConfigs(),
+                durableExecutorConfig.getName(), durableExecutorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddExecutorConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddExecutorConfigCodec;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -51,5 +52,13 @@ public class AddExecutorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addExecutorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ExecutorConfig executorConfig = (ExecutorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getExecutorConfigs(),
+                executorConfig.getName(), executorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddFlakeIdGeneratorConfigCodec;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -54,5 +55,13 @@ public class AddFlakeIdGeneratorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addFlakeIdGeneratorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        FlakeIdGeneratorConfig flakeIdGeneratorConfig = (FlakeIdGeneratorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getFlakeIdGeneratorConfigs(),
+                flakeIdGeneratorConfig.getName(), flakeIdGeneratorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddListConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddListConfigMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -64,5 +65,13 @@ public class AddListConfigMessageTask
     @Override
     public String getMethodName() {
         return "addListConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ListConfig listConfig = (ListConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getListConfigs(),
+                listConfig.getName(), listConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.partition.PartitioningStrategy;
@@ -113,5 +114,14 @@ public class AddMapConfigMessageTask
     @Override
     public String getMethodName() {
         return "addMapConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        MapConfig mapConfig = (MapConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(
+                nodeConfig.getStaticConfig().getMapConfigs(),
+                mapConfig.getName(), mapConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMultiMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMultiMapConfigMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -65,5 +66,13 @@ public class AddMultiMapConfigMessageTask extends
     @Override
     public String getMethodName() {
         return "addMultiMapConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        MultiMapConfig multiMapConfig = (MultiMapConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getMultiMapConfigs(),
+                multiMapConfig.getName(), multiMapConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddPNCounterConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddPNCounterConfigMessageTask.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.dynamicconfig;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddPNCounterConfigCodec;
+import com.hazelcast.config.PNCounterConfig;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public class AddPNCounterConfigMessageTask
+        extends AbstractAddConfigMessageTask<DynamicConfigAddPNCounterConfigCodec.RequestParameters> {
+
+    public AddPNCounterConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected DynamicConfigAddPNCounterConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return DynamicConfigAddPNCounterConfigCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return DynamicConfigAddPNCounterConfigCodec.encodeResponse();
+    }
+
+    @Override
+    protected IdentifiedDataSerializable getConfig() {
+        PNCounterConfig config = new PNCounterConfig(parameters.name);
+        config.setReplicaCount(parameters.replicaCount);
+        config.setStatisticsEnabled(parameters.statisticsEnabled);
+        config.setSplitBrainProtectionName(parameters.splitBrainProtectionName);
+        return config;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "addPNCounterConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        PNCounterConfig pnCounterConfig = (PNCounterConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getPNCounterConfigs(),
+                pnCounterConfig.getName(), pnCounterConfig);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddQueueConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddQueueConfigMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -71,5 +72,13 @@ public class AddQueueConfigMessageTask
     @Override
     public String getMethodName() {
         return "addQueueConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        QueueConfig queueConfig = (QueueConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getQueueConfigs(),
+                queueConfig.getName(), queueConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableTopicConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableTopicConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableTopicCon
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.topic.TopicOverloadPolicy;
@@ -63,5 +64,13 @@ public class AddReliableTopicConfigMessageTask
     @Override
     public String getMethodName() {
         return "addReliableTopicConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ReliableTopicConfig reliableTopicConfig = (ReliableTopicConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getReliableTopicConfigs(),
+                reliableTopicConfig.getName(), reliableTopicConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -67,5 +68,13 @@ public class AddReplicatedMapConfigMessageTask
     @Override
     public String getMethodName() {
         return "addReplicatedMapConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ReplicatedMapConfig replicatedMapConfig = (ReplicatedMapConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getReplicatedMapConfigs(),
+                replicatedMapConfig.getName(), replicatedMapConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddRingbufferConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddRingbufferConfigMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.RingbufferStoreConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -63,5 +64,13 @@ public class AddRingbufferConfigMessageTask
     @Override
     public String getMethodName() {
         return "addRingbufferConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        RingbufferConfig ringbufferConfig = (RingbufferConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getRingbufferConfigs(),
+                ringbufferConfig.getName(), ringbufferConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddScheduledExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddScheduledExecutorConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddScheduledExecuto
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -56,5 +57,13 @@ public class AddScheduledExecutorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addScheduledExecutorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ScheduledExecutorConfig scheduledExecutorConfig = (ScheduledExecutorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getScheduledExecutorConfigs(),
+                scheduledExecutorConfig.getName(), scheduledExecutorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSetConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSetConfigMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.SetConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -64,5 +65,13 @@ public class AddSetConfigMessageTask
     @Override
     public String getMethodName() {
         return "addSetConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        SetConfig setConfig = (SetConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getSetConfigs(),
+                setConfig.getName(), setConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddTopicConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddTopicConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddTopicConfigCodec
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -59,5 +60,13 @@ public class AddTopicConfigMessageTask
     @Override
     public String getMethodName() {
         return "addTopicConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        TopicConfig topicConfig = (TopicConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getTopicConfigs(),
+                topicConfig.getName(), topicConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -17,12 +17,12 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
+import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.merge.SplitBrainMergeTypeProvider;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes;
-import com.hazelcast.internal.partition.IPartition;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -122,7 +122,9 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
         this.cacheLoaderFactory = cacheSimpleConfig.cacheLoaderFactory;
         this.cacheWriterFactory = cacheSimpleConfig.cacheWriterFactory;
         this.expiryPolicyFactoryConfig = cacheSimpleConfig.expiryPolicyFactoryConfig;
-        this.cacheEntryListeners = cacheSimpleConfig.cacheEntryListeners;
+        this.cacheEntryListeners = cacheSimpleConfig.cacheEntryListeners == null
+                ? null
+                : new ArrayList<>(cacheSimpleConfig.cacheEntryListeners);
         this.asyncBackupCount = cacheSimpleConfig.asyncBackupCount;
         this.backupCount = cacheSimpleConfig.backupCount;
         this.inMemoryFormat = cacheSimpleConfig.inMemoryFormat;
@@ -131,8 +133,9 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
             this.evictionConfig = cacheSimpleConfig.evictionConfig;
         }
         this.wanReplicationRef = cacheSimpleConfig.wanReplicationRef;
-        this.partitionLostListenerConfigs =
-                new ArrayList<>(cacheSimpleConfig.getPartitionLostListenerConfigs());
+        this.partitionLostListenerConfigs = cacheSimpleConfig.partitionLostListenerConfigs == null
+                ? null
+                : new ArrayList<>(cacheSimpleConfig.partitionLostListenerConfigs);
         this.splitBrainProtectionName = cacheSimpleConfig.splitBrainProtectionName;
         this.mergePolicyConfig = new MergePolicyConfig(cacheSimpleConfig.mergePolicyConfig);
         this.hotRestartConfig = new HotRestartConfig(cacheSimpleConfig.hotRestartConfig);
@@ -563,7 +566,7 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
      */
     public List<CachePartitionLostListenerConfig> getPartitionLostListenerConfigs() {
         if (partitionLostListenerConfigs == null) {
-            partitionLostListenerConfigs = new ArrayList<CachePartitionLostListenerConfig>();
+            partitionLostListenerConfigs = new ArrayList<>();
         }
         return partitionLostListenerConfigs;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -253,13 +253,17 @@ public class DynamicConfigurationAwareConfig extends Config {
         return this;
     }
 
-    private <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
+    public <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
         if (existingConfiguration != null && !existingConfiguration.equals(newConfig)) {
             throw new InvalidConfigurationException("Cannot add a new dynamic configuration " + newConfig
                     + " as static configuration already contains " + existingConfiguration);
         }
         return existingConfiguration == null;
+    }
+
+    public Config getStaticConfig() {
+        return staticConfig;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/clientside/ClientDynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/clientside/ClientDynamicConfigSmokeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigSmokeTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientDynamicConfigSmokeTest extends DynamicConfigSmokeTest {
+
+    @Override
+    protected HazelcastInstance[] members(int count, Config config) {
+        factory = new TestHazelcastFactory(count);
+        if (config == null) {
+            config = smallInstanceConfig();
+        }
+        HazelcastInstance[] members = new HazelcastInstance[count];
+        for (int i = 0; i < count; i++) {
+            members[i] = factory.newHazelcastInstance(config);
+        }
+        return members;
+    }
+
+    @Override
+    protected HazelcastInstance driver() {
+        return ((TestHazelcastFactory) factory).newHazelcastClient();
+    }
+
+    @Override
+    @Ignore("Only makes sense to be executed on the member side")
+    public void mapConfig_withLiteMemberJoiningLater_isImmediatelyAvailable() {
+        super.mapConfig_withLiteMemberJoiningLater_isImmediatelyAvailable();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -31,8 +31,10 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import javax.cache.Cache;
@@ -48,6 +50,9 @@ import static org.junit.Assert.assertEquals;
 public class DynamicConfigSmokeTest extends HazelcastTestSupport {
 
     private static final int DEFAULT_INITIAL_CLUSTER_SIZE = 3;
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     protected TestHazelcastInstanceFactory factory;
     private HazelcastInstance[] members;
@@ -94,7 +99,7 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         }
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Test
     public void map_testConflictingDynamicConfig() {
         String mapName = randomMapName();
         int initialClusterSize = 2;
@@ -109,6 +114,7 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         mapConfig2.setBackupCount(1);
 
         driver.getConfig().addMapConfig(mapConfig1);
+        expected.expect(InvalidConfigurationException.class);
         driver.getConfig().addMapConfig(mapConfig2);
     }
 
@@ -236,7 +242,7 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         driver.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Test
     public void map_testConflictingStaticConfig() {
         String mapName = "test_map";
         Config config = new Config();
@@ -244,6 +250,7 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
 
         members(1, config);
         HazelcastInstance hz = driver();
+        expected.expect(InvalidConfigurationException.class);
         hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 50));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.TopicConfig;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -29,9 +30,16 @@ import com.hazelcast.test.TestConfigUtils;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import java.io.Serializable;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,13 +49,39 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
 
     private static final int DEFAULT_INITIAL_CLUSTER_SIZE = 3;
 
+    protected TestHazelcastInstanceFactory factory;
+    private HazelcastInstance[] members;
+
+    @After
+    public void tearDown() {
+        if (factory != null) {
+            factory.terminateAll();
+        }
+    }
+
+    protected HazelcastInstance[] members(int count) {
+        return members(count, null);
+    }
+
+    protected HazelcastInstance[] members(int count, Config config) {
+        if (config == null) {
+            config = smallInstanceConfig();
+        }
+        factory = createHazelcastInstanceFactory(count);
+        members = factory.newInstances(config);
+        return members;
+    }
+
+    protected HazelcastInstance driver() {
+        return members[0];
+    }
+
     @Test
     public void multimap_initialSubmitTest() {
         String mapName = randomMapName();
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance i1 = driver();
 
         MultiMapConfig multiMapConfig = new MultiMapConfig(mapName);
         multiMapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
@@ -60,15 +94,13 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         }
     }
 
-    @Test(expected = HazelcastException.class)
+    @Test(expected = InvalidConfigurationException.class)
     public void map_testConflictingDynamicConfig() {
         String mapName = randomMapName();
         int initialClusterSize = 2;
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(initialClusterSize);
-
-        HazelcastInstance i1 = factory.newHazelcastInstance();
-        HazelcastInstance i2 = factory.newHazelcastInstance();
+        members(initialClusterSize);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig1 = new MapConfig(mapName);
         mapConfig1.setBackupCount(0);
@@ -76,17 +108,15 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         MapConfig mapConfig2 = new MapConfig(mapName);
         mapConfig2.setBackupCount(1);
 
-        i1.getConfig().addMapConfig(mapConfig1);
-        i1.getConfig().addMapConfig(mapConfig2);
+        driver.getConfig().addMapConfig(mapConfig1);
+        driver.getConfig().addMapConfig(mapConfig2);
     }
 
     @Test
     public void map_testNonConflictingDynamicConfigWithTheSameName() {
         String mapName = randomMapName();
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-
-        HazelcastInstance i1 = factory.newHazelcastInstance();
-        HazelcastInstance i2 = factory.newHazelcastInstance();
+        members(2);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig1 = new MapConfig(mapName);
         mapConfig1.setBackupCount(0);
@@ -94,8 +124,8 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         MapConfig mapConfig2 = new MapConfig(mapName);
         mapConfig2.setBackupCount(0);
 
-        i1.getConfig().addMapConfig(mapConfig1);
-        i1.getConfig().addMapConfig(mapConfig2);
+        driver.getConfig().addMapConfig(mapConfig1);
+        driver.getConfig().addMapConfig(mapConfig2);
     }
 
     @Test
@@ -122,13 +152,12 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
     public void map_initialSubmitTest() {
         String mapName = randomMapName();
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig = new MapConfig(mapName);
         mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
-        Config config = i1.getConfig();
+        Config config = driver.getConfig();
         config.addMapConfig(mapConfig);
 
         for (HazelcastInstance instance : instances) {
@@ -141,13 +170,12 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
     public void map_initialSubmitTest_withWildcards() {
         String prefixWithWildcard = randomMapName() + "*";
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig = new MapConfig(prefixWithWildcard);
         mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
-        Config config = i1.getConfig();
+        Config config = driver.getConfig();
         config.addMapConfig(mapConfig);
 
         for (HazelcastInstance instance : instances) {
@@ -162,13 +190,12 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         String topicName = randomName();
         String listenerClassName = randomName();
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance driver = driver();
 
         TopicConfig topicConfig = new TopicConfig(topicName);
         topicConfig.addMessageListenerConfig(new ListenerConfig(listenerClassName));
-        i1.getConfig().addTopicConfig(topicConfig);
+        driver.getConfig().addTopicConfig(topicConfig);
 
         for (HazelcastInstance instance : instances) {
             topicConfig = instance.getConfig().getTopicConfig(topicName);
@@ -204,23 +231,55 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         Config config = new Config();
         config.addMapConfig(getMapConfigWithTTL(mapName, 20));
 
-        HazelcastInstance hz = createHazelcastInstance(config);
-        hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
+        members(1, config);
+        HazelcastInstance driver = driver();
+        driver.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
     }
 
-    @Test(expected = HazelcastException.class)
+    @Test(expected = InvalidConfigurationException.class)
     public void map_testConflictingStaticConfig() {
         String mapName = "test_map";
         Config config = new Config();
         config.addMapConfig(getMapConfigWithTTL(mapName, 20));
 
-        HazelcastInstance hz = createHazelcastInstance(config);
+        members(1, config);
+        HazelcastInstance hz = driver();
         hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 50));
+    }
+
+    @Test
+    public void cacheConfig_whenListenerIsRegistered() {
+        String cacheName = randomMapName();
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
+                .setName(cacheName)
+                .setKeyType(String.class.getName())
+                .setValueType((new String[0]).getClass().getName())
+                .setStatisticsEnabled(false)
+                .setManagementEnabled(false);
+
+        members(2);
+        HazelcastInstance driver = driver();
+
+        driver.getConfig().addCacheConfig(cacheSimpleConfig);
+        Cache cache = driver.getCacheManager().getCache(cacheName);
+        cache.registerCacheEntryListener(new CacheEntryListenerConfig(() ->
+                (CacheEntryCreatedListener & Serializable) System.out::println,
+                null,
+                true,
+                true));
+        driver.getConfig().addCacheConfig(cacheSimpleConfig);
     }
 
     private MapConfig getMapConfigWithTTL(String mapName, int ttl) {
         MapConfig mapConfig = new MapConfig(mapName);
         mapConfig.setTimeToLiveSeconds(ttl);
         return mapConfig;
+    }
+
+    public static class CacheEntryListenerConfig extends MutableCacheEntryListenerConfiguration implements Serializable {
+        public CacheEntryListenerConfig(Factory listenerFactory, Factory filterFactory, boolean isOldValueRequired,
+                                        boolean isSynchronous) {
+            super(listenerFactory, filterFactory, isOldValueRequired, isSynchronous);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -59,14 +59,14 @@ import com.hazelcast.config.TopicConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.eviction.EvictableEntryView;
-import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.map.MapPartitionLostEvent;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.ringbuffer.RingbufferStore;
 import com.hazelcast.ringbuffer.RingbufferStoreFactory;
+import com.hazelcast.spi.eviction.EvictableEntryView;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -89,6 +89,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.config.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.MaxSizePolicy.PER_NODE;
 import static com.hazelcast.config.MultiMapConfig.ValueCollectionType.LIST;
+import static com.hazelcast.test.TestConfigUtils.NON_DEFAULT_BACKUP_COUNT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -453,6 +454,17 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         driver.getConfig().addCacheConfig(config);
 
         assertConfigurationsEqualsOnAllMembers(config);
+    }
+
+    @Test
+    public void testSameCacheConfig_canBeAddedTwice() {
+        CacheSimpleConfig config = new CacheSimpleConfig()
+                .setName(name)
+                .setBackupCount(NON_DEFAULT_BACKUP_COUNT);
+
+        driver.getConfig().addCacheConfig(config);
+        driver.getCacheManager().getCache(name);
+        driver.getConfig().addCacheConfig(config);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
@@ -44,8 +45,10 @@ import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
@@ -639,6 +642,24 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         assertConfigurationsEqualsOnAllMembers(reliableTopicConfig);
     }
 
+    @Test
+    public void testPNCounterConfig() {
+        PNCounterConfig pnCounterConfig = new PNCounterConfig(name)
+                .setReplicaCount(NON_DEFAULT_BACKUP_COUNT)
+                .setStatisticsEnabled(false);
+
+        driver.getConfig().addPNCounterConfig(pnCounterConfig);
+        assertConfigurationsEqualsOnAllMembers(pnCounterConfig);
+    }
+
+    private void assertConfigurationsEqualsOnAllMembers(PNCounterConfig config) {
+        String name = config.getName();
+        for (HazelcastInstance instance : members) {
+            PNCounterConfig registeredConfig = instance.getConfig().getPNCounterConfig(name);
+            assertEquals(config, registeredConfig);
+        }
+    }
+
     private void assertConfigurationsEqualsOnAllMembers(CacheSimpleConfig config) {
         String name = config.getName();
         for (HazelcastInstance instance : members) {
@@ -765,7 +786,6 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         entryListenerConfig.setOldValueRequired(true);
         entryListenerConfig.setCacheEntryEventFilterFactory("CacheEntryEventFilterFactory");
 
-        // TODO add journal config when client protocol for map codec is updated
         CacheSimpleConfig config = new CacheSimpleConfig()
                 .setName(name)
                 .setSplitBrainProtectionName("split-brain-protection")
@@ -780,10 +800,9 @@ public class DynamicConfigTest extends HazelcastTestSupport {
                 .setReadThrough(true)
                 .setWriteThrough(true)
                 .setHotRestartConfig(new HotRestartConfig().setEnabled(true).setFsync(true))
-//                .setEventJournalConfig(new EventJournalConfig().setEnabled(true)
-//                                                               .setCapacity(42)
-//                                                               .setTimeToLiveSeconds(52))
-                ;
+                .setEventJournalConfig(new EventJournalConfig().setEnabled(true)
+                                                               .setCapacity(42)
+                                                               .setTimeToLiveSeconds(52));
 
         config.setWanReplicationRef(new WanReplicationRef(randomName(), "com.hazelcast.MergePolicy",
                 Collections.singletonList("filter"), true));
@@ -825,11 +844,10 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         mapConfig.setAsyncBackupCount(3)
                 .setBackupCount(2)
                 .setCacheDeserializedValues(CacheDeserializedValues.ALWAYS)
-                // TODO add merkle tree and journal config when client protocol for map codec is updated
-                //.setMerkleTreeConfig(new MerkleTreeConfig().setEnabled(true).setDepth(15))
-//                .setEventJournalConfig(new EventJournalConfig().setEnabled(true)
-//                                                               .setCapacity(42)
-//                                                               .setTimeToLiveSeconds(52))
+                .setMerkleTreeConfig(new MerkleTreeConfig().setEnabled(true).setDepth(15))
+                .setEventJournalConfig(new EventJournalConfig().setEnabled(true)
+                                                               .setCapacity(42)
+                                                               .setTimeToLiveSeconds(52))
                 .setHotRestartConfig(new HotRestartConfig().setEnabled(true).setFsync(true))
                 .setInMemoryFormat(InMemoryFormat.OBJECT)
                 .setMergePolicyConfig(new MergePolicyConfig(NON_DEFAULT_MERGE_POLICY, NON_DEFAULT_MERGE_BATCH_SIZE))


### PR DESCRIPTION
When adding dynamic data structure config from client, a check
for existing conflicting static config has to be made before
broadcasting the config to all members (the same is already
done for member-side implementation).

Also fixes an issue with `CacheSimpleConfig` copies not being
equal to their original which resulted in inability to add
the same cache config twice.

Fixes #16165 
Fixes issue https://github.com/hazelcast/hazelcast/issues/12222#issuecomment-517763733