### PR TITLE
[BACKPORT] add getOrCreate method to HazelcastClient

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -28,17 +28,22 @@ import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OutOfMemoryHandler;
+import com.hazelcast.instance.HazelcastInstanceFactory.InstanceFuture;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig;
 import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientFailoverConfig;
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * The HazelcastClient is comparable to the {@link com.hazelcast.core.Hazelcast} class and provides the ability
@@ -63,12 +68,13 @@ import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.r
  */
 public final class HazelcastClient {
 
+    private static final AtomicInteger CLIENT_ID_GEN = new AtomicInteger();
+    private static final ConcurrentMap<String, InstanceFuture<HazelcastClientProxy>> CLIENTS
+            = new ConcurrentHashMap<String, InstanceFuture<HazelcastClientProxy>>(5);
+
     static {
         OutOfMemoryErrorDispatcher.setClientHandler(new ClientOutOfMemoryHandler());
     }
-
-    static final ConcurrentMap<String, HazelcastClientProxy> CLIENTS
-            = new ConcurrentHashMap<String, HazelcastClientProxy>(5);
 
     private HazelcastClient() {
     }
@@ -80,7 +86,7 @@ public final class HazelcastClient {
      * <p/>
      * To shutdown all running HazelcastInstances (all clients on this JVM)
      * call {@link #shutdownAll()}.
-     *
+     * <p>
      * Hazelcast will look into two places for the configuration file:
      * <ol>
      *     <li>
@@ -135,7 +141,7 @@ public final class HazelcastClient {
     /**
      * Creates a client with cluster switch capability. Client will try to connect to alternative clusters according to
      * {@link ClientFailoverConfig} when it disconnects from a cluster.
-     *
+     * <p>
      * The configuration is loaded using using the following resolution mechanism:
      * <ol>
      * <li>first it checks if a system property 'hazelcast.client.failover.config' is set. If it exist and it begins with
@@ -160,7 +166,7 @@ public final class HazelcastClient {
     /**
      * Creates a client with cluster switch capability. Client will try to connect to alternative clusters according to
      * {@link ClientFailoverConfig} when it disconnects from a cluster.
-     *
+     * <p>
      * If provided clientFailoverConfig is {@code null}, the configuration is loaded using using the following resolution
      * mechanism:
      * <ol>
@@ -175,7 +181,6 @@ public final class HazelcastClient {
      *      <li>if none available {@link HazelcastException} is thrown</li>
      * </ol>
      *
-     *
      * @param clientFailoverConfig config describing the failover configs and try count
      * @return the client instance
      * @throws HazelcastException            if no failover configuration is found
@@ -185,29 +190,6 @@ public final class HazelcastClient {
         return newHazelcastClientInternal(null, null, resolveClientFailoverConfig(clientFailoverConfig));
     }
 
-    static HazelcastInstance newHazelcastClientInternal(AddressProvider addressProvider, ClientConfig clientConfig,
-                                                        ClientFailoverConfig failoverConfig) {
-        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-        HazelcastClientProxy proxy;
-        try {
-            Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
-            ClientConnectionManagerFactory factory = new DefaultClientConnectionManagerFactory();
-            HazelcastClientInstanceImpl client =
-                    new HazelcastClientInstanceImpl(clientConfig, failoverConfig, factory, addressProvider);
-            client.start();
-            OutOfMemoryErrorDispatcher.registerClient(client);
-            proxy = new HazelcastClientProxy(client);
-
-            if (CLIENTS.putIfAbsent(client.getName(), proxy) != null) {
-                throw new DuplicateInstanceNameException("HazelcastClientInstance with name '" + client.getName()
-                        + "' already exists!");
-            }
-        } finally {
-            Thread.currentThread().setContextClassLoader(contextClassLoader);
-        }
-        return proxy;
-    }
-
     /**
      * Returns an existing HazelcastClient with instanceName.
      *
@@ -215,7 +197,95 @@ public final class HazelcastClient {
      * @return HazelcastInstance
      */
     public static HazelcastInstance getHazelcastClientByName(String instanceName) {
-        return CLIENTS.get(instanceName);
+        InstanceFuture<HazelcastClientProxy> future = CLIENTS.get(instanceName);
+        if (future == null) {
+            return null;
+        }
+
+        try {
+            return future.get();
+        } catch (IllegalStateException t) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets or creates a new HazelcastInstance (a new client in a cluster) with the default XML configuration looked up in:
+     * <ol>
+     *     <li>
+     *         System property: Hazelcast will first check if "hazelcast.client.config" system property is set to a file or a
+     *         {@code classpath:...} path. The configuration can either be an XML or a YAML configuration, distinguished by the
+     *         suffix ('.xml' or '.yaml') of the provided configuration file's name
+     *         Examples: -Dhazelcast.client.config=C:/myhazelcastclient.xml ,
+     *         -Dhazelcast.client.config=classpath:the-hazelcast-config.yaml ,
+     *         -Dhazelcast.client.config=classpath:com/mydomain/hazelcast.xml
+     *     </li>
+     *     <li>
+     *         "hazelcast-client.xml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast-client.xml file.
+     *     </li>
+     *     <li>
+     *         "hazelcast-client.yaml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast-client.yaml file.
+     *     </li>
+     * </ol>
+     * <p>
+     * If Hazelcast doesn't find any config file, it will start with the default configuration (hazelcast-client-default.xml)
+     * located in hazelcast.jar.
+     *
+     * @return the new HazelcastInstance
+     * @throws IllegalArgumentException if the instance name of the config is null or empty or if no config file can be
+     *                                  located.
+     * @see #getHazelcastClientByName(String) (String)
+     */
+    public static HazelcastInstance getOrCreateHazelcastClient() {
+        return getOrCreateClientInternal(null);
+    }
+
+    /**
+     * Gets or creates a new HazelcastInstance (a new client in a cluster) with a certain name.
+     * <p>
+     * If a Hazelcast instance with the same name as the configuration exists, then it is returned, otherwise it is created.
+     * <p>
+     * If {@code config} is {@code null}, Hazelcast will look into two places for the configuration file:
+     * <ol>
+     *     <li>
+     *         System property: Hazelcast will first check if "hazelcast.client.config" system property is set to a file or a
+     *         {@code classpath:...} path. The configuration can either be an XML or a YAML configuration, distinguished by the
+     *         suffix ('.xml' or '.yaml') of the provided configuration file's name
+     *         Examples: -Dhazelcast.client.config=C:/myhazelcastclient.xml ,
+     *         -Dhazelcast.client.config=classpath:the-hazelcast-config.yaml ,
+     *         -Dhazelcast.client.config=classpath:com/mydomain/hazelcast.xml
+     *     </li>
+     *     <li>
+     *         "hazelcast-client.xml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast-client.xml file.
+     *     </li>
+     *     <li>
+     *         "hazelcast-client.yaml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast-client.yaml file.
+     *     </li>
+     * </ol>
+     * <p>
+     * If Hazelcast doesn't find any config file, it will start with the default configuration (hazelcast-client-default.xml)
+     * located in hazelcast.jar.
+     *
+     * @param config Client configuration
+     * @return the new HazelcastInstance
+     * @throws IllegalArgumentException if the instance name of the config is null or empty or if no config file can be
+     *                                  located.
+     * @see #getHazelcastClientByName(String) (String)
+     */
+    public static HazelcastInstance getOrCreateHazelcastClient(ClientConfig config) {
+        return getOrCreateClientInternal(config);
     }
 
     /**
@@ -231,8 +301,11 @@ public final class HazelcastClient {
      * @return the collection of client HazelcastInstances
      */
     public static Collection<HazelcastInstance> getAllHazelcastClients() {
-        Collection<HazelcastClientProxy> values = CLIENTS.values();
-        return Collections.unmodifiableCollection(new HashSet<HazelcastInstance>(values));
+        Set<HazelcastInstance> result = createHashSet(CLIENTS.size());
+        for (InstanceFuture<HazelcastClientProxy> f : CLIENTS.values()) {
+            result.add(f.get());
+        }
+        return Collections.unmodifiableCollection(result);
     }
 
     /**
@@ -246,13 +319,14 @@ public final class HazelcastClient {
      * @see #getAllHazelcastClients()
      */
     public static void shutdownAll() {
-        for (HazelcastClientProxy proxy : CLIENTS.values()) {
-            HazelcastClientInstanceImpl client = proxy.client;
-            if (client == null) {
-                continue;
-            }
-            proxy.client = null;
+        for (InstanceFuture<HazelcastClientProxy> future : CLIENTS.values()) {
             try {
+                HazelcastClientProxy proxy = future.get();
+                HazelcastClientInstanceImpl client = proxy.client;
+                if (client == null) {
+                    continue;
+                }
+                proxy.client = null;
                 client.shutdown();
             } catch (Throwable ignored) {
                 EmptyStatement.ignore(ignored);
@@ -293,10 +367,12 @@ public final class HazelcastClient {
      * @param instanceName the hazelcast client instance name
      */
     public static void shutdown(String instanceName) {
-        HazelcastClientProxy proxy = CLIENTS.remove(instanceName);
-        if (proxy == null) {
+        InstanceFuture<HazelcastClientProxy> future = CLIENTS.remove(instanceName);
+        if (future == null) {
             return;
         }
+
+        HazelcastClientProxy proxy = future.get();
         HazelcastClientInstanceImpl client = proxy.client;
         if (client == null) {
             return;
@@ -328,5 +404,92 @@ public final class HazelcastClient {
      */
     public static void setOutOfMemoryHandler(OutOfMemoryHandler outOfMemoryHandler) {
         OutOfMemoryErrorDispatcher.setClientHandler(outOfMemoryHandler);
+    }
+
+    static HazelcastInstance newHazelcastClientInternal(AddressProvider addressProvider, ClientConfig clientConfig,
+                                                        ClientFailoverConfig failoverConfig) {
+        checkConfigs(clientConfig, failoverConfig);
+        String instanceName = getInstanceName(clientConfig, failoverConfig);
+
+        InstanceFuture<HazelcastClientProxy> future = new InstanceFuture<HazelcastClientProxy>();
+        if (CLIENTS.putIfAbsent(instanceName, future) != null) {
+            throw new DuplicateInstanceNameException("HazelcastClientInstance with name '" + instanceName
+                    + "' already exists!");
+        }
+
+        try {
+            return constructHazelcastClient(addressProvider, clientConfig, failoverConfig, instanceName, future);
+        } catch (Throwable t) {
+            CLIENTS.remove(instanceName, future);
+            future.setFailure(t);
+            throw ExceptionUtil.rethrow(t);
+        }
+    }
+
+    private static HazelcastInstance getOrCreateClientInternal(ClientConfig config) {
+        config = resolveClientConfig(config);
+
+        String instanceName = config.getInstanceName();
+        checkHasText(instanceName, "instanceName must contain text");
+
+        InstanceFuture<HazelcastClientProxy> future = CLIENTS.get(instanceName);
+        if (future != null) {
+            return future.get();
+        }
+
+        future = new InstanceFuture<HazelcastClientProxy>();
+        InstanceFuture<HazelcastClientProxy> found = CLIENTS.putIfAbsent(instanceName, future);
+        if (found != null) {
+            return found.get();
+        }
+
+        try {
+            return constructHazelcastClient(null, config, null, instanceName, future);
+        } catch (Throwable t) {
+            CLIENTS.remove(instanceName, future);
+            future.setFailure(t);
+            throw ExceptionUtil.rethrow(t);
+        }
+    }
+
+    private static HazelcastInstance constructHazelcastClient(AddressProvider addressProvider, ClientConfig clientConfig,
+                                                              ClientFailoverConfig failoverConfig, String instanceName,
+                                                              InstanceFuture<HazelcastClientProxy> future) {
+        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        HazelcastClientProxy proxy;
+        try {
+            Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
+            ClientConnectionManagerFactory factory = new DefaultClientConnectionManagerFactory();
+            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(instanceName, clientConfig,
+                    failoverConfig, factory, addressProvider);
+            client.start();
+            OutOfMemoryErrorDispatcher.registerClient(client);
+            proxy = new HazelcastClientProxy(client);
+            future.set(proxy);
+        } catch (Throwable t) {
+            throw ExceptionUtil.rethrow(t);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+        return proxy;
+    }
+
+    private static void checkConfigs(ClientConfig clientConfig, ClientFailoverConfig clientFailoverConfig) {
+        assert clientConfig != null || clientFailoverConfig != null : "At most one type of config can be provided";
+        assert clientConfig == null || clientFailoverConfig == null : "At least one config should be provided ";
+    }
+
+    static String getInstanceName(ClientConfig clientConfig, ClientFailoverConfig failoverConfig) {
+        int instanceNum = CLIENT_ID_GEN.incrementAndGet();
+        String instanceName;
+        if (clientConfig != null) {
+            instanceName = clientConfig.getInstanceName();
+        } else {
+            instanceName = failoverConfig.getClientConfigs().get(0).getInstanceName();
+        }
+        if (instanceName == null || instanceName.trim().length() == 0) {
+            instanceName = "hz.client_" + instanceNum;
+        }
+        return instanceName;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -368,7 +368,7 @@ public final class HazelcastClient {
      */
     public static void shutdown(String instanceName) {
         InstanceFuture<HazelcastClientProxy> future = CLIENTS.remove(instanceName);
-        if (future == null) {
+        if (future == null || !future.isSet()) {
             return;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -234,8 +234,9 @@ public final class HazelcastClient {
      *     </li>
      * </ol>
      * <p>
-     * If Hazelcast doesn't find any config file, it will start with the default configuration (hazelcast-client-default.xml)
-     * located in hazelcast.jar.
+     * If a configuration file is not located, an {@link IllegalArgumentException} will be thrown.
+     *
+     * If a Hazelcast instance with the same name as the configuration exists, then it is returned, otherwise it is created.
      *
      * @return the new HazelcastInstance
      * @throws IllegalArgumentException if the instance name of the config is null or empty or if no config file can be
@@ -275,8 +276,7 @@ public final class HazelcastClient {
      *     </li>
      * </ol>
      * <p>
-     * If Hazelcast doesn't find any config file, it will start with the default configuration (hazelcast-client-default.xml)
-     * located in hazelcast.jar.
+     * If a configuration file is not located, an {@link IllegalArgumentException} will be thrown.
      *
      * @param config Client configuration
      * @return the new HazelcastInstance

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -205,23 +205,17 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ClientProxySessionManager proxySessionManager;
     private final CPSubsystemImpl cpSubsystem;
 
-    public HazelcastClientInstanceImpl(ClientConfig clientConfig,
+    public HazelcastClientInstanceImpl(String instanceName, ClientConfig clientConfig,
                                        ClientFailoverConfig clientFailoverConfig,
                                        ClientConnectionManagerFactory clientConnectionManagerFactory,
                                        AddressProvider externalAddressProvider) {
-        assert clientConfig != null || clientFailoverConfig != null : "At most one type of config can be provided";
-        assert clientConfig == null || clientFailoverConfig == null : "At least one config should be provided ";
         if (clientConfig != null) {
             this.config = clientConfig;
         } else {
             this.config = clientFailoverConfig.getClientConfigs().get(0);
         }
         this.clientFailoverConfig = clientFailoverConfig;
-        if (config.getInstanceName() != null) {
-            instanceName = config.getInstanceName();
-        } else {
-            instanceName = "hz.client_" + id;
-        }
+        this.instanceName = instanceName;
 
         GroupConfig groupConfig = config.getGroupConfig();
         String loggingType = config.getProperty(GroupProperty.LOGGING_TYPE.getName());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.DuplicateInstanceNameException;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastClientTest extends HazelcastTestSupport {
+
+    private static final String CLIENT_CONFIG_PROP_NAME = "hazelcast.client.config";
+
+    @Before
+    public void setUp() {
+        cleanup();
+        Hazelcast.newHazelcastInstance(smallInstanceConfig());
+    }
+
+    @After
+    public void tearDown() {
+        cleanup();
+    }
+
+    private void cleanup() {
+        HazelcastClient.shutdownAll();
+        assertEquals(0, HazelcastClient.getAllHazelcastClients().size());
+        Hazelcast.shutdownAll();
+        assertEquals(0, Hazelcast.getAllHazelcastInstances().size());
+    }
+
+    // null instance name
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetOrCreateHazelcastClient_withNullConfig() {
+        HazelcastClient.getOrCreateHazelcastClient(null);
+    }
+
+    @Test
+    public void testGetOrCreateHazelcastClient_returnsSame_withNoConfig() {
+        String hzConfigProperty = System.getProperty(CLIENT_CONFIG_PROP_NAME);
+        try {
+            System.setProperty(CLIENT_CONFIG_PROP_NAME, "classpath:hazelcast-client-test.xml");
+            HazelcastInstance client1 = HazelcastClient.getOrCreateHazelcastClient();
+            HazelcastInstance client2 = HazelcastClient.getOrCreateHazelcastClient();
+            assertEquals("Calling two times getOrCreateHazelcastClient should return same client",
+                    client1, client2);
+        } finally {
+            if (hzConfigProperty == null) {
+                System.clearProperty(CLIENT_CONFIG_PROP_NAME);
+            } else {
+                System.setProperty(CLIENT_CONFIG_PROP_NAME, hzConfigProperty);
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetOrCreateHazelcastClient_withNullName() {
+        ClientConfig config = new ClientConfig();
+        HazelcastClient.getOrCreateHazelcastClient(config);
+    }
+
+    @Test
+    public void testGetOrCreateHazelcastClient_whenClientDoesNotExist() {
+        String instanceName = randomString();
+        ClientConfig config = new ClientConfig();
+        config.setInstanceName(instanceName);
+
+        HazelcastInstance client = HazelcastClient.getOrCreateHazelcastClient(config);
+        assertEquals(client, HazelcastClient.getHazelcastClientByName(instanceName));
+    }
+
+    @Test
+    public void testGetOrCreateHazelcastClient_whenClientExists() {
+        String instanceName = randomString();
+        ClientConfig config = new ClientConfig();
+        config.setInstanceName(instanceName);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
+        assertEquals(client, HazelcastClient.getOrCreateHazelcastClient(config));
+    }
+
+    @Test
+    public void testGetOrCreateHazelcastClientConcurrently() throws ExecutionException, InterruptedException {
+        String instanceName = randomString();
+        final ClientConfig config = new ClientConfig();
+        config.setInstanceName(instanceName);
+
+        int clientCount = 10;
+        final List<HazelcastInstance> clients
+                = Collections.synchronizedList(new ArrayList<HazelcastInstance>(clientCount));
+        List<Future> futures = new ArrayList<Future>(clientCount);
+        for (int i = 0; i < clientCount; i++) {
+            futures.add(spawn(new Runnable() {
+                @Override
+                public void run() {
+                    clients.add(HazelcastClient.getOrCreateHazelcastClient(config));
+                }
+            }));
+        }
+        for (int i = 0; i < clientCount; i++) {
+            futures.get(i).get();
+        }
+        assertEquals(clientCount, clients.size());
+        for (int i = 1; i < clientCount; i++) {
+            assertEquals(clients.get(0), clients.get(i));
+        }
+    }
+
+    @Test
+    public void testGetHazelcastClientByName() {
+        String instanceName = randomString();
+        ClientConfig config = new ClientConfig();
+        config.setInstanceName(instanceName);
+
+        HazelcastInstance client1 = HazelcastClient.newHazelcastClient(config);
+        assertEquals(client1, HazelcastClient.getHazelcastClientByName(instanceName));
+    }
+
+    @Test(expected = DuplicateInstanceNameException.class)
+    public void testNewHazelcastClient_withSameConfig() {
+        String instanceName = randomString();
+        ClientConfig config = new ClientConfig();
+        config.setInstanceName(instanceName);
+
+        HazelcastClient.newHazelcastClient(config);
+        HazelcastClient.newHazelcastClient(config);
+    }
+
+    @Test
+    public void testGetAllHazelcastClients() {
+        ClientConfig clientConfig1 = new ClientConfig();
+        clientConfig1.setInstanceName(randomString());
+        ClientConfig clientConfig2 = new ClientConfig();
+        clientConfig2.setInstanceName(randomString());
+        HazelcastInstance client1 = HazelcastClient.newHazelcastClient(clientConfig1);
+        HazelcastInstance client2 = HazelcastClient.getOrCreateHazelcastClient(clientConfig2);
+
+        Collection<HazelcastInstance> clients = HazelcastClient.getAllHazelcastClients();
+        assertEquals(2, clients.size());
+        assertContains(clients, client1);
+        assertContains(clients, client2);
+    }
+
+    @Test
+    public void testShutdownAll() {
+        ClientConfig clientConfig1 = new ClientConfig();
+        clientConfig1.setInstanceName(randomString());
+        ClientConfig clientConfig2 = new ClientConfig();
+        clientConfig2.setInstanceName(randomString());
+        HazelcastClient.newHazelcastClient(clientConfig1);
+        HazelcastClient.getOrCreateHazelcastClient(clientConfig2);
+
+        HazelcastClient.shutdownAll();
+        assertEquals(0, HazelcastClient.getAllHazelcastClients().size());
+    }
+
+    @Test
+    public void testShutdown_withInstance() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setInstanceName(randomString());
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        HazelcastClient.shutdown(client);
+
+        assertEquals(0, HazelcastClient.getAllHazelcastClients().size());
+        assertFalse(client.getLifecycleService().isRunning());
+    }
+
+    public void testShutdown_withName() {
+        ClientConfig config = new ClientConfig();
+        String instanceName = randomString();
+        config.setInstanceName(instanceName);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
+        HazelcastClient.shutdown(instanceName);
+
+        assertEquals(0, HazelcastClient.getAllHazelcastClients().size());
+        assertFalse(client.getLifecycleService().isRunning());
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
@@ -20,11 +20,13 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.core.HazelcastInstance;
 
-import static com.hazelcast.client.HazelcastClient.newHazelcastClientInternal;
-
 public class HazelcastClientUtil {
 
     public static HazelcastInstance newHazelcastClient(AddressProvider addressProvider, ClientConfig clientConfig) {
-        return newHazelcastClientInternal(addressProvider, clientConfig, null);
+        return HazelcastClient.newHazelcastClientInternal(addressProvider, clientConfig, null);
+    }
+
+    public static String getInstanceName(ClientConfig config) {
+        return HazelcastClient.getInstanceName(config, null);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -38,6 +38,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.hazelcast.client.HazelcastClientUtil.getInstanceName;
+
 public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
     private final boolean mockNetwork = TestEnvironment.isMockNetwork();
@@ -76,8 +78,8 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
             if (tccl == ClassLoader.getSystemClassLoader()) {
                 currentThread.setContextClassLoader(HazelcastClient.class.getClassLoader());
             }
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(config, null,
-                    clientRegistry.createClientServiceFactory(), createAddressProvider(config));
+            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(getInstanceName(config), config,
+                    null, clientRegistry.createClientServiceFactory(), createAddressProvider(config));
             client.start();
             clients.add(client);
             OutOfMemoryErrorDispatcher.registerClient(client);


### PR DESCRIPTION
This PR adds the missing getOrCreate methods to the Hazelcast Client.

Backport of #16362 

fixes #16313