### PR TITLE
Use TestAwareInstanceFactory for RestClusterBadRequestTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterBadRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterBadRequestTest.java
@@ -25,12 +25,10 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.OverridePropertyRule;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,8 +61,6 @@ import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_WAN_RESUME_PUBLI
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_WAN_STOP_PUBLISHER;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_WAN_SYNC_ALL_MAPS;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_WAN_SYNC_MAP;
-import static com.hazelcast.test.OverridePropertyRule.set;
-import static com.hazelcast.test.TestEnvironment.HAZELCAST_TEST_USE_NETWORK;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -96,15 +92,12 @@ public class RestClusterBadRequestTest extends HazelcastTestSupport {
             URI_CP_MEMBERS_URL,
             URI_LOCAL_CP_MEMBER_URL);
 
-    private TestHazelcastInstanceFactory factory;
+    private TestAwareInstanceFactory factory;
     private HTTPCommunicator communicator;
-
-    @Rule
-    public final OverridePropertyRule overridePropertyRule = set(HAZELCAST_TEST_USE_NETWORK, "true");
 
     @Before
     public void setup() {
-        factory = new TestHazelcastInstanceFactory(1);
+        factory = new TestAwareInstanceFactory();
         HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
         communicator = new HTTPCommunicator(instance);
     }
@@ -126,7 +119,7 @@ public class RestClusterBadRequestTest extends HazelcastTestSupport {
 
     @After
     public void cleanup() {
-        factory.shutdownAll();
+        factory.terminateAll();
     }
 
     @Test


### PR DESCRIPTION
to isolate HazelcastInstances used in parallel test

Fixes #16251 