### PR TITLE
Additional logging in case of failure in NioChannelMemoryLeakTest.testNioChannelLeak_afterMultipleSplitBrainMerges

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
@@ -104,8 +104,9 @@ public class NioChannelMemoryLeakTest extends HazelcastTestSupport {
 
         assertThat(channels.size(), lessThanOrEqualTo(maxChannelCount));
         for (NioChannel channel : channels) {
-            assertTrue("Channel " + channel + " was found closed in instance " + instance,
-                    channel.socketChannel().isOpen());
+            assertTrue("Channel " + channel + " was found closed (channel: " + channel.isClosed() + ", socketChannel: " + !channel
+                            .socketChannel().isOpen() + ") in instance " + instance,
+                    !channel.isClosed() && channel.socketChannel().isOpen());
         }
     }
 


### PR DESCRIPTION
Rationale: this commit extends the assertion in
`assertNoChannelLeak()` to see if both the `NioChannel` and
its socket channel are open/closed. If, for instance,
the socket channel is closed but the `NioChannel` is not,
the socket channel must have been closed by some other
means (an interrupt?) than `AbstractChannel.close()`.

Relates to https://github.com/hazelcast/hazelcast/issues/14985