### PR TITLE
Make CP group ids unique between multiple inits of CP Subsystem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupId.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupId.java
@@ -35,16 +35,16 @@ public final class RaftGroupId implements CPGroupId, IdentifiedDataSerializable,
 
     private String name;
     private long seed;
-    private long commitIndex;
+    private long groupId;
 
     public RaftGroupId() {
     }
 
-    public RaftGroupId(String name, long seed, long commitIndex) {
+    public RaftGroupId(String name, long seed, long groupId) {
         assert name != null;
         this.name = name;
         this.seed = seed;
-        this.commitIndex = commitIndex;
+        this.groupId = groupId;
     }
 
     @Override
@@ -58,35 +58,35 @@ public final class RaftGroupId implements CPGroupId, IdentifiedDataSerializable,
 
     @Override
     public long getId() {
-        return commitIndex;
+        return groupId;
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeLong(seed);
-        out.writeLong(commitIndex);
+        out.writeLong(groupId);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
         seed = in.readLong();
-        commitIndex = in.readLong();
+        groupId = in.readLong();
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         out.writeUTF(name);
         out.writeLong(seed);
-        out.writeLong(commitIndex);
+        out.writeLong(groupId);
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         name = in.readUTF();
         seed = in.readLong();
-        commitIndex = in.readLong();
+        groupId = in.readLong();
     }
 
     @Override
@@ -113,7 +113,7 @@ public final class RaftGroupId implements CPGroupId, IdentifiedDataSerializable,
         if (seed != that.seed) {
             return false;
         }
-        if (commitIndex != that.commitIndex) {
+        if (groupId != that.groupId) {
             return false;
         }
         return name.equals(that.name);
@@ -123,12 +123,12 @@ public final class RaftGroupId implements CPGroupId, IdentifiedDataSerializable,
     public int hashCode() {
         int result = name.hashCode();
         result = 31 * result + (int) (seed ^ (seed >>> 32));
-        result = 31 * result + (int) (commitIndex ^ (commitIndex >>> 32));
+        result = 31 * result + (int) (groupId ^ (groupId >>> 32));
         return result;
     }
 
     @Override
     public String toString() {
-        return "CPGroupId{" + "name='" + name + '\'' + ", seed=" + seed + ", commitIndex=" + commitIndex + '}';
+        return "CPGroupId{" + "name='" + name + '\'' + ", seed=" + seed + ", groupId=" + groupId + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftGroupOp.java
@@ -51,18 +51,20 @@ public class CreateRaftGroupOp extends MetadataRaftGroupOp implements Indetermin
 
     private String groupName;
     private Collection<RaftEndpoint> members;
+    private long groupId;
 
     public CreateRaftGroupOp() {
     }
 
-    public CreateRaftGroupOp(String groupName, Collection<RaftEndpoint> members) {
+    public CreateRaftGroupOp(String groupName, Collection<RaftEndpoint> members, long groupId) {
         this.groupName = groupName;
         this.members = members;
+        this.groupId = groupId;
     }
 
     @Override
     public Object run(MetadataRaftGroupManager metadataGroupManager, long commitIndex) {
-        return metadataGroupManager.createRaftGroup(groupName, members, commitIndex);
+        return metadataGroupManager.createRaftGroup(groupName, members, groupId);
     }
 
     @Override
@@ -87,6 +89,7 @@ public class CreateRaftGroupOp extends MetadataRaftGroupOp implements Indetermin
         for (RaftEndpoint member : members) {
             out.writeObject(member);
         }
+        out.writeLong(groupId);
     }
 
     @Override
@@ -98,11 +101,13 @@ public class CreateRaftGroupOp extends MetadataRaftGroupOp implements Indetermin
             RaftEndpoint member = in.readObject();
             members.add(member);
         }
+        groupId = in.readLong();
     }
 
     @Override
     protected void toString(StringBuilder sb) {
         sb.append(", groupName=").append(groupName)
-          .append(", members=").append(members);
+          .append(", members=").append(members)
+          .append(", groupIndex=").append(groupId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/GetActiveCPMembersOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/GetActiveCPMembersOp.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cp.internal.raftop.metadata;
 
-import com.hazelcast.cp.internal.CPMemberInfo;
 import com.hazelcast.cp.internal.IndeterminateOperationStateAware;
 import com.hazelcast.cp.internal.MetadataRaftGroupManager;
 import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
@@ -42,7 +41,7 @@ public class GetActiveCPMembersOp extends MetadataRaftGroupOp implements Indeter
     public Object run(MetadataRaftGroupManager metadataGroupManager, long commitIndex) {
         // returning array list to be able to serialize response
         metadataGroupManager.checkMetadataGroupInitSuccessful();
-        return new ArrayList<CPMemberInfo>(metadataGroupManager.getActiveMembers());
+        return new ArrayList<>(metadataGroupManager.getActiveMembers());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
 import com.hazelcast.internal.nio.EndpointManager;
 import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.RandomPicker;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -53,7 +54,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.cp.internal.MetadataRaftGroupManager.INITIAL_METADATA_GROUP_ID;
+import static com.hazelcast.cp.CPGroup.DEFAULT_GROUP_NAME;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGroupInitStatus.IN_PROGRESS;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGroupInitStatus.SUCCESSFUL;
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
@@ -346,7 +347,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
     public void when_nonMetadataRaftGroupIsAlive_then_itCanBeForceDestroyed() throws ExecutionException, InterruptedException {
         instances = newInstances(3);
 
-        waitAllForLeaderElection(instances, INITIAL_METADATA_GROUP_ID);
+        waitAllForLeaderElection(instances, getMetadataGroupId(instances[0]));
 
         CPGroupId groupId = createNewRaftGroup(instances[0], "id", 3);
 
@@ -380,7 +381,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
     public void when_nonMetadataRaftGroupLosesMajority_then_itCanBeForceDestroyed() throws ExecutionException, InterruptedException {
         instances = newInstances(5);
 
-        waitAllForLeaderElection(instances, INITIAL_METADATA_GROUP_ID);
+        waitAllForLeaderElection(instances, getMetadataGroupId(instances[0]));
 
         CPGroupId groupId = createNewRaftGroup(instances[0], "id", 3);
 
@@ -424,7 +425,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         waitUntilCPDiscoveryCompleted(instances);
 
-        waitAllForLeaderElection(instances, INITIAL_METADATA_GROUP_ID);
+        waitAllForLeaderElection(instances, getMetadataGroupId(instances[0]));
         RaftEndpoint leaderEndpoint = getLeaderMember(getRaftNode(instances[0], getMetadataGroupId(instances[0])));
 
         HazelcastInstance leader = getInstance(leaderEndpoint);
@@ -466,7 +467,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         int otherRaftGroupSize = 2;
         instances = newInstances(metadataGroupSize + otherRaftGroupSize, metadataGroupSize, 0);
 
-        HazelcastInstance leaderInstance = getLeaderInstance(instances, INITIAL_METADATA_GROUP_ID);
+        HazelcastInstance leaderInstance = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
         RaftService raftService = getRaftService(leaderInstance);
         Collection<CPMemberInfo> allEndpoints = raftService.getMetadataGroupManager().getActiveMembers();
 
@@ -487,9 +488,9 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
             groupEndpoints.add(member.toRaftEndpoint());
         }
 
+        RaftOp op = new CreateRaftGroupOp("test", groupEndpoints, RandomPicker.getInt(Integer.MAX_VALUE));
         InternalCompletableFuture<CPGroupSummary> f = raftService.getInvocationManager()
-                                                     .invoke(getMetadataGroupId(leaderInstance),
-                                                             new CreateRaftGroupOp("test", groupEndpoints));
+                                                                 .invoke(getMetadataGroupId(leaderInstance), op);
 
         f.whenCompleteAsync((group, t) -> {
             if (t == null) {
@@ -516,7 +517,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         int metadataGroupSize = 5;
         instances = newInstances(cpNodeCount, metadataGroupSize, 0);
 
-        HazelcastInstance leaderInstance = getLeaderInstance(instances, INITIAL_METADATA_GROUP_ID);
+        HazelcastInstance leaderInstance = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
         leaderInstance.shutdown();
 
         assertTrueEventually(() -> {
@@ -602,18 +603,20 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         instances[4].getLifecycleService().terminate();
 
         RaftInvocationManager invocationManager = getRaftInvocationManager(instances[0]);
-        CPGroupId g3 = invocationManager.createRaftGroup("g3", 3).get();
-        CPGroupId g4 = invocationManager.createRaftGroup("g4", 4).get();
+        CPGroupId groupId3 = invocationManager.createRaftGroup("groupId3", 3).get();
+        CPGroupId groupId4 = invocationManager.createRaftGroup("g4", 4).get();
 
-        RaftNodeImpl leaderNode = waitAllForLeaderElection(Arrays.copyOf(instances, 3), INITIAL_METADATA_GROUP_ID);
+        RaftNodeImpl leaderNode = waitAllForLeaderElection(Arrays.copyOf(instances, 3), getMetadataGroupId(instances[0]));
         HazelcastInstance leader = getInstance(leaderNode.getLocalMember());
-        CPGroup g3Group = queryRaftGroupLocally(leader, g3);
-        assertThat(g3Group.members(), not(hasItem(endpoint3)));
-        assertThat(g3Group.members(), not(hasItem(endpoint4)));
+        CPGroup group3 = queryRaftGroupLocally(leader, groupId3);
+        assertNotNull(group3);
+        assertThat(group3.members(), not(hasItem(endpoint3)));
+        assertThat(group3.members(), not(hasItem(endpoint4)));
 
-        CPGroup g4Group = queryRaftGroupLocally(leader, g4);
-        boolean b3 = g4Group.members().contains(endpoint3);
-        boolean b4 = g4Group.members().contains(endpoint4);
+        CPGroup group4 = queryRaftGroupLocally(leader, groupId4);
+        assertNotNull(group4);
+        boolean b3 = group4.members().contains(endpoint3);
+        boolean b4 = group4.members().contains(endpoint4);
         assertTrue(b3 ^ b4);
     }
 
@@ -690,6 +693,55 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
                 assertNull(instances[i].getCPSubsystem().getLocalCPMember());
             }
         });
+    }
+
+    @Test
+    public void when_cpSubsystemReset_then_cpGroupIsCreatedWithDifferentGroupId() {
+        int cpMemberCount = 3;
+        HazelcastInstance[] instances = newInstances(cpMemberCount);
+        waitUntilCPDiscoveryCompleted(instances);
+
+        RaftGroupId groupId1 = getRaftInvocationManager(instances[0]).createRaftGroup(DEFAULT_GROUP_NAME).joinInternal();
+
+        instances[1].getLifecycleService().terminate();
+        instances[2].getLifecycleService().terminate();
+
+        HazelcastInstance[] newInstances = new HazelcastInstance[cpMemberCount];
+        newInstances[0] = instances[0];
+        newInstances[1] = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
+        newInstances[2] = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
+
+        instances[0].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().join();
+
+        waitUntilCPDiscoveryCompleted(newInstances);
+
+        RaftGroupId groupId2 = getRaftInvocationManager(newInstances[0]).createRaftGroup(DEFAULT_GROUP_NAME).joinInternal();
+
+        assertNotEquals(groupId1.getId(), groupId2.getId());
+    }
+
+    @Test
+    public void when_cpSubsystemStartsMultipleTimes_then_cpGroupIsCreatedWithDifferentGroupId() {
+        int cpMemberCount = 3;
+        HazelcastInstance[] instances = newInstances(cpMemberCount);
+        waitUntilCPDiscoveryCompleted(instances);
+
+        RaftGroupId groupId1 = getRaftInvocationManager(instances[0]).createRaftGroup(DEFAULT_GROUP_NAME).joinInternal();
+
+        instances[0].getLifecycleService().terminate();
+        instances[1].getLifecycleService().terminate();
+        instances[2].getLifecycleService().terminate();
+
+        HazelcastInstance[] newInstances = new HazelcastInstance[cpMemberCount];
+        newInstances[0] = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
+        newInstances[1] = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
+        newInstances[2] = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
+
+        waitUntilCPDiscoveryCompleted(newInstances);
+
+        RaftGroupId groupId2 = getRaftInvocationManager(newInstances[0]).createRaftGroup(DEFAULT_GROUP_NAME).joinInternal();
+
+        assertNotEquals(groupId1, groupId2);
     }
 
     private CPGroupId createNewRaftGroup(HazelcastInstance instance, String name, int groupSize) {


### PR DESCRIPTION
We have 2 fields in CPGroupId: seed and commitIndex. When a new CP group is
created, commit index of its CP group id denotes on which commit of
the Metadata CP group this custom CP group is created. In addition to this,
the seed field is incremented when CP Subsystem is reset. By this way, we
ensure uniqueness of <seed, commit index> pairs of CP group ids. However, if
the whole Hazelcast cluster is restarted, the seed will be 0 again. This can
cause the Default CP group id to be same with the one in the previous Hazelcast
cluster because usually the Default CP group is created on the same Metadata CP
group commit index (=5). If this happens, CP proxies that are created for
the Default CP group of the previous Hazelcast cluster can continue to talk to
the Default CP group created on the new Hazelcast cluster, which means we lose
our consistency guarantees.

To prevent this problem, we don't rely on the Metadata CP group commit index
for generation of CP group ids. Instead, we generate random numbers for
the commit index field of CPGroupId.

Fixes #16221