### PR TITLE
use proper title for hazelcast cmd bar to fix stop.bat

### DIFF
--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -2,8 +2,18 @@
 
 SETLOCAL
 
-if NOT DEFINED JAVA_HOME goto error
-set RUN_JAVA=%JAVA_HOME%\bin\java
+if "x%JAVA_HOME%" == "x" (
+    echo JAVA_HOME environment variable not available.
+    set RUN_JAVA=java
+) else (
+    set "RUN_JAVA=%JAVA_HOME%\bin\java"
+)
+
+"%RUN_JAVA%" -version 1>nul 2>nul || (
+    echo JAVA could not be found in your system.
+    echo Please install Java 1.8 or higher!!!
+    exit /b 2
+)
 
 
 REM ******* you can enable following variables by uncommenting them

--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -25,7 +25,7 @@ if NOT "%MAX_HEAP_SIZE%" == "" (
 
 set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar;%~dp0..\user-lib;%~dp0..\user-lib\*"
 
-FOR /F "tokens=2 delims=," %%F in ('tasklist /NH /FI "WINDOWTITLE eq hazelcast %CLASSPATH%" /fo csv') DO (
+FOR /F "tokens=2 delims=," %%F in ('tasklist /NH /FI "WINDOWTITLE eq hazelcast-imdg" /fo csv') DO (
 SET PID=%%F
 )
 IF NOT "%PID%"=="" (
@@ -38,7 +38,7 @@ ECHO # JAVA_OPTS=%JAVA_OPTS%
 ECHO # starting now...."
 ECHO ########################################
 
-start "hazelcast %CLASSPATH%" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" "com.hazelcast.core.server.StartServer"
+start "hazelcast-imdg" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" "com.hazelcast.core.server.StartServer"
 goto endofscript
 
 :error

--- a/hazelcast/src/main/resources/stop.bat
+++ b/hazelcast/src/main/resources/stop.bat
@@ -2,6 +2,4 @@
 
 SETLOCAL
 
-set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar"
-
-taskkill /F /FI "WINDOWTITLE eq hazelcast %CLASSPATH%"
+taskkill /F /FI "WINDOWTITLE eq hazelcast-imdg"


### PR DESCRIPTION
With 4.0 release, `start` command's title does not contain `%CLASSPATH%` anymore:
```
start "hazelcast-imdg" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" "com.hazelcast.core.server.HazelcastMemberStarter"
```
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/resources/start.bat

We should use same title at maintenance-3.x branch as well for 3.12.x releases to fix issues at https://github.com/hazelcast/hazelcast/issues/16355. 

If we want to allow `start.bat` to start multiple hazelcast instances at same environment, we can apply these changes that already exists at master:
https://github.com/hazelcast/hazelcast/pull/15934/files#diff-82e271779f8921d377ae28af6cbaf642