### PR TITLE
Remove the usage of listener createdCount check from the DistributedObjectListenerTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/proxy/ClientDistributedObjectListenerTest.java
@@ -47,7 +47,7 @@ public class ClientDistributedObjectListenerTest extends com.hazelcast.core.Dist
 
         hazelcastFactory.shutdownAllMembers();
 
-        final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
 
         checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
     }
@@ -62,8 +62,8 @@ public class ClientDistributedObjectListenerTest extends com.hazelcast.core.Dist
 
         hazelcastFactory.shutdownAllMembers();
 
-        final HazelcastInstance member1 = hazelcastFactory.newHazelcastInstance();
-        final HazelcastInstance member2 = hazelcastFactory.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
 
         checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
     }

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -128,7 +128,6 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
         // TODO: This line is not needed when the create destroy order is guaranteed.
         // The issue: https://github.com/hazelcast/hazelcast/issues/16374
-        assertEqualsEventually(1, listener.createdCount);
         checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
 
         map.destroy();
@@ -147,7 +146,6 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
         // TODO: This line is not needed when the create destroy order is guaranteed.
         // The issue: https://github.com/hazelcast/hazelcast/issues/16374
-        assertEqualsEventually(1, listener.createdCount);
         checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
 
         IMap<Object, Object> map2 = instance2.getMap(mapName);
@@ -167,7 +165,6 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
         // TODO: This line is not needed when the create destroy order is guaranteed.
         // The issue: https://github.com/hazelcast/hazelcast/issues/16374
-        assertEqualsEventually(1, listener.createdCount);
         checkTheNumberOfObjectsInClusterIsEventuallyAsExpected(1);
 
         IMap<Object, Object> map2 = server.getMap(mapName);
@@ -177,7 +174,6 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
     }
 
     public static class EventCountListener implements DistributedObjectListener {
-
         public AtomicInteger createdCount = new AtomicInteger();
         public AtomicInteger destroyedCount = new AtomicInteger();
         public List<DistributedObjectEvent> events = new CopyOnWriteArrayList();


### PR DESCRIPTION
Removed the usage of listener createdCount check from the DistributedObjectListenerTest since there are known issues with this event being delivered and the test is not related to the creation but destroy.

related to https://github.com/hazelcast/hazelcast/issues/16374
