### PR TITLE
Fix ClientRegressionWithRealNetworkTest failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -195,9 +195,9 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         Hazelcast.newHazelcastInstance(config);
 
         assertTrueEventually(() -> {
+            map.remove(1);
             map.put(1, 2);
             assertNotEquals(0, eventCount.get());
-            map.remove(1);
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
If the first CREATED event is missed after the client reconnects to the new
cluster, the assertion at the end of the test fails, hence prevents the remove
call to be executed. So map.remove() is never executed and all other puts fire
UPDATED events. map.remove() call is moved before map.put() to fire CREATED
events in all cases.

Special thanks to Sancar and Ihsan for their great help on digging the issue.

Fixes #16126