### PR TITLE
Stop background preloader tasks on client shutdown 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientContext.java
@@ -87,10 +87,10 @@ public class ClientContext {
         this.queryCacheContext = client.getQueryCacheContext();
         this.clientExtension = client.getClientExtension();
 
-        registerTasksTo(client);
+        registerDisposalTasksTo(client);
     }
 
-    private void registerTasksTo(HazelcastClientInstanceImpl client) {
+    private void registerDisposalTasksTo(HazelcastClientInstanceImpl client) {
         client.disposeOnClusterChange(() -> {
             nearCacheManagers.values().forEach(NearCacheManager::clearAllNearCaches);
         });

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientContext.java
@@ -30,11 +30,11 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationMetaDataFetcher;
 import com.hazelcast.internal.nearcache.impl.invalidation.MinimalPartitionService;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,25 +48,25 @@ import static java.lang.String.format;
  */
 public class ClientContext {
 
-    private final InternalSerializationService serializationService;
-    private final ClientClusterService clusterService;
-    private final ClientPartitionService partitionService;
-    private final ClientInvocationService invocationService;
-    private final ClientExecutionService executionService;
-    private final ClientListenerService listenerService;
-    private final ClientConnectionManager clientConnectionManager;
-    private final LifecycleService lifecycleService;
-    private final ClientTransactionManagerService transactionManager;
+    private final String name;
     private final ProxyManager proxyManager;
     private final ClientConfig clientConfig;
     private final LoggingService loggingService;
     private final HazelcastProperties properties;
-    private final MinimalPartitionService minimalPartitionService;
+    private final ClientExtension clientExtension;
+    private final LifecycleService lifecycleService;
+    private final ClientClusterService clusterService;
+    private final ClientListenerService listenerService;
+    private final ClientExecutionService executionService;
+    private final ClientPartitionService partitionService;
     private final ClientQueryCacheContext queryCacheContext;
+    private final ClientInvocationService invocationService;
+    private final MinimalPartitionService minimalPartitionService;
+    private final ClientConnectionManager clientConnectionManager;
+    private final InternalSerializationService serializationService;
+    private final ClientTransactionManagerService transactionManager;
     private final ConcurrentMap<String, RepairingTask> repairingTasks = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, NearCacheManager> nearCacheManagers = new ConcurrentHashMap<>();
-    private final ClientExtension clientExtension;
-    private final String name;
 
     public ClientContext(HazelcastClientInstanceImpl client) {
         this.name = client.getName();
@@ -87,10 +87,15 @@ public class ClientContext {
         this.queryCacheContext = client.getQueryCacheContext();
         this.clientExtension = client.getClientExtension();
 
-        client.getClientStatisticsService().watchNearCacheManagers(nearCacheManagers);
+        registerTasksTo(client);
+    }
+
+    private void registerTasksTo(HazelcastClientInstanceImpl client) {
         client.disposeOnClusterChange(() -> {
-            //reset near caches, clears all near cache data
             nearCacheManagers.values().forEach(NearCacheManager::clearAllNearCaches);
+        });
+        client.disposeOnClientShutdown(() -> {
+            nearCacheManagers.values().forEach(NearCacheManager::destroyAllNearCaches);
         });
     }
 
@@ -101,6 +106,10 @@ public class ClientContext {
     public NearCacheManager getNearCacheManager(String serviceName) {
         return getOrPutIfAbsent(nearCacheManagers, serviceName,
                 anyArg -> clientExtension.createNearCacheManager());
+    }
+
+    public ConcurrentMap<String, NearCacheManager> getNearCacheManagers() {
+        return nearCacheManagers;
     }
 
     public RepairingTask getRepairingTask(String serviceName) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
@@ -21,10 +21,10 @@ import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nearcache.NearCacheStats;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -45,8 +45,8 @@ public class DefaultNearCacheManager implements NearCacheManager {
     protected final SerializationService serializationService;
 
     private final Object mutex = new Object();
-    private final Queue<ScheduledFuture> preloadTaskFutures = new ConcurrentLinkedQueue<ScheduledFuture>();
-    private final ConcurrentMap<String, NearCache> nearCacheMap = new ConcurrentHashMap<String, NearCache>();
+    private final Queue<ScheduledFuture> preloadTaskFutures = new ConcurrentLinkedQueue<>();
+    private final ConcurrentMap<String, NearCache> nearCacheMap = new ConcurrentHashMap<>();
 
     private volatile ScheduledFuture storageTaskFuture;
 
@@ -143,9 +143,10 @@ public class DefaultNearCacheManager implements NearCacheManager {
 
     @Override
     public void destroyAllNearCaches() {
-        for (NearCache nearCache : new HashSet<NearCache>(nearCacheMap.values())) {
+        for (NearCache nearCache : new HashSet<>(nearCacheMap.values())) {
             destroyNearCache(nearCache.getName());
         }
+
         for (ScheduledFuture preloadTaskFuture : preloadTaskFutures) {
             preloadTaskFuture.cancel(true);
         }
@@ -173,6 +174,7 @@ public class DefaultNearCacheManager implements NearCacheManager {
     }
 
     private class PreloadTask implements Runnable {
+
         private final NearCache nearCache;
         private final DataStructureAdapter adapter;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
@@ -78,7 +78,7 @@ class NearCachePreloaderLock {
         } catch (IOException e) {
             logger.severe("Problem while releasing the lock and closing channel on " + lockFile, e);
         } finally {
-            lockFile.deleteOnExit();
+            lockFile.delete();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.nearcache.impl.preloader;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 
 import java.io.File;
@@ -78,7 +79,7 @@ class NearCachePreloaderLock {
         } catch (IOException e) {
             logger.severe("Problem while releasing the lock and closing channel on " + lockFile, e);
         } finally {
-            lockFile.delete();
+            IOUtil.delete(lockFile);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.cache.impl.ClientCacheProxy;
 import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
-import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.NearCacheConfig;
@@ -38,7 +37,6 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,9 +48,9 @@ import java.io.File;
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.cache.CacheUtil.getDistributedObjectName;
-import static com.hazelcast.config.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.NearCacheConfig.DEFAULT_INVALIDATE_ON_CHANGE;
 import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
 import static com.hazelcast.config.NearCacheConfig.DEFAULT_SERIALIZE_KEYS;
@@ -68,17 +66,10 @@ public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloade
     protected final File storeFile = new File("nearCache-" + cacheFileName + ".store").getAbsoluteFile();
     protected final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
 
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
     @Before
     public void setUp() {
         nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS, DEFAULT_INVALIDATE_ON_CHANGE,
                 KEY_COUNT, storeFile.getParent());
-    }
-
-    @After
-    public void tearDown() {
-        hazelcastFactory.shutdownAll();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -68,8 +68,8 @@ public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloade
 
     @Before
     public void setUp() {
-        nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS, DEFAULT_INVALIDATE_ON_CHANGE,
-                KEY_COUNT, storeFile.getParent());
+        nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT,
+                DEFAULT_SERIALIZE_KEYS, DEFAULT_INVALIDATE_ON_CHANGE, KEY_COUNT, storeFile.getParent());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.map.impl.nearcache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.impl.proxy.ClientMapProxy;
-import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
@@ -53,12 +52,10 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
     protected final File storeFile = new File("nearCache-" + defaultNearCache + ".store").getAbsoluteFile();
     protected final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
 
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
     @Before
     public void setUp() {
-        nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS, DEFAULT_INVALIDATE_ON_CHANGE,
-                KEY_COUNT, storeFile.getParent());
+        nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT,
+                DEFAULT_SERIALIZE_KEYS, DEFAULT_INVALIDATE_ON_CHANGE, KEY_COUNT, storeFile.getParent());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -29,12 +29,11 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
-import com.hazelcast.map.IMap;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -60,11 +59,6 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
     public void setUp() {
         nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS, DEFAULT_INVALIDATE_ON_CHANGE,
                 KEY_COUNT, storeFile.getParent());
-    }
-
-    @After
-    public void tearDown() {
-        hazelcastFactory.shutdownAll();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheIsNotSharedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheIsNotSharedTest.java
@@ -23,12 +23,19 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class NearCacheIsNotSharedTest {
 
     private TestHazelcastFactory factory;

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.nearcache;
 
 import com.hazelcast.config.EvictionConfig;
-import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
@@ -339,7 +339,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     @Test(timeout = 10 * MINUTE)
     public void testCreateAndDestroyDataStructure_withSameName() {
-        String name = randomMapName("createDestroyNearCache");
+        String name = randomMapName("createDestroyNearCache-" + getClass().getName());
         nearCacheConfig.setName(name);
 
         NearCacheTestContext<Object, String, NK, NV> context = createContext(true);
@@ -354,7 +354,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     @Test(timeout = 10 * MINUTE)
     public void testCreateAndDestroyDataStructure_withDifferentNames() {
-        String name = randomMapName("createDestroyNearCache");
+        String name = randomMapName("createDestroyNearCache-" + getClass().getName());
         nearCacheConfig.setName(name + "*");
 
         NearCacheTestContext<Object, String, NK, NV> context = createContext(true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.nearcache;
 
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
@@ -87,6 +88,8 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     protected final String defaultNearCache = randomName();
 
+    protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
     private final File preloadFile10kInt = getFileFromResources("nearcache-10k-int.store");
     private final File preloadFile10kString = getFileFromResources("nearcache-10k-string.store");
     private final File preloadFileEmpty = getFileFromResources("nearcache-empty.store");
@@ -95,9 +98,13 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
     private final File preloadFileNegativeFileFormat = getFileFromResources("nearcache-negative-fileformat.store");
 
     @After
-    public void deleteFiles() {
-        deleteQuietly(getStoreFile());
-        deleteQuietly(getStoreLockFile());
+    public void tearDown() throws Exception {
+        try {
+            hazelcastFactory.shutdownAll();
+        } finally {
+            deleteQuietly(getStoreFile());
+            deleteQuietly(getStoreLockFile());
+        }
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     protected static final int KEY_COUNT = 10023;
     protected static final int THREAD_COUNT = 10;
-    protected static final int CREATE_AND_DESTROY_RUNS = 5000;
+    protected static final int CREATE_AND_DESTROY_RUNS = 500;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -346,7 +346,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     @Test(timeout = 10 * MINUTE)
     public void testCreateAndDestroyDataStructure_withSameName() {
-        String name = randomMapName("createDestroyNearCache-" + getClass().getName());
+        String name = "testCreateAndDestroyDataStructure_withSameName_" + getClass().getSimpleName();
         nearCacheConfig.setName(name);
 
         NearCacheTestContext<Object, String, NK, NV> context = createContext(true);
@@ -362,7 +362,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     @Test(timeout = 10 * MINUTE)
     public void testCreateAndDestroyDataStructure_withDifferentNames() {
-        String name = randomMapName("createDestroyNearCache-diff-" + getClass().getName());
+        String name = "testCreateAndDestroyDataStructure_withDifferentNames_" + getClass().getSimpleName();
         nearCacheConfig.setName(name + "*");
 
         NearCacheTestContext<Object, String, NK, NV> context = createContext(true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -350,11 +350,12 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
             adapter.destroy();
             adapter = getDataStructure(context, name);
         }
+        adapter.destroy();
     }
 
     @Test(timeout = 10 * MINUTE)
     public void testCreateAndDestroyDataStructure_withDifferentNames() {
-        String name = randomMapName("createDestroyNearCache-" + getClass().getName());
+        String name = randomMapName("createDestroyNearCache-diff-" + getClass().getName());
         nearCacheConfig.setName(name + "*");
 
         NearCacheTestContext<Object, String, NK, NV> context = createContext(true);
@@ -365,6 +366,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
             adapter.destroy();
             adapter = getDataStructure(context, name + i);
         }
+        adapter.destroy();
     }
 
     protected final NearCacheConfig getNearCacheConfig(InMemoryFormat inMemoryFormat, boolean serializeKeys,


### PR DESCRIPTION
__Modifications:__
- Added a new disposable task to dispose near-cache-manager. Task will be called on client shutdown to stop near-cache-managers background tasks.
- Used `delete` instead of `deleteOnExit` when releasing lock file
- Added missing `destroy` calls for create-destroy tests in `AbstractNearCachePreloaderTest` 
- Unified `tearDown` for preloader tests in `AbstractNearCachePreloaderTest`
- Refactored client statistic service to remove nearCacheManager refs, now should be clearer than before.