### PR TITLE
Use explicit port on CloudDiscovery for private address

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
@@ -17,11 +17,11 @@
 package com.hazelcast.client.impl.spi.impl.discovery;
 
 import com.hazelcast.client.util.AddressHelper;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.internal.util.AddressUtil;
+import com.hazelcast.spi.properties.HazelcastProperty;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedReader;
@@ -82,7 +82,8 @@ public class HazelcastCloudDiscovery {
         httpsConnection.connect();
         checkCertificate(httpsConnection);
         checkError(httpsConnection);
-        return parseResponse(httpsConnection.getInputStream());
+        InputStream inputStream = httpsConnection.getInputStream();
+        return parseJsonResponse(Json.parse(readInputStream(inputStream)));
     }
 
     private void checkCertificate(HttpURLConnection connection) throws IOException, CertificateException {
@@ -99,9 +100,7 @@ public class HazelcastCloudDiscovery {
         }
     }
 
-    private Map<Address, Address> parseResponse(InputStream is) throws IOException {
-
-        JsonValue jsonValue = Json.parse(readInputStream(is));
+    static Map<Address, Address> parseJsonResponse(JsonValue jsonValue) throws IOException {
         List<JsonValue> response = jsonValue.asArray().values();
 
         Map<Address, Address> privateToPublicAddresses = new HashMap<Address, Address>();
@@ -109,15 +108,16 @@ public class HazelcastCloudDiscovery {
             String privateAddress = value.asObject().get(PRIVATE_ADDRESS_PROPERTY).asString();
             String publicAddress = value.asObject().get(PUBLIC_ADDRESS_PROPERTY).asString();
 
-            Address publicAddr = createAddress(publicAddress);
-            privateToPublicAddresses.put(new Address(privateAddress, publicAddr.getPort()), publicAddr);
+            Address publicAddr = createAddress(publicAddress, -1);
+            //if it is not explicitly given, create the private address with public addresses port
+            Address privateAddr = createAddress(privateAddress, publicAddr.getPort());
+            privateToPublicAddresses.put(privateAddr, publicAddr);
         }
-
         return privateToPublicAddresses;
     }
 
-    private Address createAddress(String hostname) throws IOException {
-        AddressUtil.AddressHolder addressHolder = AddressUtil.getAddressHolder(hostname);
+    private static Address createAddress(String hostname, int defaultPort) throws IOException {
+        AddressUtil.AddressHolder addressHolder = AddressUtil.getAddressHolder(hostname, defaultPort);
         String scopedHostName = AddressHelper.getScopedHostName(addressHolder);
         return new Address(scopedHostName, addressHolder.getPort());
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscoveryTest.java
@@ -17,8 +17,10 @@
 package com.hazelcast.client.impl.spi.impl.discovery;
 
 import com.hazelcast.client.test.ClientTestSupport;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.sun.net.httpserver.HttpExchange;
@@ -118,4 +120,27 @@ public class HazelcastCloudDiscoveryTest extends ClientTestSupport {
         HazelcastCloudDiscovery cloudDiscovery = new HazelcastCloudDiscovery(urlEndpoint, Integer.MAX_VALUE);
         cloudDiscovery.discoverNodes();
     }
+
+    @Test
+    public void testJsonResponseParse_withDifferentPortOnPrivateAddress() throws IOException {
+        JsonValue jsonResponse = Json.parse(
+                " [{\"private-address\":\"100.96.5.1:5701\",\"public-address\":\"10.113.44.139:31115\"},"
+                        + "{\"private-address\":\"100.96.4.2:5701\",\"public-address\":\"10.113.44.130:31115\"} ]");
+        Map<Address, Address> privatePublicMap = HazelcastCloudDiscovery.parseJsonResponse(jsonResponse);
+        assertEquals(2, privatePublicMap.size());
+        assertEquals(new Address("10.113.44.139", 31115), privatePublicMap.get(new Address("100.96.5.1", 5701)));
+        assertEquals(new Address("10.113.44.130", 31115), privatePublicMap.get(new Address("100.96.4.2", 5701)));
+    }
+
+    @Test
+    public void testJsonResponseParse() throws IOException {
+        JsonValue jsonResponse = Json.parse(
+                "[{\"private-address\":\"100.96.5.1\",\"public-address\":\"10.113.44.139:31115\"},"
+                        + "{\"private-address\":\"100.96.4.2\",\"public-address\":\"10.113.44.130:31115\"} ]");
+        Map<Address, Address> privatePublicMap = HazelcastCloudDiscovery.parseJsonResponse(jsonResponse);
+        assertEquals(2, privatePublicMap.size());
+        assertEquals(new Address("10.113.44.139", 31115), privatePublicMap.get(new Address("100.96.5.1", 31115)));
+        assertEquals(new Address("10.113.44.130", 31115), privatePublicMap.get(new Address("100.96.4.2", 31115)));
+    }
+
 }


### PR DESCRIPTION
In certain scenarios like AWS private link, public and private
addresses can not have same port. Let the client use the explicit
private address if it is provided.
If it is not given explicitly, the client will use the port of public
address for the private address as before to maintain backward
compatibility.