### PR TITLE
Fixed EvictionMaxSizePolicyTest unit test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -159,8 +159,8 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
         LocalMapStats localMapStats1 = map1.getLocalMapStats();
         LocalMapStats localMapStats2 = map2.getLocalMapStats();
 
-        assertEquals(localMapStats1.getOwnedEntryCount(), localMapStats2.getBackupEntryCount());
-        assertEquals(localMapStats2.getOwnedEntryCount(), localMapStats1.getBackupEntryCount());
+        assertEqualsEventually(() -> localMapStats2.getBackupEntryCount(), localMapStats1.getOwnedEntryCount());
+        assertEqualsEventually(() -> localMapStats1.getBackupEntryCount(), localMapStats2.getOwnedEntryCount());
     }
 
     @Test


### PR DESCRIPTION
Use eventual asserts in the test because entry eviction ack may
come eventually from the backup and IMap#put() operation may proceed
not getting acks from the backup in slow environment.

Fixes: https://github.com/hazelcast/hazelcast/issues/16431