### PR TITLE
Removes usages of Bits.readUtf8

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/EndiannessUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/EndiannessUtil.java
@@ -20,9 +20,6 @@ import com.hazelcast.internal.memory.ByteAccessStrategy;
 import com.hazelcast.internal.memory.GlobalMemoryAccessorRegistry;
 import com.hazelcast.internal.memory.MemoryAccessor;
 
-import java.io.DataInput;
-import java.io.IOException;
-import java.io.UTFDataFormatException;
 import java.nio.ByteBuffer;
 
 /**
@@ -312,63 +309,6 @@ public final class EndiannessUtil {
             strategy.putByte(resource, pos, (byte) (0xC0 | c >> 6 & 0x1F));
             strategy.putByte(resource, pos + 1, (byte) (0x80 | c & 0x3F));
             return 2;
-        }
-    }
-
-    public static char readUtf8Char(DataInput in, byte firstByte) throws IOException {
-        int b = firstByte & 0xFF;
-        switch (b >> 4) {
-            case 0:
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-            case 6:
-            case 7:
-                return (char) b;
-            case 12:
-            case 13:
-                int first = (b & 0x1F) << 6;
-                int second = in.readByte() & 0x3F;
-                return (char) (first | second);
-            case 14:
-                int first2 = (b & 0x0F) << 12;
-                int second2 = (in.readByte() & 0x3F) << 6;
-                int third2 = in.readByte() & 0x3F;
-                return (char) (first2 | second2 | third2);
-            default:
-                throw new UTFDataFormatException("Malformed byte sequence");
-        }
-    }
-
-    public static int readUtf8Char(byte[] buffer, int pos, char[] dst, int dstPos) throws IOException {
-        int b = buffer[pos] & 0xFF;
-        switch (b >> 4) {
-            case 0:
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-            case 6:
-            case 7:
-                dst[dstPos] = (char) b;
-                return 1;
-            case 12:
-            case 13:
-                int first = (b & 0x1F) << 6;
-                int second = buffer[pos + 1] & 0x3F;
-                dst[dstPos] = (char) (first | second);
-                return 2;
-            case 14:
-                int first2 = (b & 0x0F) << 12;
-                int second2 = (buffer[pos + 1] & 0x3F) << 6;
-                int third2 = buffer[pos + 2] & 0x3F;
-                dst[dstPos] = (char) (first2 | second2 | third2);
-                return 3;
-            default:
-                throw new UTFDataFormatException("Malformed byte sequence");
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
@@ -18,8 +18,6 @@ package com.hazelcast.internal.nio;
 
 import com.hazelcast.internal.memory.impl.EndiannessUtil;
 
-import java.io.DataInput;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -199,16 +197,6 @@ public final class Bits {
 
     public static int writeUtf8Char(byte[] buffer, int pos, int c) {
         return EndiannessUtil.writeUtf8Char(BYTE_ARRAY_ACCESS, buffer, pos, c);
-    }
-
-    public static int readUtf8Char(byte[] buffer, int pos, char[] dst, int dstPos)
-            throws IOException {
-        return EndiannessUtil.readUtf8Char(buffer, pos, dst, dstPos);
-    }
-
-    public static char readUtf8Char(DataInput in, byte firstByte)
-            throws IOException {
-        return EndiannessUtil.readUtf8Char(in, firstByte);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.query.impl.getters.JsonPathCursor;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationThread;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -131,7 +132,9 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
 
         @Override
         public int read(char[] cbuf, int off, int len) throws IOException {
-            final CharsetDecoder decoder = DECODER_THREAD_LOCAL.get();
+            final CharsetDecoder decoder = Thread.currentThread() instanceof OperationThread
+                    ? DECODER_THREAD_LOCAL.get()
+                    : Bits.UTF_8.newDecoder();
             decoder.reset();
             if (off < 0 || (off + len) > cbuf.length) {
                 throw new IndexOutOfBoundsException();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -98,7 +98,6 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
         private final CharsetDecoder decoder;
         private final ByteBuffer inputBuffer;
         // required to support read() for surrogate pairs
-        private final char[] buffer = new char[2];
         private boolean hasLeftoverChar;
         private int leftoverChar;
 
@@ -118,6 +117,7 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
                 hasLeftoverChar = false;
                 return leftoverChar;
             }
+            char[] buffer = new char[2];
             int charsRead = read(buffer, 0, 2);
             switch (charsRead) {
                 case -1:
@@ -187,6 +187,7 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
                 throw new IllegalArgumentException("All BufferObjectDataInput are instances of ByteArrayObjectDataInput");
             }
         }
+
         @Override
         public void close() throws IOException {
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
@@ -126,7 +126,8 @@ public class DataInputNavigableJsonAdapterTest {
 
     @Test
     public void testCreateAndUseConcurrently() throws InterruptedException {
-        // UTF8Reader is not thread safe; the purpose is to ensure no
+        // UTF8Reader is not thread safe; the purpose of the test
+        // is to ensure there is no interference across UTF8Reader instances
         int concurrency = 8;
         CountDownLatch latch = new CountDownLatch(1);
         Thread[] threads = new Thread[concurrency];

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.nio.CharBuffer;
+import java.nio.charset.MalformedInputException;
+
+import static com.hazelcast.internal.nio.Bits.UTF_8;
+import static com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder.DEFAULT_BYTE_ORDER;
+import static com.hazelcast.test.HazelcastTestSupport.ignore;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DataInputNavigableJsonAdapterTest {
+
+    private static final byte[][] SAMPLE_BYTES = new byte[][] {
+            "\uD83E\uDD13".getBytes(UTF_8),
+            "Bariš".getBytes(UTF_8),
+            "Simple code points".getBytes(UTF_8),
+            "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム".getBytes(UTF_8),
+    };
+
+    private static final byte[][] MALFORMED_SAMPLE_BYTES = new byte[][] {
+            // unexpected continuation bytes
+            new byte[] {70, 65, 73, 76, 83, (byte) 0x80},
+            new byte[] {(byte) 0xbf},
+            // 2-byte sequence start characters followed by space
+            new byte[] {(byte) 0xc0, 32},
+            new byte[] {(byte) 0xc1, 32},
+            new byte[] {(byte) 0xcf, 32},
+            new byte[] {(byte) 0xdf, 32},
+            // 3-byte sequence start characters followed by space
+            new byte[] {(byte) 0xe0, 32},
+            new byte[] {(byte) 0xe1, 32},
+            new byte[] {(byte) 0xef, 32},
+            // 4-byte sequence start characters followed by space
+            new byte[] {(byte) 0xf0, 32},
+            new byte[] {(byte) 0xf1, 32},
+            new byte[] {(byte) 0xf4, 32},
+            // non minimal sequences
+            new byte[] {(byte) 0xc0, (byte) 0xaf},
+            new byte[] {(byte) 0xe0, (byte) 0x9f, (byte) 0xbf},
+            new byte[] {(byte) 0xf0, (byte) 0x8f, (byte) 0xbf, (byte) 0xbf},
+    };
+
+    private InternalSerializationService serializationService;
+    private BufferObjectDataInput input;
+
+    @Before
+    public void setup() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    @Test
+    public void testSamplesWhenReadingOne()
+            throws IOException {
+        for (int i = 0; i < SAMPLE_BYTES.length; i++) {
+            input = new ByteArrayObjectDataInput(SAMPLE_BYTES[i], serializationService, DEFAULT_BYTE_ORDER);
+            DataInputNavigableJsonAdapter.UTF8Reader reader = new DataInputNavigableJsonAdapter.UTF8Reader(input);
+            assertReadOne(reader, SAMPLE_BYTES[i]);
+        }
+    }
+
+    @Test
+    public void testReadAround() throws IOException {
+        byte[] sample = SAMPLE_BYTES[2];
+
+    }
+
+    @Test
+    public void testSamples()
+            throws IOException {
+        for (byte[] sample : SAMPLE_BYTES) {
+            input = new ByteArrayObjectDataInput(sample, serializationService, DEFAULT_BYTE_ORDER);
+            DataInputNavigableJsonAdapter.UTF8Reader reader = new DataInputNavigableJsonAdapter.UTF8Reader(input);
+            assertReadFully(reader, sample);
+        }
+    }
+
+    @Test
+    public void testMalformedSamples()
+            throws IOException {
+        for (byte[] sample : MALFORMED_SAMPLE_BYTES) {
+            input = new ByteArrayObjectDataInput(sample, serializationService, DEFAULT_BYTE_ORDER);
+            DataInputNavigableJsonAdapter.UTF8Reader reader = new DataInputNavigableJsonAdapter.UTF8Reader(input);
+            assertMalformed(reader);
+        }
+    }
+
+    private void assertReadFully(DataInputNavigableJsonAdapter.UTF8Reader reader, byte[] sample)
+            throws IOException {
+        String expected = new String(sample, UTF_8);
+        char[] chars = new char[expected.length()];
+        int charsRead = reader.read(chars, 0, chars.length);
+        assertEquals(chars.length, charsRead);
+        assertEquals(expected, new String(chars));
+    }
+
+    private void assertReadOne(DataInputNavigableJsonAdapter.UTF8Reader reader, byte[] sample)
+            throws IOException {
+        String expected = new String(sample, UTF_8);
+        CharBuffer buffer = CharBuffer.allocate(expected.length() * 3);
+        int next = reader.read();
+        while (next != -1) {
+            buffer.append((char) next);
+            next = reader.read();
+        }
+        buffer.limit(buffer.position());
+        buffer.rewind();
+        String actual = buffer.toString();
+        assertEquals(expected, actual);
+    }
+
+    private void assertMalformed(DataInputNavigableJsonAdapter.UTF8Reader reader)
+            throws IOException {
+        char[] chars = new char[6];
+        try {
+            reader.read(chars, 0, chars.length);
+            fail("MalformedInputException was expected but not thrown");
+        } catch (MalformedInputException e) {
+            ignore(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/BitsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/BitsTest.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.io.UTFDataFormatException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
@@ -226,35 +224,6 @@ public class BitsTest {
         assertEquals(1, Bits.writeUtf8Char(bytes, 0, c1));
         assertEquals(2, Bits.writeUtf8Char(bytes, 0, c2));
         assertEquals(3, Bits.writeUtf8Char(bytes, 0, c3));
-    }
-
-    @Test
-    public void testReadUtf8Char() throws IOException {
-        byte[] bytes = new byte[6];
-        char c0 = 0x0010; //1 byte
-        char c1 = 0x0080; //2 byte
-        char c2 = 0x0800; //3 byte
-
-        Bits.writeUtf8Char(bytes, 0, c0);
-        Bits.writeUtf8Char(bytes, 1, c1);
-        Bits.writeUtf8Char(bytes, 3, c2);
-
-        char[] chars = new char[3];
-        Bits.readUtf8Char(bytes, 0, chars, 0);
-        Bits.readUtf8Char(bytes, 1, chars, 1);
-        Bits.readUtf8Char(bytes, 3, chars, 2);
-
-        assertEquals(c0, chars[0]);
-        assertEquals(c1, chars[1]);
-        assertEquals(c2, chars[2]);
-    }
-
-    @Test(expected = UTFDataFormatException.class)
-    public void testReadUtf8CharMalformedBytes() throws IOException {
-        byte[] bytes = new byte[]{(byte) 0xFF};
-
-        char[] chars = new char[1];
-        Bits.readUtf8Char(bytes, 0, chars, 0);
     }
 
     @Test


### PR DESCRIPTION
Replaced with usage of JDK's `CharsetDecoder` which handles properly multi-byte characters, while avoiding full JSON string materialization.

Benchmark results:

```
this PR
Benchmark                                                                    Mode  Cnt        Score       Error   Units
JsonBenchmark.queryOnJsonIndexedAttribute                                   thrpt   10      173,150 ±    29,230   ops/s
JsonBenchmark.queryOnJsonIndexedAttribute:·gc.alloc.rate.norm               thrpt   10  5923897,069 ±   152,287    B/op

commit 905c8a50 (https://github.com/hazelcast/hazelcast/pull/16210)
Benchmark                                                                    Mode  Cnt        Score        Error   Units
JsonBenchmark.queryOnJsonIndexedAttribute                                   thrpt   10      147,944 ±      5,610   ops/s
JsonBenchmark.queryOnJsonIndexedAttribute:·gc.alloc.rate.norm               thrpt   10  8271544,542 ±    169,463    B/op

commit 320b492c (Bits.readUtf8)
Benchmark                                                                    Mode  Cnt        Score       Error   Units
JsonBenchmark.queryOnJsonIndexedAttribute                                   thrpt   10      164,960 ±     3,288   ops/s
JsonBenchmark.queryOnJsonIndexedAttribute:·gc.alloc.rate.norm               thrpt   10  4403908,434 ±   151,382    B/op
```
(see also https://github.com/hazelcast/hazelcast/pull/16210#discussion_r355978535)

Allocation rate is worse than previous but definitely better than whole-JSON-deserialization and since the additional allocations are constant, the overhead will matter less with larger JSONs (benchmark above was executed with a ~100bytes long JSON string).

Update: pushed a commit that should make `UTF8Reader` substantially cheaper when used from a generic operation or partition operation thread (probably most of the time on a cluster): instead of creating a `CharsetDecoder` per each `UTF8Reader` instance, the decoders are now provided as `ThreadLocal`s. 

Fixes #15402 

