### PR TITLE
Prevent migration operations running before previous finalization completes v2

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -72,6 +72,10 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
         PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
         int partitionId = migrationInfo.getPartitionId();
 
+        if (!partitionService.getMigrationManager().removeFinalizingMigration(migrationInfo)) {
+            throw new IllegalStateException("This migration is not registered as finalizing: " + migrationInfo);
+        }
+
         if (isOldBackupReplicaOwner() && partitionStateManager.isMigrating(partitionId)) {
             // On old backup replica, migrating flag is not set during migration.
             // Because replica is copied from partition owner to new backup replica.
@@ -79,11 +83,8 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
             // and completed migration is published by master.
             // If this partition's migrating flag is set, then it means another migration
             // is submitted to this member for the same partition and it's already executed.
-            // This finalization is now obsolete.
-            getLogger().fine("Cannot execute migration finalization, because this member was previous owner of a backup replica,"
-                    + " and a new migration operation has already superseded this finalization. "
-                    + "This operation is now obsolete. -> " + migrationInfo);
-            return;
+            throw new IllegalStateException("Another replica migration is started on the same partition before finalizing "
+                    + migrationInfo);
         }
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
@@ -185,8 +186,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
                         + partitionId);
             }
         } else {
-            int replicaOffset = migrationInfo.getDestinationCurrentReplicaIndex() <= 1 ? 1 : migrationInfo
-                    .getDestinationCurrentReplicaIndex();
+            int replicaOffset = Math.max(migrationInfo.getDestinationCurrentReplicaIndex(), 1);
 
             for (ServiceNamespace namespace : replicaManager.getNamespaces(partitionId)) {
                 long[] versions = updatePartitionReplicaVersions(replicaManager, partitionId, namespace, replicaOffset - 1);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -148,7 +148,7 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
             InternalPartitionServiceImpl partitionService = getService();
             PartitionReplicaManager replicaManager = partitionService.getReplicaManager();
             int destinationNewReplicaIndex = migrationInfo.getDestinationNewReplicaIndex();
-            int replicaOffset = destinationNewReplicaIndex <= 1 ? 1 : destinationNewReplicaIndex;
+            int replicaOffset = Math.max(destinationNewReplicaIndex, 1);
 
             Map<ServiceNamespace, long[]> namespaceVersions = fragmentMigrationState.getNamespaceVersionMap();
             for (Entry<ServiceNamespace, long[]> e  : namespaceVersions.entrySet()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -147,6 +148,7 @@ public abstract class AbstractGracefulShutdownCorrectnessTest extends PartitionC
 
         for (int p = 0; p < partitionCount; p++) {
             Integer actual = (Integer) operationService.invokeOnPartition(null, new TestGetOperation(), p).join();
+            assertNotNull(actual);
             assertEquals(value, actual.intValue());
         }
     }


### PR DESCRIPTION
If a node was the source of a backup replica migration
and then if it becomes the destination of another replica migration
on the same partition, `MigrationOperation` can be executed before
the former migration is finalized. Reason is, sources of backup migrations
are not part of migration transactions and they learn the migration
only while applying completed migrations.

Previously, when we detect this, we skipped the execution of previous
migrations finalization to prevent data loss. See https://github.com/hazelcast/hazelcast/pull/14834

But this may cause replica data leak, because of ignored finalization.

This time, migration finalizations are registered before
they are executed or enqueued. If there's an pending finalization
while a migration operation is being executed then migration operation
is rejected with a retryable exception.

Fixes #15562
Fixes #16066
Backport of https://github.com/hazelcast/hazelcast/pull/16189