### PR TITLE
Change default fallback for unrecognised REST group text commands

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2657,6 +2657,7 @@
             <xs:enumeration value="WAN"/>
             <xs:enumeration value="DATA"/>
             <xs:enumeration value="MEMCACHE"/>
+            <xs:enumeration value="CP"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -203,6 +203,7 @@
                     <hz:endpoint-group name="HOT_RESTART" enabled="true"/>
                     <hz:endpoint-group name="WAN" enabled="true"/>
                     <hz:endpoint-group name="DATA" enabled="true"/>
+                    <hz:endpoint-group name="CP" enabled="true"/>
                 </hz:rest-api>
                 <hz:memcache-protocol enabled="true"/>
             </hz:network>

--- a/hazelcast/src/main/java/com/hazelcast/config/RestEndpointGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestEndpointGroup.java
@@ -48,7 +48,12 @@ public enum RestEndpointGroup {
     /**
      * Group of HTTP REST APIs for data manipulation in the cluster (e.g. IMap and IQueue operations).
      */
-    DATA(false);
+    DATA(false),
+
+    /**
+     * Groups of HTTP REST APIs for CP subsystem interaction
+     */
+    CP(false);
 
     private final boolean enabledByDefault;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiTextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiTextDecoder.java
@@ -47,6 +47,6 @@ public class RestApiTextDecoder extends TextDecoder {
 
     private static RestApiFilter createFilter(TcpIpConnection connection) {
         IOService ioService = connection.getEndpointManager().getNetworkingService().getIoService();
-        return new RestApiFilter(ioService.getRestApiConfig(), TEXT_PARSERS);
+        return new RestApiFilter(ioService.getLoggingService(), ioService.getRestApiConfig(), TEXT_PARSERS);
     }
 }

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -4095,6 +4095,7 @@
             <xs:enumeration value="HOT_RESTART"/>
             <xs:enumeration value="WAN"/>
             <xs:enumeration value="DATA"/>
+            <xs:enumeration value="CP"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterBadRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterBadRequestTest.java
@@ -48,7 +48,6 @@ import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_CP_MEMBERS_URL;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_FORCESTART_CLUSTER_URL;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_HOT_RESTART_BACKUP_CLUSTER_URL;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_HOT_RESTART_BACKUP_INTERRUPT_CLUSTER_URL;
-import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_LICENSE_INFO;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_LOCAL_CP_MEMBER_URL;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_PARTIALSTART_CLUSTER_URL;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_RESET_CP_SUBSYSTEM_URL;
@@ -86,7 +85,6 @@ public class RestClusterBadRequestTest extends HazelcastTestSupport {
             URI_WAN_STOP_PUBLISHER,
             URI_WAN_RESUME_PUBLISHER,
             URI_WAN_CONSISTENCY_CHECK_MAP,
-            URI_LICENSE_INFO,
             URI_RESET_CP_SUBSYSTEM_URL,
             URI_CP_GROUPS_URL,
             URI_CP_MEMBERS_URL,

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.http.NoHttpResponseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -56,7 +57,6 @@ import static com.hazelcast.test.HazelcastTestSupport.randomName;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastSeconds;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -318,28 +318,24 @@ public class RestTest {
         assertEquals(HTTP_OK, response);
     }
 
-    @Test
+    @Test(expected = NoHttpResponseException.class)
     public void testUndefined_HeadRequest() throws IOException {
-        int response = communicator.headRequestToUndefinedURI().responseCode;
-        assertEquals(HTTP_NOT_FOUND, response);
+        communicator.headRequestToUndefinedURI();
     }
 
-    @Test
+    @Test(expected = NoHttpResponseException.class)
     public void testUndefined_GetRequest() throws IOException {
-        int response = communicator.getRequestToUndefinedURI().responseCode;
-        assertEquals(HTTP_NOT_FOUND, response);
+        communicator.getRequestToUndefinedURI();
     }
 
-    @Test
+    @Test(expected = NoHttpResponseException.class)
     public void testUndefined_PostRequest() throws IOException {
-        int response = communicator.postRequestToUndefinedURI().responseCode;
-        assertEquals(HTTP_NOT_FOUND, response);
+        communicator.postRequestToUndefinedURI();
     }
 
-    @Test
+    @Test(expected = NoHttpResponseException.class)
     public void testUndefined_DeleteRequest() throws IOException {
-        int response = communicator.deleteRequestToUndefinedURI().responseCode;
-        assertEquals(HTTP_NOT_FOUND, response);
+        communicator.deleteRequestToUndefinedURI();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/RestApiConfigTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/RestApiConfigTestBase.java
@@ -16,14 +16,6 @@
 
 package com.hazelcast.internal.nio.ascii;
 
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.HazelcastTestSupport.getAddress;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.net.UnknownHostException;
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.RestEndpointGroup;
@@ -31,12 +23,19 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.cluster.Versions;
 
+import java.io.IOException;
+import java.net.UnknownHostException;
+
 import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
 import static com.hazelcast.config.RestEndpointGroup.CLUSTER_WRITE;
 import static com.hazelcast.config.RestEndpointGroup.DATA;
 import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
 import static com.hazelcast.config.RestEndpointGroup.HOT_RESTART;
 import static com.hazelcast.config.RestEndpointGroup.WAN;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.getAddress;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Shared code for HTTP REST API and Memcache protocol testing.
@@ -76,15 +75,15 @@ public abstract class RestApiConfigTestBase extends AbstractTextProtocolsTestBas
             new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-safe", "HTTP/1.1 200"),
             new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/migration-queue-size", "HTTP/1.1 200"),
             new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-size", "HTTP/1.1 200"),
-            new TestUrl(DATA, POST, "/hazelcast/rest/maps/", "HTTP/1.1 400"),
+            new TestUrl(DATA, POST, "/hazelcast/rest/maps/", "HTTPTestFullApplicationContext/1.1 400"),
             new TestUrl(DATA, GET, "/hazelcast/rest/maps/", "HTTP/1.1 400"),
             new TestUrl(DATA, DELETE, "/hazelcast/rest/maps/", "HTTP/1.1 200"),
             new TestUrl(DATA, POST, "/hazelcast/rest/queues/", "HTTP/1.1 400"),
             new TestUrl(DATA, GET, "/hazelcast/rest/queues/", "HTTP/1.1 400"),
             new TestUrl(DATA, DELETE, "/hazelcast/rest/queues/", "HTTP/1.1 400"),
-            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/1", "HTTP/1.1 404"),
-            new TestUrl(CLUSTER_WRITE, GET, "/hazelcast/1", "HTTP/1.1 404"),
-            new TestUrl(CLUSTER_WRITE, DELETE, "/hazelcast/1", "HTTP/1.1 404"),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/1", ""),
+            new TestUrl(CLUSTER_WRITE, GET, "/hazelcast/1", ""),
+            new TestUrl(CLUSTER_WRITE, DELETE, "/hazelcast/1", ""),
     };
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/RestApiConfigTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/RestApiConfigTestBase.java
@@ -75,7 +75,7 @@ public abstract class RestApiConfigTestBase extends AbstractTextProtocolsTestBas
             new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-safe", "HTTP/1.1 200"),
             new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/migration-queue-size", "HTTP/1.1 200"),
             new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-size", "HTTP/1.1 200"),
-            new TestUrl(DATA, POST, "/hazelcast/rest/maps/", "HTTPTestFullApplicationContext/1.1 400"),
+            new TestUrl(DATA, POST, "/hazelcast/rest/maps/", "HTTP/1.1 400"),
             new TestUrl(DATA, GET, "/hazelcast/rest/maps/", "HTTP/1.1 400"),
             new TestUrl(DATA, DELETE, "/hazelcast/rest/maps/", "HTTP/1.1 200"),
             new TestUrl(DATA, POST, "/hazelcast/rest/queues/", "HTTP/1.1 400"),


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/15957

Added a new REST group too for CP APIs, and fixed some of the CP URIs.

I was also tempted to throw handle the error differently for each protocol, but at this stage of filtering the incoming request, for unified networking, we don't know whether its HTTP or Memcache. Therefore we rely on the previous way of just closing the connection without responding.
