### PR TITLE
Fix LossToleranceTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
@@ -34,7 +34,6 @@ import org.junit.runner.RunWith;
 import java.util.UUID;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -103,10 +102,7 @@ public class LossToleranceTest extends HazelcastTestSupport {
         topic.addMessageListener(listener);
         topic.publish("newItem");
 
-        assertTrueEventually(() -> {
-            assertContains(listener.objects, "newItem");
-            assertFalse(topic.runnersMap.isEmpty());
-        });
+        assertTrueEventually(() -> assertContains(listener.objects, "newItem"));
     }
 
     @Test
@@ -126,10 +122,7 @@ public class LossToleranceTest extends HazelcastTestSupport {
         assertTrueEventually(() -> {
             String item = "newItem " + UUID.randomUUID();
             topic.publish(item);
-            assertTrueEventually(() -> {
-                assertContains(listener.objects, item);
-                assertFalse(topic.runnersMap.isEmpty());
-            }, 5);
+            assertTrueEventually(() -> assertContains(listener.objects, item), 5);
         });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
@@ -16,13 +16,12 @@
 
 package com.hazelcast.topic.impl.reliable;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.impl.TestUtil;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -31,6 +30,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.UUID;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
 import static org.junit.Assert.assertFalse;
@@ -80,20 +81,12 @@ public class LossToleranceTest extends HazelcastTestSupport {
         topic.publish("foo");
 
         // we add so many items that the items the listener wants to listen to, doesn't exist anymore
-        for (; ; ) {
+        do {
             topic.publish("item");
-            if (ringbuffer.headSequence() > listener.initialSequence) {
-                break;
-            }
-        }
+        } while (ringbuffer.headSequence() <= listener.initialSequence);
         topic.addMessageListener(listener);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertTrue(topic.runnersMap.isEmpty());
-            }
-        });
+        assertTrueEventually(() -> assertTrue(topic.runnersMap.isEmpty()));
     }
 
     @Test
@@ -103,22 +96,16 @@ public class LossToleranceTest extends HazelcastTestSupport {
         listener.isLossTolerant = true;
 
         // we add so many items that the items the listener wants to listen to, doesn't exist anymore
-        for (; ; ) {
+        do {
             topic.publish("item");
-            if (ringbuffer.headSequence() > listener.initialSequence) {
-                break;
-            }
-        }
+        } while (ringbuffer.headSequence() <= listener.initialSequence);
 
         topic.addMessageListener(listener);
         topic.publish("newItem");
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertContains(listener.objects, "newItem");
-                assertFalse(topic.runnersMap.isEmpty());
-            }
+        assertTrueEventually(() -> {
+            assertContains(listener.objects, "newItem");
+            assertFalse(topic.runnersMap.isEmpty());
         });
     }
 
@@ -130,24 +117,19 @@ public class LossToleranceTest extends HazelcastTestSupport {
         topic.publish("item1");
         topic.publish("item2");
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertContains(listener.objects, "item1");
-                assertContains(listener.objects, "item2");
-            }
+        assertTrueEventually(() -> {
+            assertContains(listener.objects, "item1");
+            assertContains(listener.objects, "item2");
         });
         TestUtil.terminateInstance(topicOwnerInstance);
 
-        topic.publish("newItem");
-
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertContains(listener.objects, "newItem");
+        assertTrueEventually(() -> {
+            String item = "newItem " + UUID.randomUUID();
+            topic.publish(item);
+            assertTrueEventually(() -> {
+                assertContains(listener.objects, item);
                 assertFalse(topic.runnersMap.isEmpty());
-            }
+            }, 5);
         });
     }
 }


### PR DESCRIPTION
Because of the behaviour change introduced in
https://github.com/hazelcast/hazelcast/pull/16303, when the requested
sequence is larger than the largest sequence (tailSequence) + 1, we
don't listen from the oldest sequence (headSequence) but rather from the
tailSequence + 1. Both approaches are fine and both approaches work
better in some scenarios. Since the listener is loss tolerant, we can
skip items from headSequence..tailSequence+1 anyway.

Fixed the test to adhere to the new behaviour. We assume that eventually
as we publish an item, it will reach the listener.

A better fix would be to introduce unique IDs per ringbuffer, where we
would then be able to distinguish between a completely lost ringbuffer
and a ringbuffer which has not received the last few items and
appropriately reset the requested sequence to the headSequence or
tailSequence.

Fixes: https://github.com/hazelcast/hazelcast/issues/16430