### PR TITLE
Complete exceptionally proxy future when destroyed during creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
@@ -53,6 +53,14 @@ public class DistributedObjectFuture {
         throw ExceptionUtil.rethrow(error);
     }
 
+    public DistributedObject getNow() {
+        if (error != null) {
+            throw ExceptionUtil.rethrow(error);
+        }
+        // return completed proxy or null
+        return proxy;
+    }
+
     private boolean waitUntilSetAndInitialized() {
         boolean interrupted = false;
         synchronized (this) {
@@ -89,10 +97,12 @@ public class DistributedObjectFuture {
             throw new IllegalArgumentException("Proxy should not be null!");
         }
         synchronized (this) {
-            if (!initialized && o instanceof InitializingObject) {
-                rawProxy = o;
-            } else {
-                proxy = o;
+            if (error == null) {
+                if (!initialized && o instanceof InitializingObject) {
+                    rawProxy = o;
+                } else {
+                    proxy = o;
+                }
             }
             notifyAll();
         }


### PR DESCRIPTION
Destruction of a proxy that is not yet initialized should not block
on its construction, otherwise there is risk of deadlock. Instead,
the proxy future is completed with a `DistributedObjectDestroyed`
exception.

Fixes #13216 

(see also https://github.com/hazelcast/hazelcast/issues/13216#issuecomment-567166090)