### PR TITLE
Make sure that client receives members map before partition map (#16343)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClusterViewListenerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClusterViewListenerService.java
@@ -96,15 +96,15 @@ public class ClusterViewListenerService {
         }
         clusterListeningEndpoints.put(clientEndpoint, correlationId);
 
+        ClientMessage memberListViewMessage = getMemberListViewMessage();
+        memberListViewMessage.setCorrelationId(correlationId);
+        clientEndpoint.getConnection().write(memberListViewMessage);
+
         ClientMessage partitionViewMessage = getPartitionViewMessageOrNull();
         if (partitionViewMessage != null) {
             partitionViewMessage.setCorrelationId(correlationId);
             clientEndpoint.getConnection().write(partitionViewMessage);
         }
-
-        ClientMessage memberListViewMessage = getMemberListViewMessage();
-        memberListViewMessage.setCorrelationId(correlationId);
-        clientEndpoint.getConnection().write(memberListViewMessage);
     }
 
     private ClientMessage getPartitionViewMessageOrNull() {


### PR DESCRIPTION
This change fixes NPE in the `AdvancedNetworkClientIntegrationTest.testPartitions`. 

The test compares partition tables of a member and a client by invoking `Partition.getOwner()` method. The client requires two pieces of information to make it work: partition view and membership view. Both are delivered from the server to a client listener. With the old implementation, it is possible that the partition view is applied before the membership view. It happens if the server already has an initialized partition table. Both pieces of information are delivered to a client through a single connection and are executed in the order in the event executor (see `ClientEventProcessor.getKey()`). As a result, we successfully return partitions from the client, but cannot resolve the partition owner, since it requires a membership view, which is not processed yet. Note that the window of inconsistency is extremely small. I failed to reproduce the problem locally.

The solution is to reorder membership and partition messages in the server handler so that membership info is always installed first.

Fixes #16343