### PR TITLE
Removed the dependencies on Data from the SplitBrainMergePolicy API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -57,6 +57,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
+import com.hazelcast.spi.impl.merge.CacheMergingEntryImpl;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CacheMergeTypes;
 import com.hazelcast.wan.impl.CallerProvenance;
@@ -1750,8 +1751,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         injectDependencies(mergePolicy);
 
         boolean merged = false;
-
-        Data key = toData(mergingEntry.getRawKey());
+        assert mergingEntry instanceof CacheMergingEntryImpl;
+        CacheMergingEntryImpl<Object, Object> mergingEntryImpl = (CacheMergingEntryImpl<Object, Object>) mergingEntry;
+        Data key = mergingEntryImpl.getRawKey();
         long expiryTime = mergingEntry.getExpirationTime();
         R record = records.get(key);
         boolean isExpired = processExpiredEntry(key, record, now);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -57,7 +57,6 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
-import com.hazelcast.spi.impl.merge.CacheMergingEntryImpl;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CacheMergeTypes;
 import com.hazelcast.wan.impl.CallerProvenance;
@@ -1751,9 +1750,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         injectDependencies(mergePolicy);
 
         boolean merged = false;
-        assert mergingEntry instanceof CacheMergingEntryImpl;
-        CacheMergingEntryImpl<Object, Object> mergingEntryImpl = (CacheMergingEntryImpl<Object, Object>) mergingEntry;
-        Data key = mergingEntryImpl.getRawKey();
+        Data key = (Data) mergingEntry.getRawKey();
         long expiryTime = mergingEntry.getExpirationTime();
         R record = records.get(key);
         boolean isExpired = processExpiredEntry(key, record, now);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -37,7 +37,7 @@ import static com.hazelcast.cache.impl.AbstractCacheRecordStore.SOURCE_NOT_AVAIL
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
-class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordStore, CacheMergeTypes> {
+class CacheMergeRunnable extends AbstractMergeRunnable<Object, Object, ICacheRecordStore, CacheMergeTypes<Object, Object>> {
 
     private final CacheService cacheService;
     private final ConcurrentMap<String, CacheConfig> configs;
@@ -66,7 +66,7 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
     }
 
     @Override
-    protected void mergeStore(ICacheRecordStore store, BiConsumer<Integer, CacheMergeTypes> consumer) {
+    protected void mergeStore(ICacheRecordStore store, BiConsumer<Integer, CacheMergeTypes<Object, Object>> consumer) {
         int partitionId = store.getPartitionId();
 
         for (Map.Entry<Data, CacheRecord> entry : store.getReadOnlyRecords().entrySet()) {
@@ -106,8 +106,9 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
 
     @Override
     protected OperationFactory createMergeOperationFactory(String dataStructureName,
-                                                           SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy,
-                                                           int[] partitions, List<CacheMergeTypes>[] entries) {
+                                                           SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>,
+                                                                   Object> mergePolicy,
+                                                           int[] partitions, List<CacheMergeTypes<Object, Object>>[] entries) {
         CacheConfig cacheConfig = cacheService.getCacheConfig(dataStructureName);
         CacheOperationProvider operationProvider
                 = cacheService.getCacheOperationProvider(dataStructureName, cacheConfig.getInMemoryFormat());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -70,12 +70,12 @@ public interface CacheOperationProvider {
      */
     Operation createFetchEntriesOperation(IterationPointer[] pointers, int fetchSize);
 
-    Operation createMergeOperation(String name, List<CacheMergeTypes> mergingEntries,
-                                   SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
+    Operation createMergeOperation(String name, List<CacheMergeTypes<Object, Object>> mergingEntries,
+                                   SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> policy);
 
     OperationFactory createMergeOperationFactory(String name, int[] partitions,
-                                                 List<CacheMergeTypes>[] mergingEntries,
-                                                 SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
+                                                 List<CacheMergeTypes<Object, Object>>[] mergingEntries,
+                                                 SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> policy);
 
     Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -123,15 +123,16 @@ public class DefaultOperationProvider implements CacheOperationProvider {
     }
 
     @Override
-    public Operation createMergeOperation(String name, List<CacheMergeTypes> mergingEntries,
-                                          SplitBrainMergePolicy<Data, CacheMergeTypes> policy) {
+    public Operation createMergeOperation(String name, List<CacheMergeTypes<Object, Object>> mergingEntries,
+                                          SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> policy) {
         return new CacheMergeOperation(name, mergingEntries, policy);
     }
 
     @Override
     public OperationFactory createMergeOperationFactory(String name, int[] partitions,
-                                                        List<CacheMergeTypes>[] mergingEntries,
-                                                        SplitBrainMergePolicy<Data, CacheMergeTypes> policy) {
+                                                        List<CacheMergeTypes<Object, Object>>[] mergingEntries,
+                                                        SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>,
+                                                                Object> policy) {
         return new CacheMergeOperationFactory(name, partitions, mergingEntries, policy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -539,8 +539,9 @@ public interface ICacheRecordStore {
      * @param callerProvenance
      * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
      */
-    CacheRecord merge(CacheMergeTypes mergingEntry,
-                      SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy, CallerProvenance callerProvenance);
+    CacheRecord merge(CacheMergeTypes<Object, Object> mergingEntry,
+                      SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> mergePolicy,
+                      CallerProvenance callerProvenance);
 
     /**
      * @return partition ID of this store

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -41,8 +41,8 @@ import static com.hazelcast.wan.impl.CallerProvenance.NOT_WAN;
  */
 public class CacheMergeOperation extends CacheOperation implements BackupAwareOperation {
 
-    private List<CacheMergeTypes> mergingEntries;
-    private SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy;
+    private List<CacheMergeTypes<Object, Object>> mergingEntries;
+    private SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> mergePolicy;
 
     private transient boolean hasBackups;
     private transient Map<Data, CacheRecord> backupRecords;
@@ -50,8 +50,8 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
     public CacheMergeOperation() {
     }
 
-    public CacheMergeOperation(String name, List<CacheMergeTypes> mergingEntries,
-                               SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy) {
+    public CacheMergeOperation(String name, List<CacheMergeTypes<Object, Object>> mergingEntries,
+                               SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> mergePolicy) {
         super(name);
         this.mergingEntries = mergingEntries;
         this.mergePolicy = mergePolicy;
@@ -67,13 +67,13 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
 
     @Override
     public void run() {
-        for (CacheMergeTypes mergingEntry : mergingEntries) {
+        for (CacheMergeTypes<Object, Object> mergingEntry : mergingEntries) {
             merge(mergingEntry);
         }
     }
 
-    private void merge(CacheMergeTypes mergingEntry) {
-        Data dataKey = mergingEntry.getKey();
+    private void merge(CacheMergeTypes<Object, Object> mergingEntry) {
+        Data dataKey = (Data) mergingEntry.getRawKey();
 
         CacheRecord backupRecord = recordStore.merge(mergingEntry, mergePolicy, NOT_WAN);
         if (backupRecords != null && backupRecord != null) {
@@ -107,7 +107,7 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(mergingEntries.size());
-        for (CacheMergeTypes mergingEntry : mergingEntries) {
+        for (CacheMergeTypes<Object, Object> mergingEntry : mergingEntries) {
             out.writeObject(mergingEntry);
         }
         out.writeObject(mergePolicy);
@@ -119,7 +119,7 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
         int size = in.readInt();
         mergingEntries = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            CacheMergeTypes mergingEntry = in.readObject();
+            CacheMergeTypes<Object, Object> mergingEntry = in.readObject();
             mergingEntries.add(mergingEntry);
         }
         mergePolicy = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
@@ -39,15 +38,15 @@ import java.util.List;
 public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
 
     private String name;
-    private List<CacheMergeTypes>[] mergingEntries;
-    private SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy;
+    private List<CacheMergeTypes<Object, Object>>[] mergingEntries;
+    private SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> mergePolicy;
 
     public CacheMergeOperationFactory() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public CacheMergeOperationFactory(String name, int[] partitions, List<CacheMergeTypes>[] mergingEntries,
-                                      SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy) {
+    public CacheMergeOperationFactory(String name, int[] partitions, List<CacheMergeTypes<Object, Object>>[] mergingEntries,
+                                      SplitBrainMergePolicy<Object, CacheMergeTypes<Object, Object>, Object> mergePolicy) {
         this.name = name;
         this.partitions = partitions;
         this.mergingEntries = mergingEntries;
@@ -68,9 +67,9 @@ public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeIntArray(partitions);
-        for (List<CacheMergeTypes> list : mergingEntries) {
+        for (List<CacheMergeTypes<Object, Object>> list : mergingEntries) {
             out.writeInt(list.size());
-            for (CacheMergeTypes mergingEntry : list) {
+            for (CacheMergeTypes<Object, Object> mergingEntry : list) {
                 out.writeObject(mergingEntry);
             }
         }
@@ -85,9 +84,9 @@ public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
         mergingEntries = new List[partitions.length];
         for (int partitionIndex = 0; partitionIndex < partitions.length; partitionIndex++) {
             int size = in.readInt();
-            List<CacheMergeTypes> list = new ArrayList<CacheMergeTypes>(size);
+            List<CacheMergeTypes<Object, Object>> list = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                CacheMergeTypes mergingEntry = in.readObject();
+                CacheMergeTypes<Object, Object> mergingEntry = in.readObject();
                 list.add(mergingEntry);
             }
             mergingEntries[partitionIndex] = list;

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -78,12 +78,12 @@ public class CardinalityEstimatorContainer
      * @return the used {@link HyperLogLog} if merge is applied, otherwise {@code null}
      */
     public HyperLogLog merge(CardinalityEstimatorMergeTypes mergingEntry,
-                             SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes> mergePolicy,
+                             SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes, HyperLogLog> mergePolicy,
                              SerializationService serializationService) {
         serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        String name = mergingEntry.getKey();
+        String name = mergingEntry.getDeserializedKey();
         if (hll.estimate() != 0) {
             CardinalityEstimatorMergeTypes existingEntry = createMergingEntry(serializationService, name, hll);
             HyperLogLog newValue = mergePolicy.merge(mergingEntry, existingEntry);

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -83,7 +83,7 @@ public class CardinalityEstimatorContainer
         serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        String name = mergingEntry.getDeserializedKey();
+        String name = mergingEntry.getKey();
         if (hll.estimate() != 0) {
             CardinalityEstimatorMergeTypes existingEntry = createMergingEntry(serializationService, name, hll);
             HyperLogLog newValue = mergePolicy.merge(mergingEntry, existingEntry);

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -217,7 +217,7 @@ public class CardinalityEstimatorService
 
                 for (CardinalityEstimatorContainer container : containerList) {
                     String containerName = collector.getContainerName(container);
-                    SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes, HyperLogLog> mergePolicy
                             = getMergePolicy(collector.getMergePolicyConfig(container));
 
                     MergeOperation operation = new MergeOperation(containerName, mergePolicy, container.hll);

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeOperation.java
@@ -37,7 +37,7 @@ import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntr
 public class MergeOperation
         extends CardinalityEstimatorBackupAwareOperation {
 
-    private SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes, HyperLogLog> mergePolicy;
     private HyperLogLog value;
 
     private transient HyperLogLog backupValue;
@@ -45,7 +45,8 @@ public class MergeOperation
     public MergeOperation() {
     }
 
-    public MergeOperation(String name, SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes> mergePolicy,
+    public MergeOperation(String name,
+                          SplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes, HyperLogLog> mergePolicy,
                           HyperLogLog value) {
         super(name);
         this.mergePolicy = mergePolicy;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -202,7 +202,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
         return new Merger(collector);
     }
 
-    private class Merger extends AbstractContainerMerger<CollectionContainer, Collection<Object>, CollectionMergeTypes> {
+    private class Merger extends AbstractContainerMerger<CollectionContainer, Collection<Object>, CollectionMergeTypes<Object>> {
 
         Merger(CollectionContainerCollector collector) {
             super(collector, nodeEngine);
@@ -223,10 +223,10 @@ public abstract class CollectionService implements ManagedService, RemoteService
                     Collection<CollectionItem> items = container.getCollection();
 
                     String name = container.getName();
-                    SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes<Object>, Collection<Object>> mergePolicy
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
-                    CollectionMergeTypes mergingValue = createMergingValue(serializationService, items);
+                    CollectionMergeTypes<Object> mergingValue = createMergingValue(serializationService, items);
                     sendBatch(partitionId, name, mergePolicy, mergingValue);
 
                     items.clear();
@@ -235,8 +235,9 @@ public abstract class CollectionService implements ManagedService, RemoteService
         }
 
         private void sendBatch(int partitionId, String name,
-                               SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy,
-                               CollectionMergeTypes mergingValue) {
+                               SplitBrainMergePolicy<Collection<Object>,
+                                       CollectionMergeTypes<Object>, Collection<Object>> mergePolicy,
+                               CollectionMergeTypes<Object> mergingValue) {
             CollectionOperation operation = new CollectionMergeOperation(name, mergePolicy, mergingValue);
             invoke(getServiceName(), operation, partitionId);
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
@@ -40,14 +40,15 @@ import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
  */
 public class CollectionMergeOperation extends CollectionBackupAwareOperation {
 
-    private SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes<Object>, Collection<Object>> mergePolicy;
     private CollectionMergeTypes mergingValue;
 
     private transient Collection<CollectionItem> backupCollection;
     private transient boolean shouldBackup;
 
-    public CollectionMergeOperation(String name, SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy,
-                                    CollectionMergeTypes mergingValue) {
+    public CollectionMergeOperation(String name,
+                                    SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes<Object>,
+                                            Collection<Object>> mergePolicy, CollectionMergeTypes<Object> mergingValue) {
         super(name);
         this.mergePolicy = mergePolicy;
         this.mergingValue = mergingValue;
@@ -66,15 +67,16 @@ public class CollectionMergeOperation extends CollectionBackupAwareOperation {
         shouldBackup = currentCollectionIsEmpty != backupCollection.isEmpty() || currentItemId != container.getCurrentId();
     }
 
-    private Collection<CollectionItem> merge(CollectionContainer container, CollectionMergeTypes mergingValue,
-                                             SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy) {
+    private Collection<CollectionItem> merge(CollectionContainer container, CollectionMergeTypes<Object> mergingValue,
+                                             SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes<Object>,
+                                                     Collection<Object>> mergePolicy) {
         SerializationService serializationService = getNodeEngine().getSerializationService();
         serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
 
         Collection<CollectionItem> existingItems = container.getCollection();
 
-        CollectionMergeTypes existingValue = createMergingValueOrNull(serializationService, existingItems);
+        CollectionMergeTypes<Object> existingValue = createMergingValueOrNull(serializationService, existingItems);
         Collection<Object> newValues = mergePolicy.merge(mergingValue, existingValue);
 
         if (isEmpty(newValues)) {
@@ -82,15 +84,15 @@ public class CollectionMergeOperation extends CollectionBackupAwareOperation {
             service.destroyDistributedObject(name);
         } else if (existingValue == null) {
             createNewCollectionItems(container, existingItems, newValues, serializationService);
-        } else if (!newValues.equals(existingValue.getValue())) {
+        } else if (!newValues.equals(existingValue.getRawValue())) {
             container.clear(false);
             createNewCollectionItems(container, existingItems, newValues, serializationService);
         }
         return existingItems;
     }
 
-    private CollectionMergeTypes createMergingValueOrNull(SerializationService serializationService,
-                                                          Collection<CollectionItem> existingItems) {
+    private CollectionMergeTypes<Object> createMergingValueOrNull(SerializationService serializationService,
+                                                                  Collection<CollectionItem> existingItems) {
         return existingItems.isEmpty() ? null : createMergingValue(serializationService, existingItems);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -38,6 +38,7 @@ import com.hazelcast.internal.partition.MigrationAwareService;
 import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.ManagedService;
 import com.hazelcast.internal.services.RemoteService;
@@ -51,7 +52,6 @@ import com.hazelcast.internal.util.ContextMutexFactory;
 import com.hazelcast.internal.util.scheduler.EntryTaskScheduler;
 import com.hazelcast.internal.util.scheduler.EntryTaskSchedulerFactory;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -417,7 +417,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         provide(descriptor, context, "queue", getStats());
     }
 
-    private class Merger extends AbstractContainerMerger<QueueContainer, Collection<Object>, QueueMergeTypes> {
+    private class Merger extends AbstractContainerMerger<QueueContainer, Collection<Object>, QueueMergeTypes<Object>> {
 
         Merger(QueueContainerCollector collector) {
             super(collector, nodeEngine);
@@ -438,7 +438,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
                     Queue<QueueItem> items = container.getItemQueue();
 
                     String name = container.getName();
-                    SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes<Object>, Collection<Object>> mergePolicy
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
                     QueueMergeTypes mergingValue = createMergingValue(serializationService, items);
@@ -448,7 +448,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         }
 
         private void sendBatch(int partitionId, String name,
-                               SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy,
+                               SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes<Object>, Collection<Object>> mergePolicy,
                                QueueMergeTypes mergingValue) {
             QueueMergeOperation operation = new QueueMergeOperation(name, mergePolicy, mergingValue);
             invoke(SERVICE_NAME, operation, partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
@@ -41,8 +41,8 @@ import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
  */
 public class QueueMergeOperation extends QueueBackupAwareOperation implements MutatingOperation {
 
-    private SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy;
-    private QueueMergeTypes mergingValue;
+    private SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes<Object>, Collection<Object>> mergePolicy;
+    private QueueMergeTypes<Object> mergingValue;
 
     private transient Collection<QueueItem> backupCollection;
     private transient boolean shouldBackup;
@@ -50,8 +50,9 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
     public QueueMergeOperation() {
     }
 
-    public QueueMergeOperation(String name, SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy,
-                               QueueMergeTypes mergingValue) {
+    public QueueMergeOperation(String name,
+                               SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes<Object>, Collection<Object>> mergePolicy,
+                               QueueMergeTypes<Object> mergingValue) {
         super(name);
         this.mergePolicy = mergePolicy;
         this.mergingValue = mergingValue;
@@ -67,14 +68,15 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
         shouldBackup = currentCollectionIsEmpty != backupCollection.isEmpty() || currentItemId != container.getCurrentId();
     }
 
-    private Queue<QueueItem> merge(QueueContainer container, QueueMergeTypes mergingValue,
-                                   SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy) {
+    private Queue<QueueItem> merge(QueueContainer container, QueueMergeTypes<Object> mergingValue,
+                                   SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes<Object>,
+                                           Collection<Object>> mergePolicy) {
         SerializationService serializationService = getNodeEngine().getSerializationService();
         serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
 
         Queue<QueueItem> existingItems = container.getItemQueue();
-        QueueMergeTypes existingValue = createMergingValueOrNull(serializationService, existingItems);
+        QueueMergeTypes<Object> existingValue = createMergingValueOrNull(serializationService, existingItems);
         Collection<Object> newValues = mergePolicy.merge(mergingValue, existingValue);
 
         if (isEmpty(newValues)) {
@@ -84,14 +86,15 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
             getQueueService().destroyDistributedObject(name);
         } else if (existingValue == null) {
             createNewQueueItems(container, newValues, serializationService);
-        } else if (!newValues.equals(existingValue.getValue())) {
+        } else if (!newValues.equals(existingValue.getRawValue())) {
             container.clear();
             createNewQueueItems(container, newValues, serializationService);
         }
         return existingItems;
     }
 
-    private QueueMergeTypes createMergingValueOrNull(SerializationService serializationService, Queue<QueueItem> existingItems) {
+    private QueueMergeTypes<Object> createMergingValueOrNull(SerializationService serializationService,
+                                                             Queue<QueueItem> existingItems) {
         return existingItems.isEmpty() ? null : createMergingValue(serializationService, existingItems);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MergePolicyValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MergePolicyValidator.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.spi.merge.MergingExpirationTime;
 import com.hazelcast.spi.merge.MergingLastStoredTime;
 import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.MergingView;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes;
@@ -176,8 +177,8 @@ public final class MergePolicyValidator {
 
     private static void checkRequiredMergeTypeClass(List<Class> requiredMergeTypes, Class providedMergeTypes,
                                                     String mergePolicyClassName, Class<?> requiredMergeTypeClass) {
-        if (!MergingValue.class.isAssignableFrom(requiredMergeTypeClass)) {
-            // just check types, which inherit from MergingValue
+        if (!MergingView.class.isAssignableFrom(requiredMergeTypeClass)) {
+            // just check types, which inherit from MergingView
             return;
         }
         if (!requiredMergeTypeClass.isAssignableFrom(providedMergeTypes)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
@@ -34,7 +34,7 @@ import java.util.function.BiConsumer;
 
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
-class MapMergeRunnable extends AbstractMergeRunnable<Data, Data, RecordStore, MapMergeTypes> {
+class MapMergeRunnable extends AbstractMergeRunnable<Object, Object, RecordStore, MapMergeTypes<Object, Object>> {
 
     private final MapServiceContext mapServiceContext;
 
@@ -47,7 +47,7 @@ class MapMergeRunnable extends AbstractMergeRunnable<Data, Data, RecordStore, Ma
     }
 
     @Override
-    protected void mergeStore(RecordStore store, BiConsumer<Integer, MapMergeTypes> consumer) {
+    protected void mergeStore(RecordStore store, BiConsumer<Integer, MapMergeTypes<Object, Object>> consumer) {
         int partitionId = store.getPartitionId();
 
         store.forEach((BiConsumer<Data, Record>) (key, record) -> {
@@ -90,8 +90,9 @@ class MapMergeRunnable extends AbstractMergeRunnable<Data, Data, RecordStore, Ma
 
     @Override
     protected OperationFactory createMergeOperationFactory(String dataStructureName,
-                                                           SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
-                                                           int[] partitions, List<MapMergeTypes>[] entries) {
+                                                           SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>,
+                                                                   Object> mergePolicy,
+                                                           int[] partitions, List<MapMergeTypes<Object, Object>>[] entries) {
         MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(dataStructureName);
         return operationProvider.createMergeOperationFactory(dataStructureName, partitions, entries, mergePolicy);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/WanMapSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/WanMapSupportingService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.config.WanAcknowledgeType;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.WanSupportingService;
 import com.hazelcast.map.impl.operation.MapOperation;
@@ -80,10 +79,10 @@ class WanMapSupportingService implements WanSupportingService {
         MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(mapName);
 
         SerializationService serializationService = nodeEngine.getSerializationService();
-        MapMergeTypes mergingEntry = createMergingEntry(serializationService, replicationUpdate.getEntryView());
+        MapMergeTypes<Object, Object> mergingEntry = createMergingEntry(serializationService, replicationUpdate.getEntryView());
         //noinspection unchecked
         MapOperation operation = operationProvider.createMergeOperation(mapName, mergingEntry,
-                (SplitBrainMergePolicy<Data, MapMergeTypes>) mergePolicy, true);
+                (SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object>) mergePolicy, true);
 
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(replicationUpdate.getEntryView().getKey());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -215,8 +215,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createMergeOperation(String name, MapMergeTypes mergingValue,
-                                             SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+    public MapOperation createMergeOperation(String name, MapMergeTypes<Object, Object> mergingValue,
+                                             SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
                                              boolean disableWanReplicationEvent) {
         return new MergeOperation(name, singletonList(mergingValue), mergePolicy, disableWanReplicationEvent);
     }
@@ -275,8 +275,10 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public OperationFactory createMergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                                        SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy) {
+    public OperationFactory createMergeOperationFactory(String name, int[] partitions,
+                                                        List<MapMergeTypes<Object, Object>>[] mergingEntries,
+                                                        SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>,
+                                                                Object> mergePolicy) {
         return new MergeOperationFactory(name, partitions, mergingEntries, mergePolicy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -111,8 +111,8 @@ public interface MapOperationProvider {
 
     MapOperation createTxnSetOperation(String name, Data dataKey, Data value, long version, long ttl);
 
-    MapOperation createMergeOperation(String name, MapMergeTypes mergingValue,
-                                      SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+    MapOperation createMergeOperation(String name, MapMergeTypes<Object, Object> mergingValue,
+                                      SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
                                       boolean disableWanReplicationEvent);
 
     MapOperation createMapFlushOperation(String name);
@@ -168,6 +168,8 @@ public interface MapOperationProvider {
 
     OperationFactory createPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries);
 
-    OperationFactory createMergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                                 SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy);
+    OperationFactory createMergeOperationFactory(String name, int[] partitions,
+                                                 List<MapMergeTypes<Object, Object>>[] mergingEntries,
+                                                 SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>,
+                                                         Object> mergePolicy);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -44,8 +44,8 @@ public class MergeOperation extends MapOperation
         implements PartitionAwareOperation, BackupAwareOperation {
 
     private boolean disableWanReplicationEvent;
-    private List<MapMergeTypes> mergingEntries;
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private List<MapMergeTypes<Object, Object>> mergingEntries;
+    private SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy;
 
     private transient int currentIndex;
     private transient boolean hasMapListener;
@@ -61,8 +61,8 @@ public class MergeOperation extends MapOperation
     public MergeOperation() {
     }
 
-    public MergeOperation(String name, List<MapMergeTypes> mergingEntries,
-                          SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+    public MergeOperation(String name, List<MapMergeTypes<Object, Object>> mergingEntries,
+                          SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
                           boolean disableWanReplicationEvent) {
         super(name);
         this.mergingEntries = mergingEntries;
@@ -100,8 +100,8 @@ public class MergeOperation extends MapOperation
         }
     }
 
-    private void merge(MapMergeTypes mergingEntry) {
-        Data dataKey = mergingEntry.getKey();
+    private void merge(MapMergeTypes<Object, Object> mergingEntry) {
+        Data dataKey = getNodeEngine().toData(mergingEntry.getRawKey());
         Data oldValue = hasMapListener ? getValue(dataKey) : null;
 
         if (recordStore.merge(mergingEntry, mergePolicy, getCallerProvenance())) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
@@ -40,15 +39,15 @@ import java.util.List;
 public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     protected String name;
-    protected List<MapMergeTypes>[] mergingEntries;
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    protected List<MapMergeTypes<Object, Object>>[] mergingEntries;
+    protected SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy;
 
     public MergeOperationFactory() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public MergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                 SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy) {
+    public MergeOperationFactory(String name, int[] partitions, List<MapMergeTypes<Object, Object>>[] mergingEntries,
+                                 SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy) {
         this.name = name;
         this.partitions = partitions;
         this.mergingEntries = mergingEntries;
@@ -69,9 +68,9 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeIntArray(partitions);
-        for (List<MapMergeTypes> list : mergingEntries) {
+        for (List<MapMergeTypes<Object, Object>> list : mergingEntries) {
             out.writeInt(list.size());
-            for (MapMergeTypes mergingEntry : list) {
+            for (MapMergeTypes<Object, Object> mergingEntry : list) {
                 out.writeObject(mergingEntry);
             }
         }
@@ -86,9 +85,9 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
         mergingEntries = new List[partitions.length];
         for (int partitionIndex = 0; partitionIndex < partitions.length; partitionIndex++) {
             int size = in.readInt();
-            List<MapMergeTypes> list = new ArrayList<>(size);
+            List<MapMergeTypes<Object, Object>> list = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                MapMergeTypes mergingEntry = in.readObject();
+                MapMergeTypes<Object, Object> mergingEntry = in.readObject();
                 list.add(mergingEntry);
             }
             mergingEntries[partitionIndex] = list;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -50,6 +50,7 @@ import com.hazelcast.map.impl.querycache.publisher.PublisherRegistry;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.merge.MapMergingEntryImpl;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.wan.impl.CallerProvenance;
@@ -788,7 +789,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        Data key = toData(mergingEntry.getRawKey());
+        assert mergingEntry instanceof MapMergingEntryImpl;
+        MapMergingEntryImpl<Object, Object> mergingEntryImpl = (MapMergingEntryImpl<Object, Object>) mergingEntry;
+        Data key = mergingEntryImpl.getRawKey();
         Record record = getRecordOrNull(key, now, false);
         Object newValue;
         Object oldValue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -50,7 +50,6 @@ import com.hazelcast.map.impl.querycache.publisher.PublisherRegistry;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.merge.MapMergingEntryImpl;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.wan.impl.CallerProvenance;
@@ -789,9 +788,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        assert mergingEntry instanceof MapMergingEntryImpl;
-        MapMergingEntryImpl<Object, Object> mergingEntryImpl = (MapMergingEntryImpl<Object, Object>) mergingEntry;
-        Data key = mergingEntryImpl.getRawKey();
+        Data key = (Data) mergingEntry.getRawKey();
         Record record = getRecordOrNull(key, now, false);
         Object newValue;
         Object oldValue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -773,13 +773,14 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public boolean merge(MapMergeTypes mergingEntry, SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy) {
+    public boolean merge(MapMergeTypes<Object, Object> mergingEntry,
+                         SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy) {
         return merge(mergingEntry, mergePolicy, CallerProvenance.NOT_WAN);
     }
 
     @Override
-    public boolean merge(MapMergeTypes mergingEntry,
-                         SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+    public boolean merge(MapMergeTypes<Object, Object> mergingEntry,
+                         SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
                          CallerProvenance provenance) {
         checkIfLoaded();
         long now = getNow();
@@ -787,7 +788,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        Data key = mergingEntry.getKey();
+        Data key = toData(mergingEntry.getRawKey());
         Record record = getRecordOrNull(key, now, false);
         Object newValue;
         Object oldValue;
@@ -806,7 +807,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             mutationObserver.onPutRecord(key, record, null, false);
         } else {
             oldValue = record.getValue();
-            MapMergeTypes existingEntry = createMergingEntry(serializationService, key, record);
+            MapMergeTypes<Object, Object> existingEntry = createMergingEntry(serializationService, key, record);
             newValue = mergePolicy.merge(mergingEntry, existingEntry);
             // existing entry will be removed
             if (newValue == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -258,8 +258,8 @@ public interface RecordStore<R extends Record> {
      */
     Object putFromLoadBackup(Data key, Object value, long expirationTime);
 
-    boolean merge(MapMergeTypes mergingEntry,
-                  SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy);
+    boolean merge(MapMergeTypes<Object, Object> mergingEntry,
+                  SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy);
 
     /**
      * Merges the given {@link MapMergeTypes} via the given {@link SplitBrainMergePolicy}.
@@ -269,8 +269,8 @@ public interface RecordStore<R extends Record> {
      * @param provenance   origin of call to this method.
      * @return {@code true} if merge is applied, otherwise {@code false}
      */
-    boolean merge(MapMergeTypes mergingEntry,
-                  SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+    boolean merge(MapMergeTypes<Object, Object> mergingEntry,
+                  SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
                   CallerProvenance provenance);
 
     R getRecord(Data key);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.multimap.impl;
 
-import com.hazelcast.internal.locksupport.LockSupportService;
 import com.hazelcast.internal.locksupport.LockStore;
+import com.hazelcast.internal.locksupport.LockSupportService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.DistributedObjectNamespace;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MultiMapMergeTypes;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,9 +33,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 import static com.hazelcast.internal.util.Clock.currentTimeMillis;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
 /**
  * MultiMap container which holds a map of {@link MultiMapValue}.
@@ -118,11 +118,11 @@ public class MultiMapContainer extends MultiMapContainerSupport {
 
     public Set<Data> keySet() {
         Set<Data> keySet = multiMapValues.keySet();
-        return new HashSet<Data>(keySet);
+        return new HashSet<>(keySet);
     }
 
     public Collection<MultiMapRecord> values() {
-        Collection<MultiMapRecord> valueCollection = new LinkedList<MultiMapRecord>();
+        Collection<MultiMapRecord> valueCollection = new LinkedList<>();
         for (MultiMapValue multiMapValue : multiMapValues.values()) {
             valueCollection.addAll(multiMapValue.getCollection(false));
         }
@@ -170,7 +170,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     public int clear() {
-        Collection<Data> locks = lockStore != null ? lockStore.getLockedKeys() : Collections.<Data>emptySet();
+        Collection<Data> locks = lockStore != null ? lockStore.getLockedKeys() : Collections.emptySet();
         Map<Data, MultiMapValue> lockedKeys = createHashMap(locks.size());
         for (Data key : locks) {
             MultiMapValue multiMapValue = multiMapValues.get(key);
@@ -232,11 +232,12 @@ public class MultiMapContainer extends MultiMapContainerSupport {
      * @return the used {@link MultiMapValue} if merge is applied, otherwise {@code null}
      */
     public MultiMapValue merge(MultiMapMergeContainer mergeContainer,
-                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy) {
+                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>,
+                                       Collection<Object>> mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        MultiMapMergeTypes mergingEntry = createMergingEntry(serializationService, mergeContainer);
+        MultiMapMergeTypes<Object, Object> mergingEntry = createMergingEntry(serializationService, mergeContainer);
         MultiMapValue existingValue = getMultiMapValueOrNull(mergeContainer.getKey());
         if (existingValue == null) {
             return mergeNewValue(mergePolicy, mergingEntry);
@@ -244,14 +245,16 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return mergeExistingValue(mergePolicy, mergingEntry, existingValue, serializationService);
     }
 
-    private MultiMapValue mergeNewValue(SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
-                                        MultiMapMergeTypes mergingEntry) {
+    private MultiMapValue mergeNewValue(
+            SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>, Collection<Object>> mergePolicy,
+            MultiMapMergeTypes<Object, Object> mergingEntry) {
         Collection<Object> newValues = mergePolicy.merge(mergingEntry, null);
         if (newValues != null && !newValues.isEmpty()) {
-            MultiMapValue mergedValue = getOrCreateMultiMapValue(mergingEntry.getKey());
+            SerializationService serializationService = nodeEngine.getSerializationService();
+            MultiMapValue mergedValue = getOrCreateMultiMapValue(serializationService.toData(mergingEntry.getRawKey()));
             Collection<MultiMapRecord> records = mergedValue.getCollection(false);
             createNewMultiMapRecords(records, newValues);
-            if (newValues.equals(mergingEntry.getValue())) {
+            if (newValues.equals(mergingEntry.getRawValue())) {
                 setMergedStatistics(mergingEntry, mergedValue);
             }
             return mergedValue;
@@ -259,13 +262,15 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return null;
     }
 
-    private MultiMapValue mergeExistingValue(SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
-                                             MultiMapMergeTypes mergingEntry, MultiMapValue existingValue,
-                                             SerializationService ss) {
+    private MultiMapValue mergeExistingValue(
+            SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>, Collection<Object>> mergePolicy,
+            MultiMapMergeTypes<Object, Object> mergingEntry, MultiMapValue existingValue, SerializationService ss) {
         Collection<MultiMapRecord> existingRecords = existingValue.getCollection(false);
 
-        Data dataKey = mergingEntry.getKey();
-        MultiMapMergeTypes existingEntry = createMergingEntry(ss, this, dataKey, existingRecords, existingValue.getHits());
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        Data dataKey = serializationService.toData(mergingEntry.getRawKey());
+        MultiMapMergeTypes<Object, Object> existingEntry = createMergingEntry(ss, this, dataKey, existingRecords,
+                existingValue.getHits());
         Collection<Object> newValues = mergePolicy.merge(mergingEntry, existingEntry);
         if (newValues == null || newValues.isEmpty()) {
             existingRecords.clear();
@@ -273,7 +278,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         } else if (!newValues.equals(existingRecords)) {
             existingRecords.clear();
             createNewMultiMapRecords(existingRecords, newValues);
-            if (newValues.equals(mergingEntry.getValue())) {
+            if (newValues.equals(mergingEntry.getRawValue())) {
                 setMergedStatistics(mergingEntry, existingValue);
             }
         }
@@ -292,7 +297,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    private void setMergedStatistics(MultiMapMergeTypes mergingEntry, MultiMapValue multiMapValue) {
+    private void setMergedStatistics(MultiMapMergeTypes<Object, Object> mergingEntry, MultiMapValue multiMapValue) {
         multiMapValue.setHits(mergingEntry.getHits());
         lastAccessTime = Math.max(lastAccessTime, mergingEntry.getLastAccessTime());
         lastUpdateTime = Math.max(lastUpdateTime, mergingEntry.getLastUpdateTime());

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -33,6 +33,7 @@ import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.LockInterceptorService;
 import com.hazelcast.internal.services.ManagedService;
@@ -51,7 +52,6 @@ import com.hazelcast.multimap.LocalMultiMapStats;
 import com.hazelcast.multimap.impl.operations.MergeOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapReplicationOperation;
 import com.hazelcast.multimap.impl.txn.TransactionalMultiMapProxy;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
@@ -552,7 +552,8 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         provide(descriptor, context, "multiMap", getStats());
     }
 
-    private class Merger extends AbstractContainerMerger<MultiMapContainer, Collection<Object>, MultiMapMergeTypes> {
+    private class Merger extends
+                         AbstractContainerMerger<MultiMapContainer, Collection<Object>, MultiMapMergeTypes<Object, Object>> {
 
         Merger(MultiMapContainerCollector collector) {
             super(collector, nodeEngine);
@@ -571,8 +572,8 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
                 for (MultiMapContainer container : containers) {
                     String name = container.getObjectNamespace().getObjectName();
-                    SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy
-                            = getMergePolicy(container.getConfig().getMergePolicyConfig());
+                    SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>,
+                            Collection<Object>> mergePolicy = getMergePolicy(container.getConfig().getMergePolicyConfig());
                     int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
 
                     List<MultiMapMergeContainer> mergeContainers = new ArrayList<>(batchSize);
@@ -599,7 +600,8 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         }
 
         private void sendBatch(int partitionId, String name,
-                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
+                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>,
+                                       Collection<Object>> mergePolicy,
                                List<MultiMapMergeContainer> mergeContainers) {
             MergeOperation operation = new MergeOperation(name, mergeContainers, mergePolicy);
             invoke(SERVICE_NAME, operation, partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeOperation.java
@@ -45,7 +45,7 @@ import static com.hazelcast.internal.util.MapUtil.createHashMap;
 public class MergeOperation extends AbstractMultiMapOperation implements BackupAwareOperation {
 
     private List<MultiMapMergeContainer> mergeContainers;
-    private SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>, Collection<Object>> mergePolicy;
 
     private transient Map<Data, Collection<MultiMapRecord>> resultMap;
 
@@ -53,7 +53,8 @@ public class MergeOperation extends AbstractMultiMapOperation implements BackupA
     }
 
     public MergeOperation(String name, List<MultiMapMergeContainer> mergeContainers,
-                          SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy) {
+                          SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes<Object, Object>,
+                                  Collection<Object>> mergePolicy) {
         super(name);
         this.mergeContainers = mergeContainers;
         this.mergePolicy = mergePolicy;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapMergeRunnable.java
@@ -37,7 +37,7 @@ import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
 class ReplicatedMapMergeRunnable
-        extends AbstractMergeRunnable<Object, Object, ReplicatedRecordStore, ReplicatedMapMergeTypes> {
+        extends AbstractMergeRunnable<Object, Object, ReplicatedRecordStore, ReplicatedMapMergeTypes<Object, Object>> {
 
     private final ReplicatedMapService service;
 
@@ -50,14 +50,15 @@ class ReplicatedMapMergeRunnable
     }
 
     @Override
-    protected void mergeStore(ReplicatedRecordStore store, BiConsumer<Integer, ReplicatedMapMergeTypes> consumer) {
+    protected void mergeStore(ReplicatedRecordStore store,
+                              BiConsumer<Integer, ReplicatedMapMergeTypes<Object, Object>> consumer) {
         int partitionId = store.getPartitionId();
 
         Iterator<ReplicatedRecord> iterator = store.recordIterator();
         while (iterator.hasNext()) {
             ReplicatedRecord record = iterator.next();
 
-            ReplicatedMapMergeTypes mergingEntry = createMergingEntry(getSerializationService(), record);
+            ReplicatedMapMergeTypes<Object, Object> mergingEntry = createMergingEntry(getSerializationService(), record);
             consumer.accept(partitionId, mergingEntry);
         }
     }
@@ -93,8 +94,10 @@ class ReplicatedMapMergeRunnable
 
     @Override
     protected OperationFactory createMergeOperationFactory(String dataStructureName,
-                                                           SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy,
-                                                           int[] partitions, List<ReplicatedMapMergeTypes>[] entries) {
+                                                           SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes<Object, Object>,
+                                                                   Object> mergePolicy,
+                                                           int[] partitions,
+                                                           List<ReplicatedMapMergeTypes<Object, Object>>[] entries) {
         return new MergeOperationFactory(dataStructureName, partitions, entries, mergePolicy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -35,16 +35,16 @@ import java.util.List;
 public class MergeOperation extends AbstractNamedSerializableOperation {
 
     private String name;
-    private List<ReplicatedMapMergeTypes> mergingEntries;
-    private SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy;
+    private List<ReplicatedMapMergeTypes<Object, Object>> mergingEntries;
+    private SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes<Object, Object>, Object> mergePolicy;
 
     private transient boolean hasMergedValues;
 
     public MergeOperation() {
     }
 
-    MergeOperation(String name, List<ReplicatedMapMergeTypes> mergingEntries,
-                   SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy) {
+    MergeOperation(String name, List<ReplicatedMapMergeTypes<Object, Object>> mergingEntries,
+                   SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes<Object, Object>, Object> mergePolicy) {
         this.name = name;
         this.mergingEntries = mergingEntries;
         this.mergePolicy = mergePolicy;
@@ -60,7 +60,7 @@ public class MergeOperation extends AbstractNamedSerializableOperation {
         ReplicatedMapService service = getService();
         ReplicatedRecordStore recordStore = service.getReplicatedRecordStore(name, true, getPartitionId());
 
-        for (ReplicatedMapMergeTypes mergingEntry : mergingEntries) {
+        for (ReplicatedMapMergeTypes<Object, Object> mergingEntry : mergingEntries) {
             if (recordStore.merge(mergingEntry, mergePolicy)) {
                 hasMergedValues = true;
             }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
@@ -37,15 +37,15 @@ import java.util.List;
 public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     private String name;
-    private List<ReplicatedMapMergeTypes>[] mergingEntries;
-    private SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy;
+    private List<ReplicatedMapMergeTypes<Object, Object>>[] mergingEntries;
+    private SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes<Object, Object>, Object> mergePolicy;
 
     public MergeOperationFactory() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public MergeOperationFactory(String name, int[] partitions, List<ReplicatedMapMergeTypes>[] mergingEntries,
-                                 SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy) {
+    public MergeOperationFactory(String name, int[] partitions, List<ReplicatedMapMergeTypes<Object, Object>>[] mergingEntries,
+                                 SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes<Object, Object>, Object> mergePolicy) {
         this.name = name;
         this.partitions = partitions;
         this.mergingEntries = mergingEntries;
@@ -66,9 +66,9 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeIntArray(partitions);
-        for (List<ReplicatedMapMergeTypes> list : mergingEntries) {
+        for (List<ReplicatedMapMergeTypes<Object, Object>> list : mergingEntries) {
             out.writeInt(list.size());
-            for (ReplicatedMapMergeTypes mergingEntry : list) {
+            for (ReplicatedMapMergeTypes<Object, Object> mergingEntry : list) {
                 out.writeObject(mergingEntry);
             }
         }
@@ -83,9 +83,9 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
         mergingEntries = new List[partitions.length];
         for (int partitionIndex = 0; partitionIndex < partitions.length; partitionIndex++) {
             int size = in.readInt();
-            List<ReplicatedMapMergeTypes> list = new ArrayList<>(size);
+            List<ReplicatedMapMergeTypes<Object, Object>> list = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                ReplicatedMapMergeTypes mergingEntry = in.readObject();
+                ReplicatedMapMergeTypes<Object, Object> mergingEntry = in.readObject();
                 list.add(mergingEntry);
             }
             mergingEntries[partitionIndex] = list;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
@@ -105,5 +105,6 @@ public interface ReplicatedRecordStore {
      * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
      * @return {@code true} if merge is applied, otherwise {@code false}
      */
-    boolean merge(ReplicatedMapMergeTypes mergingEntry, SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy);
+    boolean merge(ReplicatedMapMergeTypes<Object, Object> mergingEntry,
+                  SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes<Object, Object>, Object> mergePolicy);
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -361,7 +361,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
                 Collection<RingbufferContainer> containerList = entry.getValue();
                 for (RingbufferContainer container : containerList) {
                     // TODO: add batching (which is a bit complex, since collections don't have a multi-name operation yet
-                    SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes, RingbufferMergeData> mergePolicy
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
                     sendBatch(partitionId, mergePolicy, container);
@@ -370,7 +370,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
         }
 
         private void sendBatch(int partitionId,
-                               SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes> mergePolicy,
+                               SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes, RingbufferMergeData> mergePolicy,
                                RingbufferContainer mergingContainer) {
             final MergeOperation operation = new MergeOperation(mergingContainer.getNamespace(), mergePolicy,
                     mergingContainer.getRingbuffer());

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
@@ -60,7 +60,7 @@ public class MergeOperation extends Operation
         implements IdentifiedDataSerializable, BackupAwareOperation, ServiceNamespaceAware {
 
     private ObjectNamespace namespace;
-    private SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes, RingbufferMergeData> mergePolicy;
     private Ringbuffer<Object> mergingRingbuffer;
 
     private transient Ringbuffer<Object> resultRingbuffer;
@@ -72,7 +72,7 @@ public class MergeOperation extends Operation
     }
 
     public MergeOperation(ObjectNamespace namespace,
-                          SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes> mergePolicy,
+                          SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes, RingbufferMergeData> mergePolicy,
                           Ringbuffer<Object> mergingRingbuffer) {
         this.namespace = namespace;
         this.mergePolicy = mergePolicy;

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -340,8 +340,8 @@ public class DistributedScheduledExecutorService
                 for (ScheduledExecutorContainer container : containers) {
                     String name = container.getName();
                     MergePolicyConfig mergePolicyConfig = collector.getMergePolicyConfig(container);
-                    SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes> mergePolicy
-                            = getMergePolicy(mergePolicyConfig);
+                    SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes,
+                            ScheduledTaskDescriptor> mergePolicy = getMergePolicy(mergePolicyConfig);
                     int batchSize = mergePolicyConfig.getBatchSize();
 
                     mergingEntries = new ArrayList<>(batchSize);
@@ -364,7 +364,8 @@ public class DistributedScheduledExecutorService
         }
 
         private void sendBatch(int partitionId, String name, List<ScheduledExecutorMergeTypes> mergingEntries,
-                               SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes> mergePolicy) {
+                               SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes,
+                                       ScheduledTaskDescriptor> mergePolicy) {
             MergeOperation operation = new MergeOperation(name, mergingEntries, mergePolicy);
             invoke(SERVICE_NAME, operation, partitionId);
         }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -27,6 +27,7 @@ import com.hazelcast.scheduledexecutor.StaleTaskException;
 import com.hazelcast.scheduledexecutor.impl.operations.SyncStateOperation;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.impl.merge.ScheduledExecutorMergingEntryImpl;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
@@ -276,13 +277,13 @@ public class ScheduledExecutorContainer {
      */
     public ScheduledTaskDescriptor merge(
             ScheduledExecutorMergeTypes mergingEntry,
-            SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes> mergePolicy) {
+            SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes, ScheduledTaskDescriptor> mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
         serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
         // try to find an existing task with the same definition
-        ScheduledTaskDescriptor mergingTask = mergingEntry.getValue();
+        ScheduledTaskDescriptor mergingTask = ((ScheduledExecutorMergingEntryImpl) mergingEntry).getRawValue();
         ScheduledTaskDescriptor existingTask = null;
         for (ScheduledTaskDescriptor task : tasks.values()) {
             if (mergingTask.equals(task)) {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/MergeOperation.java
@@ -34,7 +34,7 @@ public class MergeOperation
         extends AbstractBackupAwareSchedulerOperation {
 
     private List<ScheduledExecutorMergeTypes> mergingEntries;
-    private SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes, ScheduledTaskDescriptor> mergePolicy;
 
     private transient List<ScheduledTaskDescriptor> mergedTasks;
 
@@ -43,7 +43,8 @@ public class MergeOperation
     }
 
     public MergeOperation(String name, List<ScheduledExecutorMergeTypes> mergingEntries,
-                          SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes> mergePolicy) {
+                          SplitBrainMergePolicy<ScheduledTaskDescriptor, ScheduledExecutorMergeTypes,
+                                  ScheduledTaskDescriptor> mergePolicy) {
         super(name);
         this.mergingEntries = mergingEntries;
         this.mergePolicy = mergePolicy;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
@@ -56,7 +56,7 @@ public abstract class AbstractCollectionMergingValueImpl<V, T extends AbstractCo
     }
 
     @Override
-    public Collection<V> getDeserializedValue() {
+    public Collection<V> getValue() {
         Collection<Object> deserializedValues = new ArrayList<>(value.size());
         for (Object aValue : value) {
             deserializedValues.add(serializationService.toObject(aValue));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.serialization.SerializationServiceAware;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Implementation of {@link MergingValue} for data structures with collections.
@@ -35,10 +36,10 @@ import java.util.Collection;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class AbstractCollectionMergingValueImpl<V extends Collection, T extends AbstractCollectionMergingValueImpl<V, T>>
-        implements MergingValue<V>, SerializationServiceAware, IdentifiedDataSerializable {
+public abstract class AbstractCollectionMergingValueImpl<V, T extends AbstractCollectionMergingValueImpl<V, T>>
+        implements MergingValue<Collection<V>>, SerializationServiceAware, IdentifiedDataSerializable {
 
-    private V value;
+    private Collection<Object> value;
 
     private transient SerializationService serializationService;
 
@@ -50,21 +51,21 @@ public abstract class AbstractCollectionMergingValueImpl<V extends Collection, T
     }
 
     @Override
-    public V getValue() {
+    public Collection<Object> getRawValue() {
         return value;
     }
 
     @Override
-    public <DV> DV getDeserializedValue() {
-        Collection<Object> deserializedValues = new ArrayList<Object>(value.size());
+    public Collection<V> getDeserializedValue() {
+        Collection<Object> deserializedValues = new ArrayList<>(value.size());
         for (Object aValue : value) {
             deserializedValues.add(serializationService.toObject(aValue));
         }
         //noinspection unchecked
-        return (DV) deserializedValues;
+        return (Collection<V>) deserializedValues;
     }
 
-    public T setValue(V value) {
+    public T setValue(Collection<Object> value) {
         this.value = value;
         //noinspection unchecked
         return (T) this;
@@ -86,12 +87,11 @@ public abstract class AbstractCollectionMergingValueImpl<V extends Collection, T
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        ArrayList<Object> list = new ArrayList<Object>(size);
+        ArrayList<Object> list = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             list.add(IOUtil.readObject(in));
         }
-        //noinspection unchecked
-        value = (V) list;
+        value = list;
     }
 
     @Override
@@ -109,7 +109,7 @@ public abstract class AbstractCollectionMergingValueImpl<V extends Collection, T
         }
 
         AbstractCollectionMergingValueImpl<?, ?> that = (AbstractCollectionMergingValueImpl<?, ?>) o;
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
@@ -109,7 +109,7 @@ public abstract class AbstractContainerMerger<C, V, T extends MergingValue<V>> i
      * @param mergePolicyConfig the {@link MergePolicyConfig} to retrieve the merge policy from
      * @return the {@link SplitBrainMergePolicy} instance
      */
-    protected SplitBrainMergePolicy<V, T> getMergePolicy(MergePolicyConfig mergePolicyConfig) {
+    protected <R> SplitBrainMergePolicy<V, T, R> getMergePolicy(MergePolicyConfig mergePolicyConfig) {
         String mergePolicyName = mergePolicyConfig.getPolicy();
         return splitBrainMergePolicyProvider.getMergePolicy(mergePolicyName);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergeRunnable.java
@@ -142,7 +142,7 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
     }
 
     private MergingItemBiConsumer newConsumer(String dataStructureName) {
-        SplitBrainMergePolicy<V, MergingItem> policy = getMergePolicy(dataStructureName);
+        SplitBrainMergePolicy<V, MergingItem, Object> policy = getMergePolicy(dataStructureName);
         int batchSize = getBatchSize(dataStructureName);
         return new MergingItemBiConsumer(dataStructureName, policy, batchSize);
     }
@@ -169,13 +169,14 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
         private final String dataStructureName;
         private final Address[] addresses;
         private final MutableLong[] counterPerMember;
-        private final SplitBrainMergePolicy<V, MergingItem> mergePolicy;
+        private final SplitBrainMergePolicy<V, MergingItem, Object> mergePolicy;
         private final List<MergingItem>[] mergingItemsPerPartition;
         private final Map<Address, List<Integer>> memberPartitionsMap;
 
         private int mergedCount;
 
-        MergingItemBiConsumer(String dataStructureName, SplitBrainMergePolicy<V, MergingItem> mergePolicy, int batchSize) {
+        MergingItemBiConsumer(String dataStructureName, SplitBrainMergePolicy<V, MergingItem, Object> mergePolicy,
+                              int batchSize) {
             this.dataStructureName = dataStructureName;
             this.batchSize = batchSize;
             this.mergePolicy = mergePolicy;
@@ -230,7 +231,7 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
         }
 
         private void sendBatch(String dataStructureName, List<Integer> memberPartitions, List<MergingItem>[] entriesPerPartition,
-                               SplitBrainMergePolicy<V, MergingItem> mergePolicy) {
+                               SplitBrainMergePolicy<V, MergingItem, Object> mergePolicy) {
             int size = memberPartitions.size();
             int[] partitions = new int[size];
             int index = 0;
@@ -265,7 +266,7 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
             sendMergingData(dataStructureName, mergePolicy, partitions, entries, totalSize);
         }
 
-        private void sendMergingData(String dataStructureName, SplitBrainMergePolicy<V, MergingItem> mergePolicy,
+        private void sendMergingData(String dataStructureName, SplitBrainMergePolicy<V, MergingItem, Object> mergePolicy,
                                      int[] partitions, List<MergingItem>[] entries, int totalSize) {
             try {
                 OperationFactory factory = createMergeOperationFactory(dataStructureName, mergePolicy, partitions, entries);
@@ -316,7 +317,7 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
     /**
      * @return a type of {@link SplitBrainMergePolicy}
      */
-    protected abstract SplitBrainMergePolicy<V, MergingItem> getMergePolicy(String dataStructureName);
+    protected abstract SplitBrainMergePolicy<V, MergingItem, Object> getMergePolicy(String dataStructureName);
 
     protected abstract String getDataStructureName(Store store);
 
@@ -333,6 +334,6 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
      * @return a new operation factory
      */
     protected abstract OperationFactory createMergeOperationFactory(String dataStructureName,
-                                                                    SplitBrainMergePolicy<V, MergingItem> mergePolicy,
+                                                                    SplitBrainMergePolicy<V, MergingItem, Object> mergePolicy,
                                                                     int[] partitions, List<MergingItem>[] entries);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
@@ -56,7 +56,7 @@ public abstract class AbstractMergingEntryImpl<K, V, T extends AbstractMergingEn
     }
 
     @Override
-    public K getDeserializedKey() {
+    public K getKey() {
         return serializationService.toObject(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceAware;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Implementation of {@link MergingEntry}.
@@ -50,12 +51,12 @@ public abstract class AbstractMergingEntryImpl<K, V, T extends AbstractMergingEn
     }
 
     @Override
-    public K getKey() {
+    public K getRawKey() {
         return key;
     }
 
     @Override
-    public Object getDeserializedKey() {
+    public K getDeserializedKey() {
         return serializationService.toObject(key);
     }
 
@@ -65,12 +66,12 @@ public abstract class AbstractMergingEntryImpl<K, V, T extends AbstractMergingEn
     }
 
     @Override
-    public V getValue() {
+    public V getRawValue() {
         return value;
     }
 
     @Override
-    public Object getDeserializedValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 
@@ -111,10 +112,10 @@ public abstract class AbstractMergingEntryImpl<K, V, T extends AbstractMergingEn
         }
 
         AbstractMergingEntryImpl<?, ?, ?> that = (AbstractMergingEntryImpl<?, ?, ?>) o;
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (!Objects.equals(key, that.key)) {
             return false;
         }
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
@@ -71,7 +71,7 @@ public abstract class AbstractMergingEntryImpl<K, V, T extends AbstractMergingEn
     }
 
     @Override
-    public V getDeserializedValue() {
+    public V getValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingValueImpl.java
@@ -53,7 +53,7 @@ public abstract class AbstractMergingValueImpl<V, T extends AbstractMergingValue
     }
 
     @Override
-    public V getDeserializedValue() {
+    public V getValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingValueImpl.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 public abstract class AbstractMergingValueImpl<V, T extends AbstractMergingValueImpl<V, T>>
         implements MergingValue<V>, SerializationServiceAware, IdentifiedDataSerializable {
 
-    private V value;
+    private Object value;
 
     private transient SerializationService serializationService;
 
@@ -48,16 +48,16 @@ public abstract class AbstractMergingValueImpl<V, T extends AbstractMergingValue
     }
 
     @Override
-    public V getValue() {
+    public Object getRawValue() {
         return value;
     }
 
     @Override
-    public Object getDeserializedValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 
-    public T setValue(V value) {
+    public T setValue(Object value) {
         this.value = value;
         //noinspection unchecked
         return (T) this;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractSplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractSplitBrainMergePolicy.java
@@ -33,8 +33,8 @@ import com.hazelcast.internal.serialization.SerializationService;
  *            or a composition like {@code MergingEntry<String, V> & MergingHits}
  * @since 3.10
  */
-public abstract class AbstractSplitBrainMergePolicy<V, T extends MergingValue<V>>
-        implements SplitBrainMergePolicy<V, T>, IdentifiedDataSerializable {
+public abstract class AbstractSplitBrainMergePolicy<V, T extends MergingValue<V>, R>
+        implements SplitBrainMergePolicy<V, T, R>, IdentifiedDataSerializable {
 
     @Override
     public int getFactoryId() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
@@ -74,7 +74,7 @@ public class CacheMergingEntryImpl<K, V>
     }
 
     @Override
-    public K getDeserializedKey() {
+    public K getKey() {
         return serializationService.toObject(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceAware;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Implementation of {@link CacheMergeTypes}.
@@ -33,7 +34,8 @@ import java.io.IOException;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServiceAware, IdentifiedDataSerializable {
+public class CacheMergingEntryImpl<K, V>
+        implements CacheMergeTypes<K, V>, SerializationServiceAware, IdentifiedDataSerializable {
 
     private Data value;
     private Data key;
@@ -52,31 +54,31 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
     }
 
     @Override
-    public Data getValue() {
+    public Data getRawValue() {
         return value;
     }
 
     @Override
-    public Object getDeserializedValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 
-    public CacheMergingEntryImpl setValue(Data value) {
+    public CacheMergingEntryImpl<K, V> setValue(Data value) {
         this.value = value;
         return this;
     }
 
     @Override
-    public Data getKey() {
+    public Data getRawKey() {
         return key;
     }
 
     @Override
-    public Object getDeserializedKey() {
+    public K getDeserializedKey() {
         return serializationService.toObject(key);
     }
 
-    public CacheMergingEntryImpl setKey(Data key) {
+    public CacheMergingEntryImpl<K, V> setKey(Data key) {
         this.key = key;
         return this;
     }
@@ -86,7 +88,7 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
         return creationTime;
     }
 
-    public CacheMergingEntryImpl setCreationTime(long creationTime) {
+    public CacheMergingEntryImpl<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
         return this;
     }
@@ -96,7 +98,7 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
         return expirationTime;
     }
 
-    public CacheMergingEntryImpl setExpirationTime(long expirationTime) {
+    public CacheMergingEntryImpl<K, V> setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;
         return this;
     }
@@ -106,7 +108,7 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
         return hits;
     }
 
-    public CacheMergingEntryImpl setHits(long hits) {
+    public CacheMergingEntryImpl<K, V> setHits(long hits) {
         this.hits = hits;
         return this;
     }
@@ -116,7 +118,7 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
         return lastAccessTime;
     }
 
-    public CacheMergingEntryImpl setLastAccessTime(long lastAccessTime) {
+    public CacheMergingEntryImpl<K, V> setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
         return this;
     }
@@ -179,10 +181,10 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
         if (lastAccessTime != that.lastAccessTime) {
             return false;
         }
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (!Objects.equals(key, that.key)) {
             return false;
         }
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
@@ -59,7 +59,7 @@ public class CacheMergingEntryImpl<K, V>
     }
 
     @Override
-    public V getDeserializedValue() {
+    public V getValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CollectionMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CollectionMergingValueImpl.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.spi.impl.merge;
 
-import com.hazelcast.spi.merge.SplitBrainMergeTypes.CollectionMergeTypes;
 import com.hazelcast.internal.serialization.SerializationService;
-
-import java.util.Collection;
+import com.hazelcast.spi.merge.SplitBrainMergeTypes.CollectionMergeTypes;
 
 /**
  * Implementation of {@link CollectionMergeTypes}.
@@ -27,9 +25,8 @@ import java.util.Collection;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public class CollectionMergingValueImpl
-        extends AbstractCollectionMergingValueImpl<Collection<Object>, CollectionMergingValueImpl>
-        implements CollectionMergeTypes {
+public class CollectionMergingValueImpl<V> extends AbstractCollectionMergingValueImpl<V, CollectionMergingValueImpl<V>>
+        implements CollectionMergeTypes<V> {
 
     public CollectionMergingValueImpl() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -82,7 +82,7 @@ public class MapMergingEntryImpl<K, V>
     }
 
     @Override
-    public K getDeserializedKey() {
+    public K getKey() {
         return serializationService.toObject(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceAware;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Implementation of {@link MapMergeTypes}.
@@ -33,8 +34,8 @@ import java.io.IOException;
  * @since 3.10
  */
 @SuppressWarnings({"WeakerAccess", "checkstyle:methodcount"})
-public class MapMergingEntryImpl
-        implements MapMergeTypes, SerializationServiceAware, IdentifiedDataSerializable {
+public class MapMergingEntryImpl<K, V>
+        implements MapMergeTypes<K, V>, SerializationServiceAware, IdentifiedDataSerializable {
 
     private Data value;
     private Data key;
@@ -61,31 +62,31 @@ public class MapMergingEntryImpl
     }
 
     @Override
-    public Data getValue() {
+    public Data getRawValue() {
         return value;
     }
 
     @Override
-    public Object getDeserializedValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 
-    public MapMergingEntryImpl setValue(Data value) {
+    public MapMergingEntryImpl<K, V> setValue(Data value) {
         this.value = value;
         return this;
     }
 
     @Override
-    public Data getKey() {
+    public Data getRawKey() {
         return key;
     }
 
     @Override
-    public Object getDeserializedKey() {
+    public K getDeserializedKey() {
         return serializationService.toObject(key);
     }
 
-    public MapMergingEntryImpl setKey(Data key) {
+    public MapMergingEntryImpl<K, V> setKey(Data key) {
         this.key = key;
         return this;
     }
@@ -95,7 +96,7 @@ public class MapMergingEntryImpl
         return cost;
     }
 
-    public MapMergingEntryImpl setCost(long cost) {
+    public MapMergingEntryImpl<K, V> setCost(long cost) {
         this.cost = cost;
         return this;
     }
@@ -105,7 +106,7 @@ public class MapMergingEntryImpl
         return creationTime;
     }
 
-    public MapMergingEntryImpl setCreationTime(long creationTime) {
+    public MapMergingEntryImpl<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
         return this;
     }
@@ -115,7 +116,7 @@ public class MapMergingEntryImpl
         return expirationTime;
     }
 
-    public MapMergingEntryImpl setExpirationTime(long expirationTime) {
+    public MapMergingEntryImpl<K, V> setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;
         return this;
     }
@@ -125,7 +126,7 @@ public class MapMergingEntryImpl
         return hits;
     }
 
-    public MapMergingEntryImpl setHits(long hits) {
+    public MapMergingEntryImpl<K, V> setHits(long hits) {
         this.hits = hits;
         return this;
     }
@@ -135,7 +136,7 @@ public class MapMergingEntryImpl
         return lastAccessTime;
     }
 
-    public MapMergingEntryImpl setLastAccessTime(long lastAccessTime) {
+    public MapMergingEntryImpl<K, V> setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
         return this;
     }
@@ -145,7 +146,7 @@ public class MapMergingEntryImpl
         return lastStoredTime;
     }
 
-    public MapMergingEntryImpl setLastStoredTime(long lastStoredTime) {
+    public MapMergingEntryImpl<K, V> setLastStoredTime(long lastStoredTime) {
         this.lastStoredTime = lastStoredTime;
         return this;
     }
@@ -155,7 +156,7 @@ public class MapMergingEntryImpl
         return lastUpdateTime;
     }
 
-    public MapMergingEntryImpl setLastUpdateTime(long lastUpdateTime) {
+    public MapMergingEntryImpl<K, V> setLastUpdateTime(long lastUpdateTime) {
         this.lastUpdateTime = lastUpdateTime;
         return this;
     }
@@ -165,7 +166,7 @@ public class MapMergingEntryImpl
         return version;
     }
 
-    public MapMergingEntryImpl setVersion(long version) {
+    public MapMergingEntryImpl<K, V> setVersion(long version) {
         this.version = version;
         return this;
     }
@@ -175,7 +176,7 @@ public class MapMergingEntryImpl
         return ttl;
     }
 
-    public MapMergingEntryImpl setTtl(long ttl) {
+    public MapMergingEntryImpl<K, V> setTtl(long ttl) {
         this.ttl = ttl;
         return this;
     }
@@ -185,7 +186,7 @@ public class MapMergingEntryImpl
         return maxIdle;
     }
 
-    public MapMergingEntryImpl setMaxIdle(Long maxIdle) {
+    public MapMergingEntryImpl<K, V> setMaxIdle(Long maxIdle) {
         this.maxIdle = maxIdle;
         return this;
     }
@@ -287,13 +288,13 @@ public class MapMergingEntryImpl
         if (ttl != that.ttl) {
             return false;
         }
-        if (value != null ? !value.equals(that.value) : that.value != null) {
+        if (!Objects.equals(value, that.value)) {
             return false;
         }
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (!Objects.equals(key, that.key)) {
             return false;
         }
-        return maxIdle != null ? maxIdle.equals(that.maxIdle) : that.maxIdle == null;
+        return Objects.equals(maxIdle, that.maxIdle);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -67,7 +67,7 @@ public class MapMergingEntryImpl<K, V>
     }
 
     @Override
-    public V getDeserializedValue() {
+    public V getValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -56,27 +56,28 @@ import java.util.Queue;
  *
  * @since 3.10
  */
+@SuppressWarnings({"checkstyle:classfanoutcomplexity"})
 public final class MergingValueFactory {
 
     private MergingValueFactory() {
     }
 
-    public static CollectionMergeTypes createMergingValue(SerializationService serializationService,
-                                                          Collection<CollectionItem> items) {
-        Collection<Object> values = new ArrayList<Object>(items.size());
+    public static <V> CollectionMergeTypes<V> createMergingValue(SerializationService serializationService,
+                                                                 Collection<CollectionItem> items) {
+        Collection<Object> values = new ArrayList<>(items.size());
         for (CollectionItem item : items) {
             values.add(item.getValue());
         }
-        return new CollectionMergingValueImpl(serializationService)
+        return new CollectionMergingValueImpl<V>(serializationService)
                 .setValue(values);
     }
 
-    public static QueueMergeTypes createMergingValue(SerializationService serializationService, Queue<QueueItem> items) {
-        Collection<Object> values = new ArrayList<Object>(items.size());
+    public static <V> QueueMergeTypes<V> createMergingValue(SerializationService serializationService, Queue<QueueItem> items) {
+        Collection<Object> values = new ArrayList<>(items.size());
         for (QueueItem item : items) {
             values.add(item.getData());
         }
-        return new QueueMergingValueImpl(serializationService)
+        return new QueueMergingValueImpl<V>(serializationService)
                 .setValue(values);
     }
 
@@ -90,8 +91,9 @@ public final class MergingValueFactory {
                 .setValue(value);
     }
 
-    public static MapMergeTypes createMergingEntry(SerializationService serializationService, EntryView<Data, Data> entryView) {
-        return new MapMergingEntryImpl(serializationService)
+    public static <K, V> MapMergeTypes<K, V> createMergingEntry(SerializationService serializationService,
+                                                                EntryView<Data, Data> entryView) {
+        return new MapMergingEntryImpl<K, V>(serializationService)
                 .setKey(entryView.getKey())
                 .setValue(entryView.getValue())
                 .setCreationTime(entryView.getCreationTime())
@@ -106,9 +108,9 @@ public final class MergingValueFactory {
                 .setCost(entryView.getCost());
     }
 
-    public static MapMergeTypes createMergingEntry(SerializationService serializationService,
-                                                   WanMapEntryView<Object, Object> entryView) {
-        return new MapMergingEntryImpl(serializationService)
+    public static MapMergingEntryImpl<Object, Object> createMergingEntry(SerializationService serializationService,
+                                                                         WanMapEntryView<Object, Object> entryView) {
+        return new MapMergingEntryImpl<>(serializationService)
                 .setKey(entryView.getDataKey())
                 .setValue(entryView.getDataValue())
                 .setCreationTime(entryView.getCreationTime())
@@ -123,9 +125,9 @@ public final class MergingValueFactory {
                 .setCost(entryView.getCost());
     }
 
-    public static MapMergeTypes createMergingEntry(SerializationService serializationService,
-                                                   Data dataKey, Record record) {
-        return new MapMergingEntryImpl(serializationService)
+    public static <K, V> MapMergeTypes<K, V> createMergingEntry(SerializationService serializationService, Data dataKey,
+                                                                Record record) {
+        return new MapMergingEntryImpl<K, V>(serializationService)
                 .setKey(dataKey)
                 .setValue(serializationService.toData(record.getValue()))
                 .setCreationTime(record.getCreationTime())
@@ -141,9 +143,9 @@ public final class MergingValueFactory {
                 .setCost(record.getCost());
     }
 
-    public static MapMergeTypes createMergingEntry(SerializationService serializationService,
-                                                   Data dataKey, Data dataValue, Record record) {
-        return new MapMergingEntryImpl(serializationService)
+    public static <K, V> MapMergeTypes<K, V> createMergingEntry(SerializationService serializationService, Data dataKey,
+                                                                Data dataValue, Record record) {
+        return new MapMergingEntryImpl<K, V>(serializationService)
                 .setKey(dataKey)
                 .setValue(dataValue)
                 .setCreationTime(record.getCreationTime())
@@ -158,9 +160,9 @@ public final class MergingValueFactory {
                 .setCost(record.getCost());
     }
 
-    public static CacheMergeTypes createMergingEntry(SerializationService serializationService,
-                                                     WanCacheEntryView<Object, Object> entryView) {
-        return new CacheMergingEntryImpl(serializationService)
+    public static <K, V> CacheMergeTypes<K, V> createMergingEntry(SerializationService serializationService,
+                                                                  WanCacheEntryView<Object, Object> entryView) {
+        return new CacheMergingEntryImpl<K, V>(serializationService)
                 .setKey(entryView.getDataKey())
                 .setValue(entryView.getDataValue())
                 .setCreationTime(entryView.getCreationTime())
@@ -169,9 +171,9 @@ public final class MergingValueFactory {
                 .setHits(entryView.getHits());
     }
 
-    public static <R extends CacheRecord> CacheMergeTypes createMergingEntry(SerializationService serializationService,
-                                                                             Data key, Data value, R record) {
-        return new CacheMergingEntryImpl(serializationService)
+    public static <K, V, R extends CacheRecord> CacheMergeTypes<K, V> createMergingEntry(
+            SerializationService serializationService, Data key, Data value, R record) {
+        return new CacheMergingEntryImpl<K, V>(serializationService)
                 .setKey(key)
                 .setValue(value)
                 .setCreationTime(record.getCreationTime())
@@ -180,8 +182,9 @@ public final class MergingValueFactory {
                 .setHits(record.getHits());
     }
 
-    public static ReplicatedMapMergeTypes createMergingEntry(SerializationService serializationService, ReplicatedRecord record) {
-        return new ReplicatedMapMergingEntryImpl(serializationService)
+    public static <K, V> ReplicatedMapMergeTypes<K, V> createMergingEntry(SerializationService serializationService,
+                                                                          ReplicatedRecord record) {
+        return new ReplicatedMapMergingEntryImpl<K, V>(serializationService)
                 .setKey(record.getKeyInternal())
                 .setValue(record.getValueInternal())
                 .setCreationTime(record.getCreationTime())
@@ -191,14 +194,14 @@ public final class MergingValueFactory {
                 .setTtl(record.getTtlMillis());
     }
 
-    public static MultiMapMergeTypes createMergingEntry(SerializationService serializationService,
-                                                        MultiMapMergeContainer container) {
-        Collection<Object> values = new ArrayList<Object>(container.getRecords().size());
+    public static <K, V> MultiMapMergeTypes<K, V> createMergingEntry(SerializationService serializationService,
+                                                                     MultiMapMergeContainer container) {
+        Collection<Object> values = new ArrayList<>(container.getRecords().size());
         for (MultiMapRecord record : container.getRecords()) {
             values.add(record.getObject());
         }
 
-        return new MultiMapMergingEntryImpl(serializationService)
+        return new MultiMapMergingEntryImpl<K, V>(serializationService)
                 .setKey(container.getKey())
                 .setValues(values)
                 .setCreationTime(container.getCreationTime())
@@ -207,14 +210,15 @@ public final class MergingValueFactory {
                 .setHits(container.getHits());
     }
 
-    public static MultiMapMergeTypes createMergingEntry(SerializationService serializationService, MultiMapContainer container,
-                                                        Data dataKey, Collection<MultiMapRecord> records, long hits) {
-        Collection<Object> values = new ArrayList<Object>(records.size());
+    public static <K, V> MultiMapMergeTypes<K, V> createMergingEntry(SerializationService serializationService,
+                                                                     MultiMapContainer container, Data dataKey,
+                                                                     Collection<MultiMapRecord> records, long hits) {
+        Collection<Object> values = new ArrayList<>(records.size());
         for (MultiMapRecord record : records) {
             values.add(record.getObject());
         }
 
-        return new MultiMapMergingEntryImpl(serializationService)
+        return new MultiMapMergingEntryImpl<K, V>(serializationService)
                 .setKey(dataKey)
                 .setValues(values)
                 .setCreationTime(container.getCreationTime())

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
@@ -62,7 +62,7 @@ public class MultiMapMergingEntryImpl<K, V> implements MultiMapMergeTypes<K, V>,
     }
 
     @Override
-    public K getDeserializedKey() {
+    public K getKey() {
         return serializationService.toObject(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.serialization.SerializationServiceAware;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Implementation of {@link MultiMapMergeTypes}.
@@ -35,7 +36,8 @@ import java.util.Collection;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, SerializationServiceAware, IdentifiedDataSerializable {
+public class MultiMapMergingEntryImpl<K, V> implements MultiMapMergeTypes<K, V>, SerializationServiceAware,
+                                                       IdentifiedDataSerializable {
 
     private Data key;
     private Collection<Object> value;
@@ -55,35 +57,35 @@ public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, Serializati
     }
 
     @Override
-    public Data getKey() {
+    public Data getRawKey() {
         return key;
     }
 
     @Override
-    public <DK> DK getDeserializedKey() {
+    public K getDeserializedKey() {
         return serializationService.toObject(key);
     }
 
-    public MultiMapMergingEntryImpl setKey(Data key) {
+    public MultiMapMergingEntryImpl<K, V> setKey(Data key) {
         this.key = key;
         return this;
     }
 
     @Override
-    public Collection<Object> getValue() {
+    public Collection<Object> getRawValue() {
         return value;
     }
 
     @Override
-    public <DV> DV getDeserializedValue() {
-        Collection<Object> deserializedValues = new ArrayList<Object>(value.size());
+    public Collection<V> getDeserializedValue() {
+        Collection<Object> deserializedValues = new ArrayList<>(value.size());
         for (Object aValue : value) {
             deserializedValues.add(serializationService.toObject(aValue));
         }
-        return (DV) deserializedValues;
+        return (Collection<V>) deserializedValues;
     }
 
-    public MultiMapMergingEntryImpl setValues(Collection<Object> values) {
+    public MultiMapMergingEntryImpl<K, V> setValues(Collection<Object> values) {
         this.value = values;
         return this;
     }
@@ -93,7 +95,7 @@ public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, Serializati
         return creationTime;
     }
 
-    public MultiMapMergingEntryImpl setCreationTime(long creationTime) {
+    public MultiMapMergingEntryImpl<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
         return this;
     }
@@ -103,7 +105,7 @@ public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, Serializati
         return hits;
     }
 
-    public MultiMapMergingEntryImpl setHits(long hits) {
+    public MultiMapMergingEntryImpl<K, V> setHits(long hits) {
         this.hits = hits;
         return this;
     }
@@ -113,7 +115,7 @@ public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, Serializati
         return lastAccessTime;
     }
 
-    public MultiMapMergingEntryImpl setLastAccessTime(long lastAccessTime) {
+    public MultiMapMergingEntryImpl<K, V> setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
         return this;
     }
@@ -123,7 +125,7 @@ public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, Serializati
         return lastUpdateTime;
     }
 
-    public MultiMapMergingEntryImpl setLastUpdateTime(long lastUpdateTime) {
+    public MultiMapMergingEntryImpl<K, V> setLastUpdateTime(long lastUpdateTime) {
         this.lastUpdateTime = lastUpdateTime;
         return this;
     }
@@ -198,10 +200,10 @@ public class MultiMapMergingEntryImpl implements MultiMapMergeTypes, Serializati
         if (lastUpdateTime != that.lastUpdateTime) {
             return false;
         }
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (!Objects.equals(key, that.key)) {
             return false;
         }
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
@@ -77,7 +77,7 @@ public class MultiMapMergingEntryImpl<K, V> implements MultiMapMergeTypes<K, V>,
     }
 
     @Override
-    public Collection<V> getDeserializedValue() {
+    public Collection<V> getValue() {
         Collection<Object> deserializedValues = new ArrayList<>(value.size());
         for (Object aValue : value) {
             deserializedValues.add(serializationService.toObject(aValue));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/QueueMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/QueueMergingValueImpl.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.spi.impl.merge;
 
-import com.hazelcast.spi.merge.SplitBrainMergeTypes.QueueMergeTypes;
 import com.hazelcast.internal.serialization.SerializationService;
-
-import java.util.Collection;
+import com.hazelcast.spi.merge.SplitBrainMergeTypes.QueueMergeTypes;
 
 /**
  * Implementation of {@link QueueMergeTypes}.
@@ -27,8 +25,8 @@ import java.util.Collection;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public class QueueMergingValueImpl extends AbstractCollectionMergingValueImpl<Collection<Object>, QueueMergingValueImpl>
-        implements QueueMergeTypes {
+public class QueueMergingValueImpl<V> extends AbstractCollectionMergingValueImpl<V, QueueMergingValueImpl<V>>
+        implements QueueMergeTypes<V> {
 
     public QueueMergingValueImpl() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
@@ -74,7 +74,7 @@ public class ReplicatedMapMergingEntryImpl<K, V>
     }
 
     @Override
-    public K getDeserializedKey() {
+    public K getKey() {
         return serializationService.toObject(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
@@ -59,7 +59,7 @@ public class ReplicatedMapMergingEntryImpl<K, V>
     }
 
     @Override
-    public V getDeserializedValue() {
+    public V getValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceAware;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Implementation of {@link ReplicatedMapMergeTypes}.
@@ -32,8 +33,8 @@ import java.io.IOException;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public class ReplicatedMapMergingEntryImpl
-        implements ReplicatedMapMergeTypes, SerializationServiceAware, IdentifiedDataSerializable {
+public class ReplicatedMapMergingEntryImpl<K, V>
+        implements ReplicatedMapMergeTypes<K, V>, SerializationServiceAware, IdentifiedDataSerializable {
 
     private Object value;
     private Object key;
@@ -53,31 +54,31 @@ public class ReplicatedMapMergingEntryImpl
     }
 
     @Override
-    public Object getValue() {
+    public Object getRawValue() {
         return value;
     }
 
     @Override
-    public Object getDeserializedValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 
-    public ReplicatedMapMergingEntryImpl setValue(Object value) {
+    public ReplicatedMapMergingEntryImpl<K, V> setValue(Object value) {
         this.value = value;
         return this;
     }
 
     @Override
-    public Object getKey() {
+    public Object getRawKey() {
         return key;
     }
 
     @Override
-    public Object getDeserializedKey() {
+    public K getDeserializedKey() {
         return serializationService.toObject(key);
     }
 
-    public ReplicatedMapMergingEntryImpl setKey(Object key) {
+    public ReplicatedMapMergingEntryImpl<K, V> setKey(Object key) {
         this.key = key;
         return this;
     }
@@ -87,7 +88,7 @@ public class ReplicatedMapMergingEntryImpl
         return creationTime;
     }
 
-    public ReplicatedMapMergingEntryImpl setCreationTime(long creationTime) {
+    public ReplicatedMapMergingEntryImpl<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
         return this;
     }
@@ -97,7 +98,7 @@ public class ReplicatedMapMergingEntryImpl
         return hits;
     }
 
-    public ReplicatedMapMergingEntryImpl setHits(long hits) {
+    public ReplicatedMapMergingEntryImpl<K, V> setHits(long hits) {
         this.hits = hits;
         return this;
     }
@@ -107,7 +108,7 @@ public class ReplicatedMapMergingEntryImpl
         return lastAccessTime;
     }
 
-    public ReplicatedMapMergingEntryImpl setLastAccessTime(long lastAccessTime) {
+    public ReplicatedMapMergingEntryImpl<K, V> setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
         return this;
     }
@@ -117,7 +118,7 @@ public class ReplicatedMapMergingEntryImpl
         return lastUpdateTime;
     }
 
-    public ReplicatedMapMergingEntryImpl setLastUpdateTime(long lastUpdateTime) {
+    public ReplicatedMapMergingEntryImpl<K, V> setLastUpdateTime(long lastUpdateTime) {
         this.lastUpdateTime = lastUpdateTime;
         return this;
     }
@@ -127,7 +128,7 @@ public class ReplicatedMapMergingEntryImpl
         return ttl;
     }
 
-    public ReplicatedMapMergingEntryImpl setTtl(long ttl) {
+    public ReplicatedMapMergingEntryImpl<K, V> setTtl(long ttl) {
         this.ttl = ttl;
         return this;
     }
@@ -195,10 +196,10 @@ public class ReplicatedMapMergingEntryImpl
         if (ttl != that.ttl) {
             return false;
         }
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (!Objects.equals(key, that.key)) {
             return false;
         }
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/RingbufferMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/RingbufferMergingValueImpl.java
@@ -51,12 +51,12 @@ public class RingbufferMergingValueImpl
     }
 
     @Override
-    public RingbufferMergeData getValue() {
+    public RingbufferMergeData getRawValue() {
         return value;
     }
 
     @Override
-    public <DV> DV getDeserializedValue() {
+    public RingbufferMergeData getDeserializedValue() {
         final RingbufferMergeData deserializedValues = new RingbufferMergeData(value.getItems().length);
         deserializedValues.setHeadSequence(value.getHeadSequence());
         deserializedValues.setTailSequence(value.getTailSequence());
@@ -65,7 +65,7 @@ public class RingbufferMergingValueImpl
             deserializedValues.set(seq, serializationService.toObject(value.read(seq)));
         }
 
-        return (DV) deserializedValues;
+        return deserializedValues;
     }
 
     public RingbufferMergingValueImpl setValues(RingbufferMergeData values) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/RingbufferMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/RingbufferMergingValueImpl.java
@@ -56,7 +56,7 @@ public class RingbufferMergingValueImpl
     }
 
     @Override
-    public RingbufferMergeData getDeserializedValue() {
+    public RingbufferMergeData getValue() {
         final RingbufferMergeData deserializedValues = new RingbufferMergeData(value.getItems().length);
         deserializedValues.setHeadSequence(value.getHeadSequence());
         deserializedValues.setTailSequence(value.getTailSequence());

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
@@ -26,17 +26,17 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class DiscardMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T> {
+public class DiscardMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     public DiscardMergePolicy() {
     }
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (existingValue == null) {
             return null;
         }
-        return existingValue.getValue();
+        return existingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/ExpirationTimeMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/ExpirationTimeMergePolicy.java
@@ -29,21 +29,21 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class ExpirationTimeMergePolicy<V, T extends MergingExpirationTime<V>>
-        extends AbstractSplitBrainMergePolicy<V, T> {
+public class ExpirationTimeMergePolicy<V, T extends MergingValue<V> & MergingExpirationTime>
+        extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (mergingValue == null) {
-            return existingValue.getValue();
+            return existingValue.getRawValue();
         }
         if (existingValue == null) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
         if (mergingValue.getExpirationTime() >= existingValue.getExpirationTime()) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
-        return existingValue.getValue();
+        return existingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
@@ -27,23 +27,24 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class HigherHitsMergePolicy<V, T extends MergingHits<V>> extends AbstractSplitBrainMergePolicy<V, T> {
+public class HigherHitsMergePolicy<V, T extends MergingValue<V> & MergingHits>
+        extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     public HigherHitsMergePolicy() {
     }
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (mergingValue == null) {
-            return existingValue.getValue();
+            return existingValue.getRawValue();
         }
         if (existingValue == null) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
         if (mergingValue.getHits() >= existingValue.getHits()) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
-        return existingValue.getValue();
+        return existingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.merge;
 
 import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
+import com.hazelcast.spi.impl.merge.CardinalityEstimatorMergingEntry;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CardinalityEstimatorMergeTypes;
 
 import static com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook.HYPER_LOG_LOG;
@@ -30,18 +31,21 @@ import static com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook.HYPER_LO
  *
  * @since 3.10
  */
-public class HyperLogLogMergePolicy extends AbstractSplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes> {
+public class HyperLogLogMergePolicy
+        extends AbstractSplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes, HyperLogLog> {
 
     public HyperLogLogMergePolicy() {
     }
 
     @Override
-    public HyperLogLog merge(CardinalityEstimatorMergeTypes mergingValue, CardinalityEstimatorMergeTypes existingValue) {
+    public HyperLogLog merge(CardinalityEstimatorMergeTypes mergingValue,
+                                                CardinalityEstimatorMergeTypes existingValue) {
+        HyperLogLog merging = ((CardinalityEstimatorMergingEntry) mergingValue).getRawValue();
         if (existingValue == null) {
-            return mergingValue.getValue();
+            return merging;
         }
-        mergingValue.getValue().merge(existingValue.getValue());
-        return mergingValue.getValue();
+        merging.merge(((CardinalityEstimatorMergingEntry) existingValue).getRawValue());
+        return merging;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
@@ -29,24 +29,24 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class LatestAccessMergePolicy<V, T extends MergingLastAccessTime<V>>
-        extends AbstractSplitBrainMergePolicy<V, T> {
+public class LatestAccessMergePolicy<V, T extends MergingValue<V> & MergingLastAccessTime>
+        extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     public LatestAccessMergePolicy() {
     }
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (mergingValue == null) {
-            return existingValue.getValue();
+            return existingValue.getRawValue();
         }
         if (existingValue == null) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
         if (mergingValue.getLastAccessTime() >= existingValue.getLastAccessTime()) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
-        return existingValue.getValue();
+        return existingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
@@ -29,24 +29,24 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class LatestUpdateMergePolicy<V, T extends MergingLastUpdateTime<V>>
-        extends AbstractSplitBrainMergePolicy<V, T> {
+public class LatestUpdateMergePolicy<V, T extends MergingValue<V> & MergingLastUpdateTime>
+        extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     public LatestUpdateMergePolicy() {
     }
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (mergingValue == null) {
-            return existingValue.getValue();
+            return existingValue.getRawValue();
         }
         if (existingValue == null) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
         if (mergingValue.getLastUpdateTime() >= existingValue.getLastUpdateTime()) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
-        return existingValue.getValue();
+        return existingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCosts.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCosts.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of memory costs for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingCosts<V> extends MergingValue<V> {
+public interface MergingCosts {
 
     /**
      * Returns the memory cost of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCreationTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCreationTime.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingCreationTime {
+public interface MergingCreationTime extends MergingView {
 
     /**
      * Returns the creation time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCreationTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCreationTime.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view a creation time for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingCreationTime<V> extends MergingValue<V> {
+public interface MergingCreationTime {
 
     /**
      * Returns the creation time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
@@ -26,16 +26,16 @@ package com.hazelcast.spi.merge;
 public interface MergingEntry<K, V> extends MergingValue<V> {
 
     /**
+     * Returns the deserialized merging key.
+     *
+     * @return the deserialized merging key
+     */
+    K getKey();
+
+    /**
      * Returns the merging key in the in-memory format of the backing data structure.
      *
      * @return the merging key
      */
     Object getRawKey();
-
-    /**
-     * Returns the deserialized merging key.
-     *
-     * @return the deserialized merging key
-     */
-    K getDeserializedKey();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
@@ -30,13 +30,12 @@ public interface MergingEntry<K, V> extends MergingValue<V> {
      *
      * @return the merging key
      */
-    K getKey();
+    Object getRawKey();
 
     /**
      * Returns the deserialized merging key.
      *
-     * @param <DK> the type of the deserialized key
      * @return the deserialized merging key
      */
-    <DK> DK getDeserializedKey();
+    K getDeserializedKey();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingExpirationTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingExpirationTime.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingExpirationTime {
+public interface MergingExpirationTime extends MergingView {
 
     /**
      * Returns the expiration time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingExpirationTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingExpirationTime.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of an expiration time for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingExpirationTime<V> extends MergingValue<V> {
+public interface MergingExpirationTime {
 
     /**
      * Returns the expiration time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingHits.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingHits.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingHits {
+public interface MergingHits extends MergingView {
 
     /**
      * Returns the access hits of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingHits.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingHits.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view access hits for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingHits<V> extends MergingValue<V> {
+public interface MergingHits {
 
     /**
      * Returns the access hits of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastAccessTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastAccessTime.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of a last access time for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingLastAccessTime<V> extends MergingValue<V> {
+public interface MergingLastAccessTime {
 
     /**
      * Returns the last access time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastAccessTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastAccessTime.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingLastAccessTime {
+public interface MergingLastAccessTime extends MergingView {
 
     /**
      * Returns the last access time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastStoredTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastStoredTime.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of a last stored time for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingLastStoredTime<V> extends MergingValue<V> {
+public interface MergingLastStoredTime {
 
     /**
      * Returns the last stored time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastStoredTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastStoredTime.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingLastStoredTime {
+public interface MergingLastStoredTime extends MergingView {
 
     /**
      * Returns the last stored time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastUpdateTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastUpdateTime.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingLastUpdateTime {
+public interface MergingLastUpdateTime extends MergingView {
 
     /**
      * Returns the last update time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastUpdateTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastUpdateTime.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of a last update time for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingLastUpdateTime<V> extends MergingValue<V> {
+public interface MergingLastUpdateTime {
 
     /**
      * Returns the last update time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingMaxIdle.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingMaxIdle.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of a MaxIdle for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingMaxIdle<V> extends MergingValue<V> {
+public interface MergingMaxIdle {
 
     /**
      * Returns the MaxIdle of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingMaxIdle.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingMaxIdle.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingMaxIdle {
+public interface MergingMaxIdle extends MergingView {
 
     /**
      * Returns the MaxIdle of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingTTL.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingTTL.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of a TTL for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingTTL<V> extends MergingValue<V> {
+public interface MergingTTL {
 
     /**
      * Returns the TTL of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingTTL.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingTTL.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingTTL {
+public interface MergingTTL extends MergingView {
 
     /**
      * Returns the TTL of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -25,16 +25,16 @@ package com.hazelcast.spi.merge;
 public interface MergingValue<V> extends MergingView {
 
     /**
+     * Returns the deserialized merging value.
+     *
+     * @return the deserialized merging value
+     */
+    V getValue();
+
+    /**
      * Returns the merging value in the in-memory format of the backing data structure.
      *
      * @return the merging value
      */
     Object getRawValue();
-
-    /**
-     * Returns the deserialized merging value.
-     *
-     * @return the deserialized merging value
-     */
-    V getDeserializedValue();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -22,7 +22,7 @@ package com.hazelcast.spi.merge;
  * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingValue<V> {
+public interface MergingValue<V> extends MergingView {
 
     /**
      * Returns the merging value in the in-memory format of the backing data structure.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -29,13 +29,12 @@ public interface MergingValue<V> {
      *
      * @return the merging value
      */
-    V getValue();
+    Object getRawValue();
 
     /**
      * Returns the deserialized merging value.
      *
-     * @param <DV> the type of the deserialized value
      * @return the deserialized merging value
      */
-    <DV> DV getDeserializedValue();
+    V getDeserializedValue();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingVersion.java
@@ -21,7 +21,7 @@ package com.hazelcast.spi.merge;
  *
  * @since 3.10
  */
-public interface MergingVersion {
+public interface MergingVersion extends MergingView {
 
     /**
      * Returns the version of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingVersion.java
@@ -19,10 +19,9 @@ package com.hazelcast.spi.merge;
 /**
  * Represents a read-only view of a version for the merging process after a split-brain.
  *
- * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingVersion<V> extends MergingValue<V> {
+public interface MergingVersion {
 
     /**
      * Returns the version of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingView.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingView.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingView.java
@@ -17,7 +17,8 @@
 package com.hazelcast.spi.merge;
 
 /**
- * Marker interface representing a read-only view of a data structure for the merging process after a split-brain.
+ * Marker interface representing a read-only view of a data structure
+ * for the merging process after a split-brain.
  *
  * @since 4.0
  */

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingView.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,9 @@
 package com.hazelcast.spi.merge;
 
 /**
- * Represents a read-only view of memory costs for the merging process after a split-brain.
+ * Marker interface representing a read-only view of a data structure for the merging process after a split-brain.
  *
- * @since 3.10
+ * @since 4.0
  */
-public interface MergingCosts extends MergingView {
-
-    /**
-     * Returns the memory cost of the merge data.
-     *
-     * @return the memory cost of the merge data
-     */
-    long getCost();
+public interface MergingView {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
@@ -26,17 +26,17 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class PassThroughMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T> {
+public class PassThroughMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     public PassThroughMergePolicy() {
     }
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (mergingValue == null) {
-            return existingValue.getValue();
+            return existingValue.getRawValue();
         }
-        return mergingValue.getValue();
+        return mergingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
@@ -26,17 +26,17 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
-public class PutIfAbsentMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T> {
+public class PutIfAbsentMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T, Object> {
 
     public PutIfAbsentMergePolicy() {
     }
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         if (existingValue == null) {
-            return mergingValue.getValue();
+            return mergingValue.getRawValue();
         }
-        return existingValue.getValue();
+        return existingValue.getRawValue();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
@@ -19,8 +19,8 @@ package com.hazelcast.spi.merge;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.instance.impl.Node;
-import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.internal.services.NodeAware;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 /**
  * Policy for merging data structure values
@@ -56,13 +56,14 @@ import com.hazelcast.internal.services.NodeAware;
  * A merge policy can also implement {@link NodeAware}
  * to get an instance of {@link Node} injected.
  *
- * @param <V> the type of the returned merged value
+ * @param <V> the (deserialized) type of the merging value
  * @param <T> the type of the required merging value, e.g. a simple
  *            {@code MergingValue<V>} or a composition like {@code
- *            MergingEntry<String, V> & MergingHits<V> & MergingLastAccessTime<V>}
+ *            MergingEntry<String, V> & MergingHits & MergingLastAccessTime}
+ * @param <R> the type of the merged value as returned by {@link #merge(MergingValue, MergingValue)}
  * @since 3.10
  */
-public interface SplitBrainMergePolicy<V, T extends MergingValue<V>>
+public interface SplitBrainMergePolicy<V, T extends MergingValue<V>, R>
         extends DataSerializable {
 
     /**
@@ -78,5 +79,5 @@ public interface SplitBrainMergePolicy<V, T extends MergingValue<V>>
      *                      data or {@code null} if no matching data exists
      * @return the selected value for merging
      */
-    V merge(T mergingValue, T existingValue);
+    R merge(T mergingValue, T existingValue);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
@@ -45,7 +45,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
  * </ul>
  * If you need the deserialized data you can call
  * {@link MergingValue#getValue()}
- * or {@link MergingEntry#getDeserializedKey()},
+ * or {@link MergingEntry#getKey()},
  * which will deserialize the data lazily.
  * <p>
  * A merge policy can implement {@link HazelcastInstanceAware} to get the

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
@@ -44,7 +44,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
  * could throw a {@link java.lang.ClassNotFoundException}.</li>
  * </ul>
  * If you need the deserialized data you can call
- * {@link MergingValue#getDeserializedValue()}
+ * {@link MergingValue#getValue()}
  * or {@link MergingEntry#getDeserializedKey()},
  * which will deserialize the data lazily.
  * <p>

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -22,7 +22,6 @@ import com.hazelcast.collection.IQueue;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.IAtomicReference;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.IMap;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
@@ -46,55 +45,66 @@ public class SplitBrainMergeTypes {
     /**
      * Provided merge types of {@link IMap}.
      *
+     * @param <K> key type
+     * @param <V> value type
      * @since 3.10
      */
-    public interface MapMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
-            MergingLastAccessTime<Data>, MergingLastUpdateTime<Data>, MergingTTL<Data>, MergingMaxIdle<Data>, MergingCosts<Data>,
-            MergingVersion<Data>, MergingExpirationTime<Data>, MergingLastStoredTime<Data> {
+    public interface MapMergeTypes<K, V>
+            extends MergingEntry<K, V>, MergingCreationTime, MergingHits, MergingLastAccessTime, MergingLastUpdateTime,
+                    MergingTTL, MergingMaxIdle, MergingCosts, MergingVersion, MergingExpirationTime, MergingLastStoredTime {
     }
 
     /**
      * Provided merge types of {@link com.hazelcast.cache.ICache}.
      *
+     * @param <K> key type
+     * @param <V> value type
      * @since 3.10
      */
-    public interface CacheMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
-            MergingLastAccessTime<Data>, MergingExpirationTime<Data> {
+    public interface CacheMergeTypes<K, V>
+            extends MergingEntry<K, V>, MergingCreationTime, MergingHits, MergingLastAccessTime, MergingExpirationTime {
     }
 
     /**
      * Provided merge types of {@link ReplicatedMap}.
      *
+     * @param <K> key type
+     * @param <V> value type
      * @since 3.10
      */
-    public interface ReplicatedMapMergeTypes extends MergingEntry<Object, Object>, MergingCreationTime<Object>,
-            MergingHits<Object>, MergingLastAccessTime<Object>, MergingLastUpdateTime<Object>, MergingTTL<Object> {
+    public interface ReplicatedMapMergeTypes<K, V>
+            extends MergingEntry<K, V>, MergingCreationTime, MergingHits, MergingLastAccessTime, MergingLastUpdateTime,
+                    MergingTTL {
     }
 
     /**
      * Provided merge types of {@link MultiMap}.
      *
+     * @param <K> key type
+     * @param <V> value type
      * @since 3.10
      */
-    public interface MultiMapMergeTypes extends MergingEntry<Data, Collection<Object>>, MergingCreationTime<Collection<Object>>,
-            MergingHits<Collection<Object>>, MergingLastAccessTime<Collection<Object>>,
-            MergingLastUpdateTime<Collection<Object>> {
+    public interface MultiMapMergeTypes<K, V>
+            extends MergingEntry<K, Collection<V>>, MergingCreationTime, MergingHits, MergingLastAccessTime,
+                    MergingLastUpdateTime {
     }
 
     /**
      * Provided merge types of collections ({@link ISet} and {@link IList}).
      *
+     * @param <V> value type
      * @since 3.10
      */
-    public interface CollectionMergeTypes extends MergingValue<Collection<Object>> {
+    public interface CollectionMergeTypes<V> extends MergingValue<Collection<V>> {
     }
 
     /**
      * Provided merge types of {@link IQueue}.
      *
+     * @param <V> value type
      * @since 3.10
      */
-    public interface QueueMergeTypes extends MergingValue<Collection<Object>> {
+    public interface QueueMergeTypes<V> extends MergingValue<Collection<V>> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/ComplexCustomBaseMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/ComplexCustomBaseMergePolicy.java
@@ -20,17 +20,18 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.merge.MergingCosts;
 import com.hazelcast.spi.merge.MergingExpirationTime;
+import com.hazelcast.spi.merge.MergingValue;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 
 import java.io.IOException;
 
 @SuppressWarnings("unused")
 public class ComplexCustomBaseMergePolicy<V, C extends Comparable<V>, S extends String,
-        T extends MergingExpirationTime<V> & MergingCosts<V>, U extends Comparable<T>>
-        implements SplitBrainMergePolicy<V, T> {
+        T extends MergingValue<V> & MergingExpirationTime & MergingCosts, U extends Comparable<T>>
+        implements SplitBrainMergePolicy<V, T, Object> {
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         return null;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/ComplexCustomMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/ComplexCustomMergePolicy.java
@@ -29,6 +29,6 @@ import com.hazelcast.spi.merge.MergingExpirationTime;
  * It also uses inheritance to ensure that we check the complete class hierarchy.
  */
 @SuppressWarnings("unused")
-public class ComplexCustomMergePolicy<N extends Number, C extends Comparable<N>>
+public class ComplexCustomMergePolicy<N extends Number, C extends Comparable<N>, U>
         extends ComplexCustomBaseMergePolicy {
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicy.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.config.mergepolicies;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes;
 
@@ -30,10 +29,11 @@ import java.io.IOException;
  *
  * @see SplitBrainMergeTypes
  */
-public class CustomMapMergePolicy<T extends SplitBrainMergeTypes.MapMergeTypes> implements SplitBrainMergePolicy<Data, T> {
+public class CustomMapMergePolicy<K, V, T extends SplitBrainMergeTypes.MapMergeTypes<K, V>, U>
+        implements SplitBrainMergePolicy<V, T, U> {
 
     @Override
-    public Data merge(T mergingValue, T existingValue) {
+    public U merge(T mergingValue, T existingValue) {
         return null;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicyNoTypeVariable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicyNoTypeVariable.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.config.mergepolicies;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes;
 
@@ -32,10 +31,12 @@ import java.io.IOException;
  *
  * @see SplitBrainMergeTypes
  */
-public class CustomMapMergePolicyNoTypeVariable implements SplitBrainMergePolicy<Data, SplitBrainMergeTypes.MapMergeTypes> {
+public class CustomMapMergePolicyNoTypeVariable
+        implements SplitBrainMergePolicy<Object, SplitBrainMergeTypes.MapMergeTypes<Object, Object>, Object> {
 
     @Override
-    public Data merge(SplitBrainMergeTypes.MapMergeTypes mergingValue, SplitBrainMergeTypes.MapMergeTypes existingValue) {
+    public Object merge(SplitBrainMergeTypes.MapMergeTypes<Object, Object> mergingValue,
+                      SplitBrainMergeTypes.MapMergeTypes<Object, Object> existingValue) {
         return null;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/LastStoredTimeMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/LastStoredTimeMergePolicy.java
@@ -20,6 +20,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.merge.MergingLastStoredTime;
+import com.hazelcast.spi.merge.MergingValue;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 
 import java.io.IOException;
@@ -28,10 +29,11 @@ import java.io.IOException;
  * Custom merge policy which uses a single merge type,
  * which is just provided by by {@link IMap}.
  */
-public class LastStoredTimeMergePolicy<V, T extends MergingLastStoredTime<V>> implements SplitBrainMergePolicy<V, T> {
+public class LastStoredTimeMergePolicy<V, T extends MergingValue<V> & MergingLastStoredTime>
+        implements SplitBrainMergePolicy<V, T, Object> {
 
     @Override
-    public V merge(T mergingValue, T existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         return null;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/LastStoredTimeMergePolicyNoTypeVariable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/LastStoredTimeMergePolicyNoTypeVariable.java
@@ -20,20 +20,22 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.merge.MergingLastStoredTime;
+import com.hazelcast.spi.merge.MergingValue;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 
 import java.io.IOException;
 
 /**
  * Custom merge policy which uses a single merge type,
- * which is just provided by by {@link IMap}.
+ * which is just provided by {@link IMap}.
  * <p>
  * Doesn't use type variables to define the required merge types.
  */
-public class LastStoredTimeMergePolicyNoTypeVariable<V> implements SplitBrainMergePolicy<V, MergingLastStoredTime<V>> {
+public class LastStoredTimeMergePolicyNoTypeVariable<V, T extends MergingValue<V> & MergingLastStoredTime>
+        implements SplitBrainMergePolicy<V, T, Object> {
 
     @Override
-    public V merge(MergingLastStoredTime<V> mergingValue, MergingLastStoredTime<V> existingValue) {
+    public Object merge(T mergingValue, T existingValue) {
         return null;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/TestCustomMapMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestCustomMapMergePolicy.java
@@ -27,7 +27,7 @@ class TestCustomMapMergePolicy implements SplitBrainMergePolicy<Integer, Merging
 
     @Override
     public Integer merge(MergingValue<Integer> mergingEntry, MergingValue<Integer> existingEntry) {
-        return mergingEntry.getDeserializedValue();
+        return mergingEntry.getValue();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/TestCustomMapMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestCustomMapMergePolicy.java
@@ -23,14 +23,11 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 
 import java.io.IOException;
 
-class TestCustomMapMergePolicy implements SplitBrainMergePolicy<Integer, MergingValue<Integer>> {
+class TestCustomMapMergePolicy implements SplitBrainMergePolicy<Integer, MergingValue<Integer>, Integer> {
 
     @Override
     public Integer merge(MergingValue<Integer> mergingEntry, MergingValue<Integer> existingEntry) {
-        if (mergingEntry.getDeserializedValue() instanceof Integer) {
-            return mergingEntry.getDeserializedValue();
-        }
-        return null;
+        return mergingEntry.getDeserializedValue();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/CustomReplicatedMapMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/CustomReplicatedMapMergePolicy.java
@@ -28,7 +28,7 @@ public class CustomReplicatedMapMergePolicy
 
     @Override
     public Integer merge(MergingValue<Integer> mergingValue, MergingValue<Integer> existingValue) {
-        return mergingValue.getDeserializedValue();
+        return mergingValue.getValue();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/CustomReplicatedMapMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/CustomReplicatedMapMergePolicy.java
@@ -24,14 +24,11 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import java.io.IOException;
 
 public class CustomReplicatedMapMergePolicy
-        implements SplitBrainMergePolicy<Integer, MergingValue<Integer>> {
+        implements SplitBrainMergePolicy<Integer, MergingValue<Integer>, Integer> {
 
     @Override
     public Integer merge(MergingValue<Integer> mergingValue, MergingValue<Integer> existingValue) {
-        if (mergingValue.getValue() instanceof Integer) {
-            return mergingValue.getValue();
-        }
-        return null;
+        return mergingValue.getDeserializedValue();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferMergeIntegerValuesMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferMergeIntegerValuesMergePolicy.java
@@ -23,7 +23,7 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.RingbufferMergeTypes;
 
 class RingbufferMergeIntegerValuesMergePolicy
-        implements SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes> {
+        implements SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes, RingbufferMergeData> {
 
     @Override
     public RingbufferMergeData merge(RingbufferMergeTypes mergingValue, RingbufferMergeTypes existingValue) {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferMergeIntegerValuesMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferMergeIntegerValuesMergePolicy.java
@@ -27,11 +27,11 @@ class RingbufferMergeIntegerValuesMergePolicy
 
     @Override
     public RingbufferMergeData merge(RingbufferMergeTypes mergingValue, RingbufferMergeTypes existingValue) {
-        final RingbufferMergeData mergingRingbuffer = mergingValue.getDeserializedValue();
+        final RingbufferMergeData mergingRingbuffer = mergingValue.getValue();
         final RingbufferMergeData result = new RingbufferMergeData(mergingRingbuffer.getCapacity());
         RingbufferMergeData existingRingbuffer;
         if (existingValue != null) {
-            existingRingbuffer = existingValue.getDeserializedValue();
+            existingRingbuffer = existingValue.getValue();
         } else {
             existingRingbuffer = new RingbufferMergeData(mergingRingbuffer.getCapacity());
         }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferRemoveValuesMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferRemoveValuesMergePolicy.java
@@ -23,7 +23,7 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.RingbufferMergeTypes;
 
 class RingbufferRemoveValuesMergePolicy
-        implements SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes> {
+        implements SplitBrainMergePolicy<RingbufferMergeData, RingbufferMergeTypes, RingbufferMergeData> {
 
     @Override
     public RingbufferMergeData merge(RingbufferMergeTypes mergingValue, RingbufferMergeTypes existingValue) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractSplitBrainMergePolicyTest {
                 fail("Unsupported MergePolicy type");
             }
             when(mergingEntry.getRawValue()).thenReturn(value);
-            when(mergingEntry.getDeserializedValue()).thenReturn(SERIALIZATION_SERVICE.toObject(value));
+            when(mergingEntry.getValue()).thenReturn(SERIALIZATION_SERVICE.toObject(value));
             return mergingEntry;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
@@ -34,35 +34,35 @@ public abstract class AbstractSplitBrainMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    protected SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> mergePolicy;
 
     @Before
     public void setup() {
         mergePolicy = createMergePolicy();
     }
 
-    protected abstract SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy();
+    protected abstract SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> createMergePolicy();
 
     @Test
     public void merge_mergingWins() {
-        MapMergeTypes existing = mergingValueWithGivenPropertyAndValue(1, EXISTING);
-        MapMergeTypes merging = mergingValueWithGivenPropertyAndValue(333, MERGING);
+        MapMergeTypes<Object, String> existing = mergingValueWithGivenPropertyAndValue(1, EXISTING);
+        MapMergeTypes<Object, String> merging = mergingValueWithGivenPropertyAndValue(333, MERGING);
 
         assertEquals(MERGING, mergePolicy.merge(merging, existing));
     }
 
     @Test
     public void merge_existingWins() {
-        MapMergeTypes existing = mergingValueWithGivenPropertyAndValue(333, EXISTING);
-        MapMergeTypes merging = mergingValueWithGivenPropertyAndValue(1, MERGING);
+        MapMergeTypes<Object, String> existing = mergingValueWithGivenPropertyAndValue(333, EXISTING);
+        MapMergeTypes<Object, String> merging = mergingValueWithGivenPropertyAndValue(1, MERGING);
 
         assertEquals(EXISTING, mergePolicy.merge(merging, existing));
     }
 
     @Test
     public void merge_draw_mergingWins() {
-        MapMergeTypes existing = mergingValueWithGivenPropertyAndValue(1, EXISTING);
-        MapMergeTypes merging = mergingValueWithGivenPropertyAndValue(1, MERGING);
+        MapMergeTypes<Object, String> existing = mergingValueWithGivenPropertyAndValue(1, EXISTING);
+        MapMergeTypes<Object, String> merging = mergingValueWithGivenPropertyAndValue(1, MERGING);
 
         assertEquals(MERGING, mergePolicy.merge(merging, existing));
     }
@@ -70,8 +70,8 @@ public abstract class AbstractSplitBrainMergePolicyTest {
     @Test
     @SuppressWarnings("ConstantConditions")
     public void merge_mergingWins_sinceExistingIsNotExist() {
-        MapMergeTypes existing = null;
-        MapMergeTypes merging = mergingValueWithGivenPropertyAndValue(1, MERGING);
+        MapMergeTypes<Object, String> existing = null;
+        MapMergeTypes<Object, String> merging = mergingValueWithGivenPropertyAndValue(1, MERGING);
 
         assertEquals(MERGING, mergePolicy.merge(merging, existing));
     }
@@ -79,14 +79,14 @@ public abstract class AbstractSplitBrainMergePolicyTest {
     @Test
     @SuppressWarnings("ConstantConditions")
     public void merge_existingWins_sinceMergingIsNotExist() {
-        MapMergeTypes existing = mergingValueWithGivenPropertyAndValue(1, EXISTING);
-        MapMergeTypes merging = null;
+        MapMergeTypes<Object, String> existing = mergingValueWithGivenPropertyAndValue(1, EXISTING);
+        MapMergeTypes<Object, String> merging = null;
 
         assertEquals(EXISTING, mergePolicy.merge(merging, existing));
     }
 
-    private MapMergeTypes mergingValueWithGivenPropertyAndValue(long testedProperty, Data value) {
-        MapMergeTypes mergingEntry = mock(MapMergeTypes.class);
+    private MapMergeTypes<Object, String> mergingValueWithGivenPropertyAndValue(long testedProperty, Data value) {
+        MapMergeTypes<Object, String> mergingEntry = mock(MapMergeTypes.class);
         try {
             if (mergePolicy instanceof ExpirationTimeMergePolicy) {
                 when(mergingEntry.getExpirationTime()).thenReturn(testedProperty);
@@ -99,7 +99,7 @@ public abstract class AbstractSplitBrainMergePolicyTest {
             } else {
                 fail("Unsupported MergePolicy type");
             }
-            when(mergingEntry.getValue()).thenReturn(value);
+            when(mergingEntry.getRawValue()).thenReturn(value);
             when(mergingEntry.getDeserializedValue()).thenReturn(SERIALIZATION_SERVICE.toObject(value));
             return mergingEntry;
         } catch (Exception e) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
@@ -41,7 +41,7 @@ public class DiscardMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> mergePolicy;
 
     @Before
     public void setup() {
@@ -85,7 +85,7 @@ public class DiscardMergePolicyTest {
     private MapMergeTypes mergingValueWithGivenValue(Data value) {
         MapMergeTypes mergingValue = mock(MapMergeTypes.class);
         try {
-            when(mergingValue.getValue()).thenReturn(value);
+            when(mergingValue.getRawValue()).thenReturn(value);
             return mergingValue;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/ExpirationTimeSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/ExpirationTimeSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class ExpirationTimeSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new ExpirationTimeMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> createMergePolicy() {
+        return new ExpirationTimeMergePolicy<>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class HigherHitsSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new HigherHitsMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> createMergePolicy() {
+        return new HigherHitsMergePolicy<>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class LatestAccessSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new LatestAccessMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> createMergePolicy() {
+        return new LatestAccessMergePolicy<>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class LatestUpdateSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new LatestUpdateMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> createMergePolicy() {
+        return new LatestUpdateMergePolicy<>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
@@ -40,11 +40,11 @@ public class PassThroughMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> mergePolicy;
 
     @Before
     public void setup() {
-        mergePolicy = new PassThroughMergePolicy<Data, MapMergeTypes>();
+        mergePolicy = new PassThroughMergePolicy<>();
     }
 
     @Test
@@ -67,7 +67,7 @@ public class PassThroughMergePolicyTest {
     private MapMergeTypes mergingValueWithGivenValue(Data value) {
         MapMergeTypes mergingValue = mock(MapMergeTypes.class);
         try {
-            when(mergingValue.getValue()).thenReturn(value);
+            when(mergingValue.getRawValue()).thenReturn(value);
             return mergingValue;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
@@ -41,11 +41,11 @@ public class PutIfAbsentMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<String, MapMergeTypes<Object, String>, Object> mergePolicy;
 
     @Before
     public void setup() {
-        mergePolicy = new PutIfAbsentMergePolicy<Data, MapMergeTypes>();
+        mergePolicy = new PutIfAbsentMergePolicy<>();
     }
 
     @Test
@@ -76,7 +76,7 @@ public class PutIfAbsentMergePolicyTest {
     private MapMergeTypes mergingValueWithGivenValue(Data value) {
         MapMergeTypes mergingValue = mock(MapMergeTypes.class);
         try {
-            when(mergingValue.getValue()).thenReturn(value);
+            when(mergingValue.getRawValue()).thenReturn(value);
             return mergingValue;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -564,10 +564,10 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
 
         @Override
         public Object merge(T mergingValue, T existingValue) {
-            if (mergingValue.getDeserializedValue() instanceof Integer) {
+            if (mergingValue.getValue() instanceof Integer) {
                 return mergingValue.getRawValue();
             }
-            if (existingValue != null && existingValue.getDeserializedValue() instanceof Integer) {
+            if (existingValue != null && existingValue.getValue() instanceof Integer) {
                 return existingValue.getRawValue();
             }
             return null;
@@ -594,13 +594,13 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         public Collection<Object> merge(MergingValue<Collection<Object>> mergingValue,
                                         MergingValue<Collection<Object>> existingValue) {
             Collection<Object> result = new ArrayList<>();
-            for (Object value : mergingValue.getDeserializedValue()) {
+            for (Object value : mergingValue.getValue()) {
                 if (value instanceof Integer) {
                     result.add(value);
                 }
             }
             if (existingValue != null) {
-                for (Object value : existingValue.getDeserializedValue()) {
+                for (Object value : existingValue.getValue()) {
                     if (value instanceof Integer) {
                         result.add(value);
                     }

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -80,33 +80,13 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      */
     private boolean unblacklistHint = false;
 
-    private static final SplitBrainAction BLOCK_COMMUNICATION = new SplitBrainAction() {
-        @Override
-        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
-            blockCommunicationBetween(h1, h2);
-        }
-    };
+    private static final SplitBrainAction BLOCK_COMMUNICATION = SplitBrainTestSupport::blockCommunicationBetween;
 
-    private static final SplitBrainAction UNBLOCK_COMMUNICATION = new SplitBrainAction() {
-        @Override
-        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
-            unblockCommunicationBetween(h1, h2);
-        }
-    };
+    private static final SplitBrainAction UNBLOCK_COMMUNICATION = SplitBrainTestSupport::unblockCommunicationBetween;
 
-    private static final SplitBrainAction CLOSE_CONNECTION = new SplitBrainAction() {
-        @Override
-        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
-            closeConnectionBetween(h1, h2);
-        }
-    };
+    private static final SplitBrainAction CLOSE_CONNECTION = HazelcastTestSupport::closeConnectionBetween;
 
-    private static final SplitBrainAction UNBLACKLIST_MEMBERS = new SplitBrainAction() {
-        @Override
-        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
-            unblacklistJoinerBetween(h1, h2);
-        }
-    };
+    private static final SplitBrainAction UNBLACKLIST_MEMBERS = SplitBrainTestSupport::unblacklistJoinerBetween;
 
     @Before
     public final void setUpInternals() {
@@ -251,7 +231,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         Brains brains = getBrains();
         HazelcastInstance[] instancesToBlock = brain == 1 ? brains.firstHalf : brains.secondHalf;
 
-        List<Address> addressesToBlock = new ArrayList<Address>(instancesToBlock.length);
+        List<Address> addressesToBlock = new ArrayList<>(instancesToBlock.length);
         for (HazelcastInstance hz : instancesToBlock) {
             if (isInstanceActive(hz)) {
                 addressesToBlock.add(getAddress(hz));
@@ -344,7 +324,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
     private static FirewallingNetworkingService.FirewallingEndpointManager getFireWalledEndpointManager(HazelcastInstance hz) {
         Node node = getNode(hz);
         return (FirewallingNetworkingService.FirewallingEndpointManager)
-                ((FirewallingNetworkingService) node.getNetworkingService()).getEndpointManager(MEMBER);
+                node.getNetworkingService().getEndpointManager(MEMBER);
     }
 
     protected Brains getBrains() {
@@ -502,7 +482,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      * <p>
      * Used to test the removal of all values from a data structure.
      */
-    protected static class RemoveValuesMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>> {
+    protected static class RemoveValuesMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>, Object> {
 
         @Override
         public Object merge(MergingValue<Object> mergingValue, MergingValue<Object> existingValue) {
@@ -523,7 +503,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      * <p>
      * Used to test that data structures can deal with user created data in OBJECT format.
      */
-    protected static class ReturnPiMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>> {
+    protected static class ReturnPiMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>, Object> {
 
         @Override
         public Object merge(MergingValue<Object> mergingValue, MergingValue<Object> existingValue) {
@@ -545,19 +525,19 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      * Used to test that data structures can deal with user created data in OBJECT format.
      */
     protected static class ReturnPiCollectionMergePolicy
-            implements SplitBrainMergePolicy<Collection<Object>, MergingValue<Collection<Object>>> {
+            implements SplitBrainMergePolicy<Collection<Object>, MergingValue<Collection<Object>>, Collection<Object>> {
 
         private static final Collection<Object> PI_COLLECTION;
         private static final Set<Object> PI_SET;
 
         static {
-            PI_COLLECTION = new ArrayList<Object>(5);
+            PI_COLLECTION = new ArrayList<>(5);
             PI_COLLECTION.add(3);
             PI_COLLECTION.add(1);
             PI_COLLECTION.add(4);
             PI_COLLECTION.add(1);
             PI_COLLECTION.add(5);
-            PI_SET = new HashSet<Object>(PI_COLLECTION);
+            PI_SET = new HashSet<>(PI_COLLECTION);
         }
 
         @Override
@@ -580,15 +560,15 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      * <p>
      * Used to test the deserialization of values.
      */
-    protected static class MergeIntegerValuesMergePolicy<V, T extends MergingValue<V>> implements SplitBrainMergePolicy<V, T> {
+    protected static class MergeIntegerValuesMergePolicy<V, T extends MergingValue<V>> implements SplitBrainMergePolicy<V, T, Object> {
 
         @Override
-        public V merge(T mergingValue, T existingValue) {
+        public Object merge(T mergingValue, T existingValue) {
             if (mergingValue.getDeserializedValue() instanceof Integer) {
-                return mergingValue.getValue();
+                return mergingValue.getRawValue();
             }
             if (existingValue != null && existingValue.getDeserializedValue() instanceof Integer) {
-                return existingValue.getValue();
+                return existingValue.getRawValue();
             }
             return null;
         }
@@ -608,19 +588,19 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      * Used to test the deserialization of values.
      */
     protected static class MergeCollectionOfIntegerValuesMergePolicy
-            implements SplitBrainMergePolicy<Collection<Object>, MergingValue<Collection<Object>>> {
+            implements SplitBrainMergePolicy<Collection<Object>, MergingValue<Collection<Object>>, Collection<Object>> {
 
         @Override
         public Collection<Object> merge(MergingValue<Collection<Object>> mergingValue,
                                         MergingValue<Collection<Object>> existingValue) {
-            Collection<Object> result = new ArrayList<Object>();
-            for (Object value : mergingValue.<Collection<Object>>getDeserializedValue()) {
+            Collection<Object> result = new ArrayList<>();
+            for (Object value : mergingValue.getDeserializedValue()) {
                 if (value instanceof Integer) {
                     result.add(value);
                 }
             }
             if (existingValue != null) {
-                for (Object value : existingValue.<Collection<Object>>getDeserializedValue()) {
+                for (Object value : existingValue.getDeserializedValue()) {
                     if (value instanceof Integer) {
                         result.add(value);
                     }

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/AbstractWanCustomPublisherMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/AbstractWanCustomPublisherMapTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -240,8 +239,9 @@ public class AbstractWanCustomPublisherMapTest extends HazelcastTestSupport {
         MapOperation op;
         SimpleEntryView<Data, Data> entryView = new SimpleEntryView<Data, Data>().withKey(data).withValue(data);
 
-        MapMergeTypes mergingEntry = createMergingEntry(serializationService, entryView);
-        SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy = new PassThroughMergePolicy<>();
+        MapMergeTypes<Object, Object> mergingEntry = createMergingEntry(serializationService, entryView);
+        SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy
+                = new com.hazelcast.spi.merge.PassThroughMergePolicy<>();
         op = operationProvider.createMergeOperation(mapName, mergingEntry, mergePolicy, !enableWANReplicationEvent);
         operationService.createInvocationBuilder(MapService.SERVICE_NAME, op, partitionService.getPartitionId(data)).invoke();
     }


### PR DESCRIPTION
Changed `MergingValue`/`MergingEntry` so that the newly introduced
methods `getRawValue`/`Key` (which supersede the old `getValue`/`Key`)
return the in-memory representation as `Object`. The deserialized
value can be obtained using `getDeserializedValue`/`Key`.

The merge types in `SplitBrainMergeTypes` no longer depend on `Data`.
Instead of specifying the in-memory storage type of the keys and
values (`Data`), they specify the deserialized types. Also, the value
type has been removed from the various 'view' interfaces such as
`MergingHits`, `MergingCreationTime`, etc. Related to that, a new
marker super-interface - `MergingView` - has been introduced that
all the 'view' interfaces (including `MergingValue`) now extend.

The generic type signature of `SplitBrainMergePolicy` has changed
to specify the (deserialized) type of the merging value; the
type of merging value object (typically, `MergingValue<V>`, but it can
be a composition like `MergingEntry<String, V> & MergingHits`); and
finally, the return type of the `merge` method (typically `Object` for merge
policies that work with the in-memory storage type).

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3484