### PR TITLE
Control instance creation of singleton serializable comparators

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/function/ComparatorsEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ComparatorsEx.java
@@ -27,7 +27,7 @@ final class ComparatorsEx {
     }
 
     @BinaryInterface
-    private static class NaturalOrderComparator implements ComparatorEx<Comparable<Object>> {
+    private static final class NaturalOrderComparator implements ComparatorEx<Comparable<Object>> {
 
         @Override
         public int compareEx(Comparable<Object> left, Comparable<Object> right) {
@@ -38,10 +38,14 @@ final class ComparatorsEx {
         public ComparatorEx<Comparable<Object>> reversed() {
             return REVERSE_ORDER;
         }
+
+        private Object readResolve() {
+            return NATURAL_ORDER;
+        }
     }
 
     @BinaryInterface
-    private static class ReverseOrderComparator implements ComparatorEx<Comparable<Object>> {
+    private static final class ReverseOrderComparator implements ComparatorEx<Comparable<Object>> {
 
         @Override
         public int compareEx(Comparable<Object> left, Comparable<Object> right) {
@@ -51,6 +55,10 @@ final class ComparatorsEx {
         @Override
         public ComparatorEx<Comparable<Object>> reversed() {
             return NATURAL_ORDER;
+        }
+
+        private Object readResolve() {
+            return REVERSE_ORDER;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/function/ComparatorExTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/function/ComparatorExTest.java
@@ -23,6 +23,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import static com.hazelcast.function.ComparatorEx.nullsFirst;
 import static com.hazelcast.function.ComparatorEx.nullsLast;
 import static com.hazelcast.function.ComparatorsEx.NATURAL_ORDER;
@@ -179,5 +185,34 @@ public class ComparatorExTest {
     @Test
     public void testSerializable_comparingDouble() {
         checkSerializable(ComparatorEx.comparingDouble(Double::doubleValue), null);
+    }
+
+    @Test
+    public void testSerializableSingleton_naturalOrder()
+            throws IOException, ClassNotFoundException {
+        testSerializableSingletonIsSame(NATURAL_ORDER);
+    }
+
+    @Test
+    public void testSerializableSingleton_reverseOrder()
+            throws IOException, ClassNotFoundException {
+        testSerializableSingletonIsSame(REVERSE_ORDER);
+    }
+
+    private void testSerializableSingletonIsSame(Object singleton)
+            throws IOException, ClassNotFoundException {
+        byte[] serialized;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(singleton);
+            objectOutputStream.flush();
+            serialized = outputStream.toByteArray();
+        }
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(serialized);
+             ObjectInputStream objectInputStream = new ObjectInputStream(inputStream)) {
+            Object deserialized = objectInputStream.readObject();
+            assertSame(singleton, deserialized);
+        }
     }
 }


### PR DESCRIPTION
Serializable singleton comparators for natural
and reverse order should not create new instances
on deserialization.