### PR TITLE
Fix METADATA group snapshot issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupInfo.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -36,8 +37,8 @@ import java.util.UUID;
 import static com.hazelcast.cp.CPGroup.CPGroupStatus.ACTIVE;
 import static com.hazelcast.cp.CPGroup.CPGroupStatus.DESTROYED;
 import static com.hazelcast.cp.CPGroup.CPGroupStatus.DESTROYING;
-import static java.util.Collections.unmodifiableSet;
 import static com.hazelcast.internal.util.Preconditions.checkState;
+import static java.util.Collections.unmodifiableSet;
 
 /**
  * Contains metadata information for Raft groups, such as group id,
@@ -61,6 +62,15 @@ public final class CPGroupInfo implements IdentifiedDataSerializable {
         this.status = ACTIVE;
         this.initialMembers = unmodifiableSet(new LinkedHashSet<>(members));
         this.members = unmodifiableSet(new LinkedHashSet<>(members));
+    }
+
+    // Copy constructor
+    CPGroupInfo(CPGroupInfo other) {
+        this.id = other.id;
+        this.status = other.status;
+        this.membersCommitIndex = other.membersCommitIndex;
+        this.initialMembers = Collections.unmodifiableSet(new LinkedHashSet<>(other.initialMembers));
+        this.members = Collections.unmodifiableSet(new LinkedHashSet<>(other.members));
     }
 
     public RaftGroupId id() {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
@@ -148,6 +148,7 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeObject(groupId);
             out.writeLong(membersCommitIndex);
             out.writeInt(members.size());
             for (RaftEndpoint member : members) {
@@ -159,6 +160,7 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
+            groupId = in.readObject();
             membersCommitIndex = in.readLong();
             int len = in.readInt();
             members = new HashSet<>(len);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -852,8 +852,8 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
         logger.severe("Could not apply add-member: " + (addedMember != null ? addedMember : "-")
                 + " and remove-member: " + (removedMember != null ? removedMember : "-") + " in "  + group
-                + " with new members commit index: " + newMembersCommitIndex + " expected members commit index: "
-                + expectedMembersCommitIndex + " known members commit index: " + group.getMembersCommitIndex());
+                + " with new members commit index: " + newMembersCommitIndex + ", expected members commit index: "
+                + expectedMembersCommitIndex + ", known members commit index: " + group.getMembersCommitIndex());
 
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
@@ -43,7 +43,10 @@ public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializab
     private Set<Long> initializationCommitIndices = new HashSet<>();
 
     public void setGroups(Collection<CPGroupInfo> groups) {
-        this.groups.addAll(groups);
+        for (CPGroupInfo group : groups) {
+            // Deep copy CPGroupInfo, because it's a mutable object.
+            this.groups.add(new CPGroupInfo(group));
+        }
     }
 
     public void setMembers(Collection<CPMemberInfo> members) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
@@ -218,6 +218,7 @@ final class NodeEngineRaftIntegration implements RaftIntegration {
         try {
             return operation.run(groupId, commitIndex);
         } catch (Throwable t) {
+            operation.logFailure(t);
             return t;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftOp.java
@@ -16,10 +16,16 @@
 
 package com.hazelcast.cp.internal;
 
+import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.spi.exception.RetryableException;
+import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.spi.impl.NodeEngine;
+
+import java.util.logging.Level;
+
+import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 /**
  * Base operation class for operations to be replicated to and executed on
@@ -69,6 +75,30 @@ public abstract class RaftOp implements DataSerializable {
     }
 
     protected abstract String getServiceName();
+
+    public void logFailure(Throwable e) {
+        ILogger logger = getLogger();
+        if (e instanceof SilentException) {
+            if (logger.isFinestEnabled()) {
+                logger.finest(e.getMessage(), e);
+            }
+        } else if (e instanceof RetryableException) {
+            if (logger.isFineEnabled()) {
+                logger.fine(e.getClass().getName() + ": " + e.getMessage());
+            }
+        } else if (e instanceof OutOfMemoryError) {
+            try {
+                logger.severe(e.getMessage(), e);
+            } catch (Throwable t) {
+                ignore(t);
+            }
+        } else {
+            Level level = nodeEngine != null && nodeEngine.isRunning() ? Level.WARNING : Level.FINE;
+            if (logger.isLoggable(level)) {
+                logger.log(level, e.getMessage(), e);
+            }
+        }
+    }
 
     protected void toString(StringBuilder sb) {
     }


### PR DESCRIPTION
- `CPGroupMembershipChange` was not serializing `groupId` (unintentionally).
If snapshot is produced during a membership change, this was causing failure
during restore.

- `CPGroupInfo`s should be deep copied while creating snapshot,
since it's a mutable class. But snapshots must be immutable.

Fixes #15771