### PR TITLE
Remove the test unrelated bug in test `DistributedObjectListenerTest.testDestroyEventReceived_WhenDestroyedByServer`

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,8 +33,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientDistributedObjectListenerTest
-        extends com.hazelcast.core.DistributedObjectListenerTest {
+public class ClientDistributedObjectListenerTest extends com.hazelcast.core.DistributedObjectListenerTest {
 
     @Override
     protected HazelcastInstance newInstance() {
@@ -86,6 +86,11 @@ public class ClientDistributedObjectListenerTest
             Collection<DistributedObject> distributedObjects2 = newClusterInstance2.getDistributedObjects();
             assertEquals(1, distributedObjects2.size());
         });
+    }
+
+    @Test
+    @Ignore("TODO: Unignore when https://github.com/hazelcast/hazelcast/issues/16374 is fixed")
+    public void getDistributedObjects_ShouldNotRecreateProxy_AfterDestroy() {
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.impl.proxy;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,9 +35,13 @@ import static org.junit.Assert.assertEquals;
 public class ClientDistributedObjectListenerTest
         extends com.hazelcast.core.DistributedObjectListenerTest {
 
+    @Override
+    protected HazelcastInstance newInstance() {
+        return hazelcastFactory.newHazelcastClient();
+    }
+
     @Test
     public void distributedObjectsCreatedBack_whenClusterRestart_withSingleNode() {
-        final HazelcastInstance server = getRandomServer();
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
@@ -77,14 +80,11 @@ public class ClientDistributedObjectListenerTest
         final HazelcastInstance newClusterInstance1 = hazelcastFactory.newHazelcastInstance();
         final HazelcastInstance newClusterInstance2 = hazelcastFactory.newHazelcastInstance();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                Collection<DistributedObject> distributedObjects1 = newClusterInstance1.getDistributedObjects();
-                assertEquals(1, distributedObjects1.size());
-                Collection<DistributedObject> distributedObjects2 = newClusterInstance2.getDistributedObjects();
-                assertEquals(1, distributedObjects2.size());
-            }
+        assertTrueEventually(() -> {
+            Collection<DistributedObject> distributedObjects1 = newClusterInstance1.getDistributedObjects();
+            assertEquals(1, distributedObjects1.size());
+            Collection<DistributedObject> distributedObjects2 = newClusterInstance2.getDistributedObjects();
+            assertEquals(1, distributedObjects2.size());
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,8 +40,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
     protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory(3);

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -165,14 +165,15 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         map2.destroy();
         AssertTask task = () -> {
             /**
-             * Uncomment the following lines once the race reported at issue(https://github.com/hazelcast/hazelcast/issues/16374)
-             * is properly solved. This test aims to test the destroy case only, hence the proxy creation race is not in
-             * the scope of this test.
+             * TODO: Uncomment the following lines once the race reported at
+             * issue(https://github.com/hazelcast/hazelcast/issues/16374)
+             * is properly solved. This test aims to test the destroy case only,
+             * hence the proxy creation race is not in the scope of this test.
              */
             /**
             Assert.assertEquals("Create event failed. unexpectedObjectName:" + listener.unexpectedObjectName, 1,
                     listener.createdCount.get());
-             */
+            */
             Assert.assertEquals("Destroy event failed. unexpectedObjectName:" + listener.unexpectedObjectName, 1,
                     listener.destroyedCount.get());
             Collection<DistributedObject> distributedObjects = instance.getDistributedObjects();

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -164,8 +164,15 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = server.getMap(mapName);
         map2.destroy();
         AssertTask task = () -> {
+            /**
+             * Uncomment the following lines once the race reported at issue(https://github.com/hazelcast/hazelcast/issues/16374)
+             * is properly solved. This test aims to test the destroy case only, hence the proxy creation race is not in
+             * the scope of this test.
+             */
+            /**
             Assert.assertEquals("Create event failed. unexpectedObjectName:" + listener.unexpectedObjectName, 1,
                     listener.createdCount.get());
+             */
             Assert.assertEquals("Destroy event failed. unexpectedObjectName:" + listener.unexpectedObjectName, 1,
                     listener.destroyedCount.get());
             Collection<DistributedObject> distributedObjects = instance.getDistributedObjects();


### PR DESCRIPTION
Removed the test unrelated bug which was triggered by this new test (`DistributedObjectListenerTest.testDestroyEventReceived_WhenDestroyedByServer`) and let it be solved later in an another PR so that the master PRs do not randomly fail due to this test.

Redesigned the tests so that known bugs will not cause the test failures. Namely, we wait for the cluster state propagated before going to next step of destroying or checking with the `getDistributedObjects` API.

related issue: https://github.com/hazelcast/hazelcast/issues/16374

Please see explanation of the actual bug at https://github.com/hazelcast/hazelcast/issues/16374#issuecomment-569700585
