### PR TITLE
Adds debug logging to MapLoaderFailoverTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -22,12 +22,14 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapLoader;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,6 +44,10 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MapLoaderFailoverTest extends HazelcastTestSupport {
+
+    // debug logging for https://github.com/hazelcast/hazelcast/issues/7959#issuecomment-533283947
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug-map.xml");
 
     private static final int MAP_STORE_ENTRY_COUNT = 10000;
     private static final int BATCH_SIZE = 100;


### PR DESCRIPTION
Triggering of key loading more times than required (as seen in https://github.com/hazelcast/hazelcast/issues/7959#issuecomment-533283947) does not affect correctness but may cause unnecessary load. Existing logs do not provide enough information to reason about what happened during the failed test run. This PR does not resolve the issue but adds debug logging to the particular test so there will be more information in the logs.

Closes #7959 