### PR TITLE
Recreate under mutex 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndProvider.java
@@ -24,9 +24,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.map.impl.querycache.subscriber.NullQueryCache.NULL_QUERY_CACHE;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static com.hazelcast.map.impl.querycache.subscriber.NullQueryCache.NULL_QUERY_CACHE;
 
 /**
  * Provides construction of whole {@link com.hazelcast.map.QueryCache
@@ -82,8 +82,8 @@ public class QueryCacheEndToEndProvider<K, V> {
                 InternalQueryCache<K, V> queryCache = queryCacheRegistry.get(cacheName);
                 // if this is a recreation we expect to have a Uuid otherwise we
                 // need to generate one for the first creation of query cache.
-                String cacheId = queryCache == null
-                        ? UuidUtil.newUnsecureUuidString() : queryCache.getCacheId();
+                String cacheId = queryCache != null
+                        ? queryCache.getCacheId() : UuidUtil.newUnsecureUuidString();
 
                 queryCache = constructor.createNew(cacheId);
 


### PR DESCRIPTION
Needed for the fix of hazelcast/hazelcast-enterprise#3464

__Modification:__
Used `mutex` as in `queryCache#destroy`.