### PR TITLE
Prevent concurrent modification exceptions in TestHazelcastFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -66,8 +66,7 @@ public final class HazelcastClient {
         OutOfMemoryErrorDispatcher.setClientHandler(new ClientOutOfMemoryHandler());
     }
 
-    static final ConcurrentMap<String, HazelcastClientProxy> CLIENTS
-            = new ConcurrentHashMap<String, HazelcastClientProxy>(5);
+    static final ConcurrentMap<String, HazelcastClientProxy> CLIENTS = new ConcurrentHashMap<>(5);
 
     private HazelcastClient() {
     }
@@ -173,7 +172,6 @@ public final class HazelcastClient {
      *      <li>it checks if a hazelcast-client-failover.yaml is available on the classpath</li>
      *      <li>if none available {@link HazelcastException} is thrown</li>
      * </ol>
-     *
      *
      * @param clientFailoverConfig config describing the failover configs and try count
      * @return the client instance

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertFalse;
 
 public final class TestNodeRegistry {
 
-    private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
+    private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<>(10);
     private final Collection<Address> joinAddresses;
     private final List<String> nodeExtensionPriorityList;
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/3462

Based on [test failure](http://jenkins.hazelcast.com/job/Hazelcast-EE-pr-builder/1857/testReport/junit/com.hazelcast.client.management/MCHotRestartOperationsTest/testGetTimedMemberState_onIncompleteStart/)

```
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
	at java.util.ArrayList$Itr.next(ArrayList.java:859)
	at com.hazelcast.client.test.TestHazelcastFactory.shutdownAll(TestHazelcastFactory.ja
va:138)
	at com.hazelcast.client.management.MCHotRestartOperationsTest.tearDown(MCHotRestartOp
erationsTest.java:58)
```


__Modifications:__
- Used ConcurrentHashMap instead of synchronizedList to register client instances.
- Some polishing