### PR TITLE
Rename WanReplicationRef.setMergePolicy to setMergePolicyClassName

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -3694,11 +3694,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="merge-policy" type="xs:string">
+        <xs:attribute name="merge-policy-class-name" type="xs:string"
+                      default="com.hazelcast.spi.merge.PassThroughMergePolicy">
             <xs:annotation>
                 <xs:documentation>
-                    Resolve conflicts that occurred when target cluster already has the replicated
-                    entry key.
+                    Sets the merge policy sent to the WAN replication target to merge
+                    replicated entries with existing target entries.
+                    The default merge policy is com.hazelcast.spi.merge.PassThroughMergePolicy.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -311,7 +311,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         WanReplicationRef wanRef = cacheConfig.getWanReplicationRef();
         assertEquals("testWan", wanRef.getName());
-        assertEquals("PUT_IF_ABSENT", wanRef.getMergePolicy());
+        assertEquals("PUT_IF_ABSENT", wanRef.getMergePolicyClassName());
         assertEquals(1, wanRef.getFilters().size());
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
     }
@@ -396,7 +396,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         // test testMapConfig2's WanReplicationConfig
         WanReplicationRef wanReplicationRef = testMapConfig2.getWanReplicationRef();
         assertEquals("testWan", wanReplicationRef.getName());
-        assertEquals("PUT_IF_ABSENT", wanReplicationRef.getMergePolicy());
+        assertEquals("PUT_IF_ABSENT", wanReplicationRef.getMergePolicyClassName());
         assertTrue(wanReplicationRef.isRepublishingEnabled());
 
         assertEquals(1000, testMapConfig2.getEvictionConfig().getSize());
@@ -463,7 +463,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         // test testMapConfig2's WanReplicationConfig
         WanReplicationRef wanReplicationRef = testMapConfig2.getWanReplicationRef();
         assertEquals("testWan", wanReplicationRef.getName());
-        assertEquals("PUT_IF_ABSENT", wanReplicationRef.getMergePolicy());
+        assertEquals("PUT_IF_ABSENT", wanReplicationRef.getMergePolicyClassName());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -362,7 +362,7 @@
                               implementation="dummyMapStore"
                               write-delay-seconds="0"
                               initial-mode="LAZY"/>
-                <hz:wan-replication-ref name="testWan" merge-policy="PUT_IF_ABSENT"/>
+                <hz:wan-replication-ref name="testWan" merge-policy-class-name="PUT_IF_ABSENT"/>
 
                 <hz:entry-listeners>
                     <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener" include-value="true"/>
@@ -494,7 +494,7 @@
             </hz:map>
 
             <hz:cache name="testCache" disable-per-entry-invalidation-events="true">
-                <hz:wan-replication-ref name="testWan" merge-policy="PUT_IF_ABSENT"
+                <hz:wan-replication-ref name="testWan" merge-policy-class-name="PUT_IF_ABSENT"
                                         republishing-enabled="false">
                     <hz:filters>
                         <hz:filter-impl>com.example.SampleFilter</hz:filter-impl>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/WanReplicationRefCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/WanReplicationRefCodec.java
@@ -24,7 +24,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("1abe58d6ac48de956ed0c217b325e385")
+@Generated("c551c2693fc4b86be41806caf438dc38")
 public final class WanReplicationRefCodec {
     private static final int REPUBLISHING_ENABLED_FIELD_OFFSET = 0;
     private static final int INITIAL_FRAME_SIZE = REPUBLISHING_ENABLED_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
@@ -54,11 +54,11 @@ public final class WanReplicationRefCodec {
         boolean republishingEnabled = decodeBoolean(initialFrame.content, REPUBLISHING_ENABLED_FIELD_OFFSET);
 
         java.lang.String name = StringCodec.decode(iterator);
-        java.lang.String mergePolicy = StringCodec.decode(iterator);
+        java.lang.String mergePolicyClassName = StringCodec.decode(iterator);
         java.util.List<java.lang.String> filters = ListMultiFrameCodec.decodeNullable(iterator, StringCodec::decode);
 
         fastForwardToEndFrame(iterator);
 
-        return new com.hazelcast.config.WanReplicationRef(name, mergePolicy, filters, republishingEnabled);
+        return new com.hazelcast.config.WanReplicationRef(name, mergePolicyClassName, filters, republishingEnabled);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/WanReplicationRefCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/WanReplicationRefCodec.java
@@ -40,7 +40,7 @@ public final class WanReplicationRefCodec {
         clientMessage.add(initialFrame);
 
         StringCodec.encode(clientMessage, wanReplicationRef.getName());
-        StringCodec.encode(clientMessage, wanReplicationRef.getMergePolicy());
+        StringCodec.encode(clientMessage, wanReplicationRef.getMergePolicyClassName());
         ListMultiFrameCodec.encodeNullable(clientMessage, wanReplicationRef.getFilters(), StringCodec::encode);
 
         clientMessage.add(END_FRAME.copy());

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1137,9 +1137,9 @@ public class ConfigXmlGenerator {
         if (wan != null) {
             gen.open("wan-replication-ref", "name", wan.getName());
 
-            String mergePolicy = wan.getMergePolicy();
+            String mergePolicy = wan.getMergePolicyClassName();
             if (!isNullOrEmpty(mergePolicy)) {
-                gen.node("merge-policy", mergePolicy);
+                gen.node("merge-policy-class-name", mergePolicy);
             }
 
             List<String> filters = wan.getFilters();

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -222,10 +222,10 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
             return false;
         }
         WanReplicationRef that = (WanReplicationRef) o;
-        return republishingEnabled == that.republishingEnabled &&
-                Objects.equals(name, that.name) &&
-                Objects.equals(mergePolicyClassName, that.mergePolicyClassName) &&
-                Objects.equals(filters, that.filters);
+        return republishingEnabled == that.republishingEnabled
+                && Objects.equals(name, that.name)
+                && Objects.equals(mergePolicyClassName, that.mergePolicyClassName)
+                && Objects.equals(filters, that.filters);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -20,11 +20,16 @@ import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * Configuration for a WAN target replication reference. This configuration
@@ -36,22 +41,26 @@ import java.util.List;
  */
 public class WanReplicationRef implements IdentifiedDataSerializable, Serializable {
 
+    private static final String DEFAULT_MERGE_POLICY_CLASS_NAME = PassThroughMergePolicy.class.getName();
+
     private boolean republishingEnabled = true;
     private String name;
-    private String mergePolicy;
-    private List<String> filters = new LinkedList<String>();
+    private String mergePolicyClassName = DEFAULT_MERGE_POLICY_CLASS_NAME;
+    private List<String> filters = new LinkedList<>();
 
     public WanReplicationRef() {
     }
 
     public WanReplicationRef(WanReplicationRef ref) {
-        this(ref.name, ref.mergePolicy, ref.filters, ref.republishingEnabled);
+        this(ref.name, ref.mergePolicyClassName, ref.filters, ref.republishingEnabled);
     }
 
-    public WanReplicationRef(String name, String mergePolicy, List<String> filters,
+    public WanReplicationRef(String name,
+                             String mergePolicyClassName,
+                             List<String> filters,
                              boolean republishingEnabled) {
         this.name = name;
-        this.mergePolicy = mergePolicy;
+        this.mergePolicyClassName = mergePolicyClassName;
         this.filters = filters;
         this.republishingEnabled = republishingEnabled;
     }
@@ -69,7 +78,8 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
      * @param name the reference name
      * @return this config
      */
-    public WanReplicationRef setName(String name) {
+    public WanReplicationRef setName(@Nonnull String name) {
+        checkNotNull(name, "Name must not be null");
         this.name = name;
         return this;
     }
@@ -77,20 +87,23 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
     /**
      * Returns the merge policy sent to the WAN replication target to merge
      * replicated entries with existing target entries.
+     * The default merge policy is {@link #DEFAULT_MERGE_POLICY_CLASS_NAME}
      */
-    public String getMergePolicy() {
-        return mergePolicy;
+    public @Nonnull String getMergePolicyClassName() {
+        return mergePolicyClassName;
     }
 
     /**
      * Sets the merge policy sent to the WAN replication target to merge
      * replicated entries with existing target entries.
+     * The default merge policy is {@link #DEFAULT_MERGE_POLICY_CLASS_NAME}
      *
-     * @param mergePolicy the merge policy
+     * @param mergePolicyClassName the merge policy
      * @return this config
      */
-    public WanReplicationRef setMergePolicy(String mergePolicy) {
-        this.mergePolicy = mergePolicy;
+    public WanReplicationRef setMergePolicyClassName(@Nonnull String mergePolicyClassName) {
+        checkNotNull(mergePolicyClassName, "Merge policy class name must not be null");
+        this.mergePolicyClassName = mergePolicyClassName;
         return this;
     }
 
@@ -100,11 +113,12 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
      * <p>
      * NOTE: EE only
      *
-     * @param filter the class name
+     * @param filterClassName the class name
      * @return this config
      */
-    public WanReplicationRef addFilter(String filter) {
-        filters.add(filter);
+    public WanReplicationRef addFilter(@Nonnull String filterClassName) {
+        checkNotNull(filterClassName, "Filter class name must not be null");
+        filters.add(filterClassName);
         return this;
     }
 
@@ -116,7 +130,8 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
      *
      * @return list of class names implementing the CacheWanEventFilter or MapWanEventFilter
      */
-    public List<String> getFilters() {
+    public @Nonnull
+    List<String> getFilters() {
         return filters;
     }
 
@@ -129,7 +144,8 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
      * @param filters the list of class names implementing CacheWanEventFilter or MapWanEventFilter
      * @return this config
      */
-    public WanReplicationRef setFilters(List<String> filters) {
+    public WanReplicationRef setFilters(@Nonnull List<String> filters) {
+        checkNotNull(filters, "Filters must not be null");
         this.filters = filters;
         return this;
     }
@@ -167,7 +183,7 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeUTF(mergePolicy);
+        out.writeUTF(mergePolicyClassName);
         out.writeInt(filters.size());
         for (String filter : filters) {
             out.writeUTF(filter);
@@ -178,7 +194,7 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        mergePolicy = in.readUTF();
+        mergePolicyClassName = in.readUTF();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             filters.add(in.readUTF());
@@ -190,7 +206,7 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
     public String toString() {
         return "WanReplicationRef{"
                 + "name='" + name + '\''
-                + ", mergePolicy='" + mergePolicy + '\''
+                + ", mergePolicy='" + mergePolicyClassName + '\''
                 + ", filters='" + filters + '\''
                 + ", republishingEnabled='" + republishingEnabled
                 + '\''
@@ -198,7 +214,6 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
     }
 
     @Override
-    @SuppressWarnings("checkstyle:npathcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -206,26 +221,15 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         WanReplicationRef that = (WanReplicationRef) o;
-        if (republishingEnabled != that.republishingEnabled) {
-            return false;
-        }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
-            return false;
-        }
-        if (mergePolicy != null ? !mergePolicy.equals(that.mergePolicy) : that.mergePolicy != null) {
-            return false;
-        }
-        return filters != null ? filters.equals(that.filters) : that.filters == null;
+        return republishingEnabled == that.republishingEnabled &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(mergePolicyClassName, that.mergePolicyClassName) &&
+                Objects.equals(filters, that.filters);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (mergePolicy != null ? mergePolicy.hashCode() : 0);
-        result = 31 * result + (filters != null ? filters.hashCode() : 0);
-        result = 31 * result + (republishingEnabled ? 1 : 0);
-        return result;
+        return Objects.hash(republishingEnabled, name, mergePolicyClassName, filters);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2029,8 +2029,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         for (Node wanChild : childElements(n)) {
             String wanChildName = cleanNodeName(wanChild);
             String wanChildValue = getTextContent(wanChild);
-            if ("merge-policy".equals(wanChildName)) {
-                wanReplicationRef.setMergePolicy(wanChildValue);
+            if ("merge-policy-class-name".equals(wanChildName)) {
+                wanReplicationRef.setMergePolicyClassName(wanChildValue);
             } else if ("filters".equals(wanChildName)) {
                 handleWanFilters(wanChild, wanReplicationRef);
             } else if ("republishing-enabled".equals(wanChildName)) {
@@ -2093,8 +2093,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         for (Node wanChild : childElements(n)) {
             String wanChildName = cleanNodeName(wanChild);
             String wanChildValue = getTextContent(wanChild);
-            if ("merge-policy".equals(wanChildName)) {
-                wanReplicationRef.setMergePolicy(wanChildValue);
+            if ("merge-policy-class-name".equals(wanChildName)) {
+                wanReplicationRef.setMergePolicyClassName(wanChildValue);
             } else if ("republishing-enabled".equals(wanChildName)) {
                 wanReplicationRef.setRepublishingEnabled(getBooleanValue(wanChildValue));
             } else if ("filters".equals(wanChildName)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/WanReplicationRefReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/WanReplicationRefReadOnly.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.WanReplicationRef;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -30,22 +31,22 @@ public class WanReplicationRefReadOnly extends WanReplicationRef {
     }
 
     @Override
-    public WanReplicationRef setName(String name) {
+    public WanReplicationRef setName(@Nonnull String name) {
         throw throwReadOnly();
     }
 
     @Override
-    public WanReplicationRef setMergePolicy(String mergePolicy) {
+    public WanReplicationRef setMergePolicyClassName(@Nonnull String mergePolicyClassName) {
         throw throwReadOnly();
     }
 
     @Override
-    public WanReplicationRef setFilters(List<String> filters) {
+    public WanReplicationRef setFilters(@Nonnull List<String> filters) {
         throw throwReadOnly();
     }
 
     @Override
-    public WanReplicationRef addFilter(String filter) {
+    public WanReplicationRef addFilter(@Nonnull String filterClassName) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -229,7 +229,8 @@ public class MapContainer {
 
         WanReplicationService wanReplicationService = nodeEngine.getWanReplicationService();
         wanReplicationDelegate = wanReplicationService.getWanReplicationPublishers(wanReplicationRefName);
-        wanMergePolicy = nodeEngine.getSplitBrainMergePolicyProvider().getMergePolicy(wanReplicationRef.getMergePolicyClassName());
+        wanMergePolicy = nodeEngine.getSplitBrainMergePolicyProvider()
+                                   .getMergePolicy(wanReplicationRef.getMergePolicyClassName());
 
         WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(wanReplicationRefName);
         if (wanReplicationConfig != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -229,7 +229,7 @@ public class MapContainer {
 
         WanReplicationService wanReplicationService = nodeEngine.getWanReplicationService();
         wanReplicationDelegate = wanReplicationService.getWanReplicationPublishers(wanReplicationRefName);
-        wanMergePolicy = nodeEngine.getSplitBrainMergePolicyProvider().getMergePolicy(wanReplicationRef.getMergePolicy());
+        wanMergePolicy = nodeEngine.getSplitBrainMergePolicyProvider().getMergePolicy(wanReplicationRef.getMergePolicyClassName());
 
         WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(wanReplicationRefName);
         if (wanReplicationConfig != null) {

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -512,7 +512,7 @@
             <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Wan replication configuration for cache.
+                        WAN replication configuration for cache.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -3227,11 +3227,13 @@
 
     <xs:complexType name="wan-replication-ref">
         <xs:all>
-            <xs:element name="merge-policy" type="xs:string" minOccurs="0">
+            <xs:element name="merge-policy-class-name" type="xs:string" minOccurs="0"
+                        default="com.hazelcast.spi.merge.PassThroughMergePolicy">
                 <xs:annotation>
                     <xs:documentation>
-                        Resolve conflicts that occurred when target cluster already has the replicated
-                        entry key.
+                        Sets the merge policy sent to the WAN replication target to merge
+                        replicated entries with existing target entries.
+                        The default merge policy is com.hazelcast.spi.merge.PassThroughMergePolicy.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1217,7 +1217,7 @@
             - <republishing-enabled>:
                 When enabled, an incoming event to a member is forwarded to target cluster of that member. Its
                 default value is true.
-             - <merge-policy>:
+             - <merge-policy-class-name>:
                 Resolve conflicts that occurred when target cluster already has the replicated
                 entry key.
 
@@ -1242,6 +1242,8 @@
                 target one.
                 com.hazelcast.spi.merge.PassThroughMergePolicy: Incoming entry merges from
                 the source cache to the target cache unless the incoming entry is not null.
+
+                The default policy is com.hazelcast.spi.merge.PassThroughMergePolicy.
         * <indexes>:
         You can define indexes for your map using this element's <index> sub-elements. Index definition consists
         of type, optional name and the list of columns to be indexed. Valid types are SORTED (default) and HASH.
@@ -1300,7 +1302,7 @@
             <eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
         </near-cache>
         <wan-replication-ref name="my-wan-cluster-batch">
-            <merge-policy>PassThroughMergePolicy</merge-policy>
+            <merge-policy-class-name>PassThroughMergePolicy</merge-policy-class-name>
             <filters>
                 <filter-impl>com.example.SampleFilter</filter-impl>
                 <filter-impl>com.example.SampleFilter2</filter-impl>
@@ -1631,7 +1633,7 @@
         <async-backup-count>0</async-backup-count>
         <eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
         <wan-replication-ref name="my-wan-cluster-batch">
-            <merge-policy>PassThroughMergePolicy</merge-policy>
+            <merge-policy-class-name>PassThroughMergePolicy</merge-policy-class-name>
             <republishing-enabled>true</republishing-enabled>
             <filters>
                 <filter-impl>com.example.SampleFilter</filter-impl>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -1623,7 +1623,7 @@ hazelcast:
         eviction-policy: LFU
       wan-replication-ref:
          name: my-wan-cluster-batch
-         merge-policy: PassThroughMergePolicy
+         merge-policy-class-name: PassThroughMergePolicy
          republishing-enabled: true
          filters:
            - com.example.SampleFilter

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -1200,7 +1200,7 @@ hazelcast:
   #     - "republishing-enabled":
   #         When enabled, an incoming event to a member is forwarded to target cluster of that member. Its
   #         default value is true.
-  #      - "merge-policy":
+  #      - "merge-policy-class-name":
   #         Resolve conflicts that occurred when target cluster already has the replicated
   #         entry key.
   #
@@ -1225,6 +1225,8 @@ hazelcast:
   #         target one.
   #         com.hazelcast.spi.merge.PassThroughMergePolicy: Incoming entry merges from
   #         the source cache to the target cache unless the incoming entry is not null.
+  #
+  #         The default policy is com.hazelcast.spi.merge.PassThroughMergePolicy.
   # * "indexes":
   # You can define indexes for your map using this element's "index" sub-elements. Index definition consists of type,
   # optional name and the list of columns to be indexed. Valid types are SORTED (default) and HASH.
@@ -1291,7 +1293,7 @@ hazelcast:
           eviction-policy: LFU
       wan-replication-ref:
         my-wan-cluster-batch:
-          merge-policy: PassThroughMergePolicy
+          merge-policy-class-name: PassThroughMergePolicy
           filters:
             - com.example.SampleFilter
             - com.example.SampleFilter2

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
@@ -83,7 +83,7 @@ public class ClientMapWANExceptionTest extends HazelcastTestSupport {
 
         WanReplicationRef wanRef = new WanReplicationRef();
         wanRef.setName("dummyWan");
-        wanRef.setMergePolicy(PassThroughMergePolicy.class.getName());
+        wanRef.setMergePolicyClassName(PassThroughMergePolicy.class.getName());
 
         config.addWanReplicationConfig(wanReplicationConfig);
         config.getMapConfig("default").setWanReplicationRef(wanRef);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -234,7 +234,7 @@ public class ReferenceObjects {
         if (!a.getName().equals(b.getName())) {
             return false;
         }
-        if (!a.getMergePolicy().equals(b.getMergePolicy())) {
+        if (!a.getMergePolicyClassName().equals(b.getMergePolicyClassName())) {
             return false;
         }
         return a.getFilters() != null ? a.getFilters().equals(b.getFilters()) : b.getFilters() == null;

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -165,7 +165,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
         WanReplicationRef wanRefCacheConfig = config1.getCacheConfig("wanRefTestCache").getWanReplicationRef();
         assertEquals("testWanRef", wanRefCacheConfig.getName());
-        assertEquals("TestMergePolicy", wanRefCacheConfig.getMergePolicy());
+        assertEquals("TestMergePolicy", wanRefCacheConfig.getMergePolicyClassName());
         assertTrue(wanRefCacheConfig.isRepublishingEnabled());
 
         WanReplicationRef wanRefDisabledRepublishingTestCache =

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -832,7 +832,7 @@ public class ConfigCompatibilityChecker {
         private static boolean isCompatible(WanReplicationRef c1, WanReplicationRef c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getName(), c2.getName())
-                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
+                    && nullSafeEqual(c1.getMergePolicyClassName(), c2.getMergePolicyClassName())
                     && nullSafeEqual(c1.getFilters(), c2.getFilters())
                     && nullSafeEqual(c1.isRepublishingEnabled(), c2.isRepublishingEnabled());
         }
@@ -889,7 +889,7 @@ public class ConfigCompatibilityChecker {
         private static boolean isCompatible(WanReplicationRef c1, WanReplicationRef c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getName(), c2.getName())
-                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
+                    && nullSafeEqual(c1.getMergePolicyClassName(), c2.getMergePolicyClassName())
                     && nullSafeEqual(c1.getFilters(), c2.getFilters())
                     && nullSafeEqual(c1.isRepublishingEnabled(), c2.isRepublishingEnabled());
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -2010,7 +2010,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
     private static WanReplicationRef wanReplicationRef() {
         return new WanReplicationRef()
                 .setName("wanReplication")
-                .setMergePolicy("mergePolicy")
+                .setMergePolicyClassName("mergePolicy")
                 .setRepublishingEnabled(true)
                 .setFilters(Arrays.asList("filter1", "filter2"));
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefReadOnlyTest.java
@@ -41,7 +41,7 @@ public class WanReplicationRefReadOnlyTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void setMergePolicyOnReadOnlyWanReplicationRefShouldFail() {
-        getReadOnlyRef().setMergePolicy("myMergePolicy");
+        getReadOnlyRef().setMergePolicyClassName("myMergePolicy");
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefTest.java
@@ -44,7 +44,7 @@ public class WanReplicationRefTest {
         ref = new WanReplicationRef("myRef", "myMergePolicy", singletonList("myFilter"), true);
 
         assertEquals("myRef", ref.getName());
-        assertEquals("myMergePolicy", ref.getMergePolicy());
+        assertEquals("myMergePolicy", ref.getMergePolicyClassName());
         assertEquals(1, ref.getFilters().size());
         assertEquals("myFilter", ref.getFilters().get(0));
         assertTrue(ref.isRepublishingEnabled());
@@ -56,7 +56,7 @@ public class WanReplicationRefTest {
         ref = new WanReplicationRef(original);
 
         assertEquals(original.getName(), ref.getName());
-        assertEquals(original.getMergePolicy(), ref.getMergePolicy());
+        assertEquals(original.getMergePolicyClassName(), ref.getMergePolicyClassName());
         assertEquals(original.getFilters(), ref.getFilters());
         assertEquals(original.isRepublishingEnabled(), ref.isRepublishingEnabled());
     }
@@ -77,7 +77,7 @@ public class WanReplicationRefTest {
     @Test
     public void testSerialization() {
         ref.setName("myWanReplicationRef");
-        ref.setMergePolicy("myMergePolicy");
+        ref.setMergePolicyClassName("myMergePolicy");
         ref.setRepublishingEnabled(true);
         ref.addFilter("myFilter");
 
@@ -86,7 +86,7 @@ public class WanReplicationRefTest {
         WanReplicationRef deserialized = serializationService.toObject(serialized);
 
         assertEquals(ref.getName(), deserialized.getName());
-        assertEquals(ref.getMergePolicy(), deserialized.getMergePolicy());
+        assertEquals(ref.getMergePolicyClassName(), deserialized.getMergePolicyClassName());
         assertEquals(ref.isRepublishingEnabled(), deserialized.isRepublishingEnabled());
         assertEquals(ref.getFilters(), deserialized.getFilters());
         assertEquals(ref.toString(), deserialized.toString());

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1208,7 +1208,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         WanReplicationRef wanRef = mapConfig.getWanReplicationRef();
 
         assertEquals(refName, wanRef.getName());
-        assertEquals(mergePolicy, wanRef.getMergePolicy());
+        assertEquals(mergePolicy, wanRef.getMergePolicyClassName());
         assertTrue(wanRef.isRepublishingEnabled());
         assertEquals(1, wanRef.getFilters().size());
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
@@ -2305,7 +2305,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         WanReplicationRef wanReplicationRef = mapConfig.getWanReplicationRef();
         assertNotNull(wanReplicationRef);
         assertFalse(wanReplicationRef.isRepublishingEnabled());
-        assertEquals("PassThroughMergePolicy", wanReplicationRef.getMergePolicy());
+        assertEquals("PassThroughMergePolicy", wanReplicationRef.getMergePolicyClassName());
         assertEquals(1, wanReplicationRef.getFilters().size());
         assertEquals("com.example.SampleFilter".toLowerCase(), wanReplicationRef.getFilters().get(0).toLowerCase());
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1195,7 +1195,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String xml = HAZELCAST_START_TAG
                 + "  <map name=\"" + mapName + "\">\n"
                 + "    <wan-replication-ref name=\"test\">\n"
-                + "      <merge-policy>TestMergePolicy</merge-policy>\n"
+                + "      <merge-policy-class-name>TestMergePolicy</merge-policy-class-name>\n"
                 + "      <filters>\n"
                 + "        <filter-impl>com.example.SampleFilter</filter-impl>\n"
                 + "      </filters>\n"
@@ -2216,7 +2216,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "            <eviction size=\"1000\" max-size-policy=\"ENTRY_COUNT\" eviction-policy=\"LFU\"/>\n"
                 + "          </near-cache>"
                 + "        <wan-replication-ref name=\"my-wan-cluster-batch\">\n"
-                + "            <merge-policy>PassThroughMergePolicy</merge-policy>\n"
+                + "            <merge-policy-class-name>PassThroughMergePolicy</merge-policy-class-name>\n"
                 + "            <filters>\n"
                 + "                <filter-impl>com.example.SampleFilter</filter-impl>\n"
                 + "            </filters>\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1211,7 +1211,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    " + mapName + ":\n"
                 + "      wan-replication-ref:\n"
                 + "        test:\n"
-                + "          merge-policy: TestMergePolicy\n"
+                + "          merge-policy-class-name: TestMergePolicy\n"
                 + "          filters:\n"
                 + "            - com.example.SampleFilter\n";
 
@@ -2233,7 +2233,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          eviction-policy: LFU\n"
                 + "      wan-replication-ref:\n"
                 + "        my-wan-cluster-batch:\n"
-                + "          merge-policy: PassThroughMergePolicy\n"
+                + "          merge-policy-class-name: PassThroughMergePolicy\n"
                 + "          filters:\n"
                 + "            - com.example.SampleFilter\n"
                 + "          republishing-enabled: false\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1220,7 +1220,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         WanReplicationRef wanRef = mapConfig.getWanReplicationRef();
 
         assertEquals(refName, wanRef.getName());
-        assertEquals(mergePolicy, wanRef.getMergePolicy());
+        assertEquals(mergePolicy, wanRef.getMergePolicyClassName());
         assertTrue(wanRef.isRepublishingEnabled());
         assertEquals(1, wanRef.getFilters().size());
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
@@ -2315,7 +2315,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         WanReplicationRef wanReplicationRef = mapConfig.getWanReplicationRef();
         assertNotNull(wanReplicationRef);
         assertFalse(wanReplicationRef.isRepublishingEnabled());
-        assertEquals("PassThroughMergePolicy", wanReplicationRef.getMergePolicy());
+        assertEquals("PassThroughMergePolicy", wanReplicationRef.getMergePolicyClassName());
         assertEquals(1, wanReplicationRef.getFilters().size());
         assertEquals("com.example.SampleFilter".toLowerCase(), wanReplicationRef.getFilters().get(0).toLowerCase());
     }

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanCustomPublisherMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanCustomPublisherMapTest.java
@@ -60,7 +60,7 @@ public class WanCustomPublisherMapTest extends AbstractWanCustomPublisherMapTest
 
         WanReplicationRef wanRef = new WanReplicationRef()
                 .setName("dummyWan")
-                .setMergePolicy(PassThroughMergePolicy.class.getName());
+                .setMergePolicyClassName(PassThroughMergePolicy.class.getName());
 
         MapConfig mapConfig = new MapConfig("default")
                 .setInMemoryFormat(inMemoryFormat)

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanPublisherMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanPublisherMigrationTest.java
@@ -158,7 +158,7 @@ public class WanPublisherMigrationTest extends HazelcastTestSupport {
 
         WanReplicationRef wanRef = new WanReplicationRef()
                 .setName("dummyWan")
-                .setMergePolicy(PassThroughMergePolicy.class.getName());
+                .setMergePolicyClassName(PassThroughMergePolicy.class.getName());
 
         MapConfig mapConfig = new MapConfig("default")
                 .setWanReplicationRef(wanRef);

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationConfigurationTest.java
@@ -84,7 +84,7 @@ public class WanReplicationConfigurationTest extends HazelcastTestSupport {
 
         WanReplicationRef wanReplicationRef = mapContainer.getMapConfig().getWanReplicationRef();
         assertNotNull(wanReplicationRef);
-        assertEquals(mapContainer.getWanMergePolicy().getClass().getName(), wanReplicationRef.getMergePolicy());
+        assertEquals(mapContainer.getWanMergePolicy().getClass().getName(), wanReplicationRef.getMergePolicyClassName());
         assertFalse(wanReplicationRef.isRepublishingEnabled());
     }
 
@@ -101,7 +101,7 @@ public class WanReplicationConfigurationTest extends HazelcastTestSupport {
 
         WanReplicationRef wanReplicationRef = mapContainer.getMapConfig().getWanReplicationRef();
         assertNotNull(wanReplicationRef);
-        assertEquals(mapContainer.getWanMergePolicy().getClass().getName(), wanReplicationRef.getMergePolicy());
+        assertEquals(mapContainer.getWanMergePolicy().getClass().getName(), wanReplicationRef.getMergePolicyClassName());
         assertTrue(wanReplicationRef.isRepublishingEnabled());
     }
 
@@ -122,7 +122,7 @@ public class WanReplicationConfigurationTest extends HazelcastTestSupport {
         WanReplicationRef wanRef = new WanReplicationRef()
                 .setName("dummyWan")
                 .setRepublishingEnabled(isWanRepublishingEnabled)
-                .setMergePolicy(PassThroughMergePolicy.class.getName());
+                .setMergePolicyClassName(PassThroughMergePolicy.class.getName());
 
         MapConfig mapConfig = new MapConfig("default")
                 .setWanReplicationRef(wanRef);

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -315,7 +315,7 @@
         </near-cache>
 
         <wan-replication-ref name="my-wan-cluster">
-            <merge-policy>hz.PASS_THROUGH</merge-policy>
+            <merge-policy-class-name>hz.PASS_THROUGH</merge-policy-class-name>
             <filters>
                 <filter-impl>com.example.WanTestFilter1</filter-impl>
                 <filter-impl>com.example.WanTestFilter2</filter-impl>
@@ -486,7 +486,7 @@
         <eviction comparator-class-name="DummyClass" eviction-policy="LRU"
                   max-size-policy="ENTRY_COUNT" size="50"/>
         <wan-replication-ref name="my-wan-cluster">
-            <merge-policy>hz.PASS_THROUGH</merge-policy>
+            <merge-policy-class-name>hz.PASS_THROUGH</merge-policy-class-name>
             <filters>
                 <filter-impl>com.example.WanTestFilter1</filter-impl>
                 <filter-impl>com.example.WanTestFilter2</filter-impl>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -301,7 +301,7 @@ hazelcast:
 
       wan-replication-ref:
         my-wan-cluster:
-          merge-policy: hz.PASS_THROUGH
+          merge-policy-class-name: hz.PASS_THROUGH
           filters:
             - com.example.WanTestFilter1
             - com.example.WanTestFilter2
@@ -483,7 +483,7 @@ hazelcast:
         size: 50
       wan-replication-ref:
         name: my-wan-cluster
-        merge-policy: hz.PASS_THROUGH
+        merge-policy-class-name: hz.PASS_THROUGH
         filters:
           - com.example.WanTestFilter1
           - com.example.WanTestFilter2

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -111,7 +111,7 @@
         <statistics-enabled>false</statistics-enabled>
         <management-enabled>false</management-enabled>
         <wan-replication-ref name="testWanRef">
-            <merge-policy>TestMergePolicy</merge-policy>
+            <merge-policy-class-name>TestMergePolicy</merge-policy-class-name>
         </wan-replication-ref>
     </cache>
 
@@ -121,7 +121,7 @@
         <statistics-enabled>false</statistics-enabled>
         <management-enabled>false</management-enabled>
         <wan-replication-ref name="testWanRef">
-            <merge-policy>TestMergePolicy</merge-policy>
+            <merge-policy-class-name>TestMergePolicy</merge-policy-class-name>
             <republishing-enabled>false</republishing-enabled>
         </wan-replication-ref>
     </cache>


### PR DESCRIPTION
This brings it in line with other config classes where we set class
name, like MapStoreConfig.setFactoryClassName.

Also, makes com.hazelcast.spi.merge.PassThroughMergePolicy the default
merge policy if none is specified for ease of use.

Fixes: https://github.com/hazelcast/hazelcast/issues/15638
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3482