### PR TITLE
Fix MC event polling bug

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -66,7 +66,7 @@ public class ManagementCenterService {
     private volatile ManagementCenterEventListener eventListener;
     private volatile String lastMCConfigETag;
     private volatile long lastTMSUpdateNanos;
-    private volatile long lastMCEventsPollNanos;
+    private volatile long lastMCEventsPollNanos = System.nanoTime();
 
     public ManagementCenterService(HazelcastInstanceImpl instance) {
         this.instance = instance;

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -119,7 +119,7 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
         mcs.log(new TestEvent());
         mcs.log(new TestEvent());
 
-        assertEquals(0, mcs.pollMCEvents().size());
+        assertEquals(2, mcs.pollMCEvents().size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -115,7 +115,7 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
     }
 
     @Test
-    public void testMCEvents_ignoresEvents_noPollAtAll() {
+    public void testMCEvents_storesEvents_noPollAtAll() {
         mcs.log(new TestEvent());
         mcs.log(new TestEvent());
 


### PR DESCRIPTION
Due to this bug, if an event was logged before MC polled
for events, it was ignored.

Fixes MC test: `WANReplicationIntegrationTest`