### PR TITLE
Fix ClientEntryLoadedListenerTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
@@ -16,21 +16,21 @@
 
 package com.hazelcast.client.map;
 
+import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapLoader;
-import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryLoadedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
+public class ClientEntryLoadedListenerTest extends ClientTestSupport {
 
     private static final TestHazelcastFactory FACTORY = new TestHazelcastFactory();
 
@@ -210,6 +210,8 @@ public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
 
         IMap<Integer, Integer> map = client.getMap("load_listener_notified_but_add_listener_not_notified_after_loadAll");
         map.clear();
+
+        makeSureConnectedToServers(client, 2);
 
         MapListener listener = new LoadAndAddListener(loadEventCount, addEventCount);
         map.addEntryListener(listener, true);


### PR DESCRIPTION
Ensure client has connection to all members before registering the listener.
Otherwise, client can miss events fired by not-yet-connected members.

Fixes #16263