### PR TITLE
Fixes for client failover behaviour

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -801,7 +801,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public void onClusterChange() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
-        logger.info("Resetting local state of the client");
+        logger.info("Resetting local state of the client, because of a cluster change ");
 
         for (Disposable disposable : onClusterChangeDisposables) {
             disposable.dispose();
@@ -812,6 +812,22 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         //non retryable client messages will fail immediately
         //retryable client messages will be retried but they will wait for new partition table
         connectionManager.reset();
+    }
+
+    public void onClusterRestart() {
+        ILogger logger = loggingService.getLogger(HazelcastInstance.class);
+        logger.info("Clearing local state of the client, because of a cluster restart ");
+
+        for (Disposable disposable : onClusterChangeDisposables) {
+            disposable.dispose();
+        }
+        //clear the member list version
+        clusterService.clearMemberListVersion();
+    }
+
+    public void waitForInitialMembershipEvents() {
+        //after clusterService/connection manager has reset, cluster listeners will be re added
+        clusterService.waitInitialMemberListFetched();
     }
 
     public void sendStateToCluster() throws ExecutionException, InterruptedException {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -340,7 +340,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
         while (discoveryService.hasNext() && client.getLifecycleService().isRunning()) {
             discoveryService.current().destroy();
-
+            client.onClusterChange();
             CandidateClusterContext candidateClusterContext = discoveryService.next();
             candidateClusterContext.start();
             ((ClientLoggingService) client.getLoggingService()).updateClusterName(candidateClusterContext.getClusterName());
@@ -348,6 +348,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             logger.info("Trying to connect to next cluster with client name: " + candidateClusterContext.getClusterName());
 
             if (connectToCandidate(candidateClusterContext)) {
+                client.waitForInitialMembershipEvents();
+                fireLifecycleEvent(LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER);
                 return;
             }
         }
@@ -747,42 +749,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         AuthenticationStatus authenticationStatus = AuthenticationStatus.getById(result.status);
         switch (authenticationStatus) {
             case AUTHENTICATED:
-                checkPartitionCount(result.partitionCount);
-                connection.setConnectedServerVersion(result.serverHazelcastVersion);
-                connection.setRemoteEndpoint(result.address);
-                UUID newClusterId = result.clusterId;
-
-                if (logger.isFineEnabled()) {
-                    logger.fine("Checking the cluster id.Old: " + this.clusterId + ", new: " + newClusterId);
-                }
-
-                boolean changedCluster = clusterId != null && !newClusterId.equals(clusterId);
-                clusterId = newClusterId;
-
-                if (changedCluster) {
-                    client.onClusterChange();
-                }
-                activeConnections.put(resolveAddress(result.address), connection);
-                fireConnectionAddedEvent(connection);
-
-                logger.info("Authenticated with server " + result.address + ", server version:" + connection
-                        .getConnectedServerVersion() + " Local address: " + connection.getLocalSocketAddress());
-
-                establishConnectedState(newClusterId, changedCluster);
-
-                // Check if connection is closed by remote before authentication complete, if that is the case
-                // we need to remove it back from active connections.
-                // Race description from https://github.com/hazelcast/hazelcast/pull/8832.(A little bit changed)
-                // - open a connection client -> member
-                // - send auth message
-                // - receive auth reply -> reply processing is offloaded to an executor. Did not start to run yet.
-                // - member closes the connection -> the connection is trying to removed from map
-                //                                                     but it was not there to begin with
-                // - the executor start processing the auth reply -> it put the connection to the connection map.
-                // - we end up with a closed connection in activeConnections map
-                if (!connection.isAlive()) {
-                    removeFromActiveConnections(connection);
-                }
+                handleAuthResponse(connection, result);
                 break;
             case CREDENTIALS_FAILED:
                 throw new AuthenticationException("Invalid credentials!");
@@ -794,15 +761,51 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         }
     }
 
-    private void establishConnectedState(UUID newClusterId, boolean changedCluster) {
+    private void handleAuthResponse(ClientConnection connection, ClientAuthenticationCodec.ResponseParameters result) {
+        checkPartitionCount(result.partitionCount);
+        connection.setConnectedServerVersion(result.serverHazelcastVersion);
+        connection.setRemoteEndpoint(result.address);
+        UUID newClusterId = result.clusterId;
+
+        if (logger.isFineEnabled()) {
+            logger.fine("Checking the cluster id.Old: " + this.clusterId + ", new: " + newClusterId);
+        }
+
         boolean isFirstConnectionAfterDisconnection = connectionCount.incrementAndGet() == 1;
+        boolean changedCluster = false;
         if (isFirstConnectionAfterDisconnection) {
-            if (changedCluster) {
-                clusterConnectionExecutor.execute(() -> sendStatesToCluster(newClusterId));
-            } else {
-                state = LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
-                fireLifecycleEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
-            }
+            changedCluster = clusterId != null && !newClusterId.equals(clusterId);
+            clusterId = newClusterId;
+        }
+
+        if (changedCluster) {
+            client.onClusterRestart();
+        }
+        activeConnections.put(resolveAddress(result.address), connection);
+        fireConnectionAddedEvent(connection);
+
+        logger.info("Authenticated with server " + result.address + ", server version:" + connection
+                .getConnectedServerVersion() + " Local address: " + connection.getLocalSocketAddress());
+
+        if (changedCluster) {
+            clusterConnectionExecutor.execute(() -> sendStatesToCluster(newClusterId));
+        } else if (isFirstConnectionAfterDisconnection) {
+            state = LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
+            fireLifecycleEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
+        }
+
+        // Check if connection is closed by remote before authentication complete, if that is the case
+        // we need to remove it back from active connections.
+        // Race description from https://github.com/hazelcast/hazelcast/pull/8832.(A little bit changed)
+        // - open a connection client -> member
+        // - send auth message
+        // - receive auth reply -> reply processing is offloaded to an executor. Did not start to run yet.
+        // - member closes the connection -> the connection is trying to removed from map
+        //                                                     but it was not there to begin with
+        // - the executor start processing the auth reply -> it put the connection to the connection map.
+        // - we end up with a closed connection in activeConnections map
+        if (!connection.isAlive()) {
+            removeFromActiveConnections(connection);
         }
     }
 
@@ -886,9 +889,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 client.sendStateToCluster();
                 state = LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
                 fireLifecycleEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
-                if (failoverConfigProvided) {
-                    fireLifecycleEvent(LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER);
-                }
             }
         } catch (Exception e) {
             String clusterName = discoveryService.current().getClusterName();


### PR DESCRIPTION
Follow up to https://github.com/hazelcast/hazelcast/pull/15859
   
The client failover behaviour got broken after ownerless client
changes. This pr restores the behaviour back.

related to https://github.com/hazelcast/hazelcast-enterprise/issues/3385

- Resetting the internal client state explicitly when trying a next
cluster. For tests it is too late to wait for a connection to be
established and its uuid to be checked. Tests are expecting to see
empty memberlist when initial cluster is gone and when a next cluster
connection is not established.

- We wait for the initial membership events after a cluster change is
detected before CLIENT_CONNECTED or CLIENT_CHANGED_CLUSTER event.

- seperate cluster restart and cluster change reset behaviour.
When cluster change , we get initial membership event.
When cluster restart, we don't get initial membership event. Instead,
we get member added and removed events for each action.

- Only first connection after disconnection should check if a cluster
restarted or not. Otherwise there was a race and a second connection
could prevent the first one to fire Connected/changed events
