### PR TITLE
Avoid using on-heap indexes while indexing is in progress

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
@@ -43,6 +44,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
+import static com.hazelcast.internal.util.SetUtil.singletonPartitionIdSet;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 
@@ -113,7 +115,9 @@ public class PartitionWideEntryOperation extends MapOperation
 
         // we use the partitioned-index to operate on the selected keys only
         Indexes indexes = mapContainer.getIndexes(getPartitionId());
-        Set<QueryableEntry> entries = indexes.query(queryOptimizer.optimize(predicate, indexes));
+        int partitionCount = mapService.getMapServiceContext().getNodeEngine().getPartitionService().getPartitionCount();
+        PartitionIdSet partitions = singletonPartitionIdSet(partitionCount, getPartitionId());
+        Set<QueryableEntry> entries = indexes.query(queryOptimizer.optimize(predicate, indexes), partitions);
         if (entries == null) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
@@ -44,7 +43,6 @@ import java.util.Queue;
 import java.util.Set;
 
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
-import static com.hazelcast.internal.util.SetUtil.singletonPartitionIdSet;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 
@@ -115,9 +113,7 @@ public class PartitionWideEntryOperation extends MapOperation
 
         // we use the partitioned-index to operate on the selected keys only
         Indexes indexes = mapContainer.getIndexes(getPartitionId());
-        int partitionCount = mapService.getMapServiceContext().getNodeEngine().getPartitionService().getPartitionCount();
-        PartitionIdSet partitions = singletonPartitionIdSet(partitionCount, getPartitionId());
-        Set<QueryableEntry> entries = indexes.query(queryOptimizer.optimize(predicate, indexes), partitions);
+        Set<QueryableEntry> entries = indexes.query(queryOptimizer.optimize(predicate, indexes), 1);
         if (entries == null) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -115,7 +115,7 @@ public class QueryRunner {
 
         // then we try to run using an index, but if that doesn't work, we'll try a full table scan
         Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
-                migrationStamp, initialPartitions);
+                migrationStamp, initialPartitions.size());
 
         Result result;
         if (entries == null) {
@@ -163,7 +163,7 @@ public class QueryRunner {
 
         // then we try to run using an index
         Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
-                migrationStamp, initialPartitions);
+                migrationStamp, initialPartitions.size());
 
         Result result;
         if (entries == null) {
@@ -189,7 +189,7 @@ public class QueryRunner {
         Collection<QueryableEntry> entries = null;
         Indexes indexes = mapContainer.getIndexes(partitionId);
         if (indexes != null && !indexes.isGlobal()) {
-            entries = indexes.query(predicate, partitions);
+            entries = indexes.query(predicate, partitions.size());
         }
 
         Result result;
@@ -221,7 +221,7 @@ public class QueryRunner {
     }
 
     protected Collection<QueryableEntry> runUsingGlobalIndexSafely(Predicate predicate, MapContainer mapContainer,
-                                                                   int migrationStamp, PartitionIdSet queryPartitions) {
+                                                                   int migrationStamp, int ownedPartitionCount) {
 
         // If a migration is in progress or migration ownership changes,
         // do not attempt to use an index as they may have not been created yet.
@@ -239,7 +239,7 @@ public class QueryRunner {
             // leverage index on this node in a global way.
             return null;
         }
-        Collection<QueryableEntry> entries = indexes.query(predicate, queryPartitions);
+        Collection<QueryableEntry> entries = indexes.query(predicate, ownedPartitionCount);
         if (entries == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -114,7 +114,8 @@ public class QueryRunner {
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
 
         // then we try to run using an index, but if that doesn't work, we'll try a full table scan
-        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer, migrationStamp);
+        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
+                migrationStamp, initialPartitions);
 
         Result result;
         if (entries == null) {
@@ -161,7 +162,8 @@ public class QueryRunner {
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
 
         // then we try to run using an index
-        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer, migrationStamp);
+        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
+                migrationStamp, initialPartitions);
 
         Result result;
         if (entries == null) {
@@ -187,7 +189,7 @@ public class QueryRunner {
         Collection<QueryableEntry> entries = null;
         Indexes indexes = mapContainer.getIndexes(partitionId);
         if (indexes != null && !indexes.isGlobal()) {
-            entries = indexes.query(predicate);
+            entries = indexes.query(predicate, partitions);
         }
 
         Result result;
@@ -219,7 +221,7 @@ public class QueryRunner {
     }
 
     protected Collection<QueryableEntry> runUsingGlobalIndexSafely(Predicate predicate, MapContainer mapContainer,
-                                                                   int migrationStamp) {
+                                                                   int migrationStamp, PartitionIdSet queryPartitions) {
 
         // If a migration is in progress or migration ownership changes,
         // do not attempt to use an index as they may have not been created yet.
@@ -237,7 +239,7 @@ public class QueryRunner {
             // leverage index on this node in a global way.
             return null;
         }
-        Collection<QueryableEntry> entries = indexes.query(predicate);
+        Collection<QueryableEntry> entries = indexes.query(predicate, queryPartitions);
         if (entries == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -335,7 +335,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<K> resultingSet = new HashSet<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate, null);
+        Set<QueryableEntry> query = indexes.query(predicate, -1);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 K key = toObject(entry.getKeyData());
@@ -354,7 +354,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<Map.Entry<K, V>> resultingSet = new HashSet<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate, null);
+        Set<QueryableEntry> query = indexes.query(predicate, -1);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 Map.Entry<K, V> copyEntry = new CachedQueryEntry<>(serializationService, entry.getKeyData(),
@@ -377,7 +377,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         List<Data> resultingList = new ArrayList<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate, null);
+        Set<QueryableEntry> query = indexes.query(predicate, -1);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 resultingList.add(entry.getValueData());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -335,7 +335,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<K> resultingSet = new HashSet<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
+        Set<QueryableEntry> query = indexes.query(predicate, null);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 K key = toObject(entry.getKeyData());
@@ -354,7 +354,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<Map.Entry<K, V>> resultingSet = new HashSet<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
+        Set<QueryableEntry> query = indexes.query(predicate, null);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 Map.Entry<K, V> copyEntry = new CachedQueryEntry<>(serializationService, entry.getKeyData(),
@@ -377,7 +377,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         List<Data> resultingList = new ArrayList<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
+        Set<QueryableEntry> query = indexes.query(predicate, null);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 resultingList.add(entry.getValueData());

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -308,8 +307,8 @@ public class AttributeIndexRegistry {
         }
 
         @Override
-        public boolean allPartitionsIndexed(PartitionIdSet queryPartitions) {
-            throw newUnsupportedException();
+        public boolean allPartitionsIndexed(int ownedPartitionCount) {
+            return delegate.allPartitionsIndexed(ownedPartitionCount);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -303,6 +304,11 @@ public class AttributeIndexRegistry {
 
         @Override
         public boolean hasPartitionIndexed(int partitionId) {
+            throw newUnsupportedException();
+        }
+
+        @Override
+        public boolean allPartitionsIndexed(PartitionIdSet queryPartitions) {
             throw newUnsupportedException();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,8 +53,8 @@ public class GlobalQueryContextWithStats extends QueryContext {
     }
 
     @Override
-    public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        InternalIndex delegate = indexes.matchIndex(pattern, matchHint);
+    public Index matchIndex(String pattern, IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
+        InternalIndex delegate = indexes.matchIndex(pattern, matchHint, queryPartitions);
         if (delegate == null) {
             return null;
         }
@@ -171,6 +172,11 @@ public class GlobalQueryContextWithStats extends QueryContext {
         @Override
         public boolean hasPartitionIndexed(int partitionId) {
             return delegate.hasPartitionIndexed(partitionId);
+        }
+
+        @Override
+        public boolean allPartitionsIndexed(PartitionIdSet queryPartitions) {
+            return delegate.allPartitionsIndexed(queryPartitions);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,8 +52,8 @@ public class GlobalQueryContextWithStats extends QueryContext {
     }
 
     @Override
-    public Index matchIndex(String pattern, IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
-        InternalIndex delegate = indexes.matchIndex(pattern, matchHint, queryPartitions);
+    public Index matchIndex(String pattern, IndexMatchHint matchHint, int ownedPartitionCount) {
+        InternalIndex delegate = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (delegate == null) {
             return null;
         }
@@ -175,8 +174,8 @@ public class GlobalQueryContextWithStats extends QueryContext {
         }
 
         @Override
-        public boolean allPartitionsIndexed(PartitionIdSet queryPartitions) {
-            return delegate.allPartitionsIndexed(queryPartitions);
+        public boolean allPartitionsIndexed(int ownedPartitionCount) {
+            return delegate.allPartitionsIndexed(ownedPartitionCount);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -17,9 +17,8 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.config.IndexConfig;
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.getters.Extractors;
 
 import java.util.Set;
@@ -61,11 +60,11 @@ public class IndexImpl extends AbstractIndex {
     }
 
     @Override
-    public boolean allPartitionsIndexed(PartitionIdSet queryPartitions) {
+    public boolean allPartitionsIndexed(int ownedPartitionCount) {
         // This check guarantees that all partitions are indexed
         // only if there is no concurrent migrations. Check migration stamp
         // to detect concurrent migrations if needed.
-        return indexedPartitions.size() == queryPartitions.size();
+        return ownedPartitionCount < 0 || indexedPartitions.size() == ownedPartitionCount;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.query.impl;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.getters.Extractors;
 
 import java.util.Set;
@@ -57,6 +58,14 @@ public class IndexImpl extends AbstractIndex {
     @Override
     public boolean hasPartitionIndexed(int partitionId) {
         return indexedPartitions.contains(partitionId);
+    }
+
+    @Override
+    public boolean allPartitionsIndexed(PartitionIdSet queryPartitions) {
+        // This check guarantees that all partitions are indexed
+        // only if there is no concurrent migrations. Check migration stamp
+        // to detect concurrent migrations if needed.
+        return indexedPartitions.size() == queryPartitions.size();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -19,14 +19,13 @@ package com.hazelcast.query.impl;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.TypeConverter;
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
-import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.internal.monitor.impl.GlobalIndexesStats;
 import com.hazelcast.internal.monitor.impl.IndexesStats;
 import com.hazelcast.internal.monitor.impl.PartitionIndexesStats;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
@@ -123,12 +122,12 @@ public class Indexes {
         }
 
         index = indexProvider.createIndex(
-            indexConfig,
-            extractors,
-            serializationService,
-            indexCopyBehavior,
-            stats.createPerIndexStats(indexConfig.getType() == IndexType.SORTED, usesCachedQueryableEntries),
-            partitionStoreAdapter
+                indexConfig,
+                extractors,
+                serializationService,
+                indexCopyBehavior,
+                stats.createPerIndexStats(indexConfig.getType() == IndexType.SORTED, usesCachedQueryableEntries),
+                partitionStoreAdapter
         );
 
         indexesByName.put(name, index);
@@ -303,12 +302,14 @@ public class Indexes {
     /**
      * Performs a query on this indexes instance using the given predicate.
      *
-     * @param predicate the predicate to evaluate.
+     * @param predicate           the predicate to evaluate.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
      * @return the produced result set or {@code null} if the query can't be
      * performed using the indexes known to this indexes instance.
      */
     @SuppressWarnings("unchecked")
-    public Set<QueryableEntry> query(Predicate predicate, PartitionIdSet queryPartitions) {
+    public Set<QueryableEntry> query(Predicate predicate, int ownedPartitionCount) {
         stats.incrementQueryCount();
 
         if (!haveAtLeastOneIndex() || !(predicate instanceof IndexAwarePredicate)) {
@@ -317,11 +318,11 @@ public class Indexes {
 
         IndexAwarePredicate indexAwarePredicate = (IndexAwarePredicate) predicate;
         QueryContext queryContext = queryContextProvider.obtainContextFor(this);
-        if (!indexAwarePredicate.isIndexed(queryContext, queryPartitions)) {
+        if (!indexAwarePredicate.isIndexed(queryContext, ownedPartitionCount)) {
             return null;
         }
 
-        Set<QueryableEntry> result = indexAwarePredicate.filter(queryContext, queryPartitions);
+        Set<QueryableEntry> result = indexAwarePredicate.filter(queryContext, ownedPartitionCount);
         if (result != null) {
             stats.incrementIndexedQueryCount();
             queryContext.applyPerQueryStats();
@@ -333,22 +334,24 @@ public class Indexes {
     /**
      * Matches an index for the given pattern and match hint.
      *
-     * @param pattern   the pattern to match an index for. May be either an
-     *                  attribute name or an exact index name.
-     * @param matchHint the match hint.
+     * @param pattern             the pattern to match an index for. May be either an
+     *                            attribute name or an exact index name.
+     * @param matchHint           the match hint.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
      * @return the matched index or {@code null} if nothing matched.
      * @see QueryContext.IndexMatchHint
      * @see Indexes#matchIndex
      */
-    public InternalIndex matchIndex(String pattern, QueryContext.IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
+    public InternalIndex matchIndex(String pattern, QueryContext.IndexMatchHint matchHint, int ownedPartitionCount) {
         InternalIndex index;
         if (matchHint == QueryContext.IndexMatchHint.EXACT_NAME) {
-            index =  indexesByName.get(pattern);
+            index = indexesByName.get(pattern);
         } else {
             index = attributeIndexRegistry.match(pattern, matchHint);
         }
 
-        if (index == null || queryPartitions != null && !index.allPartitionsIndexed(queryPartitions)) {
+        if (index == null || !index.allPartitionsIndexed(ownedPartitionCount)) {
             return null;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -17,7 +17,6 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 /**
  * Provides the private index API.
@@ -45,9 +44,17 @@ public interface InternalIndex extends Index {
     /**
      * Returns {@code true} if all {@code queryPartitions} are indexed,
      * {@code false} otherwise.
-     * @param queryPartitions a set of partitions a query runs on.
+     * <p>
+     * The method is used to check whether a global index is still being constructed concurrently
+     * so that some partitions are not indexed and query may suffer from entry misses.
+     * If the index construction is still in progress, a query optimizer ignores the index.
+     * <p>
+     * The aforementioned race condition is not relevant to local off-heap indexes,
+     * since index construction is performed in partition-threads.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     * Negative value indicates that the value is not defined.
      */
-    boolean allPartitionsIndexed(PartitionIdSet queryPartitions);
+    boolean allPartitionsIndexed(int ownedPartitionCount);
 
     /**
      * Marks the given partition as indexed by this index.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 /**
  * Provides the private index API.
@@ -40,6 +41,13 @@ public interface InternalIndex extends Index {
      * {@code false} otherwise.
      */
     boolean hasPartitionIndexed(int partitionId);
+
+    /**
+     * Returns {@code true} if all {@code queryPartitions} are indexed,
+     * {@code false} otherwise.
+     * @param queryPartitions a set of partitions a query runs on.
+     */
+    boolean allPartitionsIndexed(PartitionIdSet queryPartitions);
 
     /**
      * Marks the given partition as indexed by this index.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.HashSet;
 
@@ -54,8 +55,8 @@ public class PartitionQueryContextWithStats extends QueryContext {
     }
 
     @Override
-    public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        InternalIndex index = indexes.matchIndex(pattern, matchHint);
+    public Index matchIndex(String pattern, IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
+        InternalIndex index = indexes.matchIndex(pattern, matchHint, queryPartitions);
         if (index == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -17,7 +17,6 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.HashSet;
 
@@ -55,8 +54,8 @@ public class PartitionQueryContextWithStats extends QueryContext {
     }
 
     @Override
-    public Index matchIndex(String pattern, IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
-        InternalIndex index = indexes.matchIndex(pattern, matchHint, queryPartitions);
+    public Index matchIndex(String pattern, IndexMatchHint matchHint, int ownedPartitionCount) {
+        InternalIndex index = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (index == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder;
@@ -90,19 +89,19 @@ public class PredicateBuilderImpl implements PredicateBuilder, EntryObject, Inde
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
         Predicate p = lsPredicates.get(0);
         if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).filter(queryContext, queryPartitions);
+            return ((IndexAwarePredicate) p).filter(queryContext, ownedPartitionCount);
         }
         return null;
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         Predicate p = lsPredicates.get(0);
         if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).isIndexed(queryContext, queryPartitions);
+            return ((IndexAwarePredicate) p).isIndexed(queryContext, ownedPartitionCount);
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -89,19 +90,19 @@ public class PredicateBuilderImpl implements PredicateBuilder, EntryObject, Inde
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
         Predicate p = lsPredicates.get(0);
         if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).filter(queryContext);
+            return ((IndexAwarePredicate) p).filter(queryContext, queryPartitions);
         }
         return null;
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         Predicate p = lsPredicates.get(0);
         if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).isIndexed(queryContext);
+            return ((IndexAwarePredicate) p).isIndexed(queryContext, queryPartitions);
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
+
 /**
  * Provides the context for queries execution.
  */
@@ -62,8 +64,8 @@ public class QueryContext {
      * @return the obtained index or {@code null} if there is no index available
      * for the given attribute.
      */
-    public Index getIndex(String attribute) {
-        return matchIndex(attribute, IndexMatchHint.NONE);
+    public Index getIndex(String attribute, PartitionIdSet queryPartitions) {
+        return matchIndex(attribute, IndexMatchHint.NONE, queryPartitions);
     }
 
     /**
@@ -75,8 +77,8 @@ public class QueryContext {
      * @return the matched index or {@code null} if nothing matched.
      * @see QueryContext.IndexMatchHint
      */
-    public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        return indexes.matchIndex(pattern, matchHint);
+    public Index matchIndex(String pattern, IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
+        return indexes.matchIndex(pattern, matchHint, queryPartitions);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
-
 /**
  * Provides the context for queries execution.
  */
@@ -61,11 +59,13 @@ public class QueryContext {
      * context.
      *
      * @param attribute the attribute to obtain the index for.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     * Negative value indicates that the value is not defined.
      * @return the obtained index or {@code null} if there is no index available
      * for the given attribute.
      */
-    public Index getIndex(String attribute, PartitionIdSet queryPartitions) {
-        return matchIndex(attribute, IndexMatchHint.NONE, queryPartitions);
+    public Index getIndex(String attribute, int ownedPartitionCount) {
+        return matchIndex(attribute, IndexMatchHint.NONE, ownedPartitionCount);
     }
 
     /**
@@ -74,11 +74,13 @@ public class QueryContext {
      * @param pattern   the pattern to match an index for. May be either an
      *                  attribute name or an exact index name.
      * @param matchHint the match hint.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     * Negative value indicates that the value is not defined.
      * @return the matched index or {@code null} if nothing matched.
      * @see QueryContext.IndexMatchHint
      */
-    public Index matchIndex(String pattern, IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
-        return indexes.matchIndex(pattern, matchHint, queryPartitions);
+    public Index matchIndex(String pattern, IndexMatchHint matchHint, int ownedPartitionCount) {
+        return indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.internal.serialization.BinaryInterface;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 
@@ -30,17 +31,17 @@ public abstract class AbstractIndexAwarePredicate<K, V> extends AbstractPredicat
         super(attributeName);
     }
 
-    protected Index getIndex(QueryContext queryContext) {
-        return matchIndex(queryContext, QueryContext.IndexMatchHint.NONE);
+    protected Index getIndex(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        return matchIndex(queryContext, QueryContext.IndexMatchHint.NONE, queryPartitions);
     }
 
-    protected Index matchIndex(QueryContext queryContext, QueryContext.IndexMatchHint matchHint) {
-        return queryContext.matchIndex(attributeName, matchHint);
+    protected Index matchIndex(QueryContext queryContext, QueryContext.IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
+        return queryContext.matchIndex(attributeName, matchHint, queryPartitions);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
-        return getIndex(queryContext) != null;
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        return getIndex(queryContext, queryPartitions) != null;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -17,7 +17,6 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.internal.serialization.BinaryInterface;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 
@@ -31,17 +30,17 @@ public abstract class AbstractIndexAwarePredicate<K, V> extends AbstractPredicat
         super(attributeName);
     }
 
-    protected Index getIndex(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        return matchIndex(queryContext, QueryContext.IndexMatchHint.NONE, queryPartitions);
+    protected Index getIndex(QueryContext queryContext, int ownedPartitionCount) {
+        return matchIndex(queryContext, QueryContext.IndexMatchHint.NONE, ownedPartitionCount);
     }
 
-    protected Index matchIndex(QueryContext queryContext, QueryContext.IndexMatchHint matchHint, PartitionIdSet queryPartitions) {
-        return queryContext.matchIndex(attributeName, matchHint, queryPartitions);
+    protected Index matchIndex(QueryContext queryContext, QueryContext.IndexMatchHint matchHint, int ownedPartitionCount) {
+        return queryContext.matchIndex(attributeName, matchHint, ownedPartitionCount);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        return getIndex(queryContext, queryPartitions) != null;
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+        return getIndex(queryContext, ownedPartitionCount) != null;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
@@ -69,8 +68,8 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate implements Vis
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, ownedPartitionCount);
         return index.getRecords(from, true, to, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -68,8 +69,8 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate implements Vis
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, queryPartitions);
         return index.getRecords(from, true, to, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
@@ -65,8 +66,8 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, queryPartitions);
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
@@ -66,8 +65,8 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, ownedPartitionCount);
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CompositeValue;
 import com.hazelcast.query.impl.Index;
@@ -80,8 +81,8 @@ public class CompositeEqualPredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, queryPartitions);
         return index.getRecords(value);
     }
 
@@ -91,7 +92,7 @@ public class CompositeEqualPredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CompositeValue;
 import com.hazelcast.query.impl.Index;
@@ -81,8 +80,8 @@ public class CompositeEqualPredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, ownedPartitionCount);
         return index.getRecords(value);
     }
 
@@ -92,7 +91,7 @@ public class CompositeEqualPredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CompositeValue;
 import com.hazelcast.query.impl.Index;
@@ -116,13 +115,13 @@ public class CompositeRangePredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, ownedPartitionCount);
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CompositeValue;
 import com.hazelcast.query.impl.Index;
@@ -115,13 +116,13 @@ public class CompositeRangePredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, queryPartitions);
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
@@ -55,8 +54,8 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, ownedPartitionCount);
         return index.getRecords(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -54,8 +55,8 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, queryPartitions);
         return index.getRecords(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FalsePredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -54,12 +55,12 @@ public class FalsePredicate<K, V> implements IdentifiedDataSerializable, IndexAw
     }
 
     @Override
-    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
         return Collections.emptySet();
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FalsePredicate.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -55,12 +54,12 @@ public class FalsePredicate<K, V> implements IdentifiedDataSerializable, IndexAw
     }
 
     @Override
-    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount) {
         return Collections.emptySet();
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Comparison;
@@ -69,8 +68,8 @@ public final class GreaterLessPredicate extends AbstractIndexAwarePredicate impl
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, ownedPartitionCount);
         final Comparison comparison;
         if (less) {
             comparison = equal ? Comparison.LESS_OR_EQUAL : Comparison.LESS;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -68,8 +69,8 @@ public final class GreaterLessPredicate extends AbstractIndexAwarePredicate impl
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, queryPartitions);
         final Comparison comparison;
         if (less) {
             comparison = equal ? Comparison.LESS_OR_EQUAL : Comparison.LESS;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -72,8 +73,8 @@ public class InPredicate extends AbstractIndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, queryPartitions);
         if (index != null) {
             return index.getRecords(values);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
@@ -73,8 +72,8 @@ public class InPredicate extends AbstractIndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, ownedPartitionCount);
         if (index != null) {
             return index.getRecords(values);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/IndexAwarePredicate.java
@@ -17,7 +17,6 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.internal.serialization.BinaryInterface;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -60,21 +59,25 @@ public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
      * The query engine assumes this method produces the result set faster than
      * a simple evaluation of the predicate on every entry.
      *
-     * @param queryContext the query context to access the indexes. The passed
-     *                     query context is valid only for a duration of a single
-     *                     call to the method.
+     * @param queryContext        the query context to access the indexes. The passed
+     *                            query context is valid only for a duration of a single
+     *                            call to the method.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
      * @return the produced filtered entry set.
      */
-    Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions);
+    Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount);
 
     /**
      * Signals to the query engine that this predicate is able to utilize the
      * indexes available while executing the query in the given query context.
      *
-     * @param queryContext the query context to consult for the available
-     *                     indexes.
+     * @param queryContext        the query context to consult for the available
+     *                            indexes.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
      * @return {@code true} if this predicate is able to use the indexes to
      * speed up the processing, {@code false} otherwise.
      */
-    boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions);
+    boolean isIndexed(QueryContext queryContext, int ownedPartitionCount);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/IndexAwarePredicate.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.internal.serialization.BinaryInterface;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -64,7 +65,7 @@ public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
      *                     call to the method.
      * @return the produced filtered entry set.
      */
-    Set<QueryableEntry<K, V>> filter(QueryContext queryContext);
+    Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions);
 
     /**
      * Signals to the query engine that this predicate is able to utilize the
@@ -75,5 +76,5 @@ public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
      * @return {@code true} if this predicate is able to use the indexes to
      * speed up the processing, {@code false} otherwise.
      */
-    boolean isIndexed(QueryContext queryContext);
+    boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Indexes;
@@ -56,13 +55,13 @@ public final class OrPredicate
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
         List<Set<QueryableEntry>> indexedResults = new LinkedList<Set<QueryableEntry>>();
         for (Predicate predicate : predicates) {
             if (predicate instanceof IndexAwarePredicate) {
                 IndexAwarePredicate iap = (IndexAwarePredicate) predicate;
-                if (iap.isIndexed(queryContext, queryPartitions)) {
-                    Set<QueryableEntry> s = iap.filter(queryContext, queryPartitions);
+                if (iap.isIndexed(queryContext, ownedPartitionCount)) {
+                    Set<QueryableEntry> s = iap.filter(queryContext, ownedPartitionCount);
                     if (s != null) {
                         indexedResults.add(s);
                     }
@@ -75,11 +74,11 @@ public final class OrPredicate
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         for (Predicate predicate : predicates) {
             if (predicate instanceof IndexAwarePredicate) {
                 IndexAwarePredicate iap = (IndexAwarePredicate) predicate;
-                if (!iap.isIndexed(queryContext, queryPartitions)) {
+                if (!iap.isIndexed(queryContext, ownedPartitionCount)) {
                     return false;
                 }
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -55,13 +56,13 @@ public final class OrPredicate
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
         List<Set<QueryableEntry>> indexedResults = new LinkedList<Set<QueryableEntry>>();
         for (Predicate predicate : predicates) {
             if (predicate instanceof IndexAwarePredicate) {
                 IndexAwarePredicate iap = (IndexAwarePredicate) predicate;
-                if (iap.isIndexed(queryContext)) {
-                    Set<QueryableEntry> s = iap.filter(queryContext);
+                if (iap.isIndexed(queryContext, queryPartitions)) {
+                    Set<QueryableEntry> s = iap.filter(queryContext, queryPartitions);
                     if (s != null) {
                         indexedResults.add(s);
                     }
@@ -74,11 +75,11 @@ public final class OrPredicate
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         for (Predicate predicate : predicates) {
             if (predicate instanceof IndexAwarePredicate) {
                 IndexAwarePredicate iap = (IndexAwarePredicate) predicate;
-                if (!iap.isIndexed(queryContext)) {
+                if (!iap.isIndexed(queryContext, queryPartitions)) {
                     return false;
                 }
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -183,12 +184,12 @@ public class PagingPredicateImpl<K, V>
      * @return
      */
     @Override
-    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
         if (!(predicate instanceof IndexAwarePredicate)) {
             return null;
         }
 
-        Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext);
+        Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext, queryPartitions);
         if (set == null || set.isEmpty()) {
             return set;
         }
@@ -212,9 +213,9 @@ public class PagingPredicateImpl<K, V>
      * @param queryContext
      * @return
      */
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         if (predicate instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) predicate).isIndexed(queryContext);
+            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, queryPartitions);
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -16,18 +16,17 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
+import com.hazelcast.internal.util.IterationType;
+import com.hazelcast.internal.util.SortingUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.internal.util.IterationType;
-import com.hazelcast.internal.util.SortingUtil;
 
 import java.io.IOException;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -184,12 +183,12 @@ public class PagingPredicateImpl<K, V>
      * @return
      */
     @Override
-    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount) {
         if (!(predicate instanceof IndexAwarePredicate)) {
             return null;
         }
 
-        Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext, queryPartitions);
+        Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext, ownedPartitionCount);
         if (set == null || set.isEmpty()) {
             return set;
         }
@@ -213,9 +212,9 @@ public class PagingPredicateImpl<K, V>
      * @param queryContext
      * @return
      */
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         if (predicate instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, queryPartitions);
+            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, ownedPartitionCount);
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
@@ -91,16 +92,16 @@ public class SqlPredicate
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
         if (predicate instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) predicate).isIndexed(queryContext);
+            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, queryPartitions);
         }
         return false;
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        return ((IndexAwarePredicate) predicate).filter(queryContext);
+    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        return ((IndexAwarePredicate) predicate).filter(queryContext, queryPartitions);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -16,17 +16,16 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.internal.serialization.BinaryInterface;
+import com.hazelcast.internal.util.collection.ArrayUtils;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.internal.util.collection.ArrayUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -92,16 +91,16 @@ public class SqlPredicate
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
         if (predicate instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, queryPartitions);
+            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, ownedPartitionCount);
         }
         return false;
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        return ((IndexAwarePredicate) predicate).filter(queryContext, queryPartitions);
+    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        return ((IndexAwarePredicate) predicate).filter(queryContext, ownedPartitionCount);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.config.IndexType;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.map.EntryProcessor;
@@ -162,12 +163,12 @@ public class ClientEntryProcessorTest extends AbstractClientMapTest {
         static final AtomicBoolean INDEX_CALLED = new AtomicBoolean(false);
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext) {
+        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext) {
+        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
             INDEX_CALLED.set(true);
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
@@ -17,10 +17,9 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.config.IndexType;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
-import com.hazelcast.map.IMap;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -163,12 +162,12 @@ public class ClientEntryProcessorTest extends AbstractClientMapTest {
         static final AtomicBoolean INDEX_CALLED = new AtomicBoolean(false);
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
             INDEX_CALLED.set(true);
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MultipleEntryWithPredicateOperation;
@@ -1291,13 +1292,13 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext) {
-            Index index = queryContext.getIndex(attributeName);
+        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+            Index index = queryContext.getIndex(attributeName, queryPartitions);
             return index.getRecords(key);
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext) {
+        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
             return true;
         }
 
@@ -1426,12 +1427,12 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
+        public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext) {
+        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
             indexCalled.set(true);
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MultipleEntryWithPredicateOperation;
@@ -1292,13 +1291,13 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-            Index index = queryContext.getIndex(attributeName, queryPartitions);
+        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+            Index index = queryContext.getIndex(attributeName, ownedPartitionCount);
             return index.getRecords(key);
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
             return true;
         }
 
@@ -1427,12 +1426,12 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
             indexCalled.set(true);
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
@@ -43,14 +42,14 @@ class TestPredicate implements IndexAwarePredicate<String, TestData> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Set<QueryableEntry<String, TestData>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+    public Set<QueryableEntry<String, TestData>> filter(QueryContext queryContext, int ownedPartitionCount) {
         filtered = true;
-        return (Set) queryContext.getIndex("attr1", queryPartitions).getRecords(value);
+        return (Set) queryContext.getIndex("attr1", ownedPartitionCount).getRecords(value);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
-        return queryContext.getIndex("attr1", queryPartitions) != null;
+    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+        return queryContext.getIndex("attr1", ownedPartitionCount) != null;
     }
 
     boolean isFilteredAndApplied(int times) {

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
@@ -42,14 +43,14 @@ class TestPredicate implements IndexAwarePredicate<String, TestData> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Set<QueryableEntry<String, TestData>> filter(QueryContext queryContext) {
+    public Set<QueryableEntry<String, TestData>> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
         filtered = true;
-        return (Set) queryContext.getIndex("attr1").getRecords(value);
+        return (Set) queryContext.getIndex("attr1", queryPartitions).getRecords(value);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext) {
-        return queryContext.getIndex("attr1") != null;
+    public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        return queryContext.getIndex("attr1", queryPartitions) != null;
     }
 
     boolean isFilteredAndApplied(int times) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -67,7 +67,11 @@ public class RecordStoreTest extends HazelcastTestSupport {
     public void testRecordStoreResetWithoutClearingIndexes() {
         IMap<Object, Object> map = testRecordStoreReset();
         Collection<Object> values = map.values(Predicates.equal("name", "tom"));
-        assertFalse(values.isEmpty());
+        // Although, on record store reset we don't destroy indexes, we still mark partition as
+        // "unindexed" in the IndexingMutationObserver#clearGlobalIndexes. Since introduction of
+        // indexes consistency check (before using them for query), we don't use incomplete indexes
+        // for query. Thus, the below query ignores the indexes and uses record store to run the query.
+        assertTrue(values.isEmpty());
     }
 
     private IMap<Object, Object> testRecordStoreReset() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
@@ -28,7 +29,6 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapContainer;
@@ -141,8 +142,8 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext) {
-            Index ix = queryContext.getIndex("age");
+        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+            Index ix = queryContext.getIndex("age", queryPartitions);
             if (ix != null) {
                 return ix.getRecords(Comparison.GREATER, 50);
             } else {
@@ -151,8 +152,8 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext) {
-            Index ix = queryContext.getIndex("age");
+        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+            Index ix = queryContext.getIndex("age", queryPartitions);
             if (ix != null) {
                 isIndexedInvocationCounter.incrementAndGet();
                 return true;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapContainer;
@@ -142,8 +141,8 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
-            Index ix = queryContext.getIndex("age", queryPartitions);
+        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+            Index ix = queryContext.getIndex("age", ownedPartitionCount);
             if (ix != null) {
                 return ix.getRecords(Comparison.GREATER, 50);
             } else {
@@ -152,8 +151,8 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
-            Index ix = queryContext.getIndex("age", queryPartitions);
+        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+            Index ix = queryContext.getIndex("age", ownedPartitionCount);
             if (ix != null) {
                 isIndexedInvocationCounter.incrementAndGet();
                 return true;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
@@ -349,12 +348,12 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
@@ -348,12 +349,12 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext) {
+        public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext) {
+        public boolean isIndexed(QueryContext queryContext, PartitionIdSet queryPartitions) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.internal.serialization.Data;
@@ -112,10 +113,10 @@ public class QueryRunnerTest extends HazelcastTestSupport {
 
         Predicate predicate = new EqualPredicate("this", value) {
             @Override
-            public Set<QueryableEntry> filter(QueryContext queryContext) {
+            public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
                 // start a new migration while executing an indexed query
                 mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
-                return super.filter(queryContext);
+                return super.filter(queryContext, queryPartitions);
             }
         };
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.internal.serialization.Data;
@@ -113,10 +112,10 @@ public class QueryRunnerTest extends HazelcastTestSupport {
 
         Predicate predicate = new EqualPredicate("this", value) {
             @Override
-            public Set<QueryableEntry> filter(QueryContext queryContext, PartitionIdSet queryPartitions) {
+            public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
                 // start a new migration while executing an indexed query
                 mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
-                return super.filter(queryContext, queryPartitions);
+                return super.filter(queryContext, ownedPartitionCount);
             }
         };
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.IndexType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public abstract class AbstractIndexConcurrencyTest extends HazelcastTestSupport {
+
+    private static final int QUERY_THREADS_NUM = 5;
+
+    @Before
+    public void setUp() {
+        // by default disable awaiting on latch
+        Person.accessCountDown = null;
+    }
+
+    @Test
+    public void testIndexCreationAndQueryConcurrency() throws InterruptedException {
+        Config config = getConfig();
+
+        HazelcastInstance node = createHazelcastInstance(config);
+        IMap<Integer, Person> map = node.getMap(randomMapName());
+
+        // put some data
+        for (int i = 0; i < 10000; ++i) {
+            map.put(i, new Person(i));
+        }
+
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+
+        // run index creation and queries concurrently
+        Thread[] threads = new Thread[QUERY_THREADS_NUM + 1];
+
+        threads[0] = new Thread(() -> {
+            try {
+                map.addIndex(IndexType.SORTED, "age");
+            } catch (Throwable t) {
+                exception.compareAndSet(null, t);
+            }
+        });
+        threads[0].start();
+
+        for (int i = 1; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    Collection<Person> persons = map.values(new SqlPredicate("age >= 5000"));
+                    assertEquals(5000, persons.size());
+                } catch (Throwable t) {
+                    exception.compareAndSet(null, t);
+                }
+            });
+            threads[i].start();
+        }
+
+        // wait for for all threads to finish
+        for (int i = 0; i < threads.length; ++i) {
+            threads[i].join();
+        }
+
+        // assert no unexpected exceptions
+        assertNull(exception.get());
+    }
+
+    static class Person implements Serializable {
+
+        static AtomicLong accessCountDown;
+        static final CountDownLatch indexerLatch = new CountDownLatch(1);
+        static final CountDownLatch queryLatch = new CountDownLatch(1);
+
+        public final Integer age;
+
+        Person(Integer value) {
+            this.age = value;
+        }
+
+        public Integer getAge() {
+            if (accessCountDown != null && accessCountDown.decrementAndGet() <= 0) {
+                queryLatch.countDown();
+                assertOpenEventually(indexerLatch);
+            }
+            return age;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
@@ -60,14 +60,14 @@ public class FalsePredicateTest extends HazelcastTestSupport {
     public void isIndexed() {
         QueryContext queryContext = mock(QueryContext.class);
 
-        assertTrue(FalsePredicate.INSTANCE.isIndexed(queryContext));
+        assertTrue(FalsePredicate.INSTANCE.isIndexed(queryContext, null));
     }
 
     @Test
     public void filter() {
         QueryContext queryContext = mock(QueryContext.class);
 
-        Set<QueryableEntry> result = FalsePredicate.INSTANCE.filter(queryContext);
+        Set<QueryableEntry> result = FalsePredicate.INSTANCE.filter(queryContext, null);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
@@ -60,14 +60,14 @@ public class FalsePredicateTest extends HazelcastTestSupport {
     public void isIndexed() {
         QueryContext queryContext = mock(QueryContext.class);
 
-        assertTrue(FalsePredicate.INSTANCE.isIndexed(queryContext, null));
+        assertTrue(FalsePredicate.INSTANCE.isIndexed(queryContext, -1));
     }
 
     @Test
     public void filter() {
         QueryContext queryContext = mock(QueryContext.class);
 
-        Set<QueryableEntry> result = FalsePredicate.INSTANCE.filter(queryContext, null);
+        Set<QueryableEntry> result = FalsePredicate.INSTANCE.filter(queryContext, -1);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.IndexType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.query.impl.predicates.BoundedRangePredicateQueriesTest.Person;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class IndexConcurrencyTest extends HazelcastTestSupport {
+
+    private static final int QUERY_THREADS_NUM = 5;
+
+    @Test
+    public void testIndexCreationAndQueryConcurrency() throws InterruptedException {
+        String mapName = randomMapName();
+
+        Config config = smallInstanceConfig();
+
+        HazelcastInstance node = createHazelcastInstance(config);
+        IMap<Integer, Person> map = node.getMap("persons");
+
+        // put some data
+        for (int i = 0; i < 10000; ++i) {
+            map.put(i, new Person(i));
+        }
+
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+
+        // run index creation and queries concurrently
+        Thread[] threads = new Thread[QUERY_THREADS_NUM + 1];
+
+        threads[0] = new Thread(() -> {
+            try {
+                map.addIndex(IndexType.SORTED, "age");
+            } catch (Throwable t) {
+                exception.compareAndSet(null, t);
+            }
+        });
+        threads[0].start();
+
+        for (int i = 1; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    Collection<Person> persons = map.values(new SqlPredicate("age >= 5000"));
+                    assertEquals(5000, persons.size());
+                } catch (Throwable t) {
+                    exception.compareAndSet(null, t);
+                }
+            });
+            threads[i].start();
+        }
+
+        // wait for for all threads to finish
+        for (int i = 0; i < threads.length; ++i) {
+            threads[i].join();
+        }
+
+        // assert no unexpected exceptions
+        assertNull(exception.get());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -78,9 +78,9 @@ public class IndexJsonTest {
         assertEquals(0, numberIndex.getRecords(-1).size());
         assertEquals(1001, stringIndex.getRecords("sancar").size());
         assertEquals(501, boolIndex.getRecords(true).size());
-        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true"))).size());
-        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true))).size());
-        assertEquals(1001, is.query(Predicates.sql("name == sancar")).size());
+        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true")), null).size());
+        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true)), null).size());
+        assertEquals(1001, is.query(Predicates.sql("name == sancar"), null).size());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -78,9 +78,9 @@ public class IndexJsonTest {
         assertEquals(0, numberIndex.getRecords(-1).size());
         assertEquals(1001, stringIndex.getRecords("sancar").size());
         assertEquals(501, boolIndex.getRecords(true).size());
-        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true")), null).size());
-        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true)), null).size());
-        assertEquals(1001, is.query(Predicates.sql("name == sancar"), null).size());
+        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true")), -1).size());
+        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true)), -1).size());
+        assertEquals(1001, is.query(Predicates.sql("name == sancar"), -1).size());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -184,9 +184,9 @@ public class IndexTest {
         assertEquals(401, dIndex.getRecords(Comparison.GREATER_OR_EQUAL, 600d).size());
         assertEquals(9, dIndex.getRecords(Comparison.LESS, 10d).size());
         assertEquals(10, dIndex.getRecords(Comparison.LESS_OR_EQUAL, 10d).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false"))).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE))).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false))).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")), null).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)), null).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)), null).size());
     }
 
     private void clearIndexes(Index... indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -184,9 +184,9 @@ public class IndexTest {
         assertEquals(401, dIndex.getRecords(Comparison.GREATER_OR_EQUAL, 600d).size());
         assertEquals(9, dIndex.getRecords(Comparison.LESS, 10d).size());
         assertEquals(10, dIndex.getRecords(Comparison.LESS_OR_EQUAL, 10d).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")), null).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)), null).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)), null).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")), -1).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)), -1).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)), -1).size());
     }
 
     private void clearIndexes(Index... indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -87,7 +87,7 @@ public class IndexesTest {
         EntryObject entryObject = Predicates.newPredicateBuilder().getEntryObject();
         PredicateBuilder predicate =
                 entryObject.get("name").equal("0Name").and(entryObject.get("age").in(ages.toArray(new String[0])));
-        Set<QueryableEntry> results = indexes.query(predicate);
+        Set<QueryableEntry> results = indexes.query(predicate, null);
         assertEquals(1, results.size());
     }
 
@@ -105,7 +105,7 @@ public class IndexesTest {
 
         for (int i = 0; i < 10; i++) {
             Predicate predicate = Predicates.sql("salary=161 and age >20 and age <23");
-            Set<QueryableEntry> results = new HashSet<>(indexes.query(predicate));
+            Set<QueryableEntry> results = new HashSet<>(indexes.query(predicate, null));
             assertEquals(5, results.size());
         }
     }
@@ -132,7 +132,7 @@ public class IndexesTest {
                 Index.OperationSource.USER);
         indexes.putEntry(new QueryEntry(serializationService, toData(9), new Value("qwx"), newExtractor()), null,
                 Index.OperationSource.USER);
-        assertEquals(8, new HashSet<>(indexes.query(Predicates.sql("name > 'aac'"))).size());
+        assertEquals(8, new HashSet<>(indexes.query(Predicates.sql("name > 'aac'"), null)).size());
     }
 
     protected Extractors newExtractor() {
@@ -166,7 +166,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "));
+        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), null);
 
         assertNull("There should be no result", query);
     }
@@ -182,7 +182,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "));
+        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), null);
 
         assertEquals(89, query.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -87,7 +87,7 @@ public class IndexesTest {
         EntryObject entryObject = Predicates.newPredicateBuilder().getEntryObject();
         PredicateBuilder predicate =
                 entryObject.get("name").equal("0Name").and(entryObject.get("age").in(ages.toArray(new String[0])));
-        Set<QueryableEntry> results = indexes.query(predicate, null);
+        Set<QueryableEntry> results = indexes.query(predicate, -1);
         assertEquals(1, results.size());
     }
 
@@ -105,7 +105,7 @@ public class IndexesTest {
 
         for (int i = 0; i < 10; i++) {
             Predicate predicate = Predicates.sql("salary=161 and age >20 and age <23");
-            Set<QueryableEntry> results = new HashSet<>(indexes.query(predicate, null));
+            Set<QueryableEntry> results = new HashSet<>(indexes.query(predicate, -1));
             assertEquals(5, results.size());
         }
     }
@@ -132,7 +132,7 @@ public class IndexesTest {
                 Index.OperationSource.USER);
         indexes.putEntry(new QueryEntry(serializationService, toData(9), new Value("qwx"), newExtractor()), null,
                 Index.OperationSource.USER);
-        assertEquals(8, new HashSet<>(indexes.query(Predicates.sql("name > 'aac'"), null)).size());
+        assertEquals(8, new HashSet<>(indexes.query(Predicates.sql("name > 'aac'"), -1)).size());
     }
 
     protected Extractors newExtractor() {
@@ -166,7 +166,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), null);
+        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), -1);
 
         assertNull("There should be no result", query);
     }
@@ -182,7 +182,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), null);
+        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), -1);
 
         assertEquals(89, query.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
@@ -105,12 +106,12 @@ public class PredicatesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext) {
+        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext, PartitionIdSet queryPartitions) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(final QueryContext queryContext) {
+        public boolean isIndexed(final QueryContext queryContext, PartitionIdSet queryPartitions) {
             return false;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -18,11 +18,10 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
-import com.hazelcast.map.IMap;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.IMap;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder.EntryObject;
 import com.hazelcast.query.Predicates;
@@ -106,12 +105,12 @@ public class PredicatesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext, int ownedPartitionCount) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(final QueryContext queryContext, PartitionIdSet queryPartitions) {
+        public boolean isIndexed(final QueryContext queryContext, int ownedPartitionCount) {
             return false;
         }
     }


### PR DESCRIPTION
Fixed the race condition checking that all partitions are indexed
before using an index for query. In combination with migration stamp
check which guarantees there is no concurrent partition migration,
the using of incomplete index is avoided and query engine falls back to
the full partitions scan algorithm.

Fixes: https://github.com/hazelcast/hazelcast/issues/16311
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3473