### PR TITLE
Rewrite test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLockTest.java
@@ -34,17 +34,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -127,12 +123,12 @@ public class NearCachePreloaderLockTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testRelease() throws Exception {
-        FileLock lock = mock(FileLock.class);
-        doThrow(new IOException("expected exception")).when(lock).release();
-
-        preloaderLock.releaseInternal(lock, channel);
-
-        verify(logger).severe(anyString(), any(IOException.class));
+    public void testRelease() {
+        try {
+            preloaderLock.release();
+        } catch (Throwable e) {
+            e.printStackTrace();
+            fail("Cannot release preloaderLock");
+        }
     }
 }


### PR DESCRIPTION
after https://github.com/hazelcast/hazelcast/pull/16312, test should have been rewritten, since we don't throw io exceptions any more.

closes https://github.com/hazelcast/hazelcast/issues/16300