### PR TITLE
Fix client reconnect tests with common Listener

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheProxyTest.java
@@ -20,8 +20,6 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -34,7 +32,6 @@ import javax.cache.CacheManager;
 import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.MutableConfiguration;
 import javax.cache.spi.CachingProvider;
-import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static org.junit.Assert.assertNull;
@@ -67,21 +64,14 @@ public class ClientCacheProxyTest extends ClientTestSupport {
 
         javax.cache.Cache<String, String> cache = cacheManager.createCache("example", config);
         //restarting cluster
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
+
         instance.shutdown();
-
-        final CountDownLatch clientConnectedBack = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
-                    clientConnectedBack.countDown();
-                }
-            }
-        });
-
         factory.newHazelcastInstance();
 
-        assertOpenEventually(clientConnectedBack);
+        assertOpenEventually(reconnectListener.reconnectedLatch);
+
         //expected to work without throwing exception
         assertNull(cache.get("key"));
 

--- a/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTestXmlConfig.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTestXmlConfig.java
@@ -73,7 +73,6 @@ public class ConfiguredBehaviourTestXmlConfig extends ClientTestSupport {
 
     @Test
     public void testReconnectModeASYNCSingleMemberStartLateXmlConfig() {
-        final CountDownLatch reconnectedLatch = new CountDownLatch(1);
 
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
@@ -84,20 +83,13 @@ public class ConfiguredBehaviourTestXmlConfig extends ClientTestSupport {
 
         assertTrue(client.getLifecycleService().isRunning());
 
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
+
         hazelcastInstance.shutdown();
-
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (event.getState().equals(CLIENT_CONNECTED)) {
-                    reconnectedLatch.countDown();
-                }
-            }
-        });
-
         hazelcastFactory.newHazelcastInstance();
 
-        assertOpenEventually(reconnectedLatch);
+        assertOpenEventually(reconnectListener.reconnectedLatch);
 
         client.getMap(randomMapName());
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICacheManager;
-import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -49,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
@@ -179,19 +177,14 @@ public class ClientStatisticsTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
         HazelcastClientInstanceImpl client = createHazelcastClient();
 
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
+
         hazelcastInstance.getLifecycleService().terminate();
-
-        final CountDownLatch latch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(event -> {
-            if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
-                latch.countDown();
-            }
-        });
-
         hazelcastInstance = hazelcastFactory.newHazelcastInstance();
         ClientEngineImpl clientEngine = getClientEngineImpl(hazelcastInstance);
 
-        assertOpenEventually(latch);
+        assertOpenEventually(reconnectListener.reconnectedLatch);
 
         // wait enough time for statistics collection
         waitForFirstStatisticsCollection(client, clientEngine);

--- a/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -18,19 +18,17 @@ package com.hazelcast.client.usercodedeployment;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientUserCodeDeploymentConfig;
+import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.config.AttributeConfig;
+import com.hazelcast.config.Config;
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.map.EntryProcessor;
-import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.internal.util.FilteringClassLoader;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,7 +45,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.query.Predicates.equal;
 import static java.util.Collections.singletonList;
@@ -56,7 +53,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class})
-public class ClientUserCodeDeploymentTest extends HazelcastTestSupport {
+public class ClientUserCodeDeploymentTest extends ClientTestSupport {
 
     private TestHazelcastFactory factory = new TestHazelcastFactory();
 
@@ -146,13 +143,13 @@ public class ClientUserCodeDeploymentTest extends HazelcastTestSupport {
         HazelcastInstance client = factory.newHazelcastClient(clientConfig);
         factory.newHazelcastInstance(config);
 
-        final CountDownLatch clientReconnectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new ClientReconnectionListener(clientReconnectedLatch));
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
 
         factory.shutdownAllMembers();
         factory.newHazelcastInstance(config);
 
-        assertOpenEventually(clientReconnectedLatch);
+        assertOpenEventually(reconnectListener.reconnectedLatch);
         assertCodeDeploymentWorking(client, new IncrementingEntryProcessor());
     }
 
@@ -219,18 +216,5 @@ public class ClientUserCodeDeploymentTest extends HazelcastTestSupport {
     }
 
 
-    private static class ClientReconnectionListener implements LifecycleListener {
-        private final CountDownLatch clientReconnectedLatch;
 
-        private ClientReconnectionListener(CountDownLatch clientReconnectedLatch) {
-            this.clientReconnectedLatch = clientReconnectedLatch;
-        }
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            if (event.getState() == LifecycleEvent.LifecycleState.CLIENT_CONNECTED) {
-                clientReconnectedLatch.countDown();
-            }
-        }
-    }
 }


### PR DESCRIPTION
There was common misusage causing test failure related to reconnect.
Common mistake is to wait for a connected event after restarting
cluster. First connected event may arrive late and count as
`reconnected` and breaks tests.

Introduced ReconnectedListener on ClientTestSupport and used where
applicable.

fixes https://github.com/hazelcast/hazelcast/issues/16283
fixes https://github.com/hazelcast/hazelcast/issues/16126