### PR TITLE
Refactor test_backupOperationAppliesDefaultExpiryPolicy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
@@ -17,15 +17,16 @@
 package com.hazelcast.cache;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -187,13 +188,13 @@ public class HazelcastExpiryPolicy implements ExpiryPolicy, IdentifiedDataSerial
 
         HazelcastExpiryPolicy that = (HazelcastExpiryPolicy) o;
 
-        if (create != null ? !create.equals(that.create) : that.create != null) {
+        if (!Objects.equals(create, that.create)) {
             return false;
         }
-        if (access != null ? !access.equals(that.access) : that.access != null) {
+        if (!Objects.equals(access, that.access)) {
             return false;
         }
-        if (update != null ? !update.equals(that.update) : that.update != null) {
+        if (!Objects.equals(update, that.update)) {
             return false;
         }
         return true;
@@ -208,4 +209,12 @@ public class HazelcastExpiryPolicy implements ExpiryPolicy, IdentifiedDataSerial
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "HazelcastExpiryPolicy{"
+                + "createMillis=" + create.getTimeUnit().toMillis(create.getDurationAmount())
+                + ", accessMillis=" + access.getTimeUnit().toMillis(access.getDurationAmount())
+                + ", updateMillis=" + update.getTimeUnit().toMillis(update.getDurationAmount())
+                + '}';
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -29,8 +29,8 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MaxSizePolicy;
-import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
@@ -43,6 +43,7 @@ import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.internal.eviction.impl.evaluator.EvictionPolicyEvaluator;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SamplingEvictionStrategy;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationQueue;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.util.Clock;
@@ -51,7 +52,6 @@ import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.internal.util.comparators.ValueComparator;
 import com.hazelcast.internal.util.comparators.ValueComparatorUtil;
 import com.hazelcast.map.impl.MapEntries;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
@@ -436,11 +436,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected ExpiryPolicy getExpiryPolicy(CacheRecord record, ExpiryPolicy expiryPolicy) {
         if (expiryPolicy != null) {
             return expiryPolicy;
-        } else if (record != null && record.getExpiryPolicy() != null) {
-            return (ExpiryPolicy) toValue(record.getExpiryPolicy());
-        } else {
-            return defaultExpiryPolicy;
         }
+
+        if (record != null && record.getExpiryPolicy() != null) {
+            return (ExpiryPolicy) toValue(record.getExpiryPolicy());
+        }
+
+        return defaultExpiryPolicy;
     }
 
     protected boolean evictIfExpired(Data key, R record, long now) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/eviction/CacheClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/eviction/CacheClearExpiredRecordsTask.java
@@ -80,6 +80,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class CacheClearExpiredRecordsTask
         extends ClearExpiredRecordsTask<CachePartitionSegment, ICacheRecordStore> {
 
+    public static final String PROP_CLEANUP_ENABLED = "hazelcast.internal.cache.expiration.cleanup.enabled";
     public static final String PROP_CLEANUP_PERCENTAGE = "hazelcast.internal.cache.expiration.cleanup.percentage";
     public static final String PROP_TASK_PERIOD_SECONDS = "hazelcast.internal.cache.expiration.task.period.seconds";
     public static final String PROP_CLEANUP_OPERATION_COUNT = "hazelcast.internal.cache.expiration.cleanup.operation.count";
@@ -91,6 +92,7 @@ public class CacheClearExpiredRecordsTask
     private static final HazelcastProperty CLEANUP_PERCENTAGE
             = new HazelcastProperty(PROP_CLEANUP_PERCENTAGE, DEFAULT_CLEANUP_PERCENTAGE);
     private static final HazelcastProperty CLEANUP_OPERATION_COUNT = new HazelcastProperty(PROP_CLEANUP_OPERATION_COUNT);
+    private static final HazelcastProperty CLEANUP_ENABLED = new HazelcastProperty(PROP_CLEANUP_ENABLED, true);
 
     private final Comparator<CachePartitionSegment> partitionSegmentComparator = (o1, o2) -> {
         long s1 = o1.getLastCleanupTimeBeforeSorting();
@@ -99,7 +101,7 @@ public class CacheClearExpiredRecordsTask
     };
 
     public CacheClearExpiredRecordsTask(CachePartitionSegment[] containers, NodeEngine nodeEngine) {
-        super(SERVICE_NAME, containers, CLEANUP_OPERATION_COUNT, CLEANUP_PERCENTAGE, TASK_PERIOD_SECONDS, nodeEngine);
+        super(SERVICE_NAME, containers, CLEANUP_ENABLED, CLEANUP_OPERATION_COUNT, CLEANUP_PERCENTAGE, TASK_PERIOD_SECONDS, nodeEngine);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/eviction/CacheClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/eviction/CacheClearExpiredRecordsTask.java
@@ -101,7 +101,8 @@ public class CacheClearExpiredRecordsTask
     };
 
     public CacheClearExpiredRecordsTask(CachePartitionSegment[] containers, NodeEngine nodeEngine) {
-        super(SERVICE_NAME, containers, CLEANUP_ENABLED, CLEANUP_OPERATION_COUNT, CLEANUP_PERCENTAGE, TASK_PERIOD_SECONDS, nodeEngine);
+        super(SERVICE_NAME, containers, CLEANUP_ENABLED, CLEANUP_OPERATION_COUNT,
+                CLEANUP_PERCENTAGE, TASK_PERIOD_SECONDS, nodeEngine);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetOperation.java
@@ -45,8 +45,7 @@ public class CacheGetOperation
     }
 
     @Override
-    public void run()
-            throws Exception {
+    public void run() throws Exception {
         response = recordStore.get(key, expiryPolicy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
@@ -16,17 +16,16 @@
 
 package com.hazelcast.internal.eviction;
 
-import java.util.function.BiFunction;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.partition.IPartition;
+import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.partition.PartitionLostEvent;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.internal.partition.IPartition;
-import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
-import com.hazelcast.internal.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
@@ -35,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 
 import static com.hazelcast.internal.eviction.ToBackupSender.newToBackupSender;
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
@@ -54,6 +54,7 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
     protected final ToBackupSender<S> toBackupSender;
     protected final IPartitionService partitionService;
 
+    private final boolean cleanupEnabled;
     private final int partitionCount;
     private final int taskPeriodSeconds;
     private final int cleanupPercentage;
@@ -72,6 +73,7 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
     @SuppressFBWarnings({"EI_EXPOSE_REP2"})
     protected ClearExpiredRecordsTask(String serviceName,
                                       T[] containers,
+                                      HazelcastProperty cleanupEnabled,
                                       HazelcastProperty cleanupOpProperty,
                                       HazelcastProperty cleanupPercentageProperty,
                                       HazelcastProperty taskPeriodProperty,
@@ -91,6 +93,7 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
         checkTrue(cleanupPercentage > 0 && cleanupPercentage <= 100,
                 "cleanupPercentage should be in range (0,100]");
         this.taskPeriodSeconds = properties.getSeconds(taskPeriodProperty);
+        this.cleanupEnabled = properties.getBoolean(cleanupEnabled);
         this.toBackupSender = newToBackupSender(serviceName, newBackupExpiryOpSupplier(),
                 newBackupExpiryOpFilter(), nodeEngine);
     }
@@ -273,12 +276,7 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
     }
 
     private BiFunction<S, Collection<ExpiredKey>, Operation> newBackupExpiryOpSupplier() {
-        return new BiFunction<S, Collection<ExpiredKey>, Operation>() {
-            @Override
-            public Operation apply(S recordStore, Collection<ExpiredKey> expiredKeys) {
-                return newBackupExpiryOp(recordStore, expiredKeys);
-            }
-        };
+        return (recordStore, expiredKeys) -> newBackupExpiryOp(recordStore, expiredKeys);
     }
 
     public final void sendQueuedExpiredKeys(T container) {
@@ -326,6 +324,10 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
     public abstract void tryToSendBackupExpiryOp(S store, boolean sendIfAtBatchSize);
 
     public abstract Iterator<S> storeIterator(T container);
+
+    public boolean isCleanupEnabled() {
+        return cleanupEnabled;
+    }
 
     /**
      * Used when traversing partitions. Map needs to traverse both

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ExpirationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ExpirationManager.java
@@ -84,7 +84,7 @@ public final class ExpirationManager implements LifecycleListener, PartitionLost
      * Calling this method multiple times has same effect.
      */
     public void scheduleExpirationTask() {
-        if (nodeEngine.getLocalMember().isLiteMember() || scheduled.get()
+        if (!task.isCleanupEnabled() || nodeEngine.getLocalMember().isLiteMember() || scheduled.get()
                 || !scheduled.compareAndSet(false, true)) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MapClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MapClearExpiredRecordsTask.java
@@ -20,8 +20,8 @@ import com.hazelcast.internal.eviction.ClearExpiredRecordsTask;
 import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationQueue;
 import com.hazelcast.map.impl.PartitionContainer;
-import com.hazelcast.map.impl.operation.MapClearExpiredOperation;
 import com.hazelcast.map.impl.operation.EvictBatchBackupOperation;
+import com.hazelcast.map.impl.operation.MapClearExpiredOperation;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -85,6 +85,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class MapClearExpiredRecordsTask
         extends ClearExpiredRecordsTask<PartitionContainer, RecordStore> {
 
+    public static final String PROP_CLEANUP_ENABLED = "hazelcast.internal.map.expiration.cleanup.enabled";
     public static final String PROP_PRIMARY_DRIVES_BACKUP = "hazelcast.internal.map.expiration.primary.drives_backup";
     public static final String PROP_CLEANUP_PERCENTAGE = "hazelcast.internal.map.expiration.cleanup.percentage";
     public static final String PROP_CLEANUP_OPERATION_COUNT = "hazelcast.internal.map.expiration.cleanup.operation.count";
@@ -101,6 +102,8 @@ public class MapClearExpiredRecordsTask
             = new HazelcastProperty(PROP_CLEANUP_PERCENTAGE, DEFAULT_CLEANUP_PERCENTAGE);
     private static final HazelcastProperty CLEANUP_OPERATION_COUNT
             = new HazelcastProperty(PROP_CLEANUP_OPERATION_COUNT);
+    private static final HazelcastProperty CLEANUP_ENABLED
+            = new HazelcastProperty(PROP_CLEANUP_ENABLED, true);
 
     private final boolean primaryDrivesEviction;
 
@@ -111,7 +114,8 @@ public class MapClearExpiredRecordsTask
     };
 
     public MapClearExpiredRecordsTask(PartitionContainer[] containers, NodeEngine nodeEngine) {
-        super(SERVICE_NAME, containers, CLEANUP_OPERATION_COUNT, CLEANUP_PERCENTAGE, TASK_PERIOD_SECONDS, nodeEngine);
+        super(SERVICE_NAME, containers, CLEANUP_ENABLED, CLEANUP_OPERATION_COUNT,
+                CLEANUP_PERCENTAGE, TASK_PERIOD_SECONDS, nodeEngine);
         this.primaryDrivesEviction = nodeEngine.getProperties().getBoolean(PRIMARY_DRIVES_BACKUP);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -49,7 +49,7 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
     protected abstract HazelcastInstance getHazelcastInstance();
 
     @Before
-    public final void setup() {
+    public void setup() {
         onSetup();
         cachingProvider = getCachingProvider();
         cacheManager = cachingProvider.getCacheManager();

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/ExtendedCacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/ExtendedCacheExpirationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.eviction;
+
+import com.hazelcast.cache.CacheTestSupport;
+import com.hazelcast.cache.HazelcastExpiryPolicy;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.eviction.CacheClearExpiredRecordsTask;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.backup.BackupAccessor;
+import com.hazelcast.test.backup.TestBackupUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ExpiryPolicy;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ExtendedCacheExpirationTest extends CacheTestSupport {
+
+    @Parameterized.Parameters(name = "useSyncBackups:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true},
+                {false}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public boolean useSyncBackups;
+
+    private static final int CLUSTER_SIZE = 2;
+    private final Duration THREE_SECONDS = new Duration(TimeUnit.SECONDS, 3);
+
+    protected TestHazelcastInstanceFactory factory;
+    protected HazelcastInstance[] instances = new HazelcastInstance[3];
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return instances[0];
+    }
+
+    @Override
+    protected void onSetup() {
+        factory = createHazelcastInstanceFactory(CLUSTER_SIZE);
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            instances[i] = factory.newHazelcastInstance(getConfig());
+        }
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = smallInstanceConfig();
+        config.setProperty(CacheClearExpiredRecordsTask.PROP_CLEANUP_ENABLED, "false");
+        return config;
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void test_backupOperationAppliesDefaultExpiryPolicy() {
+        HazelcastExpiryPolicy defaultExpiryPolicy = new HazelcastExpiryPolicy(THREE_SECONDS,
+                Duration.ZERO, Duration.ZERO);
+
+        CacheConfig cacheConfig = createCacheConfig(defaultExpiryPolicy);
+        ICache cache = createCache(cacheConfig);
+
+        int keyCount = 100;
+
+        for (int i = 0; i < keyCount; i++) {
+            cache.put(i, i);
+        }
+
+        // Check if all backup entries have applied the default expiry policy
+        for (int i = 1; i < CLUSTER_SIZE; i++) {
+            BackupAccessor backupAccessor = TestBackupUtils.newCacheAccessor(instances, cache.getName(), i);
+            for (int j = 0; j < keyCount; j++) {
+                TestBackupUtils.assertExpirationTimeExistsEventually(j, backupAccessor);
+            }
+        }
+
+        // terminate other nodes than number zero to cause backup promotion at the 0th member
+        for (int i = 1; i < CLUSTER_SIZE; i++) {
+            getNode(instances[i]).shutdown(true);
+        }
+
+        assertTrueEventually(() -> {
+            for (int i = 0; i < keyCount; i++) {
+                assertNull(cache.get(i));
+            }
+        });
+    }
+
+    protected <K, V, M extends Serializable & ExpiryPolicy> CacheConfig<K, V> createCacheConfig(M expiryPolicy) {
+        CacheConfig<K, V> cacheConfig = new CacheConfig<>();
+        cacheConfig.setExpiryPolicyFactory(FactoryBuilder.factoryOf(expiryPolicy));
+        cacheConfig.setName(randomName());
+
+        if (useSyncBackups) {
+            cacheConfig.setBackupCount(CLUSTER_SIZE - 1);
+            cacheConfig.setAsyncBackupCount(0);
+        } else {
+            cacheConfig.setBackupCount(0);
+            cacheConfig.setAsyncBackupCount(CLUSTER_SIZE - 1);
+        }
+
+        return cacheConfig;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/AbstractExpirationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/AbstractExpirationManagerTest.java
@@ -240,5 +240,7 @@ public abstract class AbstractExpirationManagerTest extends HazelcastTestSupport
 
     protected abstract String cleanupPercentagePropName();
 
+    protected abstract String cleanupTaskEnabledPropName();
+
     protected abstract AtomicInteger configureForTurnsActivePassiveTest(HazelcastInstance node);
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationManagerTest.java
@@ -60,16 +60,22 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
 
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
     @Test
     public void restarts_running_backgroundClearTask_when_lifecycleState_turns_to_MERGED() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         HazelcastInstance node = createHazelcastInstance(config);
 
         final SimpleEntryListener<Integer, Integer> simpleEntryListener = new SimpleEntryListener<Integer, Integer>();
 
         CacheManager cacheManager = createCacheManager(node);
-        CacheConfiguration<Integer, Integer> cacheConfig = createCacheConfig(simpleEntryListener, new HazelcastExpiryPolicy(3000, 3000, 3000));
+        CacheConfiguration<Integer, Integer> cacheConfig = createCacheConfig(simpleEntryListener,
+                new HazelcastExpiryPolicy(3000, 3000, 3000));
         Cache<Integer, Integer> cache = cacheManager.createCache("test", cacheConfig);
 
         cache.put(1, 1);
@@ -88,29 +94,41 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
 
     @Test
     public void clearExpiredRecordsTask_should_not_be_started_if_cache_has_no_expirable_records() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         final HazelcastInstance node = createHazelcastInstance(config);
 
         CacheManager cacheManager = createCacheManager(node);
         cacheManager.createCache("test", new CacheConfig());
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() {
-                assertFalse("There should be zero CacheClearExpiredRecordsTask",
-                        hasClearExpiredRecordsTaskStarted(node));
-            }
-        }, 3);
+        assertTrueAllTheTime(() -> assertFalse("There should be zero CacheClearExpiredRecordsTask",
+                hasClearExpiredRecordsTaskStarted(node)), 3);
+    }
+
+    @Test
+    public void clearExpiredRecordsTask_should_not_be_started_when_disabled() {
+        Config config = getConfig();
+        config.setProperty(cleanupTaskEnabledPropName(), "false");
+        final HazelcastInstance node = createHazelcastInstance(config);
+
+        CacheManager cacheManager = createCacheManager(node);
+        CacheConfiguration<Integer, Integer> cacheConfig = createCacheConfig(new SimpleEntryListener(),
+                new HazelcastExpiryPolicy(3000, 3000, 3000));
+        Cache<Integer, Integer> cache = cacheManager.createCache("test", cacheConfig);
+
+        cache.put(1, 1);
+
+        assertTrueAllTheTime(() -> assertFalse("There should be zero CacheClearExpiredRecordsTask",
+                hasClearExpiredRecordsTaskStarted(node)), 3);
     }
 
     @Test
     public void clearExpiredRecordsTask_should_not_be_started_if_member_is_lite() {
-        Config liteMemberConfig = new Config();
+        Config liteMemberConfig = getConfig();
         liteMemberConfig.setLiteMember(true);
         liteMemberConfig.setProperty(taskPeriodSecondsPropName(), "1");
 
-        Config dataMemberConfig = new Config();
+        Config dataMemberConfig = getConfig();
         dataMemberConfig.setProperty(taskPeriodSecondsPropName(), "1");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
@@ -118,7 +136,8 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
         factory.newHazelcastInstance(dataMemberConfig);
 
         CacheManager cacheManager = createCacheManager(liteMember);
-        CacheConfiguration<Integer, Integer> cacheConfig = createCacheConfig(new SimpleEntryListener(), new HazelcastExpiryPolicy(1, 1, 1));
+        CacheConfiguration<Integer, Integer> cacheConfig = createCacheConfig(new SimpleEntryListener(),
+                new HazelcastExpiryPolicy(1, 1, 1));
         Cache<Integer, Integer> cache = cacheManager.createCache("test", cacheConfig);
         cache.put(1, 1);
 
@@ -143,7 +162,7 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
 
     @Test
     public void no_expiration_task_starts_on_new_node_after_migration_when_there_is_no_expirable_entry() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         final HazelcastInstance node1 = factory.newHazelcastInstance(config);
@@ -166,7 +185,7 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
 
     @Test
     public void expiration_task_starts_on_new_node_after_migration_when_there_is_expirable_entry() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         final HazelcastInstance node1 = factory.newHazelcastInstance(config);
@@ -187,9 +206,8 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
         });
     }
 
-
     private void backgroundClearTaskStops_whenLifecycleState(LifecycleEvent.LifecycleState lifecycleState) {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         HazelcastInstance node = createHazelcastInstance(config);
 
@@ -233,6 +251,11 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
     @Override
     protected String cleanupPercentagePropName() {
         return CacheClearExpiredRecordsTask.PROP_CLEANUP_PERCENTAGE;
+    }
+
+    @Override
+    protected String cleanupTaskEnabledPropName() {
+        return CacheClearExpiredRecordsTask.PROP_CLEANUP_ENABLED;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/MapExpirationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/MapExpirationManagerTest.java
@@ -19,9 +19,9 @@ package com.hazelcast.internal.eviction;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.instance.impl.LifecycleServiceImpl;
+import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.eviction.MapClearExpiredRecordsTask;
@@ -69,12 +69,7 @@ public class MapExpirationManagerTest extends AbstractExpirationManagerTest {
         final AtomicInteger expirationCounter = new AtomicInteger();
 
         IMap<Integer, Integer> map = node.getMap("test");
-        map.addEntryListener(new EntryExpiredListener() {
-            @Override
-            public void entryExpired(EntryEvent event) {
-                expirationCounter.incrementAndGet();
-            }
-        }, true);
+        map.addEntryListener((EntryExpiredListener) event -> expirationCounter.incrementAndGet(), true);
 
         map.put(1, 1, 3, TimeUnit.SECONDS);
 
@@ -99,13 +94,21 @@ public class MapExpirationManagerTest extends AbstractExpirationManagerTest {
         IMap<Integer, Integer> map = node.getMap("test");
         map.put(1, 1);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() {
-                assertFalse("There should be zero ClearExpiredRecordsTask",
-                        hasClearExpiredRecordsTaskStarted(node));
-            }
-        }, 3);
+        assertTrueAllTheTime(() -> assertFalse("There should be zero ClearExpiredRecordsTask",
+                hasClearExpiredRecordsTaskStarted(node)), 3);
+    }
+
+    @Test
+    public void clearExpiredRecordsTask_should_not_be_started_when_disabled() {
+        Config config = getConfig();
+        config.setProperty(cleanupTaskEnabledPropName(), "false");
+        final HazelcastInstance node = createHazelcastInstance(config);
+
+        IMap<Integer, Integer> map = node.getMap("test");
+        map.put(1, 1, 1, SECONDS);
+
+        assertTrueAllTheTime(() -> assertFalse("There should be zero ClearExpiredRecordsTask",
+                hasClearExpiredRecordsTaskStarted(node)), 3);
     }
 
     @Test
@@ -213,6 +216,11 @@ public class MapExpirationManagerTest extends AbstractExpirationManagerTest {
     @Override
     protected String cleanupPercentagePropName() {
         return MapClearExpiredRecordsTask.PROP_CLEANUP_PERCENTAGE;
+    }
+
+    @Override
+    protected String cleanupTaskEnabledPropName() {
+        return MapClearExpiredRecordsTask.PROP_CLEANUP_ENABLED;
     }
 
     @Override


### PR DESCRIPTION
Introduce new prop to enable/disable expired entry cleanup tasks

closes https://github.com/hazelcast/hazelcast/issues/14434

__Issue:__
https://github.com/hazelcast/hazelcast/issues/14434#issuecomment-567892405
It says no key was found.

__Fix:__
We have a background task to delete expired keys, it works separately on primary and backups. Test was failing because, according to my thesis, background task was removing expired entry while assertion is expecting it on backup. So above exception was raised. In this PR, i introduced a new internal property to stop background task which is not required for the test.

