### PR TITLE
Improve testListenersAfterClientDisconnected tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -221,6 +221,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
             public void run() {
                 map.put(1, 2);
                 assertNotEquals(0, eventCount.get());
+                map.remove(1);
             }
         });
     }


### PR DESCRIPTION
Since we are adding only entry added listener, the eventual test
logic was wrong. In case we miss the first event, subsequent puts
will not trigger EntryAdded event. Removing the item back so that,
each put can trigger the event.

fixes https://github.com/hazelcast/hazelcast/issues/16126