### PR TITLE
Add metrics test rule

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -133,6 +133,7 @@ import com.hazelcast.nio.ssl.SSLContextFactory;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.ringbuffer.RingbufferStore;
 import com.hazelcast.ringbuffer.RingbufferStoreFactory;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.impl.ProbabilisticSplitBrainProtectionFunction;
 import com.hazelcast.splitbrainprotection.impl.RecentlyActiveSplitBrainProtectionFunction;
@@ -276,9 +277,17 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     private PNCounter pnCounter;
 
     @BeforeClass
-    @AfterClass
     public static void start() {
+        // OverridePropertyRule can't be used here since the Spring context
+        // with the Hazelcast instance is created before the rules
+        System.clearProperty(ClusterProperty.METRICS_COLLECTION_FREQUENCY.getName());
         HazelcastInstanceFactory.terminateAll();
+    }
+
+    @AfterClass
+    public static void stop() {
+        HazelcastInstanceFactory.terminateAll();
+        System.setProperty(ClusterProperty.METRICS_COLLECTION_FREQUENCY.getName(), "1");
     }
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsPropertiesTest.java
@@ -24,7 +24,9 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,6 +42,14 @@ import static org.junit.Assert.assertSame;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class MetricsPropertiesTest extends HazelcastTestSupport {
+
+    @Rule
+    public OverridePropertyRule overrideFrequency =
+            OverridePropertyRule.clear(ClusterProperty.METRICS_COLLECTION_FREQUENCY.getName());
+
+    @Rule
+    public OverridePropertyRule overrideDebug =
+            OverridePropertyRule.clear(ClusterProperty.METRICS_DEBUG.getName());
 
     @Test
     public void testSystemPropertiesOverrideConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -39,6 +39,8 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.nio.EndpointManager;
 import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.partition.IPartition;
+import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.impl.PartitionServiceState;
@@ -63,10 +65,9 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.internal.partition.IPartition;
-import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.jitter.JitterRule;
+import com.hazelcast.test.metrics.MetricsRule;
 import com.hazelcast.test.starter.HazelcastStarter;
 import junit.framework.AssertionFailedError;
 import org.junit.After;
@@ -148,6 +149,9 @@ public abstract class HazelcastTestSupport {
     public JitterRule jitterRule = new JitterRule();
 
     @Rule
+    public MetricsRule metricsRule = new MetricsRule();
+
+    @Rule
     public DumpBuildInfoOnFailureRule dumpInfoRule = new DumpBuildInfoOnFailureRule();
 
     private TestHazelcastInstanceFactory factory;
@@ -159,6 +163,8 @@ public abstract class HazelcastTestSupport {
         LOGGER.fine("ASSERT_COMPLETES_STALL_TOLERANCE = " + ASSERT_COMPLETES_STALL_TOLERANCE);
         String pmemDirectory = System.getProperty("hazelcast.persistent.memory");
         PERSISTENT_MEMORY_DIRECTORY =  pmemDirectory != null ? pmemDirectory : "/tmp/pmem";
+        System.setProperty(ClusterProperty.METRICS_COLLECTION_FREQUENCY.getName(), "1");
+        System.setProperty(ClusterProperty.METRICS_DEBUG.getName(), "true");
     }
 
     protected static <T> boolean containsIn(T item1, Collection<T> collection, Comparator<T> comparator) {
@@ -232,7 +238,7 @@ public abstract class HazelcastTestSupport {
         if (factory != null) {
             throw new IllegalStateException("Node factory is already created!");
         }
-        return factory = createHazelcastInstanceFactory0(nodeCount);
+        return factory = createHazelcastInstanceFactory0(nodeCount).withMetricsRule(metricsRule);
     }
 
     protected final TestHazelcastInstanceFactory createHazelcastInstanceFactory(String... addresses) {
@@ -243,7 +249,7 @@ public abstract class HazelcastTestSupport {
             throw new UnsupportedOperationException(
                     "Cannot start a factory with specific addresses when running compatibility tests");
         } else {
-            return factory = new TestHazelcastInstanceFactory(addresses);
+            return factory = new TestHazelcastInstanceFactory(addresses).withMetricsRule(metricsRule);
         }
     }
 
@@ -251,7 +257,7 @@ public abstract class HazelcastTestSupport {
         if (factory != null) {
             throw new IllegalStateException("Node factory is already created!");
         }
-        return factory = createHazelcastInstanceFactory0(null);
+        return factory = createHazelcastInstanceFactory0(null).withMetricsRule(metricsRule);
     }
 
     protected final TestHazelcastInstanceFactory createHazelcastInstanceFactory(int initialPort, String... addresses) {
@@ -262,7 +268,7 @@ public abstract class HazelcastTestSupport {
             throw new UnsupportedOperationException(
                     "Cannot start a factory with specific addresses when running compatibility tests");
         } else {
-            return factory = new TestHazelcastInstanceFactory(initialPort, addresses);
+            return factory = new TestHazelcastInstanceFactory(initialPort, addresses).withMetricsRule(metricsRule);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -16,16 +16,21 @@
 
 package com.hazelcast.test;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.function.FunctionEx;
 import com.hazelcast.instance.impl.DefaultNodeContext;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.instance.impl.NodeContext;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.metrics.impl.MetricsService;
+import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.metrics.MetricsRule;
 import com.hazelcast.test.mocknetwork.TestNodeRegistry;
 
 import java.net.UnknownHostException;
@@ -41,9 +46,10 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.instance.impl.TestUtil.terminateInstance;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.test.HazelcastTestSupport.getAddress;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableCollection;
 
@@ -54,10 +60,11 @@ public class TestHazelcastInstanceFactory {
     protected final TestNodeRegistry registry;
 
     private final boolean isMockNetwork = TestEnvironment.isMockNetwork();
-    private final ConcurrentMap<Integer, Address> addressMap = new ConcurrentHashMap<Integer, Address>();
+    private final ConcurrentMap<Integer, Address> addressMap = new ConcurrentHashMap<>();
     private final AtomicInteger nodeIndex = new AtomicInteger();
-
     private final int count;
+
+    private MetricsRule metricsRule;
 
     public TestHazelcastInstanceFactory() {
         this(0);
@@ -77,6 +84,11 @@ public class TestHazelcastInstanceFactory {
         fillAddressMap(count);
         this.count = count;
         this.registry = isMockNetwork ? createRegistry() : null;
+    }
+
+    public TestHazelcastInstanceFactory withMetricsRule(MetricsRule metricsRule) {
+        this.metricsRule = metricsRule;
+        return this;
     }
 
     protected TestNodeRegistry createRegistry() {
@@ -169,8 +181,8 @@ public class TestHazelcastInstanceFactory {
             Address thisAddress = address != null ? address : nextAddress(config.getNetworkConfig().getPort());
             NodeContext nodeContext = registry.createNodeContext(thisAddress,
                     blockedAddresses == null
-                            ? Collections.<Address>emptySet()
-                            : new HashSet<Address>(asList(blockedAddresses)));
+                            ? Collections.emptySet()
+                            : new HashSet<>(asList(blockedAddresses)));
             return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
         }
         throw new UnsupportedOperationException("Explicit address is only available for mock network setup!");
@@ -200,9 +212,22 @@ public class TestHazelcastInstanceFactory {
         if (isMockNetwork) {
             config = initOrCreateConfig(config);
             NodeContext nodeContext = registry.createNodeContext(nextAddress(config.getNetworkConfig().getPort()));
-            return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
+            HazelcastInstance hazelcastInstance = HazelcastInstanceFactory
+                    .newHazelcastInstance(config, instanceName, nodeContext);
+            registerTestMetricsPublisher(hazelcastInstance);
+            return hazelcastInstance;
         }
-        return HazelcastInstanceFactory.newHazelcastInstance(config);
+        HazelcastInstance hazelcastInstance = HazelcastInstanceFactory.newHazelcastInstance(config);
+        registerTestMetricsPublisher(hazelcastInstance);
+        return hazelcastInstance;
+    }
+
+    private void registerTestMetricsPublisher(HazelcastInstance hazelcastInstance) {
+        if (metricsRule != null && metricsRule.isEnabled()) {
+            MetricsService metricService = getNodeEngineImpl(hazelcastInstance).getService(MetricsService.SERVICE_NAME);
+            metricService.registerPublisher(
+                    (FunctionEx<NodeEngine, MetricsPublisher>) nodeEngine -> metricsRule.getMetricsPublisher(hazelcastInstance));
+        }
     }
 
     public Address nextAddress() {

--- a/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.metrics;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Test rule that records the metrics collected on the Hazelcast instances
+ * during a test run and dumps the recorded metrics if the given test
+ * fails. By default the last 10 metrics collection is recorded. After
+ * that, the rule starts overwriting the oldest recording. The metrics are
+ * recorded in the memory in compressed format, therefore, it doesn't
+ * increase the used heap noticeably.
+ */
+public class MetricsRule implements TestRule {
+    private Map<String, TestMetricPublisher> publishers = new ConcurrentHashMap<>();
+    private volatile boolean enabled = true;
+    private volatile int slots = 10;
+
+    public MetricsRule disable() {
+        enabled = false;
+        return this;
+    }
+
+    public MetricsRule slots(int slots) {
+        this.slots = slots;
+        return this;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    System.out.println("\nMetrics recorded during the test:");
+                    publishers.forEach((instanceName, publisher) -> publisher.dumpRecordings(instanceName));
+
+                    throw t;
+                }
+            }
+        };
+    }
+
+    public MetricsPublisher getMetricsPublisher(HazelcastInstance instance) {
+        TestMetricPublisher publisher = new TestMetricPublisher(slots);
+        publishers.put(instance.getName(), publisher);
+        return publisher;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/metrics/TestMetricPublisher.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/metrics/TestMetricPublisher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.metrics;
+
+import com.hazelcast.internal.metrics.MetricConsumer;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.metrics.impl.MetricsCompressor;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+
+/**
+ * {@link MetricsPublisher} implementation that records the last N metrics
+ * blobs compressed into a buffer to dump later on request. Used by the
+ * {@link MetricsRule} that requests dumping the recorded metrics on test
+ * failure.
+ */
+class TestMetricPublisher implements MetricsPublisher {
+    private final byte[][] blobs;
+    private final long[] timestamps;
+    private final MetricsCompressor compressor = new MetricsCompressor();
+    private final int slots;
+    private final SimpleDateFormat formatter = new SimpleDateFormat("HH:mm:ss,SSS");
+    private volatile int seq = 0;
+    private volatile boolean recordedMetrics;
+
+    TestMetricPublisher(int slots) {
+        this.slots = slots;
+        this.blobs = new byte[slots][];
+        this.timestamps = new long[slots];
+    }
+
+    @Override
+    public void publishLong(MetricDescriptor descriptor, long value) {
+        compressor.addLong(descriptor, value);
+    }
+
+    @Override
+    public void publishDouble(MetricDescriptor descriptor, double value) {
+        compressor.addDouble(descriptor, value);
+    }
+
+    @Override
+    public void whenComplete() {
+        synchronized (blobs) {
+            int nextSlot = seq++ % slots;
+            blobs[nextSlot] = compressor.getBlobAndReset();
+            timestamps[nextSlot] = System.currentTimeMillis();
+        }
+        recordedMetrics = true;
+    }
+
+    void dumpRecordings(String instanceName) {
+        // if there is no recording we wait for bounded time to record one blob with metrics
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        while (!recordedMetrics && System.currentTimeMillis() < deadline) {
+            sleepMillis(250);
+        }
+
+        System.out.println();
+
+        final int oldestSlotIdx;
+        final byte[][] slotsCopy = new byte[slots][];
+        synchronized (blobs) {
+            oldestSlotIdx = seq % slots;
+            System.arraycopy(blobs, 0, slotsCopy, 0, slots);
+        }
+
+        for (int i = 0; i < slots; i++) {
+            int currentSlot = (oldestSlotIdx + i) % slots;
+            byte[] blob = slotsCopy[currentSlot];
+            if (blob != null) {
+                Date date = new Date(timestamps[currentSlot]);
+                MetricsCompressor.extractMetrics(blob, new MetricConsumer() {
+                    @Override
+                    public void consumeLong(MetricDescriptor descriptor, long value) {
+                        System.out.println(metricStringBuilder(instanceName, date, descriptor).append(value).toString());
+                    }
+
+                    @Override
+                    public void consumeDouble(MetricDescriptor descriptor, double value) {
+                        System.out.println(metricStringBuilder(instanceName, date, descriptor).append(value).toString());
+                    }
+
+                    private StringBuilder metricStringBuilder(String instanceName, Date date, MetricDescriptor descriptor) {
+                        return new StringBuilder()
+                                .append('[').append(instanceName).append("] ")
+                                .append('[').append(formatter.format(date)).append("] ")
+                                .append(descriptor.metricString()).append('=');
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public String name() {
+        return "TestMetricPublisher";
+    }
+}


### PR DESCRIPTION
Introduce metrics test rule that records the metrics for every instance
periodically and retains the last N recording where N is configurable
and by default is 10. If there is a test failure, it dumps the recorded
metrics for every Hazelcast instance to the stdout. The output can be
a bit verbose, if the test runs for seconds and uses multiple Hazelcast
instances, runs with default partition and thread pool count. The 
change makes the instances to collect, record and dump debug
metrics too. 

Every test extending `HazelcastTestSupport` and creating its test
Hazelcast instances with the factory methods provided by the support
class use the rule automatically. The other tests may use
`factory.withMetricsRule(metricsRule)` to leverage it.

An example output after a failure:

```

Metrics recorded during the test:

[charming_brahmagupta] [09:22:48,478]
[partitionId=19,unit=count,metric=operation.partition.executedOperationsCounter]=0
[charming_brahmagupta] [09:22:48,478]
[thread=hz.charming_brahmagupta.priority-generic-operation.thread-0,unit=count,metric=operation.thread.completedTotalCount]=0
[charming_brahmagupta] [09:22:48,478]
[thread=hz.charming_brahmagupta.generic-operation.thread-3,unit=count,metric=operation.thread.errorCount]=0
[charming_brahmagupta] [09:22:48,478]
[thread=hz.charming_brahmagupta.partition-operation.thread-0,unit=count,metric=operation.thread.completedOperationBatchCount]=0
[charming_brahmagupta] [09:22:48,478]
[partitionId=180,unit=count,metric=operation.partition.executedOperationsCounter]=0
...
```