### PR TITLE
Destroy IMap statistics after container to avoid leak (#16252)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -402,8 +402,10 @@ class MapServiceContextImpl implements MapServiceContext {
 
         nodeEngine.getWanReplicationService().removeWanEventCounters(MapService.SERVICE_NAME, mapName);
         mapContainer.getMapStoreContext().stop();
-        localMapStatsProvider.destroyLocalMapStatsImpl(mapContainer.getName());
+
+        // Statistics are destroyed after container to prevent their leak.
         destroyPartitionsAndMapContainer(mapContainer);
+        localMapStatsProvider.destroyLocalMapStatsImpl(mapContainer.getName());
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -59,7 +59,6 @@ import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
-import static java.lang.Integer.parseInt;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
@@ -68,13 +67,12 @@ public class ProxyServiceImpl
         EventPublishingService<DistributedObjectEventPacket, Object>, StaticMetricsProvider {
 
     public static final String SERVICE_NAME = "hz:core:proxyService";
-    private static final String HAZELCAST_PROXY_DESTROY_TIMEOUT_SECONDS = "hazelcast.proxy.destroy.timeout.seconds";
 
     private static final int TRY_COUNT = 10;
+    private static final long DESTROY_TIMEOUT_SECONDS = 30;
 
     final NodeEngineImpl nodeEngine;
     final ILogger logger;
-    final long destroyTimeout;
     final ConcurrentMap<UUID, DistributedObjectListener> listeners =
             new ConcurrentHashMap<UUID, DistributedObjectListener>();
 
@@ -100,7 +98,6 @@ public class ProxyServiceImpl
 
     public ProxyServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
-        this.destroyTimeout = parseInt(System.getProperty(HAZELCAST_PROXY_DESTROY_TIMEOUT_SECONDS, "30"));
         this.logger = nodeEngine.getLogger(ProxyService.class.getName());
     }
 
@@ -173,7 +170,7 @@ public class ProxyServiceImpl
         }
 
         destroyLocalDistributedObject(serviceName, name, true);
-        waitWithDeadline(calls, destroyTimeout, TimeUnit.SECONDS, destroyProxyExceptionHandler);
+        waitWithDeadline(calls, DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS, destroyProxyExceptionHandler);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -54,8 +53,6 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LocalIndexStatsTest extends HazelcastTestSupport {
 
-    public static final String HAZELCAST_PROXY_DESTROY_TIMEOUT_SECONDS = "hazelcast.proxy.destroy.timeout.seconds";
-
     @Parameters(name = "format:{0}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{{InMemoryFormat.OBJECT}, {InMemoryFormat.BINARY}});
@@ -65,8 +62,6 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
     public InMemoryFormat inMemoryFormat;
 
     protected static final int PARTITIONS = 137;
-
-    protected static final int PROXY_DESTROY_TIMEOUT = 60;
 
     private static final int QUERIES = 10;
 
@@ -87,8 +82,6 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         mapName = randomMapName();
         noStatsMapName = mapName + "_no_stats";
 
-        System.setProperty(HAZELCAST_PROXY_DESTROY_TIMEOUT_SECONDS, Integer.toString(PROXY_DESTROY_TIMEOUT));
-
         Config config = getConfig();
         config.setProperty(PARTITION_COUNT.getName(), Integer.toString(PARTITIONS));
         config.getMapConfig(mapName).setInMemoryFormat(inMemoryFormat);
@@ -98,11 +91,6 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         map = instance.getMap(mapName);
         noStatsMap = instance.getMap(noStatsMapName);
         queryTypes = initQueryTypes();
-    }
-
-    @After
-    public void tearDown() {
-        System.clearProperty(HAZELCAST_PROXY_DESTROY_TIMEOUT_SECONDS);
     }
 
     @Override


### PR DESCRIPTION
This PR ensures that IMap statistics are destroyed after the map container, thus preventing statistics leak. Changes made in #16296 are rolled back. 
A detailed description of the original problem: https://github.com/hazelcast/hazelcast/issues/16252#issuecomment-568872030

Fixes #16252 