### PR TITLE
Make Ringbuffer not throw StaleSequenceException on read-many operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableMessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableMessageRunner.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.topic.ReliableMessageListener;
 import com.hazelcast.topic.impl.reliable.MessageRunner;
@@ -77,10 +76,5 @@ public class ClientReliableMessageRunner<E> extends MessageRunner<E> {
     @Override
     protected Throwable adjustThrowable(Throwable t) {
         return peel(t);
-    }
-
-    @Override
-    protected long getHeadSequence(StaleSequenceException staleSequenceException) {
-        return ringbuffer.headSequence();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/Ringbuffer.java
@@ -356,6 +356,17 @@ public interface Ringbuffer<E> extends DistributedObject {
      * if store is configured for the Ringbuffer. These cases may increase the
      * execution time significantly depending on the implementation of the store.
      * Note that exceptions thrown by the store are propagated to the caller.
+     * <p>
+     * If the startSequence is smaller than the smallest sequence still available
+     * in the Ringbuffer ({@link #headSequence()}, then the smallest available
+     * sequence will be used as the start sequence and the minimum/maximum
+     * number of items will be attempted to be read from there on.
+     * <p>
+     * If the startSequence is bigger than the last available sequence in the
+     * Ringbuffer ({@link #tailSequence()}), then the last available sequence
+     * plus one will be used as the start sequence and the call will block
+     * until further items become available and it can read at least the
+     * minimum number of items.
      *
      * @param startSequence the startSequence of the first item to read.
      * @param minCount      the minimum number of items to read.
@@ -364,7 +375,6 @@ public interface Ringbuffer<E> extends DistributedObject {
      *                      there is no filter.
      * @return a future containing the items read.
      * @throws IllegalArgumentException if startSequence is smaller than 0
-     *                                  or if startSequence larger than {@link #tailSequence()}
      *                                  or if minCount smaller than 0
      *                                  or if minCount larger than maxCount,
      *                                  or if maxCount larger than the capacity of the ringbuffer

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -111,7 +111,7 @@ public class ArrayRingbuffer<E> implements Ringbuffer<E> {
     @Override
     // This method is not used since the RingbufferContainer also checks if the ring buffer store is enabled before
     // throwing a StaleSequenceException
-    public void checkBlockableReadSequence(long readSequence) {
+    public void checkBlockableReadSequence(long readSequence) { //todo (xxx): check
         if (readSequence > tailSequence + 1) {
             throw new IllegalArgumentException("sequence:" + readSequence
                     + " is too large. The current tailSequence is:" + tailSequence);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -111,7 +111,7 @@ public class ArrayRingbuffer<E> implements Ringbuffer<E> {
     @Override
     // This method is not used since the RingbufferContainer also checks if the ring buffer store is enabled before
     // throwing a StaleSequenceException
-    public void checkBlockableReadSequence(long readSequence) { //todo (xxx): check
+    public void checkBlockableReadSequence(long readSequence) {
         if (readSequence > tailSequence + 1) {
             throw new IllegalArgumentException("sequence:" + readSequence
                     + " is too large. The current tailSequence is:" + tailSequence);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -473,7 +473,7 @@ public class RingbufferContainer<T, E> implements IdentifiedDataSerializable, No
      *                                  not enabled
      * @throws IllegalArgumentException if the requested sequence is greater than the tail sequence + 1 or
      */
-    public void checkBlockableReadSequence(long readSequence) { //todo (xxx): check
+    public void checkBlockableReadSequence(long readSequence) {
         if (isTooLargeSequence(readSequence)) {
             throw new IllegalArgumentException("sequence:" + readSequence
                     + " is too large. The current tailSequence is:" + tailSequence());

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -473,7 +473,7 @@ public class RingbufferContainer<T, E> implements IdentifiedDataSerializable, No
      *                                  not enabled
      * @throws IllegalArgumentException if the requested sequence is greater than the tail sequence + 1 or
      */
-    public void checkBlockableReadSequence(long readSequence) {
+    public void checkBlockableReadSequence(long readSequence) { //todo (xxx): check
         if (isTooLargeSequence(readSequence)) {
             throw new IllegalArgumentException("sequence:" + readSequence
                     + " is too large. The current tailSequence is:" + tailSequence());

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -66,7 +66,7 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
         sequence = ringbuffer.clampReadSequenceToBounds(sequence);
 
         if (minSize == 0) {
-            if (!ringbuffer.shouldWait(sequence)) {
+            if (sequence < ringbuffer.tailSequence() + 1) {
                 readMany(ringbuffer);
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -66,7 +66,7 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
         sequence = ringbuffer.clampReadSequenceToBounds(sequence);
 
         if (minSize == 0) {
-            if (sequence < ringbuffer.tailSequence() + 1) {
+            if (!ringbuffer.shouldWait(sequence)) {
                 readMany(ringbuffer);
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
@@ -205,8 +205,8 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
     private boolean isLossTolerable(long lossCount) {
         if (listener.isLossTolerant()) {
             if (logger.isFinestEnabled()) {
-                logger.finest("MessageListener " + listener + " on topic: " + topicName + " lost " + lossCount + " " +
-                        "messages");
+                logger.finest("MessageListener " + listener + " on topic: " + topicName + " lost " + lossCount
+                        + "messages");
             }
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
@@ -101,7 +101,7 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
             // but we'll process whatever was received in 1 go.
 
             long lostCount = result.getNextSequenceToReadFrom() - result.readCount() - sequence;
-            if (lostCount > 0 && !isLossTolerable(lostCount)) {
+            if (lostCount != 0 && !isLossTolerable(lostCount)) {
                 cancel();
                 return;
             }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageRunner.java
@@ -19,7 +19,6 @@ package com.hazelcast.topic.impl.reliable;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.topic.ReliableMessageListener;
 
@@ -54,11 +53,6 @@ public class ReliableMessageRunner<E> extends MessageRunner<E> {
     @Override
     protected Throwable adjustThrowable(Throwable t) {
         return t;
-    }
-
-    @Override
-    protected long getHeadSequence(StaleSequenceException staleSequenceException) {
-        return staleSequenceException.getHeadSeq();
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.ringbuffer.OverflowPolicy.OVERWRITE;
 import static java.util.Arrays.asList;
@@ -115,24 +116,22 @@ public class RingbufferTest extends HazelcastTestSupport {
         assertEquals("10", rs.get(0));
     }
 
-    @Test
+    @Test(expected = TimeoutException.class)
     public void readManyAsync_whenStartSequenceIsJustBeyondTailSequence() throws Exception {
         serverRingbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
         CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(11, 1, 10, null);
 
         //test that the read blocks (should at least fail some of the time, if not the case)
-        TimeUnit.MILLISECONDS.sleep(250);
-        assertFalse(f.toCompletableFuture().isDone());
+        f.toCompletableFuture().get(250, TimeUnit.MILLISECONDS);
     }
 
-    @Test
+    @Test(expected = TimeoutException.class)
     public void readManyAsync_whenStartSequenceIsWellBeyondTailSequence() throws Exception {
         serverRingbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
         CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(19, 1, 10, null);
 
         //test that the read blocks (should at least fail some of the time, if not the case)
-        TimeUnit.MILLISECONDS.sleep(250);
-        assertFalse(f.toCompletableFuture().isDone());
+        f.toCompletableFuture().get(250, TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeoutException;
 import static com.hazelcast.ringbuffer.OverflowPolicy.OVERWRITE;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.test.ringbuffer.filter.StartsWithStringFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;

--- a/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -42,10 +42,12 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.ringbuffer.OverflowPolicy.OVERWRITE;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -88,27 +90,62 @@ public class RingbufferTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void readManyAsync_whenStartSequenceIsNegative() {
+        clientRingbuffer.readManyAsync(-1, 1, 10, null);
+    }
+
     @Test
-    public void readManyAsync_whenHitsStale_shouldNotBeBlocked() throws Exception {
-        CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(0, 1, 10, null);
+    public void readManyAsync_whenStartSequenceIsNoLongerAvailable_getsClamped() throws Exception {
         serverRingbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
-        expectedException.expect(new RootCauseMatcher(StaleSequenceException.class));
-        f.toCompletableFuture().get();
+        CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(0, 1, 10, null);
+
+        ReadResultSet rs = f.toCompletableFuture().get();
+        assertEquals(10, rs.readCount());
+        assertEquals("1", rs.get(0));
+        assertEquals("10", rs.get(9));
+    }
+
+    @Test
+    public void readManyAsync_whenStartSequenceIsEqualToTailSequence() throws Exception {
+        serverRingbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
+        CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(10, 1, 10, null);
+
+        ReadResultSet rs = f.toCompletableFuture().get();
+        assertEquals(1, rs.readCount());
+        assertEquals("10", rs.get(0));
+    }
+
+    @Test
+    public void readManyAsync_whenStartSequenceIsJustBeyondTailSequence() throws Exception {
+        serverRingbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
+        CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(11, 1, 10, null);
+
+        //test that the read blocks (should at least fail some of the time, if not the case)
+        TimeUnit.MILLISECONDS.sleep(250);
+        assertFalse(f.toCompletableFuture().isDone());
+    }
+
+    @Test
+    public void readManyAsync_whenStartSequenceIsWellBeyondTailSequence() throws Exception {
+        serverRingbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
+        CompletionStage<ReadResultSet<String>> f = clientRingbuffer.readManyAsync(19, 1, 10, null);
+
+        //test that the read blocks (should at least fail some of the time, if not the case)
+        TimeUnit.MILLISECONDS.sleep(250);
+        assertFalse(f.toCompletableFuture().isDone());
     }
 
     @Test
     public void readOne_whenHitsStale_shouldNotBeBlocked() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        Thread consumer = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    clientRingbuffer.readOne(0);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                } catch (StaleSequenceException e) {
-                    latch.countDown();
-                }
+        Thread consumer = new Thread(() -> {
+            try {
+                clientRingbuffer.readOne(0);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (StaleSequenceException e) {
+                latch.countDown();
             }
         });
         consumer.start();

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicOnClusterRestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicOnClusterRestartTest.java
@@ -21,14 +21,13 @@ import com.hazelcast.client.impl.proxy.ClientReliableTopicProxy;
 import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.topic.Message;
-import com.hazelcast.topic.MessageListener;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
 import com.hazelcast.topic.impl.reliable.DurableSubscriptionTest;
+import com.hazelcast.topic.impl.reliable.DurableSubscriptionTest.DurableMessageListener;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -73,12 +72,7 @@ public class ClientReliableTopicOnClusterRestartTest {
         final CountDownLatch listenerLatch = new CountDownLatch(1);
 
         // Add listener using the first client
-        topic.addMessageListener(new MessageListener<Integer>() {
-            @Override
-            public void onMessage(Message<Integer> message) {
-                listenerLatch.countDown();
-            }
-        });
+        topic.addMessageListener(message -> listenerLatch.countDown());
 
         // restart the server
         server.getLifecycleService().terminate();
@@ -145,7 +139,8 @@ public class ClientReliableTopicOnClusterRestartTest {
         member.getReliableTopic(topicName).publish("message");
 
         final ITopic<String> topic = client.getReliableTopic(topicName);
-        final UUID registrationId = topic.addMessageListener(new DurableSubscriptionTest.DurableMessageListener<String>() {
+
+        DurableMessageListener<String> listener = new DurableMessageListener<String>() {
             @Override
             public void onMessage(Message<String> message) {
                 messageCount.incrementAndGet();
@@ -156,13 +151,17 @@ public class ClientReliableTopicOnClusterRestartTest {
             public boolean isLossTolerant() {
                 return true;
             }
-        });
+        };
+
+        final UUID registrationId = topic.addMessageListener(listener);
 
         member.shutdown();
-        // wait for the topic operation to timeout
-        Thread.sleep(TimeUnit.SECONDS.toMillis(invocationTimeoutSeconds));
 
         member = hazelcastFactory.newHazelcastInstance();
+
+        // wait some time for subscription
+        Thread.sleep(TimeUnit.SECONDS.toMillis(invocationTimeoutSeconds));
+
         member.getReliableTopic(topicName).publish("message");
 
         assertOpenEventually(messageArrived);
@@ -173,10 +172,12 @@ public class ClientReliableTopicOnClusterRestartTest {
     }
 
     @Test
-    public void shouldFail_OnClusterRestart_whenDataLoss_notLossTolerant() {
+    public void shouldFail_OnClusterRestart_whenDataLoss_notLossTolerant() throws InterruptedException {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
+        int invocationTimeoutSeconds = 2;
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), String.valueOf(invocationTimeoutSeconds));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final AtomicLong messageCount = new AtomicLong();
@@ -186,7 +187,8 @@ public class ClientReliableTopicOnClusterRestartTest {
         member.getReliableTopic(topicName).publish("message");
 
         final ITopic<String> topic = client.getReliableTopic(topicName);
-        final UUID registrationId = topic.addMessageListener(new DurableSubscriptionTest.DurableMessageListener<String>() {
+
+        DurableMessageListener<String> listener = new DurableMessageListener<String>() {
             @Override
             public void onMessage(Message<String> message) {
                 messageCount.incrementAndGet();
@@ -196,18 +198,23 @@ public class ClientReliableTopicOnClusterRestartTest {
             public boolean isLossTolerant() {
                 return false;
             }
-        });
+        };
+        final UUID registrationId = topic.addMessageListener(listener);
 
         member.shutdown();
 
-        hazelcastFactory.newHazelcastInstance();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                ClientReliableTopicProxy proxy = (ClientReliableTopicProxy) topic;
-                assertTrue(proxy.isListenerCancelled(registrationId));
-            }
-        });
+        member = hazelcastFactory.newHazelcastInstance();
+
+        // wait some time for re-subscription
+        Thread.sleep(TimeUnit.SECONDS.toMillis(invocationTimeoutSeconds));
+
+        // we require at least one new message to detect that the ringbuffer was recreated
+        member.getReliableTopic(topicName).publish("message");
+
+        assertTrueEventually(() -> {
+            ClientReliableTopicProxy proxy = (ClientReliableTopicProxy) topic;
+            assertTrue(proxy.isListenerCancelled(registrationId));
+        }, 10);
         assertEquals(0, messageCount.get());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
@@ -111,9 +111,7 @@ public class Issue7317Test extends HazelcastTestSupport {
     }
 
     @Test
-    public void registerListenerOnStaleSequenceClientServer()
-            throws InterruptedException {
-
+    public void registerListenerOnStaleSequenceClientServer() {
         final List<String> messages = Arrays.asList("a", "b", "c", "d", "e");
         final CountDownLatch cdl = new CountDownLatch(smallRBCapacity);
         ITopic<String> rTopic = client.getReliableTopic(smallRB);

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.cp.IAtomicLong;
-import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.ringbuffer.OverflowPolicy.FAIL;
@@ -560,8 +561,8 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
 
     // ==================== asyncReadOrWait ==============================
 
-    @Test
-    public void readManyAsync_whenReadingBeyondTail() throws InterruptedException {
+    @Test(expected = TimeoutException.class)
+    public void readManyAsync_whenReadingBeyondTail() throws Exception {
         ringbuffer.add("1");
         ringbuffer.add("2");
 
@@ -569,8 +570,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         Future<ReadResultSet<String>> f = ringbuffer.readManyAsync(seq, 1, 1, null).toCompletableFuture();
 
         //test that the read blocks (should at least fail some of the time, if not the case)
-        TimeUnit.MILLISECONDS.sleep(250);
-        assertFalse(f.isDone());
+        f.get(250, TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -116,9 +116,12 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 2, 1, 1, null);
 
         // since there is an item, we don't need to wait
-        assertFalse(op.shouldWait());
-        expectedException.expect(IllegalArgumentException.class);
-        op.beforeRun();
+        boolean shouldWait = op.shouldWait();
+        assertTrue(shouldWait);
+
+        ReadResultSetImpl response = getReadResultSet(op);
+        assertEquals(0, response.readCount());
+        assertEquals(0, response.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -140,9 +143,12 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence(), 1, 1, null);
 
         // since there is an item, we don't need to wait
-        assertFalse(op.shouldWait());
-        expectedException.expect(StaleSequenceException.class);
-        op.beforeRun();
+        boolean shouldWait = op.shouldWait();
+        assertTrue(shouldWait);
+
+        ReadResultSetImpl response = getReadResultSet(op);
+        assertEquals(0, response.readCount());
+        assertEquals(0, response.getNextSequenceToReadFrom());
     }
 
     @Test
@@ -189,19 +195,27 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void whenBeforeHead() {
+    public void whenBeforeHead() throws Exception {
         ringbuffer.add("item1");
         ringbuffer.add("item2");
         ringbuffer.add("item3");
+        ringbuffer.add("item4");
+        ringbuffer.add("item5");
 
-        long oldhead = ringbuffer.headSequence();
-        ringbufferContainer.setHeadSequence(ringbufferContainer.tailSequence());
+        ringbufferContainer.setHeadSequence(2);
 
-        ReadManyOperation op = getReadManyOperation(oldhead, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(0, 1, 2, null);
 
+        //the start sequence is stale, but it will be clamped to current head
         assertFalse(op.shouldWait());
-        expectedException.expect(StaleSequenceException.class);
-        op.beforeRun();
+
+        op.run();
+
+        ReadResultSetImpl response = getReadResultSet(op);
+        assertEquals(2, response.readCount());
+        assertEquals(asList("item3", "item4"), response);
+        assertEquals(4, response.getNextSequenceToReadFrom());
+        assertEquals(2, response.size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;


### PR DESCRIPTION
The problem we want to fix is that when producers are fast, consumers can have a really hard time keeping- and catching up with them (they often fail to do so, even when they would be able to process fast enough). For example if your head is at 1, and you ask for 100 items from 0, the `Ringbuffer.readManyAsync` call just throws an exception, instead of returning what’s available. By the time the exception travels to the consumer, gets processed and a new request is made, the requested sequence number tends to be stale again and will result in yet another exception. Meanwhile data is being overwritten in the `Ringbuffer` and is lost to the consumer.

The solution aims to remove the `StaleSequenceException` being thrown by the `ReadManyOperation` in such situations and just have it return the data that's available. 

We are able to do this for `Ringbuffer.readManyAsync`, because it returns a `ReadResultSet` carrying sequence numbers, thus allowing the client to notice potential sequence gaps and decide if it can tolerate them or not. On the other had we can't do the same for `Ringbuffer.readOne` because there is no way to observe sequence numbers in that case (it returns just an element from the `Ringbuffer`).