### PR TITLE
Fix NPE in handling auth result when MC client connects to starting cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -788,7 +788,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         boolean changedCluster = false;
         // newClusterId may be null when member has not started yet;
         // see AbstractMessageTask#acceptOnIncompleteStart
-        if (isFirstConnectionAfterDisconnection & newClusterId != null) {
+        if (isFirstConnectionAfterDisconnection && newClusterId != null) {
             changedCluster = clusterId != null && !newClusterId.equals(clusterId);
             clusterId = newClusterId;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -786,9 +786,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
         boolean isFirstConnectionAfterDisconnection = connectionCount.incrementAndGet() == 1;
         boolean changedCluster = false;
-        // newClusterId may be null when member has not started yet;
-        // see AbstractMessageTask#acceptOnIncompleteStart
-        if (isFirstConnectionAfterDisconnection && newClusterId != null) {
+        if (isFirstConnectionAfterDisconnection) {
             changedCluster = clusterId != null && !newClusterId.equals(clusterId);
             clusterId = newClusterId;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -786,7 +786,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
         boolean isFirstConnectionAfterDisconnection = connectionCount.incrementAndGet() == 1;
         boolean changedCluster = false;
-        if (isFirstConnectionAfterDisconnection) {
+        // newClusterId may be null when member has not started yet;
+        // see AbstractMessageTask#acceptOnIncompleteStart
+        if (isFirstConnectionAfterDisconnection & newClusterId != null) {
             changedCluster = clusterId != null && !newClusterId.equals(clusterId);
             clusterId = newClusterId;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task;
 import com.hazelcast.client.impl.protocol.AuthenticationStatus;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.Credentials;
@@ -174,6 +175,12 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
                 clientName, labels);
         setConnectionType();
         validateNodeStart();
+        final UUID clusterId = clientEngine.getClusterService().getClusterId();
+        // additional check: cluster id may be null when member has not started yet;
+        // see AbstractMessageTask#acceptOnIncompleteStart
+        if (clusterId == null) {
+            throw new HazelcastInstanceNotActiveException("Hazelcast instance is not ready yet!");
+        }
         if (!clientEngine.bind(endpoint)) {
             return prepareNotAllowedInCluster();
         }
@@ -182,9 +189,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
                 + ", client version: " + clientVersion);
         final Address thisAddress = clientEngine.getThisAddress();
         byte status = AUTHENTICATED.getId();
-        return encodeAuth(status, thisAddress, clientUuid,
-                serializationService.getVersion(),
-                clientEngine.getPartitionService().getPartitionCount(), clientEngine.getClusterService().getClusterId());
+        return encodeAuth(status, thisAddress, clientUuid, serializationService.getVersion(),
+                clientEngine.getPartitionService().getPartitionCount(), clusterId);
     }
 
     private void setConnectionType() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetTimedMemberStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetTimedMemberStateMessageTask.java
@@ -33,6 +33,11 @@ public class GetTimedMemberStateMessageTask extends AbstractCallableMessageTask<
     }
 
     @Override
+    protected boolean acceptOnIncompleteStart() {
+        return true;
+    }
+
+    @Override
     protected Object call() throws Exception {
         ManagementCenterService mcs = nodeEngine.getManagementCenterService();
         return mcs != null ? mcs.getTimedMemberStateJson().orElse(null) : null;


### PR DESCRIPTION
* A follow-up for #16262
* Adds an extra check to avoid NPEs when MC client connects to starting cluster (Hot Restart force/partial start scenario). Such scenario was reproduced in integration tests in MC
* Also introduces executor usage in `HotRestartTriggerBackupMessageTask`