### PR TITLE
Remove mancenter shortening from source code

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2109,7 +2109,6 @@
             <xs:enumeration value="hazelcast.log.state"/>
             <xs:enumeration value="hazelcast.jmx"/>
             <xs:enumeration value="hazelcast.jmx.detailed"/>
-            <xs:enumeration value="hazelcast.mancenter.enabled"/>
             <xs:enumeration value="hazelcast.map.load.chunk.size"/>
             <xs:enumeration value="hazelcast.in.thread.priority"/>
             <xs:enumeration value="hazelcast.out.thread.priority"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -131,7 +131,7 @@ public class ConfigXmlGenerator {
                 .node("cluster-name", config.getClusterName())
                 ;
 
-        manCenterXmlGenerator(gen, config);
+        managementCenterXmlGenerator(gen, config);
         gen.appendProperties(config.getProperties());
         securityXmlGenerator(gen, config);
         wanReplicationXmlGenerator(gen, config);
@@ -174,7 +174,7 @@ public class ConfigXmlGenerator {
         return maskSensitiveFields ? MASK_FOR_SENSITIVE_DATA : value;
     }
 
-    private void manCenterXmlGenerator(XmlGenerator gen, Config config) {
+    private void managementCenterXmlGenerator(XmlGenerator gen, Config config) {
         if (config.getManagementCenterConfig() != null) {
             ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
             gen.open("management-center",

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1072,7 +1072,7 @@ abstract class MapProxySupport<K, V>
 
     @Override
     public void flush() {
-        // TODO: add a feature to mancenter to sync cache to db completely
+        // TODO: add a feature to Management Center to sync cache to db completely
         try {
             MapOperation mapFlushOperation = operationProvider.createMapFlushOperation(name);
             BinaryOperationFactory operationFactory = new BinaryOperationFactory(mapFlushOperation, getNodeEngine());

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -662,8 +662,8 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
 
         Config xmlConfig = getNewConfigViaXMLGenerator(config);
 
-        ManagementCenterConfig xmlManCenterConfig = xmlConfig.getManagementCenterConfig();
-        assertEquals(managementCenterConfig.isScriptingEnabled(), xmlManCenterConfig.isScriptingEnabled());
+        ManagementCenterConfig xmlMCConfig = xmlConfig.getManagementCenterConfig();
+        assertEquals(managementCenterConfig.isScriptingEnabled(), xmlMCConfig.isScriptingEnabled());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -787,9 +787,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertFalse(manCenterCfg.isScriptingEnabled());
+        assertFalse(mcConfig.isScriptingEnabled());
     }
 
     @Override
@@ -801,9 +801,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(manCenterCfg.isScriptingEnabled());
+        assertTrue(mcConfig.isScriptingEnabled());
     }
 
     @Override
@@ -812,9 +812,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String xml = HAZELCAST_START_TAG + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(manCenterCfg.isScriptingEnabled());
+        assertTrue(mcConfig.isScriptingEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -791,9 +791,9 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    scripting-enabled: false\n";
 
         Config config = buildConfig(yaml);
-        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertFalse(manCenterCfg.isScriptingEnabled());
+        assertFalse(mcConfig.isScriptingEnabled());
     }
 
     @Override
@@ -804,9 +804,9 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "  management-center: {}";
 
         Config config = buildConfig(yaml);
-        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(manCenterCfg.isScriptingEnabled());
+        assertTrue(mcConfig.isScriptingEnabled());
     }
 
     @Override
@@ -815,9 +815,9 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         String yaml = "hazelcast: {}";
 
         Config config = buildConfig(yaml);
-        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(manCenterCfg.isScriptingEnabled());
+        assertTrue(mcConfig.isScriptingEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -36,7 +36,7 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
 
     //https://github.com/hazelcast/hazelcast/issues/11598
     @Test
-    public void testRedundantPartitionMigrationWhenManCenterConfigured() {
+    public void testRedundantPartitionMigrationWhenManagementCenterConfigured() {
         Config config = new Config();
 
         //don't need start management center, just configure it

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -121,7 +121,6 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             }
         }
         System.setProperty("hazelcast.phone.home.enabled", "false");
-        System.setProperty("hazelcast.mancenter.enabled", "false");
         System.setProperty("hazelcast.wait.seconds.before.join", "1");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         System.setProperty("java.net.preferIPv4Stack", "true");

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,6 @@
                         ${vmHeapSettings}
                         ${javaModuleArgs}
                         -Dhazelcast.phone.home.enabled=false
-                        -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.test.use.network=false
                         -Dlog4j.skipJansi=true
                         ${extraVmArgs}
@@ -299,7 +298,6 @@
                         ${vmHeapSettings}
                         ${javaModuleArgs}
                         -Dhazelcast.phone.home.enabled=false
-                        -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=true
                         -Dlog4j.skipJansi=true
@@ -398,7 +396,6 @@
                                         ${javaModuleArgs}
                                         -ea
                                         -Dhazelcast.phone.home.enabled=false
-                                        -Dhazelcast.mancenter.enabled=false
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
                                         -Dhazelcast.test.multiple.jvm=true
@@ -439,7 +436,6 @@
                                         ${vmHeapSettings}
                                         ${javaModuleArgs}
                                         -Dhazelcast.phone.home.enabled=false
-                                        -Dhazelcast.mancenter.enabled=false
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
                                         -Dlog4j.configurationFile=log4j2.xml
@@ -486,7 +482,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
@@ -516,7 +511,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
@@ -581,7 +575,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
@@ -612,7 +605,6 @@
                     ${vmHeapSettings}
                     ${javaModuleArgs}
                     -Dhazelcast.phone.home.enabled=false
-                    -Dhazelcast.mancenter.enabled=false
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
                     -Dhazelcast.operation.call.timeout.millis=120000
@@ -679,7 +671,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
                                 -Dlog4j.skipJansi=true
@@ -893,7 +884,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
@@ -921,7 +911,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
                                 -Dlog4j.skipJansi=true
@@ -963,7 +952,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
@@ -992,7 +980,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
                                 -Dlog4j.skipJansi=true
@@ -1081,7 +1068,6 @@
                                 ${vmHeapSettings}
                                 ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                                 -Dhazelcast.test.sample.serialized.objects=${target.dir}/serialized-objects-${project.version}-
                                 -Dlog4j.skipJansi=true


### PR DESCRIPTION
Also removes usage of obsolete `hazelcast.mancenter.enabled` sys prop