### PR TITLE
Fix MembershipEvent's member list order on newly joining members

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -84,6 +84,7 @@ import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
 import static java.lang.String.format;
+import static java.util.Collections.singleton;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public class ClusterServiceImpl implements ClusterService, ConnectionListener, ManagedService,
@@ -164,7 +165,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     public void sendLocalMembershipEvent() {
-        membershipManager.sendMembershipEvents(Collections.<MemberImpl>emptySet(), Collections.singleton(getLocalMember()));
+        membershipManager.sendMembershipEvents(Collections.<MemberImpl>emptySet(), singleton(getLocalMember()), false);
     }
 
     public void handleExplicitSuspicion(MembersViewMetadata expectedMembersViewMetadata, Address suspectedAddress) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.cluster;
 
+import com.hazelcast.cluster.ClusterMembershipListenerTest.MembershipListenerImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -37,6 +39,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -142,6 +145,36 @@ public class SplitMergeTest extends HazelcastTestSupport {
         mergeBack(h2, getAddress(h1));
 
         lifecycleListener.assertStates(LifecycleState.MERGING, LifecycleState.MERGE_FAILED);
+    }
+
+    @Test
+    public void test_membershipListener_whenMergeSuccess() {
+        HazelcastInstance h1 = factory.newHazelcastInstance(newConfig());
+        HazelcastInstance h2 = factory.newHazelcastInstance(newConfig());
+
+        // add membership listeners
+        MembershipListenerImpl listener1 = new MembershipListenerImpl();
+        h1.getCluster().addMembershipListener(listener1);
+        MembershipListenerImpl listener2 = new MembershipListenerImpl();
+        h2.getCluster().addMembershipListener(listener2);
+
+        // create split
+        closeConnectionBetween(h1, h2);
+        assertClusterSizeEventually(1, h1, h2);
+
+        // merge back
+        mergeBack(h2, getAddress(h1));
+        assertClusterSizeEventually(2, h1, h2);
+
+        assertSizeEventually(2, listener1.events);
+        MembershipEvent event = listener1.getEvent(1);
+        assertEquals(h2.getCluster().getLocalMember(), event.getMember());
+        assertArrayEquals(h1.getCluster().getMembers().toArray(), event.getMembers().toArray());
+
+        assertSizeEventually(2, listener2.events);
+        MembershipEvent event2 = listener2.getEvent(1);
+        assertEquals(h1.getCluster().getLocalMember(), event2.getMember());
+        assertArrayEquals(h2.getCluster().getMembers().toArray(), event2.getMembers().toArray());
     }
 
     private void mergeBack(HazelcastInstance hz, Address to) {


### PR DESCRIPTION
`MembershipEvent.getMembers()` should return the cluster member list
in order at the time of event.
On newly joining members (similarly on merging members after split detected),
the very first `MembershipEvent` returns the member list in wrong order.
Specifically, local member becomes the first element in member list.

This change fixes the `MembershipEvent` member list for newly joining members
by sorting them due to cluster member list before publishing the event.

Fixes #15353
Backport of https://github.com/hazelcast/hazelcast/pull/16243