### PR TITLE
Use StringBuilder in MetricsRule

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
@@ -18,6 +18,7 @@ package com.hazelcast.test.metrics;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.MetricsPublisher;
+import com.hazelcast.internal.util.StringUtil;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -60,8 +61,15 @@ public class MetricsRule implements TestRule {
                 try {
                     base.evaluate();
                 } catch (Throwable t) {
-                    System.out.println("\nMetrics recorded during the test:");
-                    publishers.forEach((instanceName, publisher) -> publisher.dumpRecordings(instanceName));
+                    StringBuilder sb = new StringBuilder();
+                    publishers.forEach((instanceName, publisher) -> publisher.dumpRecordings(instanceName, sb));
+
+                    String metricsString = sb.toString();
+                    if (!StringUtil.isNullOrEmptyAfterTrim(metricsString)) {
+                        System.out.println("\nMetrics recorded during the test:" + metricsString);
+                    } else {
+                        System.out.println("\nNo metrics recorded during the test");
+                    }
 
                     throw t;
                 }

--- a/hazelcast/src/test/java/com/hazelcast/test/metrics/TestMetricPublisher.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/metrics/TestMetricPublisher.java
@@ -68,14 +68,14 @@ class TestMetricPublisher implements MetricsPublisher {
         recordedMetrics = true;
     }
 
-    void dumpRecordings(String instanceName) {
+    void dumpRecordings(String instanceName, StringBuilder sb) {
         // if there is no recording we wait for bounded time to record one blob with metrics
         long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
         while (!recordedMetrics && System.currentTimeMillis() < deadline) {
             sleepMillis(250);
         }
 
-        System.out.println();
+        sb.append("\n");
 
         final int oldestSlotIdx;
         final byte[][] slotsCopy = new byte[slots][];
@@ -92,17 +92,17 @@ class TestMetricPublisher implements MetricsPublisher {
                 MetricsCompressor.extractMetrics(blob, new MetricConsumer() {
                     @Override
                     public void consumeLong(MetricDescriptor descriptor, long value) {
-                        System.out.println(metricStringBuilder(instanceName, date, descriptor).append(value).toString());
+                        appendMetric(sb, instanceName, date, descriptor).append(value).append("\n");
                     }
 
                     @Override
                     public void consumeDouble(MetricDescriptor descriptor, double value) {
-                        System.out.println(metricStringBuilder(instanceName, date, descriptor).append(value).toString());
+                        appendMetric(sb, instanceName, date, descriptor).append(value).append("\n");
                     }
 
-                    private StringBuilder metricStringBuilder(String instanceName, Date date, MetricDescriptor descriptor) {
-                        return new StringBuilder()
-                                .append('[').append(instanceName).append("] ")
+                    private StringBuilder appendMetric(StringBuilder sb, String instanceName, Date date,
+                                                       MetricDescriptor descriptor) {
+                        return sb.append('[').append(instanceName).append("] ")
                                 .append('[').append(formatter.format(date)).append("] ")
                                 .append(descriptor.metricString()).append('=');
                     }


### PR DESCRIPTION
Use StringBuilder in MetricsRule to prevent mixing test logs and metrics rule output in parallel tests.