### PR TITLE
Make the test `testDestroyEventReceived_WhenDestroyedByServer` wait for the proxy creation

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.impl.proxy;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -26,10 +25,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.Collection;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -42,29 +37,19 @@ public class ClientDistributedObjectListenerTest extends com.hazelcast.core.Dist
 
     @Test
     public void distributedObjectsCreatedBack_whenClusterRestart_withSingleNode() {
-
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
         HazelcastInstance instance = hazelcastFactory.newHazelcastClient(clientConfig);
 
         instance.getMap("test");
 
-        assertTrueEventually(() -> {
-            Collection<HazelcastInstance> servers = hazelcastFactory.getAllHazelcastInstances();
-            for (HazelcastInstance server1 : servers) {
-                Collection<DistributedObject> distributedObjects = server1.getDistributedObjects();
-                assertEquals(1, distributedObjects.size());
-            }
-        });
+        checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
 
         hazelcastFactory.shutdownAllMembers();
 
         final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
 
-        assertTrueEventually(() -> {
-            Collection<DistributedObject> distributedObjects = instance2.getDistributedObjects();
-            assertEquals(1, distributedObjects.size());
-        });
+        checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
     }
 
     @Test
@@ -77,15 +62,10 @@ public class ClientDistributedObjectListenerTest extends com.hazelcast.core.Dist
 
         hazelcastFactory.shutdownAllMembers();
 
-        final HazelcastInstance newClusterInstance1 = hazelcastFactory.newHazelcastInstance();
-        final HazelcastInstance newClusterInstance2 = hazelcastFactory.newHazelcastInstance();
+        final HazelcastInstance member1 = hazelcastFactory.newHazelcastInstance();
+        final HazelcastInstance member2 = hazelcastFactory.newHazelcastInstance();
 
-        assertTrueEventually(() -> {
-            Collection<DistributedObject> distributedObjects1 = newClusterInstance1.getDistributedObjects();
-            assertEquals(1, distributedObjects1.size());
-            Collection<DistributedObject> distributedObjects2 = newClusterInstance2.getDistributedObjects();
-            assertEquals(1, distributedObjects2.size());
-        });
+        checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -32,13 +32,14 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -128,6 +129,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         // TODO: This line is not needed when the create destroy order is guaranteed.
         // The issue: https://github.com/hazelcast/hazelcast/issues/16374
         assertEqualsEventually(1, listener.createdCount);
+        checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
 
         map.destroy();
 
@@ -146,6 +148,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         // TODO: This line is not needed when the create destroy order is guaranteed.
         // The issue: https://github.com/hazelcast/hazelcast/issues/16374
         assertEqualsEventually(1, listener.createdCount);
+        checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
 
         IMap<Object, Object> map2 = instance2.getMap(mapName);
         map2.destroy();
@@ -162,6 +165,11 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         instance.addDistributedObjectListener(listener);
         instance.getMap(mapName);
 
+        // TODO: This line is not needed when the create destroy order is guaranteed.
+        // The issue: https://github.com/hazelcast/hazelcast/issues/16374
+        assertEqualsEventually(1, listener.createdCount);
+        checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
+
         IMap<Object, Object> map2 = server.getMap(mapName);
         map2.destroy();
 
@@ -172,8 +180,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
         public AtomicInteger createdCount = new AtomicInteger();
         public AtomicInteger destroyedCount = new AtomicInteger();
-        public AtomicReference<DistributedObjectEvent> lastProxyDestroyedEvent = new AtomicReference<>();
-        public volatile String unexpectedObjectName;
+        public List<DistributedObjectEvent> events = new CopyOnWriteArrayList();
 
         private final String objectName;
 
@@ -185,19 +192,24 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
             Object objectName = event.getObjectName();
             if (objectName.equals(this.objectName)) {
                 createdCount.incrementAndGet();
-            } else {
-                unexpectedObjectName = (String) objectName;
             }
+
+            events.add(event);
         }
 
         public void distributedObjectDestroyed(DistributedObjectEvent event) {
             Object objectName = event.getObjectName();
             if (objectName.equals(this.objectName)) {
-                lastProxyDestroyedEvent.set(event);
                 destroyedCount.incrementAndGet();
-            } else {
-                unexpectedObjectName = (String) objectName;
             }
+
+            events.add(event);
+        }
+
+        @Override
+        public String toString() {
+            return "EventCountListener{" + "createdCount=" + createdCount + ", destroyedCount=" + destroyedCount + ", events="
+                    + events + ", objectName='" + objectName + '\'' + '}';
         }
     }
 
@@ -220,28 +232,30 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
             // other server yet, it may cause a problem. Therefore, we have the previous verification step to verify
             // that all servers in cluster deleted the proxy locally.
             Collection<DistributedObject> distributedObjects = listeningInstance.getDistributedObjects();
-            Assert.assertTrue(
-                    "Instance1 did not destroy the proxy! instance:" + listeningInstance + ", objects:" + distributedObjects,
+            Assert.assertTrue("Listening instance proxies are not destroyed! listeningInstance:" + listeningInstance
+                            + " destroyingInstance:" + destroyingInstance + ", proxies:" + distributedObjects + ", listener:" + listener,
                     distributedObjects.isEmpty());
 
             distributedObjects = destroyingInstance.getDistributedObjects();
-            Assert.assertTrue(
-                    "Instance2 did not destroy the proxy! instance:" + destroyingInstance + ", objects:" + distributedObjects,
+            Assert.assertTrue("Destroying instance proxies are not destroyed! listeningInstance:" + listeningInstance
+                            + " destroyingInstance:" + destroyingInstance + ", proxies:" + distributedObjects + ", listener:" + listener,
                     distributedObjects.isEmpty());
 
-            DistributedObjectEvent lastDestroyedEvent = listener.lastProxyDestroyedEvent.get();
-            assertNotNull(lastDestroyedEvent);
-            Assert.assertEquals(destroyingInstance.getLocalEndpoint().getUuid(), lastDestroyedEvent.getSource());
+            assertFalse("No event received. " + listener, listener.events.isEmpty());
+            DistributedObjectEvent event = listener.events.get(listener.events.size() - 1);
+            assertEquals("Last received event is not a destroy event" + listener, DistributedObjectEvent.EventType.DESTROYED,
+                    event.getEventType());
+            Assert.assertEquals(destroyingInstance.getLocalEndpoint().getUuid(), event.getSource());
         };
     }
 
-    private void checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(int numberOfObjects) {
+    protected void checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(int numberOfObjects) {
         // getDistributedObjects() call may be done against a random node when instance is client and we need to have the creation event propagated to all cluster first
         assertTrueEventually(() -> {
             hazelcastFactory.getAllHazelcastInstances().forEach(member -> {
                 Collection<DistributedObject> distributedObjects = member.getDistributedObjects();
-                assertEquals("Distributed object is not created for member:" + member + ", objects:" + distributedObjects,
-                        numberOfObjects, distributedObjects.size());
+                assertEquals("Number of distributed objects is not as expected for member" + member + ", objects:"
+                        + distributedObjects, numberOfObjects, distributedObjects.size());
             });
         });
     }


### PR DESCRIPTION
Make the test `testDestroyEventReceived_WhenDestroyedByServer` wait for the proxy creation to complete in the cluster before doing the proxy destroy. E.g. failure scenario:

1. Proxy created at server1 but not created at server2.
2. Proxy destroy called, will not do anything for server 2 since it did not yet create the proxy upon receiving the event.
3. Server2 later on receives the proxy created event (late receive) and mistakenly creates a destroyed proxy.

Also added more verbose logging for failures.

related to https://github.com/hazelcast/hazelcast/issues/16374#issuecomment-571094670
related to https://github.com/hazelcast/hazelcast/issues/16396#issuecomment-571516379
