### PR TITLE
Don't presize arrays when passing them to toArray() calls

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/security/JaasAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/JaasAuthenticationConfig.java
@@ -45,7 +45,7 @@ public class JaasAuthenticationConfig implements AuthenticationConfig {
 
     @Override
     public LoginModuleConfig[] asLoginModuleConfigs() {
-        return loginModuleConfigs.toArray(new LoginModuleConfig[loginModuleConfigs.size()]);
+        return loginModuleConfigs.toArray(new LoginModuleConfig[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -149,7 +149,7 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
 
     // visible for testing
     void collectMetrics() {
-        MetricsPublisher[] publishersArr = publishers.toArray(new MetricsPublisher[publishers.size()]);
+        MetricsPublisher[] publishersArr = publishers.toArray(new MetricsPublisher[0]);
         PublisherMetricsCollector publisherCollector = new PublisherMetricsCollector(publishersArr);
         collectMetrics(publisherCollector);
         publisherCollector.publishCollectedMetrics();


### PR DESCRIPTION
[Since a few versions of Java](https://bugs.openjdk.java.net/browse/JDK-6525802), it's a good idea to not pre-size arrays passed to `Collection#toArray` calls (these get _intrinsified_).