### PR TITLE
Fix ManagementCenterServiceTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
@@ -241,7 +241,7 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
         assertNull(metadata.getJetVersion());
         assertTrue(metadata.getClusterTime() > 0);
 
-        hazelcastInstances[0].getCluster().changeClusterState(PASSIVE);
+        changeClusterStateEventually(hazelcastInstances[0], PASSIVE);
 
         assertTrueEventually(
                 () -> {


### PR DESCRIPTION
Cluster state change can fail because of pending migrations
or stale partition table on members.

Fixes #16302