### PR TITLE
Avoid logs of *NotActive exceptions from InvalidationMeta fetcher

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
@@ -18,13 +18,13 @@ package com.hazelcast.internal.nearcache.impl.invalidation;
 
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.ConstructorFunction;
+import com.hazelcast.internal.util.ContextMutexFactory;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.util.ConstructorFunction;
-import com.hazelcast.internal.util.ContextMutexFactory;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -218,16 +218,8 @@ public final class RepairingTask implements Runnable {
     private void initRepairingHandler(RepairingHandler handler) {
         logger.finest("Initializing repairing handler");
 
-        boolean initialized = false;
-        try {
-            invalidationMetaDataFetcher.init(handler);
-            initialized = true;
-        } catch (Exception e) {
-            logger.warning(e);
-        } finally {
-            if (!initialized) {
-                initRepairingHandlerAsync(handler);
-            }
+        if (!invalidationMetaDataFetcher.init(handler)) {
+            initRepairingHandlerAsync(handler);
         }
     }
 


### PR DESCRIPTION
Inspect exception thrown and its cause in order to decide whether
to log an exception or not. This is needed as
`HazelcastInstance/ClientNotActive` exceptions are thrown wrapped
in `ExecutionException` from `extractMemberMetadata` implementations
which use `Future#get(long, TimeUnit)`.

Fixes #16187 