### PR TITLE
Retry first arrangement of partition table on member left

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
@@ -103,7 +103,7 @@ public class ConnectionRetryConfig {
     }
 
     /**
-     * Timeout value in seconds for the client to give up to connect to the current cluster
+     * Timeout value in milliseconds for the client to give up to connect to the current cluster
      * Depending on FailoverConfig, a client can shutdown or start trying on alternative cluster after reaching the timeout.
      *
      * @return clusterConnectTimeoutMillis

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -279,7 +279,12 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                                     }
                                 } else {
                                     resetMasterTriggeredFlag();
-                                    logger.severe(throwable);
+                                    if(throwable instanceof MemberLeftException) {
+                                        //if member left, retry the first arrangement
+                                        firstArrangement();
+                                    } else {
+                                        logger.severe(throwable);
+                                    }
                                 }
                             });
 


### PR DESCRIPTION
when AssignPartitions operations fails because master left, it is was
not retried. This leads clients to hang waiting for
initial partition table arrangement.
As fix first arrangement will be retried as long as we get member left
exception.

fixes #16231