### PR TITLE
Relax excpected exception due to real network testing

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.http.NoHttpResponseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -318,22 +317,22 @@ public class RestTest {
         assertEquals(HTTP_OK, response);
     }
 
-    @Test(expected = NoHttpResponseException.class)
+    @Test(expected = IOException.class)
     public void testUndefined_HeadRequest() throws IOException {
         communicator.headRequestToUndefinedURI();
     }
 
-    @Test(expected = NoHttpResponseException.class)
+    @Test(expected = IOException.class)
     public void testUndefined_GetRequest() throws IOException {
         communicator.getRequestToUndefinedURI();
     }
 
-    @Test(expected = NoHttpResponseException.class)
+    @Test(expected = IOException.class)
     public void testUndefined_PostRequest() throws IOException {
         communicator.postRequestToUndefinedURI();
     }
 
-    @Test(expected = NoHttpResponseException.class)
+    @Test(expected = IOException.class)
     public void testUndefined_DeleteRequest() throws IOException {
         communicator.deleteRequestToUndefinedURI();
     }


### PR DESCRIPTION
`RestMultiendpointTest` in contrast to `RestTest` is using real networking. Depending on state of the connection at the time of the read, we can either get an `IOException` by detection the connection was closed, or a `NoHttpResponseException` by detecting that we read 0 bytes.

The relevant exceptions

```
	at java.base/java.io.IOException.<init>(IOException.java:58)
	at java.base/java.net.SocketException.<init>(SocketException.java:47)
	at java.base/sun.net.ConnectionResetException.<init>(ConnectionResetException.java:40)
	at java.base/sun.nio.ch.SocketDispatcher.read0(Native Method)
	at java.base/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:47)
	at java.base/sun.nio.ch.NioSocketImpl.tryRead(NioSocketImpl.java:262)
	at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:313)
	at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:351)
	at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:802)
	at java.base/java.net.Socket$SocketInputStream.read(Socket.java:919)
	at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:136)
	at org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:152)
	at org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:270)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:140)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:57)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:260)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:161)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at org.apache.http.impl.conn.CPoolProxy.invoke(CPoolProxy.java:138)
	at com.sun.proxy.$Proxy31.receiveResponseHeader(Unknown Source)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:271)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:123)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:253)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:194)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:85)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:108)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:106)
	at com.hazelcast.internal.ascii.HTTPCommunicator.doGet(HTTPCommunicator.java:458)
	at com.hazelcast.internal.ascii.HTTPCommunicator.getRequestToUndefinedURI(HTTPCommunicator.java:554)
```

```
	at org.apache.http.NoHttpResponseException.<init>(NoHttpResponseException.java:47)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:143)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:57)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:260)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:161)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at org.apache.http.impl.conn.CPoolProxy.invoke(CPoolProxy.java:138)
	at com.sun.proxy.$Proxy31.receiveResponseHeader(Unknown Source)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:271)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:123)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:253)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:194)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:85)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:108)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:106)
	at com.hazelcast.internal.ascii.HTTPCommunicator.doGet(HTTPCommunicator.java:458)
	at com.hazelcast.internal.ascii.HTTPCommunicator.getRequestToUndefinedURI(HTTPCommunicator.java:554)
```

This PR relaxes the expected exceptions, by expecting the common parent exception `IOException`
Fixes https://github.com/hazelcast/hazelcast/issues/14499