### PR TITLE
Remove operations from map and replicated map MBeans

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MapMBean.java
@@ -16,16 +16,10 @@
 
 package com.hazelcast.internal.jmx;
 
-import com.hazelcast.map.IMap;
 import com.hazelcast.internal.jmx.suppliers.LocalMapStatsSupplier;
 import com.hazelcast.internal.jmx.suppliers.StatsSupplier;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.LocalMapStats;
-import com.hazelcast.query.Predicate;
-import com.hazelcast.query.Predicates;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Management bean for {@link IMap}
@@ -40,7 +34,7 @@ public class MapMBean extends HazelcastMBean<IMap> {
         super(managedObject, service);
         this.objectName = service.createObjectName("IMap", managedObject.getName());
         StatsSupplier<LocalMapStats> localMapStatsSupplier = new LocalMapStatsSupplier(managedObject);
-        this.localMapStatsDelegate = new LocalStatsDelegate<LocalMapStats>(localMapStatsSupplier, updateIntervalSec);
+        this.localMapStatsDelegate = new LocalStatsDelegate<>(localMapStatsSupplier, updateIntervalSec);
     }
 
     @ManagedAnnotation("localOwnedEntryCount")
@@ -227,55 +221,5 @@ public class MapMBean extends HazelcastMBean<IMap> {
     @ManagedDescription("Clear Map")
     public void clear() {
         managedObject.clear();
-    }
-
-    @ManagedAnnotation(value = "values", operation = true)
-    public String values(String query) {
-        Collection coll;
-        if (query != null && !query.isEmpty()) {
-            Predicate predicate = Predicates.sql(query);
-            coll = managedObject.values(predicate);
-        } else {
-            coll = managedObject.values();
-        }
-        StringBuilder buf = new StringBuilder();
-        if (coll.size() == 0) {
-            buf.append("Empty");
-        } else {
-            buf.append("[");
-            for (Object obj : coll) {
-                buf.append(obj);
-                buf.append(", ");
-            }
-            buf.replace(buf.length() - 1, buf.length(), "]");
-        }
-        return buf.toString();
-    }
-
-    @ManagedAnnotation(value = "entrySet", operation = true)
-    public String entrySet(String query) {
-        Set<Map.Entry> entrySet;
-        if (query != null && !query.isEmpty()) {
-            Predicate predicate = Predicates.sql(query);
-            entrySet = managedObject.entrySet(predicate);
-        } else {
-            entrySet = managedObject.entrySet();
-        }
-
-        StringBuilder buf = new StringBuilder();
-        if (entrySet.size() == 0) {
-            buf.append("Empty");
-        } else {
-            buf.append("[");
-            for (Map.Entry entry : entrySet) {
-                buf.append("{key:");
-                buf.append(entry.getKey());
-                buf.append(", value:");
-                buf.append(entry.getValue());
-                buf.append("}, ");
-            }
-            buf.replace(buf.length() - 1, buf.length(), "]");
-        }
-        return buf.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReplicatedMapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReplicatedMapMBean.java
@@ -21,10 +21,6 @@ import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapProxy;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-
 /**
  * Management bean for {@link ReplicatedMap}
  */
@@ -36,8 +32,7 @@ public class ReplicatedMapMBean extends HazelcastMBean<ReplicatedMapProxy> {
     protected ReplicatedMapMBean(ReplicatedMapProxy managedObject, ManagementService service) {
         super(managedObject, service);
         this.objectName = service.createObjectName("ReplicatedMap", managedObject.getName());
-        this.statsDelegate = new LocalStatsDelegate<LocalReplicatedMapStats>(
-                new LocalReplicatedMapStatsSupplier(managedObject), updateIntervalSec);
+        this.statsDelegate = new LocalStatsDelegate<>(new LocalReplicatedMapStatsSupplier(managedObject), updateIntervalSec);
     }
 
     @ManagedAnnotation("localOwnedEntryCount")
@@ -166,41 +161,4 @@ public class ReplicatedMapMBean extends HazelcastMBean<ReplicatedMapProxy> {
         managedObject.clear();
     }
 
-    @ManagedAnnotation(value = "values", operation = true)
-    public String values() {
-        Collection coll = managedObject.values();
-        StringBuilder buf = new StringBuilder();
-        if (coll.size() == 0) {
-            buf.append("Empty");
-        } else {
-            buf.append("[");
-            for (Object obj : coll) {
-                buf.append(obj);
-                buf.append(", ");
-            }
-            buf.replace(buf.length() - 1, buf.length(), "]");
-        }
-        return buf.toString();
-    }
-
-    @ManagedAnnotation(value = "entrySet", operation = true)
-    public String entrySet() {
-        Set<Map.Entry> entrySet = managedObject.entrySet();
-
-        StringBuilder buf = new StringBuilder();
-        if (entrySet.size() == 0) {
-            buf.append("Empty");
-        } else {
-            buf.append("[");
-            for (Map.Entry entry : entrySet) {
-                buf.append("{key:");
-                buf.append(entry.getKey());
-                buf.append(", value:");
-                buf.append(entry.getValue());
-                buf.append("}, ");
-            }
-            buf.replace(buf.length() - 1, buf.length(), "]");
-        }
-        return buf.toString();
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MapMBeanTest.java
@@ -80,9 +80,8 @@ public class MapMBeanTest extends HazelcastTestSupport {
         map.remove("secondKey");
         map.set("thirdKey", "thirdValue");
         map.remove("thirdKey");
+        map.size();
         String value = map.get("firstKey");
-        String values = invokeMethod("values", EMPTY_STRING_PARAMETER);
-        String entries = invokeMethod("entrySet", EMPTY_STRING_PARAMETER);
 
         long localEntryCount = getLongAttribute("localOwnedEntryCount");
         long localBackupEntryCount = getLongAttribute("localBackupEntryCount");
@@ -118,8 +117,6 @@ public class MapMBeanTest extends HazelcastTestSupport {
         int size = getIntegerAttribute("size");
 
         assertEquals("firstValue", value);
-        assertEquals("[firstValue,]", values);
-        assertEquals("[{key:firstKey, value:firstValue},]", entries);
 
         assertEquals(1, localEntryCount);
         assertEquals(0, localBackupEntryCount);
@@ -155,12 +152,8 @@ public class MapMBeanTest extends HazelcastTestSupport {
         assertEquals(1, size);
 
         holder.invokeMBeanOperation(TYPE_NAME, objectName, "clear", null, null);
-        values = invokeMethod("values", EMPTY_STRING_PARAMETER);
-        entries = invokeMethod("entrySet", EMPTY_STRING_PARAMETER);
         size = getIntegerAttribute("size");
 
-        assertEquals("Empty", values);
-        assertEquals("Empty", entries);
         assertEquals(0, size);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReplicatedMapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReplicatedMapMBeanTest.java
@@ -82,9 +82,8 @@ public class ReplicatedMapMBeanTest extends HazelcastTestSupport {
         replicatedMap.put("firstKey", "firstValue");
         replicatedMap.put("secondKey", "secondValue");
         replicatedMap.remove("secondKey");
+        replicatedMap.size();
         String value = replicatedMap.get("firstKey");
-        String values = invokeMethod("values");
-        String entries = invokeMethod("entrySet");
 
         long localEntryCount = getLongAttribute("localOwnedEntryCount");
         long localCreationTime = getLongAttribute("localCreationTime");
@@ -109,14 +108,12 @@ public class ReplicatedMapMBeanTest extends HazelcastTestSupport {
         int size = getIntegerAttribute("size");
 
         assertEquals("firstValue", value);
-        assertEquals("[firstValue,]", values);
-        assertEquals("[{key:firstKey, value:firstValue},]", entries);
 
         assertEquals(1, localEntryCount);
         assertTrue(localCreationTime >= started);
         assertTrue(localLastAccessTime >= started);
         assertTrue(localLastUpdateTime >= started);
-        assertEquals(3, localHits);
+        assertEquals(1, localHits);
 
         assertEquals(2, localPutOperationCount);
         assertEquals(1, localGetOperationCount);
@@ -135,12 +132,8 @@ public class ReplicatedMapMBeanTest extends HazelcastTestSupport {
         assertEquals(1, size);
 
         holder.invokeMBeanOperation(TYPE_NAME, objectName, "clear", null, null);
-        values = invokeMethod("values");
-        entries = invokeMethod("entrySet");
         size = getIntegerAttribute("size");
 
-        assertEquals("Empty", values);
-        assertEquals("Empty", entries);
         assertEquals(0, size);
     }
 


### PR DESCRIPTION
Operations `values()` and `entrySet()` are removed from map's and replicated
map's MBeans since these are potentially dangerous operations that can
OOME the member by a single click in JMX since by default there is no
limit on how many entries can be returned as a response for a query.

Fixes #16235