### PR TITLE
Fix initialCapacity=0 in PriorityQueue serializers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractCollectionStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractCollectionStreamSerializer.java
@@ -26,17 +26,15 @@ import java.util.Collection;
 /**
  * The {@link Collection} serializer
  */
-abstract class AbstractCollectionStreamSerializer<CollectionType extends Collection>
+abstract class AbstractCollectionStreamSerializer<CollectionType extends Collection<?>>
         implements StreamSerializer<CollectionType> {
 
     @Override
     public void write(ObjectDataOutput out, CollectionType collection) throws IOException {
         int size = collection.size();
         out.writeInt(size);
-        if (size > 0) {
-            for (Object o : collection) {
-                out.writeObject(o);
-            }
+        for (Object o : collection) {
+            out.writeObject(o);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -236,15 +236,14 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     private static HazelcastSerializationException newHazelcastSerializationException(int typeId) {
         return new HazelcastSerializationException("There is no suitable de-serializer for type " + typeId + ". "
-                + "This exception is likely to be caused by differences in the serialization configuration between members "
+                + "This exception is likely caused by differences in the serialization configuration between members "
                 + "or between clients and members.");
     }
 
     @Override
     public final void writeObject(final ObjectDataOutput out, final Object obj) {
         if (obj instanceof Data) {
-            throw new HazelcastSerializationException(
-                    "Cannot write a Data instance! " + "Use #writeData(ObjectDataOutput out, Data data) instead.");
+            throw new HazelcastSerializationException("Cannot write a Data instance, use writeData() instead");
         }
         try {
             SerializerAdapter serializer = serializerFor(obj);
@@ -357,11 +356,11 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     public final void register(Class type, Serializer serializer) {
         if (type == null) {
-            throw new IllegalArgumentException("Class type information is required!");
+            throw new IllegalArgumentException("type is required");
         }
         if (serializer.getTypeId() <= 0) {
             throw new IllegalArgumentException(
-                    "Type ID must be positive! Current: " + serializer.getTypeId() + ", Serializer: " + serializer);
+                    "Type ID must be positive. Current: " + serializer.getTypeId() + ", Serializer: " + serializer);
         }
         safeRegister(type, createSerializerAdapter(serializer, this));
     }
@@ -373,7 +372,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
     public final void registerGlobal(final Serializer serializer, boolean overrideJavaSerialization) {
         SerializerAdapter adapter = createSerializerAdapter(serializer, this);
         if (!global.compareAndSet(null, adapter)) {
-            throw new IllegalStateException("Global serializer is already registered!");
+            throw new IllegalStateException("Global serializer is already registered");
         }
         this.overrideJavaSerialization = overrideJavaSerialization;
         SerializerAdapter current = idMap.putIfAbsent(serializer.getTypeId(), adapter);
@@ -381,7 +380,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             global.compareAndSet(adapter, null);
             this.overrideJavaSerialization = false;
             throw new IllegalStateException(
-                    "Serializer [" + current.getImpl() + "] has been already registered for type-id: " + serializer.getTypeId());
+                    "Serializer [" + current.getImpl() + "] has been already registered for type ID: " + serializer.getTypeId());
         }
     }
 
@@ -404,7 +403,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     protected final boolean safeRegister(final Class type, final SerializerAdapter serializer) {
         if (constantTypesMap.containsKey(type)) {
-            throw new IllegalArgumentException("[" + type + "] serializer cannot be overridden!");
+            throw new IllegalArgumentException("[" + type + "] serializer cannot be overridden");
         }
         SerializerAdapter current = typeMap.putIfAbsent(type, serializer);
         if (current != null && current.getImpl().getClass() != serializer.getImpl().getClass()) {
@@ -414,7 +413,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         current = idMap.putIfAbsent(serializer.getTypeId(), serializer);
         if (current != null && current.getImpl().getClass() != serializer.getImpl().getClass()) {
             throw new IllegalStateException(
-                    "Serializer [" + current.getImpl() + "] has been already registered for type-id: " + serializer.getTypeId());
+                    "Serializer [" + current.getImpl() + "] has been already registered for type ID: " + serializer.getTypeId());
         }
         return current == null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityBlockingQueueStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityBlockingQueueStreamSerializer.java
@@ -43,11 +43,8 @@ public class PriorityBlockingQueueStreamSerializer<E> extends AbstractCollection
     @Override
     public PriorityBlockingQueue<E> read(ObjectDataInput in) throws IOException {
         Comparator<E> comparator = in.readObject();
-
         int size = in.readInt();
-
-        PriorityBlockingQueue<E> collection = new PriorityBlockingQueue<>(size, comparator);
-
+        PriorityBlockingQueue<E> collection = new PriorityBlockingQueue<>(Math.max(1, size), comparator);
         return deserializeEntries(in, size, collection);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityQueueStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PriorityQueueStreamSerializer.java
@@ -43,11 +43,8 @@ public class PriorityQueueStreamSerializer<E> extends AbstractCollectionStreamSe
     @Override
     public PriorityQueue<E> read(ObjectDataInput in) throws IOException {
         Comparator<E> comparator = in.readObject();
-
         int size = in.readInt();
-
-        PriorityQueue<E> collection = new PriorityQueue<>(size, comparator);
-
+        PriorityQueue<E> collection = new PriorityQueue<>(Math.max(1, size), comparator);
         return deserializeEntries(in, size, collection);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionAware.java
@@ -25,10 +25,10 @@ package com.hazelcast.partition;
  * In Hazelcast, disparate data structures will be stored on the same partition,
  * based on the partition key. For example, if "Steve" was used, then the following would be on one partition.
  * <ul>
- *     <li>a customers IMap with an entry of key "Steve"</li>
- *     <li>an orders IMap using a customer key type implementing PartitionAware with key "Steve</li>
- *     <li>any queue named "Steve"</li>
- *     <li>any PartitionAware object with partition key "Steve"</li>
+ *     <li>a customers IMap with an entry of key "Steve"
+ *     <li>an orders IMap using a customer key type implementing PartitionAware with key "Steve"
+ *     <li>any queue named "Steve"
+ *     <li>any PartitionAware object with partition key "Steve"
  * </ul>
  *
  * If you have a {@link com.hazelcast.core.IExecutorService} which needs to deal with a customer and a customer's
@@ -36,7 +36,7 @@ package com.hazelcast.partition;
  * <p>
  * {@link com.hazelcast.core.DistributedObject} also has a notion of the partition key which is of type String
  * to ensure that the same partition as distributed Objects Strings is used for the partition key.
- * <p>
+ *
  * @see com.hazelcast.core.DistributedObject
  * @param <T> key type
  */


### PR DESCRIPTION
In `PriorityQueue` and `PriorityBlockingQueue` the initial capacity must be 1
or more.

Fixes #16224