### PR TITLE
Refactor test to use a new map loader per node

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/CountingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/CountingMapLoader.java
@@ -60,12 +60,7 @@ class CountingMapLoader extends SimpleMapLoader {
     public Iterable<Integer> loadAllKeys() {
         final Iterable<Integer> allKeys = super.loadAllKeys();
         loadAllKeysInvocations.incrementAndGet();
-        return new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                return new CloseableIterator<Integer>(allKeys.iterator());
-            }
-        };
+        return () -> new CloseableIterator<>(allKeys.iterator());
     }
 
     public int getLoadAllKeysInvocations() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -123,7 +123,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
 
     @Test(timeout = MINUTE)
     public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoading() throws Exception {
-        PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
+        PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<>(mapLoader, 5000);
 
         Config cfg = newConfig("default", LAZY, 1, pausingLoader);
         HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
@@ -166,28 +166,40 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     @Test(timeout = MINUTE)
     // FIXES https://github.com/hazelcast/hazelcast/issues/7959
     public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups() {
-        PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
+        CountingMapLoader mapLoader1 = new CountingMapLoader(MAP_STORE_ENTRY_COUNT);
+        CountingMapLoader mapLoader2 = new CountingMapLoader(MAP_STORE_ENTRY_COUNT);
+        PausingMapLoader<Integer, Integer> pausingLoader3
+                = new PausingMapLoader<>(new CountingMapLoader(MAP_STORE_ENTRY_COUNT), 5000);
 
-        Config cfg = newConfig("default", LAZY, 0, pausingLoader);
-        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
-        HazelcastInstance hz3 = nodes[2];
+        Config cfg1 = newConfig("default", LAZY, 0, mapLoader1);
+        Config cfg2 = newConfig("default", LAZY, 0, mapLoader2);
+        Config cfg3 = newConfig("default", LAZY, 0, pausingLoader3);
 
-        String mapName = generateKeyOwnedBy(hz3);
-        IMap<Object, Object> map = nodes[0].getMap(mapName);
+        HazelcastInstance node1 = nodeFactory.newHazelcastInstance(cfg1);
+        HazelcastInstance node2 = nodeFactory.newHazelcastInstance(cfg2);
+        HazelcastInstance node3 = nodeFactory.newHazelcastInstance(cfg3);
+
+        String mapName = generateKeyOwnedBy(node3);
+        IMap<Object, Object> map = node1.getMap(mapName);
 
         // trigger loading and pause half way through
         map.putAsync(1, 2);
-        pausingLoader.awaitPause();
+        pausingLoader3.awaitPause();
 
-        hz3.getLifecycleService().terminate();
+        node3.getLifecycleService().terminate();
         waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
 
-        pausingLoader.resume();
+        pausingLoader3.resume();
 
         int size = map.size();
         assertEquals(MAP_STORE_ENTRY_COUNT, size);
-        assertTrue(mapLoader.getLoadedValueCount() >= MAP_STORE_ENTRY_COUNT);
-        assertEquals(2, mapLoader.getLoadAllKeysInvocations());
+
+        int loadedValueCount = mapLoader1.getLoadedValueCount() + mapLoader2.getLoadedValueCount();
+        assertTrue("loadedValueCount=" + loadedValueCount,
+                loadedValueCount >= MAP_STORE_ENTRY_COUNT);
+
+        assertEquals(1, mapLoader1.getLoadAllKeysInvocations()
+                + mapLoader2.getLoadAllKeysInvocations());
     }
 
     private void assertSizeAndLoadCount(IMap<Object, Object> map) {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/7959

```
13:27:44,284 TRACE |testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups| - 
[MapKeyLoader] hz.brave_napier.cached.thread-2 - sendKeysInBatches invoked on 
partitionId=11 on [127.0.0.1]:5703 role=StateMachine{state=SENDER} 
state=StateMachine{state=LOADING}

13:27:45,016 TRACE |testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups| - 
[MapKeyLoader] hz.brave_napier.cached.thread-4 - sendKeysInBatches invoked on 
partitionId=11 on [127.0.0.1]:5703 role=StateMachine{state=SENDER} 
state=StateMachine{state=LOADING}
```

Logs show that node3, which is shutting down, calls loadAllKeys more than once. 
Since node is shutting down, this seems not a real issue.

I modified test to use separate map-loader instances per node. So expected loadAllKeys-call-count in the cluster should be 1 after initial loader node terminates.
