### PR TITLE
Fix cluster-name in examples and cover fully in tests

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -82,7 +82,7 @@
         Specifies the cluster name. It's sent as part of the client authentication message to Hazelcast
         member(s).
     -->
-    <cluster-name>dev</cluster-name>
+    <cluster-name>my-cluster</cluster-name>
 
     <!--
         When Hazelcast instances are created, they are put in a global registry with their creation names.

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -68,8 +68,9 @@ hazelcast-client:
           secretKeyAlgorithm: DES
           secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
   #
-  # Specifies the cluster name
-  cluster-name: dev
+  # Specifies the cluster name. It's sent as part of the client authentication message to Hazelcast
+  # member(s).
+  cluster-name: my-cluster
   #
   # When Hazelcast instances are created, they are put in a global registry with their creation names.
   # "instance-name" gives you the ability to get a specific Hazelcast instance from this registry

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -23,8 +23,7 @@
 # To learn how to configure Hazelcast, please see the Reference Manual
 # at https://hazelcast.org/documentation/
 hazelcast:
-  cluster:
-    name: dev
+  cluster-name: dev
   management-center:
     enabled: false
     url: http://localhost:8080/hazelcast-mancenter

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -78,10 +78,11 @@
         </replacer>
     </config-replacers>
 
-    <!--Specifies the cluster name. It allows creating separate sub-clusters with different names.
+    <!--
+        Specifies the cluster name. It allows creating separate sub-clusters with different names.
         The name is also referenced in the WAN Replication configuration.
     -->
-    <cluster-name>dev</cluster-name>
+    <cluster-name>my-cluster</cluster-name>
     <!--
         ===== HAZELCAST LICENSE CONFIGURATION =====
 

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -68,13 +68,9 @@ hazelcast:
           secretKeyAlgorithm: DES
           secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
   #
-  # Specifies the name and password for a cluster group you create.
-  # Cluster groups allow you to create separate sub-clusters with different names.
-  # They are also referenced in the WAN Replication configuration.
-  # The group password is only used when the security is enabled (Enterprise edition feature).
-  cluster:
-    name: dev
-    password: dev-pass
+  # Specifies the cluster name. It allows creating separate sub-clusters with different names.
+  #  name is also referenced in the WAN Replication configuration.
+  cluster-name: my-cluster
   #
   # ===== HAZELCAST LICENSE CONFIGURATION =====
   #

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -375,7 +375,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
 
     @Test
     public void testClusterName() {
-        assertEquals("dev", fullClientConfig.getClusterName());
+        assertEquals("my-cluster", fullClientConfig.getClusterName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -59,6 +59,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testConfigurationURL() throws Exception;
 
     @Test
+    public abstract void testClusterName();
+
+    @Test
     public abstract void testConfigurationWithFileName() throws Exception;
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -115,6 +115,18 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testClusterName() {
+        String xml = HAZELCAST_START_TAG
+                + "  <cluster-name>my-cluster</cluster-name>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+
+        assertEquals("my-cluster", config.getClusterName());
+    }
+
+    @Override
+    @Test
     public void testConfigurationWithFileName() throws Exception {
         assumeThatNotZingJDK6(); // https://github.com/hazelcast/hazelcast/issues/9044
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -101,6 +101,17 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testClusterName() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  cluster-name: my-cluster\n";
+
+        Config config = buildConfig(yaml);
+        assertEquals("my-cluster", config.getClusterName());
+    }
+
+    @Override
+    @Test
     public void testConfigurationWithFileName() throws Exception {
         assumeThatNotZingJDK6(); // https://github.com/hazelcast/hazelcast/issues/9044
 

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -46,7 +46,7 @@
         </replacer>
     </config-replacers>
 
-    <cluster-name>dev</cluster-name>
+    <cluster-name>my-cluster</cluster-name>
 
     <instance-name>CLIENT_NAME</instance-name>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -34,7 +34,7 @@ hazelcast-client:
           secretKeyAlgorithm: DES
           secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
 
-  cluster-name: dev
+  cluster-name: my-cluster
   instance-name: CLIENT_NAME
   license-key: HAZELCAST_ENTERPRISE_LICENSE_KEY
   properties:

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -41,7 +41,7 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
-    <cluster-name>dev</cluster-name>
+    <cluster-name>my-cluster</cluster-name>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <instance-name>dummy</instance-name>
     <management-center enabled="true" update-interval="5" scripting-enabled="false">

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -33,9 +33,7 @@
 #    ’hazelcast-default.yaml’, which is included in the the Hazelcast jar
 
 hazelcast:
-  cluster:
-    name: dev
-    password: dev-pass
+  cluster-name: my-cluster
   license-key: HAZELCAST_ENTERPRISE_LICENSE_KEY
   instance-name: dummy
 


### PR DESCRIPTION
The commit addresses the following:
- `full-example` YAML config had an incorrect cluster name configuration
that was not caught by tests because the default cluster name was used
in the XML counterpart too. This is fixed and the cluster name changed
to non-default
- `hazelcast-fullconfig-without-network` xml and yaml files had the same
problem and the fix is the same.
- `hazelcast-default.yaml` had the same problem and it wasn't caught for
the same reason. The fix is the same unless the default cluster name is
kept.
- `hazelcast-client-full` and `hazelcast-client-full-example` had the same
problem and fixed the same way
- Specific tests were missing for cluster name in member config builder
tests.

Fixes #16184 