### PR TITLE
Fix MembershipEvent's member list order on newly joining members

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/InitialMembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/InitialMembershipEvent.java
@@ -63,6 +63,6 @@ public class InitialMembershipEvent extends EventObject {
 
     @Override
     public String toString() {
-        return "MembershipInitializeEvent {" + members + "}";
+        return "InitialMembershipEvent {" + members + "}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/MembershipEvent.java
@@ -118,6 +118,6 @@ public class MembershipEvent extends EventObject {
                 throw new IllegalStateException();
         }
 
-        return format("MembershipEvent {member=%s,type=%s}", member, type);
+        return format("MembershipEvent {member=%s, type=%s, members=%s}", member, type, members);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -161,7 +161,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     public void sendLocalMembershipEvent() {
-        membershipManager.sendMembershipEvents(Collections.emptySet(), Collections.singleton(getLocalMember()));
+        membershipManager.sendMembershipEvents(Collections.emptySet(), Collections.singleton(getLocalMember()), false);
     }
 
     public void handleExplicitSuspicion(MembersViewMetadata expectedMembersViewMetadata, Address suspectedAddress) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -333,7 +333,7 @@ public class MembershipManager {
         }
 
         clusterService.getClusterJoinManager().insertIntoRecentlyJoinedMemberSet(addedMembers);
-        sendMembershipEvents(currentMemberMap.getMembers(), addedMembers);
+        sendMembershipEvents(currentMemberMap.getMembers(), addedMembers, !clusterService.isJoined());
 
         removeFromMissingMembers(members);
 
@@ -742,8 +742,8 @@ public class MembershipManager {
         node.getNodeExtension().onMemberListChange();
     }
 
-    void sendMembershipEvents(Collection<MemberImpl> currentMembers, Collection<MemberImpl> newMembers) {
-        Set<Member> eventMembers = new LinkedHashSet<>(currentMembers);
+    void sendMembershipEvents(Collection<MemberImpl> currentMembers, Collection<MemberImpl> newMembers, boolean sortMembers) {
+        List<Member> eventMembers = new ArrayList<>(currentMembers);
         if (!newMembers.isEmpty()) {
             for (MemberImpl newMember : newMembers) {
                 // sync calls
@@ -752,9 +752,22 @@ public class MembershipManager {
 
                 // async events
                 eventMembers.add(newMember);
+                if (sortMembers) {
+                    sortMembersInMembershipOrder(eventMembers);
+                }
                 sendMembershipEventNotifications(newMember, unmodifiableSet(new LinkedHashSet<>(eventMembers)), true);
             }
         }
+    }
+
+    private void sortMembersInMembershipOrder(List<Member> members) {
+        MemberMap memberMap = getMemberMap();
+        members.sort((m1, m2) -> {
+            if (m1.equals(m2)) {
+                return 0;
+            }
+            return memberMap.isBeforeThan(m1.getAddress(), m2.getAddress()) ? -1 : 1;
+        });
     }
 
     private void sendMembershipEventNotifications(MemberImpl member, Set<Member> members, final boolean added) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterMembershipListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterMembershipListenerTest.java
@@ -30,23 +30,21 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EventObject;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -132,23 +130,33 @@ public class ClusterMembershipListenerTest extends HazelcastTestSupport {
     @Test
     public void testMembershipListener() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance();
-        MembershipListenerImpl listener = new MembershipListenerImpl();
-        hz1.getCluster().addMembershipListener(listener);
 
-        //start a second instance
-        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        MembershipListenerImpl listener1 = new MembershipListenerImpl();
+        HazelcastInstance hz1 = factory.newHazelcastInstance(
+                new Config().addListenerConfig(new ListenerConfig().setImplementation(listener1))
+        );
 
-        assertEventuallySizeAtLeast(listener.events, 1);
-        assertMembershipAddedEvent(listener.events.get(0), hz2.getCluster().getLocalMember(),
+        MembershipListenerImpl listener2 = new MembershipListenerImpl();
+        HazelcastInstance hz2 = factory.newHazelcastInstance(
+                new Config().addListenerConfig(new ListenerConfig().setImplementation(listener2))
+        );
+
+        assertEventuallySizeAtLeast(listener1.events, 2);
+        assertMembershipAddedEvent(listener1.events.get(0), hz1.getCluster().getLocalMember(), hz1.getCluster().getLocalMember());
+        assertMembershipAddedEvent(listener1.events.get(1), hz2.getCluster().getLocalMember(),
+                hz1.getCluster().getLocalMember(), hz2.getCluster().getLocalMember());
+
+        assertEventuallySizeAtLeast(listener2.events, 2);
+        assertMembershipAddedEvent(listener2.events.get(0), hz2.getCluster().getLocalMember(), hz2.getCluster().getLocalMember());
+        assertMembershipAddedEvent(listener2.events.get(1), hz1.getCluster().getLocalMember(),
                 hz1.getCluster().getLocalMember(), hz2.getCluster().getLocalMember());
 
         //terminate the second instance
         Member member2 = hz2.getCluster().getLocalMember();
         hz2.shutdown();
 
-        assertEventuallySizeAtLeast(listener.events, 2);
-        assertMembershipRemovedEvent(listener.events.get(1), member2, hz1.getCluster().getLocalMember());
+        assertEventuallySizeAtLeast(listener1.events, 3);
+        assertMembershipRemovedEvent(listener1.events.get(2), member2, hz1.getCluster().getLocalMember());
     }
 
     @Test
@@ -238,8 +246,8 @@ public class ClusterMembershipListenerTest extends HazelcastTestSupport {
         assertTrue(e instanceof InitialMembershipEvent);
 
         InitialMembershipEvent initialMembershipEvent = (InitialMembershipEvent) e;
-        Set<Member> foundMembers = initialMembershipEvent.getMembers();
-        assertEquals(new HashSet<Member>(Arrays.asList(expectedMembers)), foundMembers);
+        List<Member> foundMembers = new ArrayList<>(initialMembershipEvent.getMembers());
+        assertEquals(Arrays.asList(expectedMembers), foundMembers);
     }
 
     public void assertMembershipAddedEvent(EventObject e, Member addedMember, Member... expectedMembers) {
@@ -254,33 +262,18 @@ public class ClusterMembershipListenerTest extends HazelcastTestSupport {
         assertTrue(e instanceof MembershipEvent);
 
         MembershipEvent membershipEvent = (MembershipEvent) e;
-        Set<Member> foundMembers = membershipEvent.getMembers();
+        List<Member> foundMembers = new ArrayList<>(membershipEvent.getMembers());
         assertEquals(type, membershipEvent.getEventType());
         assertEquals(changedMember, membershipEvent.getMember());
-        assertEquals(new HashSet<Member>(Arrays.asList(expectedMembers)), foundMembers);
+        assertEquals(Arrays.asList(expectedMembers), foundMembers);
     }
 
-    public void assertEventuallySizeAtLeast(List list, int expectedSize) {
-        long startTimeMs = System.currentTimeMillis();
-        for (; ; ) {
-            if (list.size() >= expectedSize) {
-                return;
-            }
-
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-
-            if (System.currentTimeMillis() - startTimeMs > TimeUnit.SECONDS.toMillis(10)) {
-                fail("Timeout, size of the list didn't reach size: " + expectedSize + " in time");
-            }
-        }
+    public void assertEventuallySizeAtLeast(List<?> list, int expectedSize) {
+        assertTrueEventually(() -> assertThat("List: " + list, list.size(), greaterThanOrEqualTo(expectedSize)), 10);
     }
 
-    private static class MembershipListenerImpl implements MembershipListener {
-        private List<EventObject> events = Collections.synchronizedList(new LinkedList<EventObject>());
+    static class MembershipListenerImpl implements MembershipListener {
+        final List<EventObject> events = Collections.synchronizedList(new ArrayList<>());
 
         public void memberAdded(MembershipEvent e) {
             events.add(e);
@@ -289,21 +282,15 @@ public class ClusterMembershipListenerTest extends HazelcastTestSupport {
         public void memberRemoved(MembershipEvent e) {
             events.add(e);
         }
+
+        <E> E getEvent(int index) {
+            return (E) events.get(index);
+        }
     }
 
-    private static class InitialMembershipListenerImpl implements InitialMembershipListener {
-
-        private List<EventObject> events = Collections.synchronizedList(new LinkedList<EventObject>());
+    private static class InitialMembershipListenerImpl extends MembershipListenerImpl implements InitialMembershipListener {
 
         public void init(InitialMembershipEvent e) {
-            events.add(e);
-        }
-
-        public void memberAdded(MembershipEvent e) {
-            events.add(e);
-        }
-
-        public void memberRemoved(MembershipEvent e) {
             events.add(e);
         }
     }


### PR DESCRIPTION
`MembershipEvent.getMembers()` should return the cluster member list
in order at the time of event.
On newly joining members (similarly on merging members after split detected),
the very first `MembershipEvent` returns the member list in wrong order.
Specifically, local member becomes the first element in member list.

This change fixes the `MembershipEvent` member list for newly joining members
by sorting them due to cluster member list before publishing the event.

Fixes #15353