### PR TITLE
Adding finest ClientListenerService logs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerRegistration.java
@@ -45,4 +45,12 @@ public class ClientListenerRegistration {
     Map<Connection, ClientConnectionRegistration> getConnectionRegistrations() {
         return registrations;
     }
+
+    @Override
+    public String toString() {
+        return "ClientListenerRegistration{"
+                + "codec=" + codec
+                + ", handler=" + handler
+                + '}';
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
@@ -186,6 +186,9 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
         ListenerMessageCodec codec = listenerRegistration.getCodec();
         ClientMessage request = codec.encodeAddRequest(registersLocalOnly());
         EventHandler handler = listenerRegistration.getHandler();
+        if (logger.isFinestEnabled()) {
+            logger.finest("Register attempt of " + listenerRegistration + " to " + connection);
+        }
         handler.beforeListenerRegister(connection);
 
         ClientInvocation invocation = new ClientInvocation(client, request, null, connection);
@@ -200,6 +203,9 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
         }
 
         UUID serverRegistrationId = codec.decodeAddResponse(clientMessage);
+        if (logger.isFinestEnabled()) {
+            logger.finest("Registered " + listenerRegistration + " to " + connection);
+        }
         handler.onListenerRegister(connection);
         long correlationId = request.getCorrelationId();
         ClientConnectionRegistration registration

--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -33,6 +33,7 @@
         <!--<Logger name="com.hazelcast.test.mocknetwork" level="debug"/>-->
         <Logger name="com.hazelcast.client.impl.protocol.task" level="debug"/>
         <Logger name="com.hazelcast.client.impl.operations" level="debug"/>
+        <Logger name="com.hazelcast.client.impl.spi.ClientListenerService" level="trace"/>
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientClusterService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientInvocationService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.connection.ClientConnectionManager" level="trace"/>-->


### PR DESCRIPTION
Listener registration logs are added to help us identify
cause of related failures.

related to https://github.com/hazelcast/hazelcast/issues/16126