### PR TITLE
Prevent migration operations running before previous finalization completes v2

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -24,8 +25,10 @@ import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.partition.IPartitionLostEvent;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.MigrationInfo.MigrationStatus;
 import com.hazelcast.internal.partition.MigrationStateImpl;
@@ -48,7 +51,6 @@ import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.internal.util.scheduler.CoalescingDelayedTrigger;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.partition.ReplicaMigrationEvent;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
@@ -57,14 +59,13 @@ import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.internal.partition.IPartitionLostEvent;
-import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -75,6 +76,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -121,6 +123,7 @@ public class MigrationManager {
     private final boolean fragmentedMigrationEnabled;
     private final long memberHeartbeatTimeoutMillis;
     private boolean triggerRepartitioningWhenClusterStateAllowsMigration;
+    private final Set<MigrationInfo> finalizingMigrationsRegistry = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     MigrationManager(Node node, InternalPartitionServiceImpl service, Lock partitionServiceLock) {
         this.node = node;
@@ -213,8 +216,8 @@ public class MigrationManager {
 
                 MigrationEndpoint endpoint = source ? MigrationEndpoint.SOURCE : MigrationEndpoint.DESTINATION;
                 FinalizeMigrationOperation op = new FinalizeMigrationOperation(migrationInfo, endpoint, success);
-                op.setPartitionId(partitionId).setNodeEngine(nodeEngine).setValidateTarget(false)
-                        .setService(partitionService);
+                op.setPartitionId(partitionId).setNodeEngine(nodeEngine).setValidateTarget(false).setService(partitionService);
+                registerFinalizingMigration(migrationInfo);
                 OperationServiceImpl operationService = nodeEngine.getOperationService();
                 if (operationService.isRunAllowed(op)) {
                     // When migration finalization is triggered by subsequent migrations
@@ -242,6 +245,18 @@ public class MigrationManager {
         } finally {
             migrationInfo.doneProcessing();
         }
+    }
+
+    private void registerFinalizingMigration(MigrationInfo migration) {
+        finalizingMigrationsRegistry.add(migration);
+    }
+
+    public boolean removeFinalizingMigration(MigrationInfo migration) {
+        return finalizingMigrationsRegistry.remove(migration);
+    }
+
+    public boolean isFinalizingMigrationRegistered(int partitionId) {
+        return finalizingMigrationsRegistry.stream().anyMatch(m -> partitionId == m.getPartitionId());
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -112,6 +112,15 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
         if (!partitionService.applyCompletedMigrations(completedMigrations, migrationInfo.getMaster())) {
             throw new PartitionStateVersionMismatchException(partitionStateVersion, partitionService.getPartitionStateVersion());
         }
+        if (partitionService.getMigrationManager().isFinalizingMigrationRegistered(migrationInfo.getPartitionId())) {
+            // There's a pending migration finalization operation in the queue.
+            // This happens when this node was the source of a backup replica migration
+            // and now it is destination of another replica migration on the same partition.
+            // Sources of backup migrations are not part of migration transaction
+            // and they learn the migration only while applying completed migrations.
+            throw new RetryableHazelcastException("There is a scheduled FinalizeMigrationOperation for the same partition => "
+                    + migrationInfo);
+        }
     }
 
     /** Verifies that the sent partition state version matches the local version or this node is master. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -72,6 +72,10 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
         PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
         int partitionId = migrationInfo.getPartitionId();
 
+        if (!partitionService.getMigrationManager().removeFinalizingMigration(migrationInfo)) {
+            throw new IllegalStateException("This migration is not registered as finalizing: " + migrationInfo);
+        }
+
         if (isOldBackupReplicaOwner() && partitionStateManager.isMigrating(partitionId)) {
             // On old backup replica, migrating flag is not set during migration.
             // Because replica is copied from partition owner to new backup replica.
@@ -79,11 +83,8 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
             // and completed migration is published by master.
             // If this partition's migrating flag is set, then it means another migration
             // is submitted to this member for the same partition and it's already executed.
-            // This finalization is now obsolete.
-            getLogger().fine("Cannot execute migration finalization, because this member was previous owner of a backup replica,"
-                    + " and a new migration operation has already superseded this finalization. "
-                    + "This operation is now obsolete. -> " + migrationInfo);
-            return;
+            throw new IllegalStateException("Another replica migration is started on the same partition before finalizing "
+                    + migrationInfo);
         }
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
@@ -185,8 +186,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
                         + partitionId);
             }
         } else {
-            int replicaOffset = migrationInfo.getDestinationCurrentReplicaIndex() <= 1 ? 1 : migrationInfo
-                    .getDestinationCurrentReplicaIndex();
+            int replicaOffset = Math.max(migrationInfo.getDestinationCurrentReplicaIndex(), 1);
 
             for (ServiceNamespace namespace : replicaManager.getNamespaces(partitionId)) {
                 long[] versions = updatePartitionReplicaVersions(replicaManager, partitionId, namespace, replicaOffset - 1);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -142,7 +142,7 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
             InternalPartitionServiceImpl partitionService = getService();
             PartitionReplicaManager replicaManager = partitionService.getReplicaManager();
             int destinationNewReplicaIndex = migrationInfo.getDestinationNewReplicaIndex();
-            int replicaOffset = destinationNewReplicaIndex <= 1 ? 1 : destinationNewReplicaIndex;
+            int replicaOffset = Math.max(destinationNewReplicaIndex, 1);
 
             Map<ServiceNamespace, long[]> namespaceVersions = fragmentMigrationState.getNamespaceVersionMap();
             for (Entry<ServiceNamespace, long[]> e  : namespaceVersions.entrySet()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -147,6 +148,7 @@ public abstract class AbstractGracefulShutdownCorrectnessTest extends PartitionC
 
         for (int p = 0; p < partitionCount; p++) {
             Integer actual = (Integer) operationService.invokeOnPartition(null, new TestGetOperation(), p).join();
+            assertNotNull(actual);
             assertEquals(value, actual.intValue());
         }
     }


### PR DESCRIPTION
If a node was the source of a backup replica migration
and then if it becomes the destination of another replica migration
on the same partition, `MigrationOperation` can be executed before
the former migration is finalized. Reason is, sources of backup migrations
are not part of migration transactions and they learn the migration
only while applying completed migrations.

Previously, when we detect this, we skipped the execution of previous
migrations finalization to prevent data loss. See https://github.com/hazelcast/hazelcast/pull/14832

But this may cause replica data leak, because of ignored finalization.

This time, migration finalizations are registered before
they are executed or enqueued. If there's an pending finalization
while a migration operation is being executed then migration operation
is rejected with a retryable exception.

Fixes #15562
Fixes #16066
