### PR TITLE
Fixed ManagementCenterServiceTest.shutdownCluster

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.management.MCMapConfig;
 import com.hazelcast.client.impl.management.ManagementCenterService;
 import com.hazelcast.client.impl.management.UpdateMapConfigParameters;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionPolicy;
@@ -59,6 +60,7 @@ import static com.hazelcast.config.MapConfig.DEFAULT_MAX_IDLE_SECONDS;
 import static com.hazelcast.config.MapConfig.DEFAULT_MAX_SIZE;
 import static com.hazelcast.config.MapConfig.DEFAULT_TTL_SECONDS;
 import static com.hazelcast.config.MaxSizePolicy.PER_NODE;
+import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_STARTED;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static java.util.Arrays.stream;
@@ -252,6 +254,9 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
 
     @Test
     public void shutdownCluster() {
+        // make sure the cluster is in stable state to prevent shutdown() failures
+        changeClusterStateEventually(hazelcastInstances[0], ClusterState.PASSIVE);
+
         managementCenterService.shutdownCluster();
 
         assertTrueEventually(() -> assertTrue(


### PR DESCRIPTION
The test initiates cluster shutdown right after starting
the members. It can happen that the non-master members
don't have up-to-date partition table version yet
(PartitionStateOperation delayed or not arrived at all)
at the moment when shutdown/changeClusterState is called.
As a result, calling shutdown() may fail which is a known
design limitation (see the javadoc of Cluster#shutdown).

Since partition state on members is eventually consistent,
this commit introduces a wait until the cluster is in
a safe/stable state before shutdown() is called.

Fixes https://github.com/hazelcast/hazelcast/issues/16242