### PR TITLE
Fixed QueryCacheMemoryLeakTest test failure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -378,8 +378,12 @@ public class EventServiceImpl implements EventService, StaticMetricsProvider {
             return newCompletedFuture(false);
         }
 
-        return invokeOnAllMembers(reg, new DeregistrationOperationSupplier(reg, nodeEngine.getClusterService()))
-                .thenApplyAsync(Objects::nonNull, CALLER_RUNS);
+        if (!reg.isLocalOnly()) {
+            return invokeOnAllMembers(reg, new DeregistrationOperationSupplier(reg, nodeEngine.getClusterService()))
+                    .thenApplyAsync(Objects::nonNull, CALLER_RUNS);
+        } else {
+            return newCompletedFuture(true);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixed a regression caused by
https://github.com/hazelcast/hazelcast/pull/15860. We avoid
calling DeregistrationOperation on all members if registration
is local and the PR removed the check.

Fixes: https://github.com/hazelcast/hazelcast/issues/16079