### PR TITLE
Fixed QueueListenerTest.testItemListener_addedToQueueConfig_Issue366

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueListenerTest.java
@@ -16,15 +16,15 @@
 
 package com.hazelcast.collection.impl.queue;
 
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.ItemEvent;
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.ItemEvent;
-import com.hazelcast.collection.ItemListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -111,7 +112,13 @@ public class QueueListenerTest extends HazelcastTestSupport {
         for (int i = 0; i < TOTAL_QUEUE_PUT / 2; i++) {
             queue.put(i);
         }
-        factory.newHazelcastInstance(config);
+        HazelcastInstance second = factory.newHazelcastInstance(config);
+        assertTrueEventually(() -> {
+            assertEquals(2,
+                    getNodeEngineImpl(instance).getEventService().getRegistrations(QueueService.SERVICE_NAME, QUEUE_NAME).size());
+            assertEquals(2,
+                    getNodeEngineImpl(second).getEventService().getRegistrations(QueueService.SERVICE_NAME, QUEUE_NAME).size());
+        });
         for (int i = 0; i < TOTAL_QUEUE_PUT / 4; i++) {
             queue.put(i);
         }


### PR DESCRIPTION
The test inserts some items to the queue, then starts
a second member, inserts some more items, and then checks
that the expected number of queue events was fired across
the cluster.

If there are delays/hiccups during OnJoinOp processing when
the second member is joining the cluster, the QueueService
event registrations may be processed late, during/after
adding items to the queue. As a result, some of the
QueueEvents can be missed.

Adjusted the test to wait until all QueueService event
registrations exist on both cluster members before it
starts the second round of inserting items.

Fixes https://github.com/hazelcast/hazelcast/issues/13415