### PR TITLE
Fix CPGroupRebalanceTest failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPGroupRebalanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPGroupRebalanceTest.java
@@ -21,6 +21,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.internal.operation.GetLeadedGroupsOp;
+import com.hazelcast.cp.internal.raft.impl.RaftEndpoint;
+import com.hazelcast.cp.internal.raftop.metadata.CreateRaftGroupOp;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -31,11 +33,14 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static com.hazelcast.cp.internal.MetadataRaftGroupManager.INITIAL_METADATA_GROUP_ID;
 import static com.hazelcast.cp.internal.RaftGroupMembershipManager.LEADERSHIP_BALANCE_TASK_PERIOD;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -52,14 +57,15 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
     @Test
     public void test() throws Exception {
         int cpMemberCount = 7;
-        HazelcastInstance[] instances = newInstances(cpMemberCount, 3, 0);
+        int groupSize = 3;
+        HazelcastInstance[] instances = newInstances(cpMemberCount, groupSize, 0);
         waitUntilCPDiscoveryCompleted(instances);
 
-        final int leadershipsPerMember = 11;
-        final int extraGroups = 3;
-        final int groupCount = cpMemberCount * leadershipsPerMember + extraGroups;
+        int leadershipsPerMember = 11;
+        int extraGroups = 3;
+        int groupCount = cpMemberCount * leadershipsPerMember + extraGroups;
 
-        createRaftGroups(instances, groupCount);
+        createRaftGroups(instances, groupSize, groupCount);
 
         HazelcastInstance metadataLeader = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
         Collection<CPMember> cpMembers = metadataLeader.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
@@ -79,20 +85,33 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
         getRaftService(metadataLeader).getMetadataGroupManager().rebalanceGroupLeaderships();
     }
 
-    private void createRaftGroups(HazelcastInstance[] instances, int groupCount) {
+    private void createRaftGroups(HazelcastInstance[] instances, int groupSize, int groupCount) {
         RaftInvocationManager invocationManager = getRaftInvocationManager(instances[0]);
 
+        RaftEndpoint[] endpoints = Arrays.stream(instances)
+                                         .map(instance -> instance.getCPSubsystem().getLocalCPMember())
+                                         .map(cpMember -> ((CPMemberInfo) cpMember).toRaftEndpoint())
+                                         .toArray(RaftEndpoint[]::new);
         Collection<CPGroupId> groupIds = new ArrayList<>(groupCount);
-        Collection<InternalCompletableFuture<RaftGroupId>> futures = new ArrayList<>(groupCount);
+        Collection<InternalCompletableFuture<CPGroupSummary>> futures = new ArrayList<>(groupCount);
 
         for (int i = 0; i < groupCount; i++) {
-            InternalCompletableFuture<RaftGroupId> f = invocationManager.createRaftGroup("group-" + i);
+            List<RaftEndpoint> groupMembers = new ArrayList<>(groupSize);
+            for (int j = 0; j < groupSize; j++) {
+                groupMembers.add(endpoints[(i + j) % endpoints.length]);
+            }
+
+            RaftOp op = new CreateRaftGroupOp("group-" + i, groupMembers);
+            InternalCompletableFuture<CPGroupSummary> f = invocationManager.invoke(INITIAL_METADATA_GROUP_ID, op);
             futures.add(f);
         }
-        for (InternalCompletableFuture<RaftGroupId> future : futures) {
-            RaftGroupId groupId = future.join();
-            groupIds.add(groupId);
+
+        for (InternalCompletableFuture<CPGroupSummary> future : futures) {
+            CPGroupSummary group = future.join();
+            invocationManager.triggerRaftNodeCreation(group);
+            groupIds.add(group.id());
         }
+
         for (CPGroupId groupId : groupIds) {
             // await leader election
             getLeaderInstance(instances, groupId);


### PR DESCRIPTION
Ensure CP groups are equally distributed among CP members

Fixes #15727