### PR TITLE
Fix METADATA group snapshot issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupInfo.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -59,6 +60,16 @@ public final class CPGroupInfo implements CPGroup, IdentifiedDataSerializable {
         this.initialMembers = Collections.unmodifiableSet(new LinkedHashSet<CPMemberInfo>(members));
         this.members = Collections.unmodifiableSet(new LinkedHashSet<CPMemberInfo>(members));
         this.membersArray = members.toArray(new CPMemberInfo[0]);
+    }
+
+    // Copy constructor
+    CPGroupInfo(CPGroupInfo other) {
+        this.id = other.id;
+        this.status = other.status;
+        this.membersCommitIndex = other.membersCommitIndex;
+        this.initialMembers = Collections.unmodifiableSet(new LinkedHashSet<CPMemberInfo>(other.initialMembers));
+        this.members = Collections.unmodifiableSet(new LinkedHashSet<CPMemberInfo>(other.members));
+        this.membersArray = Arrays.copyOf(other.membersArray, other.membersArray.length);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
@@ -154,6 +154,12 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
+            // `groupId` was not written by mistake,
+            // but to keep patch compatibility we cannot serialize it in 3.12.x.
+            // That's why to avoid snapshots in METADATA group,
+            // we hardcoded METADATA log capacity to a huge size.
+            // out.writeObject(groupId);
+
             out.writeLong(membersCommitIndex);
             out.writeInt(members.size());
             for (CPMemberInfo member : members) {
@@ -165,6 +171,10 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
+            // `groupId` was not written by mistake,
+            // but to keep patch compatibility we cannot serialize it in 3.12.x.
+            // groupId = in.readObject();
+
             membersCommitIndex = in.readLong();
             int len = in.readInt();
             members = new HashSet<CPMemberInfo>(len);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -763,8 +763,8 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
         logger.severe("Could not apply add-member: " + (addedMember != null ? addedMember : "-")
                 + " and remove-member: " + (removedMember != null ? removedMember : "-") + " in "  + group
-                + " with new members commit index: " + newMembersCommitIndex + " expected members commit index: "
-                + expectedMembersCommitIndex + " known members commit index: " + group.getMembersCommitIndex());
+                + " with new members commit index: " + newMembersCommitIndex + ", expected members commit index: "
+                + expectedMembersCommitIndex + ", known members commit index: " + group.getMembersCommitIndex());
 
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
@@ -43,7 +43,10 @@ public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializab
     private Set<Long> initializationCommitIndices = new HashSet<Long>();
 
     public void setGroups(Collection<CPGroupInfo> groups) {
-        this.groups.addAll(groups);
+        for (CPGroupInfo group : groups) {
+            // Deep copy CPGroupInfo, because it's a mutable object.
+            this.groups.add(new CPGroupInfo(group));
+        }
     }
 
     public void setMembers(Collection<CPMemberInfo> members) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
@@ -184,6 +184,7 @@ final class NodeEngineRaftIntegration implements RaftIntegration {
         try {
             return operation.run(groupId, commitIndex);
         } catch (Throwable t) {
+            operation.logFailure(t);
             return t;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftOp.java
@@ -16,10 +16,16 @@
 
 package com.hazelcast.cp.internal;
 
+import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.exception.RetryableException;
+import com.hazelcast.spi.exception.SilentException;
+
+import java.util.logging.Level;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Base operation class for operations to be replicated to and executed on
@@ -69,6 +75,30 @@ public abstract class RaftOp implements DataSerializable {
     }
 
     protected abstract String getServiceName();
+
+    public void logFailure(Throwable e) {
+        ILogger logger = getLogger();
+        if (e instanceof SilentException) {
+            if (logger.isFinestEnabled()) {
+                logger.finest(e.getMessage(), e);
+            }
+        } else if (e instanceof RetryableException) {
+            if (logger.isFineEnabled()) {
+                logger.fine(e.getClass().getName() + ": " + e.getMessage());
+            }
+        } else if (e instanceof OutOfMemoryError) {
+            try {
+                logger.severe(e.getMessage(), e);
+            } catch (Throwable t) {
+                ignore(t);
+            }
+        } else {
+            Level level = nodeEngine != null && nodeEngine.isRunning() ? Level.WARNING : Level.FINE;
+            if (logger.isLoggable(level)) {
+                logger.log(level, e.getMessage(), e);
+            }
+        }
+    }
 
     protected void toString(StringBuilder sb) {
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -41,6 +41,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -652,6 +653,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
     }
 
     @Test
+    @Ignore("METADATA snapshot serialization is disabled.")
     public void when_newCPMemberIsAddedToTheMetadataGroupAfterSnapshot_newMemberInstallsSnapshot() throws ExecutionException, InterruptedException {
         int nodeCount = 3;
         final int commitIndexAdvanceCountToSnapshot = 50;
@@ -822,6 +824,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
     }
 
     @Test
+    @Ignore("METADATA snapshot serialization is disabled.")
     public void when_newCPMemberIsAddedToTheMetadataGroupAfterRestartAndSnapshot_newMemberInstallsSnapshot() throws ExecutionException, InterruptedException {
         int nodeCount = 3;
         final int commitIndexAdvanceCountToSnapshot = 50;

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -38,6 +38,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.ExceptionUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -472,6 +473,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
     }
 
     @Test
+    @Ignore("METADATA snapshot serialization is disabled.")
     public void when_metadataClusterNodeFallsFarBehind_then_itInstallsSnapshot() {
         int nodeCount = 3;
         int commitCountToSnapshot = 5;


### PR DESCRIPTION
- CPGroupMembershipChange was not serializing groupId (by mistake).
If snapshot is produced during a membership change, this was causing failure
during restore. Since we cannot change serialization format in
patch release, we hardcoded METADATA log capacity to a huge size
to practically prevent METADATA snapshots.

- `CPGroupInfo`s should be deep copied while creating snapshot,
since it's a mutable class. But snapshots must be immutable.

Fixes #15771
Backport of https://github.com/hazelcast/hazelcast/pull/16344
