### PR TITLE
Fix client and member OOME in BETA-2 tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.Client;
 import com.hazelcast.client.impl.statistics.ClientStatistics;
+import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.transaction.TransactionContext;
@@ -31,7 +32,7 @@ import java.util.concurrent.Callable;
 /**
  * Represents an endpoint to a client. So for each client connected to a member, a ClientEndpoint object is available.
  */
-public interface ClientEndpoint extends Client {
+public interface ClientEndpoint extends Client, DynamicMetricsProvider {
 
     /**
      * Checks if the endpoint is alive.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.Client;
 import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.MetricConsumer;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricTarget;
@@ -51,8 +50,7 @@ import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
 /**
  * The {@link com.hazelcast.client.impl.ClientEndpoint} and {@link Client} implementation.
  */
-public final class ClientEndpointImpl
-    implements ClientEndpoint, DynamicMetricsProvider {
+public final class ClientEndpointImpl implements ClientEndpoint {
     private static final String METRICS_TAG_CLIENT = "client";
     private static final String METRICS_TAG_TIMESTAMP = "timestamp";
 
@@ -83,7 +81,6 @@ public final class ClientEndpointImpl
         this.socketAddress = connection.getRemoteSocketAddress();
         this.clientVersion = "Unknown";
         this.creationTime = System.currentTimeMillis();
-        nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.client.impl;
 
+import com.hazelcast.internal.metrics.DynamicMetricsProvider;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.nio.Connection;
@@ -42,7 +45,7 @@ import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 /**
  * Manages and stores {@link com.hazelcast.client.impl.ClientEndpointImpl}s.
  */
-public class ClientEndpointManagerImpl implements ClientEndpointManager {
+public class ClientEndpointManagerImpl implements ClientEndpointManager, DynamicMetricsProvider {
 
     private final ILogger logger;
     private final EventService eventService;
@@ -59,6 +62,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
         this.eventService = nodeEngine.getEventService();
         MetricsRegistry metricsRegistry = ((NodeEngineImpl) nodeEngine).getMetricsRegistry();
         metricsRegistry.registerStaticMetrics(this, "client.endpoint");
+        metricsRegistry.registerDynamicMetricsProvider(this);
     }
 
     @Override
@@ -141,4 +145,8 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
         return endpoints.size();
     }
 
+    @Override
+    public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
+        endpoints.forEach((connection, clientEndpoint) -> clientEndpoint.provideDynamicMetrics(descriptor, context));
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -761,6 +761,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         invocationService.shutdown();
         executionService.shutdown();
         listenerService.shutdown();
+        clientStatisticsService.shutdown();
         metricsRegistry.shutdown();
         diagnostics.shutdown();
         serializationService.dispose();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
@@ -69,6 +69,7 @@ public class ClientStatisticsService {
     private PeriodicStatistics periodicStats;
 
     private volatile ConcurrentMap<String, NearCacheManager> nearCacheManagers;
+    private volatile PublisherMetricsCollector publisherMetricsCollector;
 
     public ClientStatisticsService(final HazelcastClientInstanceImpl clientInstance) {
         this.metricsConfig = clientInstance.getClientConfig().getMetricsConfig();
@@ -86,6 +87,12 @@ public class ClientStatisticsService {
             return;
         }
 
+        if (metricsConfig.getJmxConfig().isEnabled()) {
+            publisherMetricsCollector = new PublisherMetricsCollector(new JmxPublisher(client.getName(), "com.hazelcast"));
+        } else {
+            publisherMetricsCollector = new PublisherMetricsCollector();
+        }
+
         metricsRegistry.registerDynamicMetricsProvider(new ClusterConnectionMetricsProvider(client.getConnectionManager()));
 
         long periodSeconds = metricsConfig.getCollectionFrequencySeconds();
@@ -97,6 +104,12 @@ public class ClientStatisticsService {
         schedulePeriodicStatisticsSendTask(metricsConfig.getCollectionFrequencySeconds());
 
         logger.info("Client statistics is enabled with period " + periodSeconds + " seconds.");
+    }
+
+    public void shutdown() {
+        if (publisherMetricsCollector != null) {
+            publisherMetricsCollector.shutdown();
+        }
     }
 
     // visible for testing
@@ -115,13 +128,6 @@ public class ClientStatisticsService {
      * @param periodSeconds the interval at which the statistics collection and send is being run
      */
     private void schedulePeriodicStatisticsSendTask(long periodSeconds) {
-        PublisherMetricsCollector publisherMetricsCollector;
-        if (metricsConfig.isEnabled() && metricsConfig.getJmxConfig().isEnabled()) {
-            publisherMetricsCollector = new PublisherMetricsCollector(new JmxPublisher(client.getName(), "com.hazelcast"));
-        } else {
-            publisherMetricsCollector = new PublisherMetricsCollector();
-        }
-
         ClientMetricCollector clientMetricCollector = new ClientMetricCollector();
         CompositeMetricsCollector compositeMetricsCollector = new CompositeMetricsCollector(clientMetricCollector,
                 publisherMetricsCollector);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.metrics.jmx;
 
-import com.hazelcast.config.MetricsConfig;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsPublisher;
 import com.hazelcast.internal.metrics.ProbeUnit;
@@ -44,6 +43,7 @@ public class JmxPublisher implements MetricsPublisher {
 
     private final MBeanServer platformMBeanServer;
     private final String instanceNameEscaped;
+    private final String domainPrefix;
 
     /**
      * key: metric name, value: MetricData
@@ -59,6 +59,7 @@ public class JmxPublisher implements MetricsPublisher {
     private final Function<? super ObjectName, ? extends MetricsMBean> createMBeanFunction;
 
     public JmxPublisher(String instanceName, String domainPrefix) {
+        this.domainPrefix = domainPrefix;
         platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
         instanceNameEscaped = escapeObjectNameValue(instanceName);
         createMetricDataFunction = n -> new MetricData(n, instanceNameEscaped, domainPrefix);
@@ -175,7 +176,7 @@ public class JmxPublisher implements MetricsPublisher {
         boolean wasPresent;
 
         /**
-         * See {@link MetricsConfig#setJmxEnabled(boolean)}.
+         * See {@link com.hazelcast.config.MetricsJmxConfig#setEnabled(boolean)}.
          */
         @SuppressWarnings({"checkstyle:ExecutableStatementCount", "checkstyle:NPathComplexity",
                            "checkstyle:CyclomaticComplexity"})
@@ -244,15 +245,16 @@ public class JmxPublisher implements MetricsPublisher {
     @Override
     public void shutdown() {
         isShutdown = true;
-        ObjectName name;
         try {
-            name = new ObjectName("com.hazelcast*" + ":instance=" + instanceNameEscaped + ",type=Metrics,*");
+            // unregister the MBeans registered by this JmxPublisher
+            // the mBeans map can't be used since it is not thread-safe
+            // and is meant to be used by the publisher thread only
+            ObjectName name = new ObjectName(domainPrefix + "*" + ":instance=" + instanceNameEscaped + ",type=Metrics,*");
+            for (ObjectName bean : platformMBeanServer.queryNames(name, null)) {
+                unregisterMBeanIgnoreError(bean);
+            }
         } catch (MalformedObjectNameException e) {
             throw new RuntimeException("Exception when unregistering JMX beans", e);
-        }
-
-        for (ObjectName bean : platformMBeanServer.queryNames(name, null)) {
-            unregisterMBeanIgnoreError(bean);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -18,9 +18,9 @@ package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
+import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.networking.Channel;
@@ -356,20 +356,26 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
             context.collect(descriptorOut, channel.outboundPipeline());
         }
 
-        for (NioThread nioThread : inputThreads) {
-            MetricDescriptor descriptorInThread = descriptor
-                    .copy()
-                    .withPrefix("tcp.inputThread")
-                    .withDiscriminator("thread", nioThread.getName());
-            context.collect(descriptorInThread, nioThread);
+        NioThread[] inputThreads = this.inputThreads;
+        if (inputThreads != null) {
+            for (NioThread nioThread : inputThreads) {
+                MetricDescriptor descriptorInThread = descriptor
+                        .copy()
+                        .withPrefix("tcp.inputThread")
+                        .withDiscriminator("thread", nioThread.getName());
+                context.collect(descriptorInThread, nioThread);
+            }
         }
 
-        for (NioThread nioThread : outputThreads) {
-            MetricDescriptor descriptorOutThread = descriptor
-                    .copy()
-                    .withPrefix("tcp.outputThread")
-                    .withDiscriminator("thread", nioThread.getName());
-            context.collect(descriptorOutThread, nioThread);
+        NioThread[] outputThreads = this.outputThreads;
+        if (outputThreads != null) {
+            for (NioThread nioThread : outputThreads) {
+                MetricDescriptor descriptorOutThread = descriptor
+                        .copy()
+                        .withPrefix("tcp.outputThread")
+                        .withDiscriminator("thread", nioThread.getName());
+                context.collect(descriptorOutThread, nioThread);
+            }
         }
 
         IOBalancer ioBalancer = this.ioBalancer;

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientJmxMetricsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.internal.metrics;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.jmx.JmxPublisherTestHelper;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientJmxMetricsTest extends HazelcastTestSupport {
+    private static final String DOMAIN_PREFIX = "com.hazelcast";
+
+    private TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private JmxPublisherTestHelper helper;
+
+    @Before
+    public void setUp() throws Exception {
+        helper = new JmxPublisherTestHelper(DOMAIN_PREFIX);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testNoMBeanLeak() {
+        helper.assertNoMBeans();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getMetricsConfig()
+                    .setCollectionFrequencySeconds(1);
+        clientConfig.getConnectionStrategyConfig()
+                    .setAsyncStart(true);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        String expectedObjectName = DOMAIN_PREFIX + ":type=Metrics,instance=" + client.getName() + ",prefix=os";
+        assertTrueEventually(() -> helper.assertMBeanContains(expectedObjectName));
+
+        client.shutdown();
+        helper.assertNoMBeans();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.metrics.jmx;
 
 import com.hazelcast.internal.metrics.MetricDescriptor;
-import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -29,16 +28,8 @@ import org.junit.runner.RunWith;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
-import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.hazelcast.internal.metrics.MetricTarget.JMX;
 import static com.hazelcast.internal.metrics.impl.DefaultMetricDescriptorSupplier.DEFAULT_DESCRIPTOR_SUPPLIER;
@@ -47,8 +38,6 @@ import static com.hazelcast.internal.util.MapUtil.entry;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -56,22 +45,19 @@ public class JmxPublisherTest {
 
     private static final String MODULE_NAME = "moduleA";
 
-    private ObjectName objectNameNoModule;
-    private ObjectName objectNameWithModule;
-
     private JmxPublisher jmxPublisher;
     private MBeanServer platformMBeanServer;
     private String domainPrefix;
+    private JmxPublisherTestHelper helper;
 
     @Before
     public void before() throws Exception {
         domainPrefix = "domain" + ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
         jmxPublisher = new JmxPublisher("inst1", domainPrefix);
+        helper = new JmxPublisherTestHelper(domainPrefix);
         platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
-        objectNameNoModule = new ObjectName(domainPrefix + ":*");
-        objectNameWithModule = new ObjectName(domainPrefix + "." + MODULE_NAME + ":*");
         try {
-            assertMBeans(emptyList());
+            helper.assertMBeans(emptyList());
         } catch (AssertionError e) {
             throw new AssertionError("JMX beans used by this test are already registered", e);
         }
@@ -81,7 +67,7 @@ public class JmxPublisherTest {
     public void after() throws Exception {
         // unregister all beans in domains used in the test to not interfere with other tests
         try {
-            for (ObjectInstance instance : queryOurInstances()) {
+            for (ObjectInstance instance : helper.queryOurInstances()) {
                 platformMBeanServer.unregisterMBean(instance.getObjectName());
             }
         } catch (InstanceNotFoundException ignored) {
@@ -95,7 +81,7 @@ public class JmxPublisherTest {
                 .withTag("tag1", "a")
                 .withTag("tag2", "b");
         jmxPublisher.publishLong(descriptor, 1L);
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
                         singletonList(entry("c", 1L)))));
     }
@@ -109,7 +95,7 @@ public class JmxPublisherTest {
                 .withTag("tag1", "a")
                 .withTag("tag2", "b");
         jmxPublisher.publishLong(descriptor, 1L);
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,prefix=d,tag0=\"tag1=a\",tag1=\"tag2=b\",tag2=\"name=itsName\"",
                         singletonList(entry("c", 1L)))));
     }
@@ -121,7 +107,7 @@ public class JmxPublisherTest {
                 .withTag("tag1", "a")
                 .withTag("module", MODULE_NAME);
         jmxPublisher.publishLong(descriptor, 1L);
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
                 of(domainPrefix + "." + MODULE_NAME + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
                         singletonList(entry("c", 1L)))));
     }
@@ -147,7 +133,7 @@ public class JmxPublisherTest {
                 .withTag("tag2", "c"), 3L);
         jmxPublisher.publishLong(newDescriptor()
                 .withMetric("a"), 4L);
-        assertMBeans(asList(
+        helper.assertMBeans(asList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
                         asList(entry("c", 1L), entry("d", 2L))),
                 of(domainPrefix + "." + MODULE_NAME + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
@@ -168,7 +154,7 @@ public class JmxPublisherTest {
                 .withMetric("c")
                 .withTag("tag1", "a"), 2L);
         jmxPublisher.whenComplete();
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
                         asList(entry("b", 1L), entry("c", 2L)))
         ));
@@ -177,13 +163,13 @@ public class JmxPublisherTest {
                 .withMetric("b")
                 .withTag("tag1", "a"), 1L);
         jmxPublisher.whenComplete();
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
                         singletonList(entry("b", 1L)))
         ));
 
         jmxPublisher.whenComplete();
-        assertMBeans(emptyList());
+        helper.assertMBeans(emptyList());
     }
 
     @Test
@@ -228,7 +214,7 @@ public class JmxPublisherTest {
                 .withTag("tag1", "a"), 2L);
         jmxPublisher.whenComplete();
 
-        assertMBeans(asList(
+        helper.assertMBeans(asList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,prefix=" + JmxPublisher.escapeObjectNameValue(badText),
                         singletonList(entry("metric", 1L))),
                 of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\"",
@@ -254,7 +240,7 @@ public class JmxPublisherTest {
                 .withMetric("double"), 2.5D);
         jmxPublisher.whenComplete();
 
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
                 of(domainPrefix + ":type=Metrics,instance=inst1,prefix=notExcluded", asList(
                         entry("long", 2L),
                         entry("double", 2.5D)
@@ -270,41 +256,34 @@ public class JmxPublisherTest {
             .withTag("tag2", "b");
         jmxPublisher.publishLong(descriptor, 1L);
         jmxPublisher.whenComplete();
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
             of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
                 singletonList(entry("c", 1L)))));
 
         jmxPublisher.publishLong(descriptor, 2L);
-        assertMBeans(singletonList(
+        helper.assertMBeans(singletonList(
             of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
                 singletonList(entry("c", 2L)))));
     }
 
+    @Test
+    public void when_shutdown_noMBeansLeak() throws Exception {
+        MetricDescriptor descriptor = newDescriptor()
+                .withMetric("c")
+                .withTag("tag1", "a")
+                .withTag("tag2", "b");
+        jmxPublisher.publishLong(descriptor, 1L);
+        jmxPublisher.whenComplete();
+        helper.assertMBeans(singletonList(
+                of(domainPrefix + ":type=Metrics,instance=inst1,tag0=\"tag1=a\",tag1=\"tag2=b\"",
+                        singletonList(entry("c", 1L)))));
+
+        jmxPublisher.shutdown();
+
+        helper.assertMBeans(emptyList());
+    }
+
     private MetricDescriptor newDescriptor() {
         return DEFAULT_DESCRIPTOR_SUPPLIER.get();
-    }
-
-    private void assertMBeans(List<BiTuple<String, List<Entry<String, Number>>>> expected) throws Exception {
-        Set<ObjectInstance> instances = queryOurInstances();
-        Map<ObjectName, ObjectInstance> instanceMap =
-                instances.stream().collect(Collectors.toMap(ObjectInstance::getObjectName, Function.identity()));
-
-        assertEquals("actual: " + instances, expected.size(), instances.size());
-
-        for (BiTuple<String, List<Entry<String, Number>>> entry : expected) {
-            ObjectName on = new ObjectName(entry.element1);
-            assertTrue("name: " + on + " not in instances " + instances, instanceMap.containsKey(on));
-            for (Entry<String, Number> attribute : entry.element2) {
-                assertEquals("Attribute '" + attribute.getKey() + "' of '" + on + "' doesn't match",
-                        attribute.getValue(), platformMBeanServer.getAttribute(on, attribute.getKey()));
-            }
-        }
-    }
-
-    private Set<ObjectInstance> queryOurInstances() {
-        Set<ObjectInstance> instances = new HashSet<>();
-        instances.addAll(platformMBeanServer.queryMBeans(objectNameNoModule, null));
-        instances.addAll(platformMBeanServer.queryMBeans(objectNameWithModule, null));
-        return instances;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTestHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTestHelper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.jmx;
+
+import com.hazelcast.internal.util.BiTuple;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JmxPublisherTestHelper {
+    private static final String MODULE_NAME = "moduleA";
+
+    private final MBeanServer platformMBeanServer;
+    private final ObjectName objectNameNoModule;
+    private final ObjectName objectNameWithModule;
+
+    public JmxPublisherTestHelper(String domainPrefix) throws Exception {
+        objectNameNoModule = new ObjectName(domainPrefix + ":*");
+        objectNameWithModule = new ObjectName(domainPrefix + "." + MODULE_NAME + ":*");
+        platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+    }
+
+    public void assertNoMBeans() {
+        Set<ObjectInstance> instances = queryOurInstances();
+        assertEquals(0, instances.size());
+    }
+
+    public void assertMBeanContains(String... expectedObjectNames) throws Exception {
+        Set<ObjectInstance> instances = queryOurInstances();
+        Map<ObjectName, ObjectInstance> instanceMap =
+                instances.stream().collect(Collectors.toMap(ObjectInstance::getObjectName, Function.identity()));
+
+        for (String expectedObjectName : expectedObjectNames) {
+            ObjectName on = new ObjectName(expectedObjectName);
+            assertTrue("name: " + on + " not in instances " + instances, instanceMap.containsKey(on));
+        }
+    }
+
+    public void assertMBeans(List<BiTuple<String, List<Map.Entry<String, Number>>>> expected) throws Exception {
+        Set<ObjectInstance> instances = queryOurInstances();
+        Map<ObjectName, ObjectInstance> instanceMap =
+                instances.stream().collect(Collectors.toMap(ObjectInstance::getObjectName, Function.identity()));
+
+        assertEquals("actual: " + instances, expected.size(), instances.size());
+
+        for (BiTuple<String, List<Map.Entry<String, Number>>> entry : expected) {
+            ObjectName on = new ObjectName(entry.element1);
+            assertTrue("name: " + on + " not in instances " + instances, instanceMap.containsKey(on));
+            for (Map.Entry<String, Number> attribute : entry.element2) {
+                assertEquals("Attribute '" + attribute.getKey() + "' of '" + on + "' doesn't match",
+                        attribute.getValue(), platformMBeanServer.getAttribute(on, attribute.getKey()));
+            }
+        }
+    }
+
+    public Set<ObjectInstance> queryOurInstances() {
+        Set<ObjectInstance> instances = new HashSet<>();
+        instances.addAll(platformMBeanServer.queryMBeans(objectNameNoModule, null));
+        instances.addAll(platformMBeanServer.queryMBeans(objectNameWithModule, null));
+        return instances;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.jmx;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MemberJmxMetricsTest {
+    private static final String DOMAIN_PREFIX = "com.hazelcast";
+
+    private TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private JmxPublisherTestHelper helper;
+
+    @Before
+    public void setUp() throws Exception {
+        helper = new JmxPublisherTestHelper(DOMAIN_PREFIX);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testNoMBeanLeak() {
+        helper.assertNoMBeans();
+
+        Config config = smallInstanceConfig();
+        config.getMetricsConfig()
+              .setCollectionFrequencySeconds(1);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        String expectedObjectName = DOMAIN_PREFIX + ":type=Metrics,instance=" + member.getName() + ",prefix=os";
+        assertTrueEventually(() -> helper.assertMBeanContains(expectedObjectName));
+
+        member.shutdown();
+        helper.assertNoMBeans();
+    }
+}


### PR DESCRIPTION
Changes:
- Make `MetricsRegistry` not referencing client endpoints directly
- Fix leaking MBeans after client shutdown by calling shutdown on `JmxPublisher`
- Add tests verifying no MBeans leak after client and member shutdown
- Create and use `JmxPublisherTeshHelper`
- Fix NPE thrown in `NioNetworking` during client shutdown

Fixes hazelcast/hazelcast-enterprise#3414
Fixes hazelcast/hazelcast-enterprise#3418