### PR TITLE
Destroy near caches on shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -485,11 +485,24 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     @Override
     protected void postDestroy() {
         try {
-            removeInvalidationListener();
-            nearCacheManager.destroyNearCache(nearCache.getName());
+            destroyNearCache();
         } finally {
             super.postDestroy();
         }
+    }
+
+    @Override
+    protected void onShutdown() {
+        try {
+            destroyNearCache();
+        } finally {
+            super.onShutdown();
+        }
+    }
+
+    private void destroyNearCache() {
+        removeInvalidationListener();
+        nearCacheManager.destroyNearCache(nearCache.getName());
     }
 
     private Object getCachedValue(Object key, boolean deserializeValue) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReplicatedMapProxy.java
@@ -46,17 +46,17 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.util.IterationType;
 import com.hazelcast.internal.util.ResultSet;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.MapEvent;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
-import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
-import com.hazelcast.internal.util.IterationType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -122,12 +122,25 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     @Override
     protected void postDestroy() {
         try {
-            if (nearCache != null) {
-                removeNearCacheInvalidationListener();
-                getContext().getNearCacheManager(getServiceName()).destroyNearCache(name);
-            }
+            destroyNearCache();
         } finally {
             super.postDestroy();
+        }
+    }
+
+    @Override
+    protected void onShutdown() {
+        try {
+            destroyNearCache();
+        } finally {
+            super.onShutdown();
+        }
+    }
+
+    private void destroyNearCache() {
+        if (nearCache != null) {
+            removeNearCacheInvalidationListener();
+            getContext().getNearCacheManager(getServiceName()).destroyNearCache(name);
         }
     }
 
@@ -376,8 +389,8 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     @Nonnull
     @Override
     public UUID addEntryListener(@Nonnull EntryListener<K, V> listener,
-                                   @Nonnull Predicate<K, V> predicate,
-                                   @Nullable K key) {
+                                 @Nonnull Predicate<K, V> predicate,
+                                 @Nullable K key) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
@@ -705,7 +718,7 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
 
         @Override
         public void handleEntryEvent(Data dataKey, Data value, Data oldValue, Data mergingValue,
-                                        int eventType, UUID uuid, int numberOfAffectedEntries) {
+                                     int eventType, UUID uuid, int numberOfAffectedEntries) {
             EntryEventType entryEventType = EntryEventType.getByType(eventType);
             switch (entryEventType) {
                 case ADDED:

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
@@ -574,8 +574,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     @Override
     protected void postDestroy() {
         try {
-            removeNearCacheInvalidationListener();
-            getContext().getNearCacheManager(getServiceName()).destroyNearCache(name);
+            destroyNearCache();
         } finally {
             super.postDestroy();
         }
@@ -583,10 +582,16 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     @Override
     protected void onShutdown() {
+        try {
+            destroyNearCache();
+        } finally {
+            super.onShutdown();
+        }
+    }
+
+    private void destroyNearCache() {
         removeNearCacheInvalidationListener();
         getContext().getNearCacheManager(getServiceName()).destroyNearCache(name);
-
-        super.onShutdown();
     }
 
     private Object toNearCacheKey(Object key) {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/3411

__Cause:__
This test started to fail after merging https://github.com/hazelcast/hazelcast/pull/16160 which removed near cache destroy logic from client instance and made reliance to proxy objects for destruction. But it revealed that some proxies don't do proper destruction on shutdown hence test failed.

__Fix:__
 Every proxy should destroy its own near cache.