### PR TITLE
Ringbuffer: populate nextSequenceToReadFrom in ReadManyOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -67,7 +67,7 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
         RingbufferContainer ringbuffer = getRingBufferContainer();
         if (minSize == 0) {
             if (!ringbuffer.shouldWait(sequence)) {
-                sequence = ringbuffer.readMany(sequence, resultSet);
+                readMany(ringbuffer);
             }
 
             return false;
@@ -79,15 +79,20 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
         }
 
         if (ringbuffer.isTooLargeSequence(sequence) || ringbuffer.isStaleSequence(sequence)) {
-            //no need to wait, let the operation continue and fail in beforeRun
+            // no need to wait, let the operation continue and fail in beforeRun
             return false;
         }
         if (sequence == ringbuffer.tailSequence() + 1) {
             // the sequence is not readable
             return true;
         }
-        sequence = ringbuffer.readMany(sequence, resultSet);
+        readMany(ringbuffer);
         return !resultSet.isMinSizeReached();
+    }
+
+    private void readMany(RingbufferContainer ringbuffer) {
+        sequence = ringbuffer.readMany(sequence, resultSet);
+        resultSet.setNextSequenceToReadFrom(sequence);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -18,17 +18,16 @@ package com.hazelcast.ringbuffer.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
-import com.hazelcast.core.IFunction;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IFunction;
 import com.hazelcast.cp.IAtomicLong;
+import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.internal.util.RootCauseMatcher;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,7 +39,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -185,7 +183,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void size_whenSomeItemsAdded() throws Exception {
+    public void size_whenSomeItemsAdded() {
         // we are adding some items, but we don't go beyond the capacity
         // most of the testing already is done in the RingbufferContainerTest
 
@@ -292,7 +290,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
 
 
     @Test(expected = NullPointerException.class)
-    public void add_whenNullItem() throws Exception {
+    public void add_whenNullItem() {
         ringbuffer.add(null);
     }
 
@@ -376,7 +374,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void addAllAsync_whenEmpty() throws Exception {
+    public void addAllAsync_whenEmpty() {
         ringbuffer.addAllAsync(new LinkedList<>(), OVERWRITE);
     }
 
@@ -515,20 +513,10 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         final long tail = ringbuffer.tailSequence();
 
         // first we do the invocation. This invocation is going to block
-        final Future f = spawn(new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return ringbuffer.readOne(tail + 1);
-            }
-        });
+        final Future<String> f = spawn(() -> ringbuffer.readOne(tail + 1));
 
         // then we check if the future is not going to complete.
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertFalse(f.isDone());
-            }
-        }, 2);
+        assertTrueAllTheTime(() -> assertFalse(f.isDone()), 2);
 
         // then we add the item
         ringbuffer.add("3");
@@ -573,12 +561,12 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     // ==================== asyncReadOrWait ==============================
 
     @Test
-    public void readManyAsync_whenReadingBeyondTail() throws ExecutionException, InterruptedException {
+    public void readManyAsync_whenReadingBeyondTail() throws InterruptedException {
         ringbuffer.add("1");
         ringbuffer.add("2");
 
         long seq = ringbuffer.tailSequence() + 2;
-        Future f = ringbuffer.readManyAsync(seq, 1, 1, null).toCompletableFuture();
+        Future<ReadResultSet<String>> f = ringbuffer.readManyAsync(seq, 1, 1, null).toCompletableFuture();
         try {
             f.get();
             fail();
@@ -601,6 +589,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
 
         assertThat(f.get(), contains("1"));
         assertEquals(1, resultSet.readCount());
+        assertEquals(1, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -621,6 +610,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
 
         assertThat(f.get(), contains("1", "2"));
         assertEquals(2, resultSet.readCount());
+        assertEquals(2, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -630,7 +620,10 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         Future<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 0, 10, null).toCompletableFuture();
 
         assertCompletesEventually(f);
-        assertThat(f.get(), contains("1"));
+        ReadResultSet<String> resultSet = f.get();
+        assertNotNull(resultSet);
+        assertThat(resultSet, contains("1"));
+        assertEquals(1, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -638,7 +631,10 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         Future<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 0, 10, null).toCompletableFuture();
 
         assertCompletesEventually(f);
-        assertEquals(0, f.get().readCount());
+        ReadResultSet<String> resultSet = f.get();
+        assertNotNull(resultSet);
+        assertEquals(0, resultSet.readCount());
+        assertEquals(0, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -656,23 +652,12 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         assertNotNull(resultSet);
         Assert.assertThat(f.get(), contains("item2", "item3"));
         assertEquals(2, resultSet.readCount());
+        assertEquals(3, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test
     public void readManyAsync_whenEnoughItems_andObjectInMemoryFormat() throws ExecutionException, InterruptedException {
-        ringbuffer.add("item1");
-        ringbuffer.add("item2");
-        ringbuffer.add("item3");
-        ringbuffer.add("item4");
-
-        Future<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null).toCompletableFuture();
-        assertCompletesEventually(f);
-
-        ReadResultSet<String> resultSet = f.get();
-
-        assertNotNull(resultSet);
-        assertThat(f.get(), contains("item2", "item3"));
-        assertEquals(2, resultSet.readCount());
+        readManyAsync_whenEnoughItems();
     }
 
     public static class GoodStringFunction implements IFunction<String, Boolean>, Serializable {
@@ -700,20 +685,8 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         assertNotNull(resultSet);
         Assert.assertThat(f.get(), contains("good1", "good2", "good3"));
         assertEquals(6, resultSet.readCount());
+        assertEquals(6, resultSet.getNextSequenceToReadFrom());
     }
-
-    @Test
-    public void readManyAsync_emptyBatchAndNoItems() throws Exception {
-        Future<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 0, 10, null).toCompletableFuture();
-
-        assertCompletesEventually(f);
-
-        ReadResultSet<String> resultSet = f.get();
-
-        assertEquals(0, f.get().readCount());
-        assertEquals(0, resultSet.readCount());
-    }
-
 
     @Test
     public void readManyAsync_whenHitsStale_shouldNotBeBlocked() throws Exception {
@@ -726,16 +699,13 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     @Test
     public void readOne_whenHitsStale_shouldNotBeBlocked() {
         final CountDownLatch latch = new CountDownLatch(1);
-        Thread consumer = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    ringbuffer.readOne(0);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                } catch (StaleSequenceException e) {
-                    latch.countDown();
-                }
+        Thread consumer = new Thread(() -> {
+            try {
+                ringbuffer.readOne(0);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (StaleSequenceException e) {
+                latch.countDown();
             }
         });
         consumer.start();
@@ -758,6 +728,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         assertThat(f.get(), contains("1", "2", "3"));
 
         assertEquals(3, resultSet.readCount());
+        assertEquals(3, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -774,6 +745,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         assertNotNull(resultSet);
         assertThat(f.get(), contains("1", "2"));
         assertEquals(2, resultSet.readCount());
+        assertEquals(2, resultSet.getNextSequenceToReadFrom());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -796,15 +768,15 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         ringbuffer.readManyAsync(0, 5, 4, null);
     }
 
-    @Test
-    public void readManyAsync_whenMaxCountTooHigh() throws Exception {
-        ringbuffer.readManyAsync(0, 1, RingbufferProxy.MAX_BATCH_SIZE, null);
+    @Test(expected = IllegalArgumentException.class)
+    public void readManyAsync_whenMaxCountTooHigh() {
+        ringbuffer.readManyAsync(0, 1, RingbufferProxy.MAX_BATCH_SIZE + 1, null);
     }
 
     // ===================== destroy ==========================
 
     @Test
-    public void destroy() throws Exception {
+    public void destroy() {
         ringbuffer.add("1");
         ringbuffer.destroy();
 
@@ -814,16 +786,14 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     }
 
     @Test(expected = DistributedObjectDestroyedException.class)
-    public void destroy_whenBlockedThreads_thenDistributedObjectDestroyedException() throws Exception {
-        spawn(new Runnable() {
-            @Override
-            public void run() {
-                sleepSeconds(2);
-                ringbuffer.destroy();
-            }
+    public void destroy_whenBlockedThreads_thenDistributedObjectDestroyedException() {
+        spawn(() -> {
+            sleepSeconds(2);
+            ringbuffer.destroy();
         });
 
-        InternalCompletableFuture f = (InternalCompletableFuture) ringbuffer.readManyAsync(0, 1, 1, null);
+        InternalCompletableFuture<ReadResultSet<String>> f = (InternalCompletableFuture<ReadResultSet<String>>) ringbuffer
+                .readManyAsync(0, 1, 1, null);
         f.joinInternal();
     }
     // ===================== misc ==========================

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -20,13 +20,13 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IFunction;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -91,14 +91,14 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(asList("tail"), response);
         assertEquals(1, response.readCount());
+        assertEquals(1, response.getNextSequenceToReadFrom());
     }
 
     @Test
-    public void whenOneAfterTail() throws Exception {
+    public void whenOneAfterTail() {
         ringbuffer.add("tail");
 
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 1, 1, 1, null);
-        op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
         boolean shouldWait = op.shouldWait();
@@ -106,14 +106,14 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
         ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(0, response.readCount());
+        assertEquals(0, response.getNextSequenceToReadFrom());
     }
 
     @Test
-    public void whenTooFarAfterTail() throws Exception {
+    public void whenTooFarAfterTail() {
         ringbuffer.add("tail");
 
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 2, 1, 1, null);
-        op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
         assertFalse(op.shouldWait());
@@ -122,9 +122,8 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void whenOneAfterTailAndBufferEmpty() throws Exception {
+    public void whenOneAfterTailAndBufferEmpty() {
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 1, 1, 1, null);
-        op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
         boolean shouldWait = op.shouldWait();
@@ -132,13 +131,13 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
         ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(0, response.readCount());
+        assertEquals(0, response.getNextSequenceToReadFrom());
         assertEquals(0, response.size());
     }
 
     @Test
-    public void whenOnTailAndBufferEmpty() throws Exception {
+    public void whenOnTailAndBufferEmpty() {
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence(), 1, 1, null);
-        op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
         assertFalse(op.shouldWait());
@@ -153,7 +152,6 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer.add("item3");
 
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() - 1, 1, 1, null);
-        op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
         boolean shouldWait = op.shouldWait();
@@ -164,6 +162,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(asList("item2"), response);
         assertEquals(1, response.readCount());
+        assertEquals(2, response.getNextSequenceToReadFrom());
         assertEquals(1, response.size());
     }
 
@@ -185,11 +184,12 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(asList("item1"), response);
         assertEquals(1, response.readCount());
+        assertEquals(1, response.getNextSequenceToReadFrom());
         assertEquals(1, response.size());
     }
 
     @Test
-    public void whenBeforeHead() throws Exception {
+    public void whenBeforeHead() {
         ringbuffer.add("item1");
         ringbuffer.add("item2");
         ringbuffer.add("item3");
@@ -198,7 +198,6 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbufferContainer.setHeadSequence(ringbufferContainer.tailSequence());
 
         ReadManyOperation op = getReadManyOperation(oldhead, 1, 1, null);
-        op.setNodeEngine(nodeEngine);
 
         assertFalse(op.shouldWait());
         expectedException.expect(StaleSequenceException.class);
@@ -206,10 +205,9 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void whenMinimumNumberOfItemsNotAvailable() throws Exception {
+    public void whenMinimumNumberOfItemsNotAvailable() {
         long startSequence = ringbuffer.tailSequence() + 1;
         ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
-        op.setNodeEngine(nodeEngine);
 
         assertTrue(op.shouldWait());
         assertEquals(startSequence, op.sequence);
@@ -217,59 +215,67 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
         ringbuffer.add("item1");
         assertTrue(op.shouldWait());
+        ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(startSequence + 1, op.sequence);
-        assertEquals(asList("item1"), op.getResponse());
+
+        assertEquals(asList("item1"), response);
+        assertEquals(1, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("item2");
         assertTrue(op.shouldWait());
         assertEquals(startSequence + 2, op.sequence);
-        assertEquals(asList("item1", "item2"), op.getResponse());
+        assertEquals(asList("item1", "item2"), response);
+        assertEquals(2, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("item3");
         assertFalse(op.shouldWait());
         assertEquals(startSequence + 3, op.sequence);
-        assertEquals(asList("item1", "item2", "item3"), op.getResponse());
+        assertEquals(asList("item1", "item2", "item3"), response);
+        assertEquals(3, response.getNextSequenceToReadFrom());
     }
 
     @Test
-    public void whenBelowMinimumAvailable() throws Exception {
+    public void whenBelowMinimumAvailable() {
         long startSequence = ringbuffer.tailSequence() + 1;
         ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
-        op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
         ringbuffer.add("item2");
 
         assertTrue(op.shouldWait());
+        ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(startSequence + 2, op.sequence);
-        assertEquals(asList("item1", "item2"), op.getResponse());
+
+        assertEquals(asList("item1", "item2"), response);
+        assertEquals(2, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("item3");
         assertFalse(op.shouldWait());
         assertEquals(startSequence + 3, op.sequence);
-        assertEquals(asList("item1", "item2", "item3"), op.getResponse());
+        assertEquals(asList("item1", "item2", "item3"), response);
+        assertEquals(3, response.getNextSequenceToReadFrom());
     }
 
     @Test
-    public void whenMinimumNumberOfItemsAvailable() throws Exception {
+    public void whenMinimumNumberOfItemsAvailable() {
         long startSequence = ringbuffer.tailSequence() + 1;
         ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
-        op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
         ringbuffer.add("item2");
         ringbuffer.add("item3");
 
         assertFalse(op.shouldWait());
+        ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(startSequence + 3, op.sequence);
-        assertEquals(asList("item1", "item2", "item3"), op.getResponse());
+        assertEquals(asList("item1", "item2", "item3"), response);
+        assertEquals(3, response.getNextSequenceToReadFrom());
     }
 
     @Test
-    public void whenEnoughItemsAvailable() throws Exception {
+    public void whenEnoughItemsAvailable() {
         long startSequence = ringbuffer.tailSequence() + 1;
         ReadManyOperation op = getReadManyOperation(startSequence, 1, 3, null);
-        op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
         ringbuffer.add("item2");
@@ -283,6 +289,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         assertEquals(startSequence + 3, op.sequence);
         assertEquals(asList("item1", "item2", "item3"), response);
         assertEquals(3, response.readCount());
+        assertEquals(3, response.getNextSequenceToReadFrom());
     }
 
     private ReadResultSetImpl getReadResultSet(ReadManyOperation op) {
@@ -290,18 +297,12 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void whenFilterProvidedAndNoItemsAvailable() throws Exception {
+    public void whenFilterProvidedAndNoItemsAvailable() {
         long startSequence = ringbuffer.tailSequence() + 1;
 
-        IFunction<String, Boolean> filter = new IFunction<String, Boolean>() {
-            @Override
-            public Boolean apply(String input) {
-                return input.startsWith("good");
-            }
-        };
+        IFunction<String, Boolean> filter = (IFunction<String, Boolean>) input -> input.startsWith("good");
 
         ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, filter);
-        op.setNodeEngine(nodeEngine);
 
         assertTrue(op.shouldWait());
         ReadResultSetImpl response = getReadResultSet(op);
@@ -312,6 +313,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         assertTrue(op.shouldWait());
         assertEquals(startSequence + 1, op.sequence);
         assertEquals(1, response.readCount());
+        assertEquals(1, response.getNextSequenceToReadFrom());
         assertEquals(0, response.size());
 
 
@@ -320,45 +322,44 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         assertEquals(startSequence + 2, op.sequence);
         assertEquals(asList("good1"), response);
         assertEquals(2, response.readCount());
+        assertEquals(2, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("bad2");
         assertTrue(op.shouldWait());
         assertEquals(startSequence + 3, op.sequence);
         assertEquals(asList("good1"), response);
         assertEquals(3, response.readCount());
+        assertEquals(3, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("good2");
         assertTrue(op.shouldWait());
         assertEquals(startSequence + 4, op.sequence);
         assertEquals(asList("good1", "good2"), response);
         assertEquals(4, response.readCount());
+        assertEquals(4, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("bad3");
         assertTrue(op.shouldWait());
         assertEquals(startSequence + 5, op.sequence);
         assertEquals(asList("good1", "good2"), response);
         assertEquals(5, response.readCount());
+        assertEquals(5, response.getNextSequenceToReadFrom());
 
         ringbuffer.add("good3");
         assertFalse(op.shouldWait());
         assertEquals(startSequence + 6, op.sequence);
         assertEquals(asList("good1", "good2", "good3"), response);
         assertEquals(6, response.readCount());
+        assertEquals(6, response.getNextSequenceToReadFrom());
     }
 
     @Test
-    public void whenFilterProvidedAndAllItemsAvailable() throws Exception {
+    public void whenFilterProvidedAndAllItemsAvailable() {
         long startSequence = ringbuffer.tailSequence() + 1;
 
-        IFunction<String, Boolean> filter = new IFunction<String, Boolean>() {
-            @Override
-            public Boolean apply(String input) {
-                return input.startsWith("good");
-            }
-        };
+        IFunction<String, Boolean> filter = (IFunction<String, Boolean>) input -> input.startsWith("good");
 
         ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, filter);
-        op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("bad1");
         ringbuffer.add("good1");
@@ -368,8 +369,10 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer.add("good3");
 
         assertFalse(op.shouldWait());
+        ReadResultSetImpl response = getReadResultSet(op);
         assertEquals(startSequence + 6, op.sequence);
-        assertEquals(asList("good1", "good2", "good3"), op.getResponse());
+        assertEquals(asList("good1", "good2", "good3"), response);
+        assertEquals(6, response.getNextSequenceToReadFrom());
     }
 
     private <T> ReadManyOperation<T> getReadManyOperation(long start, int min, int max, IFunction<T, Boolean> filter) {


### PR DESCRIPTION
The `ResultSet` field `nextSequenceToReadFrom` was set only
in `EventJournalReadOperation`. This commit makes sure the
field is populated in `ReadManyOperation` as well.

Also, small cleanups in the relevant `Ringbuffer` tests.

Fixes https://github.com/hazelcast/hazelcast/issues/15103