### PR TITLE
Use CP RestEndpointGroup in RestCPSubsystemTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestCPSubsystemTest.java
@@ -74,7 +74,7 @@ public class RestCPSubsystemTest extends HazelcastTestSupport {
     public void setup() {
         RestApiConfig restApiConfig = new RestApiConfig()
                 .setEnabled(true)
-                .enableGroups(RestEndpointGroup.CLUSTER_WRITE);
+                .enableGroups(RestEndpointGroup.CP);
         config.getNetworkConfig().setRestApiConfig(restApiConfig);
 
         JoinConfig join = config.getNetworkConfig().getJoin();


### PR DESCRIPTION
CP subsystem was using `CLUSTER_WRITE` group before
but a new `CP` group is added by https://github.com/hazelcast/hazelcast/pull/16237.

Fixes #16287