### PR TITLE
Expect anti-entropy requests in WanPublisherMigrationTest assertions

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanPublisherMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanPublisherMigrationTest.java
@@ -60,6 +60,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for custom WAN publisher implementation migration support.
@@ -117,15 +118,21 @@ public class WanPublisherMigrationTest extends HazelcastTestSupport {
         if (!failMigrations) {
             assertEquals(exceptionMsg("migrationStart", publisher),
                     partitionsToMigrate, publisher.migrationStart.intValue());
-            assertEquals(exceptionMsg("migrationProcess", publisher),
-                    partitionsToMigrate, publisher.migrationProcess.intValue());
+            // it may happen that we have additional partition anti-entropy operations
+            // that call process but don't show up as migration operations
+            assertTrue("Expected at least " + partitionsToMigrate
+                            + " migration operations to be processed but was " + publisher,
+                    publisher.migrationProcess.intValue() >= partitionsToMigrate);
             assertEquals(exceptionMsg("migrationCommit", publisher),
                     partitionsToMigrate, publisher.migrationCommit.intValue());
         } else {
             assertEquals(exceptionMsg("migrationStart", publisher),
                     partitionsToMigrate + 1, publisher.migrationStart.intValue());
-            assertEquals(exceptionMsg("migrationProcess", publisher),
-                    partitionsToMigrate, publisher.migrationProcess.intValue());
+            // it may happen that we have additional partition anti-entropy operations
+            // that call process but don't show up as migration operations
+            assertTrue("Expected at least " + partitionsToMigrate
+                            + " migration operations to be processed but was " + publisher,
+                    publisher.migrationProcess.intValue() >= partitionsToMigrate);
             assertEquals(exceptionMsg("migrationCommit", publisher),
                     partitionsToMigrate, publisher.migrationCommit.intValue());
             assertEquals(exceptionMsg("migrationRollback", publisher),


### PR DESCRIPTION
In addition to migration process events,
WanMigrationAwarePublisher.prepareEventContainerReplicationData and
WanMigrationAwarePublisher.processEventContainerReplicationData can
also be called when the replication mechanism detects that there
is a difference between the partition owner and backup replica
and there's an anti-entropy process. Even if we disable periodic checks
for partition replica anti-entropy, this process can also be triggered
by reordered backup events. Because of this, we weaken the assertion for
processed WAN replication operations to allow for anti-entropy events.

Fixes: https://github.com/hazelcast/hazelcast/issues/16308