### PR TITLE
Fixed ClientClusterRestartEventTest.testMultiMemberRestart

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.MembershipListener;
@@ -41,9 +41,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertContains;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.spawn;
 import static org.junit.Assert.assertEquals;
 
@@ -139,8 +139,14 @@ public class ClientClusterRestartEventTest {
             }
         });
 
-        changeClusterStateEventually(instance1, ClusterState.PASSIVE);
-        instance1.getCluster().shutdown();
+        Cluster cluster = instance1.getCluster();
+        assertTrueEventually(() -> {
+            try {
+                cluster.shutdown();
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        });
 
         Future<HazelcastInstance> f1 = spawn(() -> hazelcastFactory.newHazelcastInstance(newConfig()));
         Future<HazelcastInstance> f2 = spawn(() -> hazelcastFactory.newHazelcastInstance(newConfig()));

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.MembershipListener;
@@ -40,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertContains;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.spawn;
@@ -137,6 +139,7 @@ public class ClientClusterRestartEventTest {
             }
         });
 
+        changeClusterStateEventually(instance1, ClusterState.PASSIVE);
         instance1.getCluster().shutdown();
 
         Future<HazelcastInstance> f1 = spawn(() -> hazelcastFactory.newHazelcastInstance(newConfig()));


### PR DESCRIPTION
The test initiates cluster shutdown right after starting
the members. It can happen that the non-master members
don't have up-to-date partition table version yet
(`PartitionStateOperation` delayed or not arrived at all)
at the moment when `shutdown`/`changeClusterState` is called.
As a result, calling shutdown() may fail which is a known
design limitation (see the javadoc of `Cluster#shutdown`).

Since partition state on members is eventually consistent,
this commit introduces a wait until the cluster is in
a safe/stable state before `shutdown()` is called.

Fixes https://github.com/hazelcast/hazelcast/issues/16217