### PR TITLE
Start preloader after registering invalidation listener

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -101,13 +101,15 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         useObjectKey = !nearCacheConfig.isSerializeKeys();
         useObjectValue = nearCacheConfig.getInMemoryFormat() == InMemoryFormat.OBJECT;
 
-        ICacheDataStructureAdapter<K, V> adapter = new ICacheDataStructureAdapter<>(this);
         nearCacheManager = getContext().getNearCacheManager(getServiceName());
-        nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig, adapter);
+        nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig);
         CacheStatistics localCacheStatistics = super.getLocalCacheStatistics();
         ((ClientCacheStatisticsImpl) localCacheStatistics).setNearCacheStats(nearCache.getNearCacheStats());
 
         registerInvalidationListener();
+        if (nearCacheConfig.getPreloaderConfig().isEnabled()) {
+            nearCacheManager.startPreloading(nearCache, new ICacheDataStructureAdapter<>(this));
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/NearCachedClientMapProxy.java
@@ -88,11 +88,14 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         serializeKeys = nearCacheConfig.isSerializeKeys();
 
         NearCacheManager nearCacheManager = getContext().getNearCacheManager(getServiceName());
-        IMapDataStructureAdapter<K, V> adapter = new IMapDataStructureAdapter<>(this);
-        nearCache = nearCacheManager.getOrCreateNearCache(name, nearCacheConfig, adapter);
+        nearCache = nearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
 
         if (nearCacheConfig.isInvalidateOnChange()) {
             registerInvalidationListener();
+        }
+
+        if (nearCacheConfig.getPreloaderConfig().isEnabled()) {
+            nearCacheManager.startPreloading(nearCache, new IMapDataStructureAdapter<>(this));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.nearcache;
 
+import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nearcache.NearCacheStats;
@@ -71,6 +72,11 @@ public interface NearCache<K, V> extends InitializingObject {
      * @return the name of this {@link NearCache} instance
      */
     String getName();
+
+    /**
+     * @return config object used by {@link NearCache} instance.
+     */
+    NearCacheConfig getNearCacheConfig();
 
     /**
      * Gets the value associated with the given {@code key}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheManager.java
@@ -50,21 +50,14 @@ public interface NearCacheManager {
     <K, V> NearCache<K, V> getOrCreateNearCache(String name, NearCacheConfig nearCacheConfig);
 
     /**
-     * Creates a new {@link NearCache} with given configurations or returns existing one.
+     * Triggers the pre-loading of the created {@link
+     * NearCache} via the supplied {@link DataStructureAdapter}.
      *
-     * Triggers the pre-loading of the created {@link NearCache} via the supplied {@link DataStructureAdapter}.
-     *
-     * @param name                 the name of the {@link NearCache}
-     *                             to be created or existing one
-     * @param nearCacheConfig      the {@link NearCacheConfig} of the {@link NearCache} to be created
-     * @param dataStructureAdapter the {@link DataStructureAdapter} of the {@link NearCache} to be created
-     * @param <K>                  the key type of the {@link NearCache}
-     * @param <V>                  the value type of the {@link NearCache}
-     * @return the created or existing {@link NearCache} instance associated with given {@code name}
+     * @param nearCache {@link NearCache} instance
+     * @param dataStructureAdapter the {@link
+     *                             DataStructureAdapter} of the {@link NearCache} to be created
      */
-    <K, V> NearCache<K, V> getOrCreateNearCache(String name,
-                                                NearCacheConfig nearCacheConfig,
-                                                DataStructureAdapter dataStructureAdapter);
+    void startPreloading(NearCache nearCache, DataStructureAdapter dataStructureAdapter);
 
     /**
      * Lists all existing {@link NearCache} instances.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -23,9 +23,9 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.store.NearCacheDataRecordStore;
 import com.hazelcast.internal.nearcache.impl.store.NearCacheObjectRecordStore;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nearcache.NearCacheStats;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
@@ -99,9 +99,10 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     }
 
     private ScheduledFuture createAndScheduleExpirationTask() {
-        if (nearCacheConfig.getMaxIdleSeconds() > 0L || nearCacheConfig.getTimeToLiveSeconds() > 0L) {
-            ExpirationTask expirationTask = new ExpirationTask();
-            return expirationTask.schedule(scheduler);
+        if (nearCacheConfig.getMaxIdleSeconds() > 0L
+                || nearCacheConfig.getTimeToLiveSeconds() > 0L) {
+
+            return new ExpirationTask().schedule(scheduler);
         }
         return null;
     }
@@ -109,6 +110,11 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public NearCacheConfig getNearCacheConfig() {
+        return nearCacheConfig;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -47,8 +48,7 @@ public class DefaultNearCacheManager implements NearCacheManager {
     private final Object mutex = new Object();
     private final Queue<ScheduledFuture> preloadTaskFutures = new ConcurrentLinkedQueue<>();
     private final ConcurrentMap<String, NearCache> nearCacheMap = new ConcurrentHashMap<>();
-
-    private volatile ScheduledFuture storageTaskFuture;
+    private final AtomicReference<Object> storageTaskFutureRef = new AtomicReference<>();
 
     public DefaultNearCacheManager(SerializationService ss, TaskScheduler es,
                                    ClassLoader classLoader, HazelcastProperties properties) {
@@ -68,31 +68,21 @@ public class DefaultNearCacheManager implements NearCacheManager {
     }
 
     @Override
-    public <K, V> NearCache<K, V> getOrCreateNearCache(String name, NearCacheConfig nearCacheConfig) {
-        return getOrCreateNearCache(name, nearCacheConfig, null);
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public <K, V> NearCache<K, V> getOrCreateNearCache(String name,
-                                                       NearCacheConfig nearCacheConfig,
-                                                       DataStructureAdapter dataStructureAdapter) {
+                                                       NearCacheConfig nearCacheConfig) {
         NearCache<K, V> nearCache = nearCacheMap.get(name);
-        if (nearCache == null) {
-            synchronized (mutex) {
-                nearCache = nearCacheMap.get(name);
-                if (nearCache == null) {
-                    nearCache = createNearCache(name, nearCacheConfig);
-                    nearCache.initialize();
+        if (nearCache != null) {
+            return nearCache;
+        }
 
-                    nearCacheMap.put(name, nearCache);
+        synchronized (mutex) {
+            nearCache = nearCacheMap.get(name);
+            if (nearCache == null) {
+                nearCache = createNearCache(name, nearCacheConfig);
+                nearCache.initialize();
 
-                    NearCachePreloaderConfig preloaderConfig = nearCacheConfig.getPreloaderConfig();
-                    if (preloaderConfig.isEnabled()) {
-                        createAndSchedulePreloadTask(nearCache, dataStructureAdapter);
-                        createAndScheduleStorageTask(preloaderConfig);
-                    }
-                }
+                nearCacheMap.put(name, nearCache);
             }
         }
         return nearCache;
@@ -101,6 +91,16 @@ public class DefaultNearCacheManager implements NearCacheManager {
     protected <K, V> NearCache<K, V> createNearCache(String name, NearCacheConfig nearCacheConfig) {
         return new DefaultNearCache<>(name, nearCacheConfig, serializationService,
                 scheduler, classLoader, properties);
+    }
+
+    @Override
+    public void startPreloading(NearCache nearCache, DataStructureAdapter dataStructureAdapter) {
+        NearCacheConfig nearCacheConfig = nearCache.getNearCacheConfig();
+        NearCachePreloaderConfig preloaderConfig = nearCacheConfig.getPreloaderConfig();
+        if (preloaderConfig.isEnabled()) {
+            createAndSchedulePreloadTask(nearCache, dataStructureAdapter);
+            createAndScheduleStorageTask();
+        }
     }
 
     @Override
@@ -140,7 +140,6 @@ public class DefaultNearCacheManager implements NearCacheManager {
         return false;
     }
 
-
     @Override
     public void destroyAllNearCaches() {
         for (NearCache nearCache : new HashSet<>(nearCacheMap.values())) {
@@ -151,8 +150,9 @@ public class DefaultNearCacheManager implements NearCacheManager {
             preloadTaskFuture.cancel(true);
         }
 
-        if (storageTaskFuture != null) {
-            storageTaskFuture.cancel(true);
+        Object future = storageTaskFutureRef.get();
+        if (future != null) {
+            ((ScheduledFuture) future).cancel(true);
         }
     }
 
@@ -166,10 +166,10 @@ public class DefaultNearCacheManager implements NearCacheManager {
         }
     }
 
-    private void createAndScheduleStorageTask(NearCachePreloaderConfig preloaderConfig) {
-        if (storageTaskFuture == null) {
-            StorageTask storageTask = new StorageTask(preloaderConfig);
-            storageTaskFuture = scheduler.scheduleWithRepetition(storageTask, 0, 1, SECONDS);
+    private void createAndScheduleStorageTask() {
+        if (storageTaskFutureRef.compareAndSet(null, this)) {
+            storageTaskFutureRef.set(scheduler.scheduleWithRepetition(new StorageTask(),
+                    0, 1, SECONDS));
         }
     }
 
@@ -199,11 +199,6 @@ public class DefaultNearCacheManager implements NearCacheManager {
     private class StorageTask implements Runnable {
 
         private final long started = System.currentTimeMillis();
-        private final NearCachePreloaderConfig preloaderConfig;
-
-        StorageTask(NearCachePreloaderConfig preloaderConfig) {
-            this.preloaderConfig = preloaderConfig;
-        }
 
         @Override
         public void run() {
@@ -217,21 +212,18 @@ public class DefaultNearCacheManager implements NearCacheManager {
         }
 
         private boolean isScheduled(NearCache nearCache, long now) {
+            NearCachePreloaderConfig preloaderConfig = nearCache.getNearCacheConfig().getPreloaderConfig();
             NearCacheStats nearCacheStats = nearCache.getNearCacheStats();
+
             if (nearCacheStats.getLastPersistenceTime() == 0) {
                 // check initial delay seconds for first persistence
                 long runningSeconds = MILLISECONDS.toSeconds(now - started);
-                if (runningSeconds < preloaderConfig.getStoreInitialDelaySeconds()) {
-                    return false;
-                }
+                return runningSeconds >= preloaderConfig.getStoreInitialDelaySeconds();
             } else {
-                // check interval seconds for all other persistences
+                // check interval seconds for all other persistence
                 long elapsedSeconds = MILLISECONDS.toSeconds(now - nearCacheStats.getLastPersistenceTime());
-                if (elapsedSeconds < preloaderConfig.getStoreIntervalSeconds()) {
-                    return false;
-                }
+                return elapsedSeconds >= preloaderConfig.getStoreIntervalSeconds();
             }
-            return true;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.nearcache.impl.invalidation.MinimalPartitionServic
 import com.hazelcast.internal.nearcache.impl.invalidation.NonStopInvalidator;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.internal.services.RemoteService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.MapManagedService;
@@ -131,7 +132,7 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     }
 
     /**
-     * @see com.hazelcast.map.impl.MapRemoteService#destroyDistributedObject(String)
+     * @see RemoteService#destroyDistributedObject(String) for IMap
      */
     @Override
     public boolean destroyNearCache(String mapName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.impl.invalidation.BatchNearCacheInvalidation;
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidation;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.InterceptorRegistry;
 import com.hazelcast.map.impl.MapEntries;
@@ -30,7 +31,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.nearcache.invalidation.InvalidationListener;
 import com.hazelcast.map.impl.nearcache.invalidation.UuidFilter;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -90,7 +90,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         super.initialize();
 
         mapNearCacheManager = mapServiceContext.getMapNearCacheManager();
-        nearCache = mapNearCacheManager.getOrCreateNearCache(name, mapConfig.getNearCacheConfig());
+        NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
+        nearCache = mapNearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
         if (invalidateOnChange) {
             registerInvalidationListener();
         }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/3456

otherwise due to the lately updated invalidation metadata, missing entries can be seen.

__Modifications:__
Introduced new method to near-cache-manager which starts preloading separately than near cache creation process.