### PR TITLE
Fire backup operations even if the original operation returns no response

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/TransferLeadershipOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/TransferLeadershipOp.java
@@ -58,7 +58,7 @@ public class TransferLeadershipOp extends Operation implements RaftSystemOperati
         RaftService service = getService();
         InternalCompletableFuture future = service.transferLeadership(groupId, (CPMemberInfo) destination);
         future.whenCompleteAsync(this);
-        return CallStatus.DONE_VOID;
+        return CallStatus.VOID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftBackupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftBackupOp.java
@@ -37,7 +37,7 @@ public class UnsafeRaftBackupOp extends AbstractUnsafeRaftOp implements BackupOp
 
     @Override
     CallStatus handleResponse(long commitIndex, Object response) {
-        return CallStatus.DONE_VOID;
+        return CallStatus.VOID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftQueryOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftQueryOp.java
@@ -38,7 +38,7 @@ public class UnsafeRaftQueryOp extends AbstractUnsafeRaftOp implements ReadonlyO
 
     @Override
     CallStatus handleResponse(long commitIndex, Object response) {
-        return CallStatus.DONE_RESPONSE;
+        return CallStatus.RESPONSE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
@@ -44,9 +44,9 @@ public class UnsafeRaftReplicateOp extends AbstractUnsafeRaftOp implements Backu
         if (response == PostponedResponse.INSTANCE) {
             RaftService service = getService();
             service.registerUnsafeWaitingOperation(groupId, commitIndex, this);
-            return CallStatus.DONE_VOID_BACKUP;
+            return CallStatus.VOID;
         }
-        return CallStatus.DONE_RESPONSE;
+        return CallStatus.RESPONSE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -91,7 +91,7 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
         if (!migrationInfo.startProcessing()) {
             getLogger().warning("Migration is cancelled -> " + migrationInfo);
             completeMigration(false);
-            return CallStatus.DONE_VOID;
+            return CallStatus.VOID;
         }
 
         return new OffloadImpl();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -120,10 +120,10 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
                 return beforePromotion();
             case FINALIZE_PROMOTION:
                 finalizePromotion();
-                return CallStatus.DONE_VOID;
+                return CallStatus.VOID;
             case COMPLETE:
                 complete();
-                return CallStatus.DONE_RESPONSE;
+                return CallStatus.RESPONSE;
             default:
                 throw new IllegalStateException("Unknown state: " + runStage);
         }
@@ -150,7 +150,7 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
                     + partitionState.getVersion() + ", current version: " + partitionStateVersion);
             partitionService.getMigrationManager().releasePromotionPermit();
             success = true;
-            return CallStatus.DONE_RESPONSE;
+            return CallStatus.RESPONSE;
         }
 
         migrationState = new MigrationStateImpl(Clock.currentTimeMillis(), promotions.size(), 0, 0L);
@@ -173,7 +173,7 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
             op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine).setService(partitionService);
             operationService.execute(op);
         }
-        return CallStatus.DONE_VOID;
+        return CallStatus.VOID;
     }
 
     /** Processes the sent partition state and sends {@link FinalizePromotionOperation} for all promotions. */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -51,7 +51,7 @@ import static com.hazelcast.core.Offloadable.NO_OFFLOADING;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 import static com.hazelcast.spi.impl.executionservice.ExecutionService.OFFLOADABLE_EXECUTOR;
-import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_RESPONSE;
+import static com.hazelcast.spi.impl.operationservice.CallStatus.RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.WAIT;
 import static com.hazelcast.spi.impl.operationservice.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
@@ -188,7 +188,7 @@ public class EntryOperation extends LockAwareOperation
                     .operateOnKey(dataKey)
                     .doPostOperateOps()
                     .getResult();
-            return DONE_RESPONSE;
+            return RESPONSE;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiConsumer;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_RESPONSE;
+import static com.hazelcast.spi.impl.operationservice.CallStatus.RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.OFFLOAD_ORDINAL;
 import static com.hazelcast.spi.impl.operationservice.ExceptionAction.THROW_EXCEPTION;
 
@@ -87,13 +87,13 @@ public class QueryOperation extends AbstractNamedOperation implements ReadonlyOp
             case BINARY:
             case OBJECT:
                 result = queryRunner.runIndexOrPartitionScanQueryOnOwnedPartitions(query);
-                return DONE_RESPONSE;
+                return RESPONSE;
             case NATIVE:
                 BitSet localPartitions = localPartitions();
                 if (localPartitions.cardinality() == 0) {
                     // important to deal with situation of not having any partitions
                     result = queryRunner.populateEmptyResult(query, Collections.emptyList());
-                    return DONE_RESPONSE;
+                    return RESPONSE;
                 } else {
                     return new OffloadedImpl(queryRunner, localPartitions);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/CallStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/CallStatus.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.impl.operationservice;
  *
  * Using the CallStatus the operation can control how the system will deal with
  * the operation after it is executed. For example when the CallStatus is
- * {@link CallStatus#DONE_RESPONSE}, a response can be send to the caller. But
+ * {@link CallStatus#RESPONSE}, a response can be send to the caller. But
  * it also allows for different behavior where no response is available yet e.g.
  * when an operation gets offloaded.
  *
@@ -33,14 +33,14 @@ package com.hazelcast.spi.impl.operationservice;
 public class CallStatus {
 
     /**
-     * The ordinal value for a {@link #DONE_RESPONSE}.
+     * The ordinal value for a {@link #RESPONSE}.
      */
-    public static final int DONE_RESPONSE_ORDINAL = 0;
+    public static final int RESPONSE_ORDINAL = 0;
 
     /**
-     * The ordinal value for a {@link #DONE_VOID}.
+     * The ordinal value for a {@link #VOID}.
      */
-    public static final int DONE_VOID_ORDINAL = 1;
+    public static final int VOID_ORDINAL = 1;
 
     /**
      * The ordinal value for a {@link #WAIT}.
@@ -53,35 +53,31 @@ public class CallStatus {
     public static final int OFFLOAD_ORDINAL = 3;
 
     /**
-     * The ordinal value for an {@link #DONE_VOID_BACKUP}.
-     */
-    public static final int DONE_VOID_BACKUP_ORDINAL = 4;
-
-    /**
      * Signals that the Operation is done running and that a response is ready
      * to be returned. Most of the normal operations like IAtomicLong.get will
      * fall in this category.
+     *
+     * Also operations like an IMap.put should return 'RESPONSE' because the
+     * operation will be checked if backups should be made.
      */
-    public static final CallStatus DONE_RESPONSE = new CallStatus(DONE_RESPONSE_ORDINAL);
+    public static final CallStatus RESPONSE = new CallStatus(RESPONSE_ORDINAL);
 
     /**
      * Signals that the Operation is done running, but no response will be
      * returned. Most of the regular operations like map.get will return a
      * response, but there are also fire and forget operations (lot of
      * cluster operations) that don't return a response.
+     *
+     * If an operation returns void, it will be checked if backups should be made.
      */
-    public static final CallStatus DONE_VOID = new CallStatus(DONE_VOID_ORDINAL);
-
-    /**
-     * Signals that the Operation is done running, its backup should be sent,
-     * but no response will be returned.
-     */
-    public static final CallStatus DONE_VOID_BACKUP = new CallStatus(DONE_VOID_BACKUP_ORDINAL);
+    public static final CallStatus VOID = new CallStatus(VOID_ORDINAL);
 
     /**
      * Indicates that the call could not complete because waiting is required.
      * E.g. a queue.take on an empty queue. This can only be returned by
      * BlockingOperations.
+     *
+     * In this case no responses/backups will be send.
      */
     public static final CallStatus WAIT = new CallStatus(WAIT_ORDINAL);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Offload.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Offload.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * more information see the {@link Operation#call()}.
  *
  * If the operation 'offloads' some work, but doesn't send a response ever,
- * {@link CallStatus#DONE_VOID} should be used instead.
+ * {@link CallStatus#VOID} should be used instead.
  *
  * <h1>Response handling</h1>
  * When the {@link Offload#init(NodeEngineImpl, Set)} is called, the original

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
@@ -38,8 +38,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.logging.Level;
 
-import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_RESPONSE;
-import static com.hazelcast.spi.impl.operationservice.CallStatus.DONE_VOID;
+import static com.hazelcast.spi.impl.operationservice.CallStatus.RESPONSE;
+import static com.hazelcast.spi.impl.operationservice.CallStatus.VOID;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.WAIT;
 import static com.hazelcast.spi.impl.operationservice.ExceptionAction.RETRY_INVOCATION;
 import static com.hazelcast.spi.impl.operationservice.ExceptionAction.THROW_EXCEPTION;
@@ -166,7 +166,7 @@ public abstract class Operation implements DataSerializable {
      * In the future it is very likely that for regular Operation that want to
      * return a concrete response, the actual response can be returned directly.
      * In this case we'll change the return type to {@link Object} to prevent
-     * forcing the response to be wrapped in a {@link CallStatus#DONE_RESPONSE}
+     * forcing the response to be wrapped in a {@link CallStatus#RESPONSE}
      * monad since that would force additional litter to be created.
      *
      * @return the CallStatus.
@@ -182,7 +182,7 @@ public abstract class Operation implements DataSerializable {
         }
 
         run();
-        return returnsResponse() ? DONE_RESPONSE : DONE_VOID;
+        return returnsResponse() ? RESPONSE : VOID;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXACompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXACompatibilityTest.java
@@ -76,6 +76,8 @@ public class HazelcastXACompatibilityTest extends HazelcastTestSupport {
         doSomeWorkWithXa(xaResource);
         performPrepareWithXa(xaResource);
         performCommitWithXa(secondXaResource);
+        assertTrueEventually(() -> assertRecoversNothing(xaResource));
+        assertTrueEventually(() -> assertRecoversNothing(secondXaResource));
     }
 
     @Test
@@ -90,11 +92,6 @@ public class HazelcastXACompatibilityTest extends HazelcastTestSupport {
         doSomeWorkWithXa(xaResource);
         performPrepareWithXa(xaResource);
         assertRecoversXid(xaResource);
-    }
-
-    private void assertRecoversXid(XAResource xaResource) throws XAException {
-        Xid[] xids = xaResource.recover(XAResource.TMSTARTRSCAN | XAResource.TMENDRSCAN);
-        assertTrue("" + xids.length, xids.length == 1);
     }
 
     @Test
@@ -238,5 +235,14 @@ public class HazelcastXACompatibilityTest extends HazelcastTestSupport {
         assertOpenEventually(latch, 10);
     }
 
+    private void assertRecoversXid(XAResource xaResource) throws XAException {
+        Xid[] xids = xaResource.recover(XAResource.TMSTARTRSCAN | XAResource.TMENDRSCAN);
+        assertEquals("One Xid was expected when calling recover", 1, xids.length);
+    }
+
+    private void assertRecoversNothing(XAResource xaResource) throws XAException {
+        Xid[] xids = xaResource.recover(XAResource.TMSTARTRSCAN | XAResource.TMENDRSCAN);
+        assertEquals("No prepared transaction should exist", 0, xids.length);
+  }
 
 }


### PR DESCRIPTION
Fixes #15175 

We failed to fire a backup operation if the original operation returned no response.