### PR TITLE
Remove redundant logging from ManagementCenterService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -77,7 +77,6 @@ public class ManagementCenterService {
         this.commandHandler = new ConsoleCommandHandler(instance);
         this.bwListConfigHandler = new ClientBwListConfigHandler(instance.node.clientEngine);
         registerExecutor();
-        logger.info("Hazelcast is ready for communication with Hazelcast Management Center");
     }
 
     private void registerExecutor() {


### PR DESCRIPTION
As member's `ManagementCenterService` is now always enabled (and works in lazy mode), its startup logging doesn't makes sense anymore. This message is critical for Jet, when IMDG is embedded into Jet and IMDG MC is not relevant.