### PR TITLE
Simplify CPGroupRebalanceTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -463,7 +463,6 @@ class RaftGroupMembershipManager {
         private void rebalanceLeaderships() {
             Map<RaftEndpoint, CPMember> members = getMembers();
             Collection<CPGroupId> groupIds = getCpGroupIds();
-            groupIds.remove(raftService.getMetadataGroupId());
 
             final int avgGroupsPerMember = groupIds.size() / members.size();
             final boolean overAvgAllowed = groupIds.size() % members.size() != 0;


### PR DESCRIPTION
Simplified the test and also made an eventual assertion
since leaderships can change during the test because of
hiccups/pauses.

Fixes #15727