### PR TITLE
Add UUID field to the BindMessage

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
@@ -27,9 +27,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
+import static com.hazelcast.internal.util.UUIDSerializationUtil.readUUID;
+import static com.hazelcast.internal.util.UUIDSerializationUtil.writeUUID;
 
 /**
  * Bind message, conveying information about all kinds of public
@@ -50,16 +53,18 @@ public class BindMessage
     private Map<ProtocolType, Collection<Address>> localAddresses;
     private Address targetAddress;
     private boolean reply;
+    private UUID uuid;
 
     public BindMessage() {
     }
 
     public BindMessage(byte schemaVersion, Map<ProtocolType, Collection<Address>> localAddresses,
-                       Address targetAddress, boolean reply) {
+                       Address targetAddress, boolean reply, UUID uuid) {
         this.schemaVersion = schemaVersion;
         this.localAddresses = new EnumMap<>(localAddresses);
         this.targetAddress = targetAddress;
         this.reply = reply;
+        this.uuid = uuid;
     }
 
     byte getSchemaVersion() {
@@ -78,6 +83,10 @@ public class BindMessage
         return reply;
     }
 
+    public UUID getUuid() {
+        return uuid;
+    }
+
     @Override
     public int getFactoryId() {
         return ClusterDataSerializerHook.F_ID;
@@ -93,6 +102,7 @@ public class BindMessage
         out.writeByte(schemaVersion);
         out.writeObject(targetAddress);
         out.writeBoolean(reply);
+        writeUUID(out, uuid);
         int size = (localAddresses == null) ? 0 : localAddresses.size();
         out.writeInt(size);
         if (size == 0) {
@@ -109,6 +119,7 @@ public class BindMessage
         schemaVersion = in.readByte();
         targetAddress = in.readObject();
         reply = in.readBoolean();
+        uuid = readUUID(in);
         int size = in.readInt();
         if (size == 0) {
             localAddresses = Collections.emptyMap();
@@ -126,6 +137,6 @@ public class BindMessage
     @Override
     public String toString() {
         return "BindMessage{" + "schemaVersion=" + schemaVersion + ", localAddresses=" + localAddresses
-                + ", targetAddress=" + targetAddress + ", reply=" + reply + '}';
+                + ", targetAddress=" + targetAddress + ", reply=" + reply + ", uuid=" + uuid + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOService.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 
 @SuppressWarnings({"checkstyle:methodcount"})
 public interface IOService {
@@ -120,4 +121,11 @@ public interface IOService {
     OutboundHandler[] createOutboundHandlers(EndpointQualifier qualifier, TcpIpConnection connection);
 
     AuditlogService getAuditLogService();
+
+    /**
+     * Returns UUID of the local member.
+     *
+     * @return member UUID
+     */
+    UUID getUuid();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/NodeIOService.java
@@ -53,6 +53,7 @@ import java.net.Socket;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
@@ -365,5 +366,10 @@ public class NodeIOService implements IOService {
     @Override
     public AuditlogService getAuditLogService() {
         return node.getNodeExtension().getAuditlogService();
+    }
+
+    @Override
+    public UUID getUuid() {
+        return node.getThisUuid();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/BindRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/BindRequest.java
@@ -54,7 +54,7 @@ public class BindRequest {
         if (logger.isFinestEnabled()) {
             logger.finest("Sending bind packet to " + remoteEndPoint);
         }
-        BindMessage bind = new BindMessage((byte) 1, getConfiguredLocalAddresses(), remoteEndPoint, reply);
+        BindMessage bind = new BindMessage((byte) 1, getConfiguredLocalAddresses(), remoteEndPoint, reply, ioService.getUuid());
         byte[] bytes = ioService.getSerializationService().toBytes(bind);
         Packet packet = new Packet(bytes).setPacketType(Packet.Type.BIND);
         connection.write(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BindMessageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BindMessageTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -48,22 +49,25 @@ public class BindMessageTest {
     private BindMessage bindMessage;
     private SerializationService serializationService;
     private Address targetAddress;
+    private UUID uuid;
 
     @Before
     public void setup() throws UnknownHostException {
         targetAddress = new Address("127.0.0.1", 9999);
         serializationService = new DefaultSerializationServiceBuilder().build();
+        uuid = UUID.randomUUID();
     }
 
     @Test
     public void testSerialization_withMultipleLocalAddresses() throws Exception {
-        bindMessage = new BindMessage((byte) 1, localAddresses(), targetAddress, true);
+        bindMessage = new BindMessage((byte) 1, localAddresses(), targetAddress, true, uuid);
         Data serialized = serializationService.toData(bindMessage);
         BindMessage deserialized = serializationService.toObject(serialized);
         assertEquals(1, deserialized.getSchemaVersion());
         assertEquals(localAddresses(), deserialized.getLocalAddresses());
         assertEquals(targetAddress, deserialized.getTargetAddress());
         assertTrue(deserialized.isReply());
+        assertEquals(uuid, deserialized.getUuid());
     }
 
     @Test
@@ -75,6 +79,7 @@ public class BindMessageTest {
         assertTrue(deserialized.getLocalAddresses().isEmpty());
         assertNull(null, deserialized.getTargetAddress());
         assertFalse(deserialized.isReply());
+        assertNull(deserialized.getUuid());
     }
 
     Map<ProtocolType, Collection<Address>> localAddresses() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/BindHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/BindHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -121,6 +122,7 @@ public class BindHandlerTest {
 
     private InternalSerializationService serializationService;
     private BindHandler bindHandler;
+    private UUID uuid = UUID.randomUUID();
 
     // mocks
     private Channel channel;
@@ -200,7 +202,7 @@ public class BindHandlerTest {
 
     private Packet bindMessage() {
         BindMessage bindMessage =
-                new BindMessage((byte) 1, localAddresses, new Address(CLIENT_SOCKET_ADDRESS), reply);
+                new BindMessage((byte) 1, localAddresses, new Address(CLIENT_SOCKET_ADDRESS), reply, uuid);
 
         Packet packet = new Packet(serializationService.toBytes(bindMessage));
         TcpIpConnection connection = new TcpIpConnection(endpointManager, null, 1, channel);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -405,5 +406,10 @@ public class MockIOService implements IOService {
     @Override
     public AuditlogService getAuditLogService() {
         return NoOpAuditlogService.INSTANCE;
+    }
+
+    @Override
+    public UUID getUuid() {
+        return null;
     }
 }


### PR DESCRIPTION
This PR adds local member UUID to `BindMessage` instances. It's the first step to resolve recurring Member-Address mapping issues.

The plan (post 4.0) is to use UUID for members and connections mappings where possible.

Currently, we identify members and connections by `Address`. We are not able to recognize proper responses in some cases (see #12334, #15722).

Following are conditions which can influence address-based mapping:
* multiple IPs for a hostname
* different hostnames used for a single IP in join configuration of cluster members
* mixing hostnames and IP addresses in join configuration
* host DNS entry unavailable until the member starts;
* ... and other