### PR TITLE
Fix MetadataRaftGroupTest snapshotting test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocationContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocationContext.java
@@ -23,6 +23,7 @@ import com.hazelcast.cp.exception.CPSubsystemException;
 import com.hazelcast.cp.internal.CPMemberInfo;
 import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.exception.RetryableIOException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -76,7 +77,7 @@ public class RaftInvocationContext {
             CPMembersContainer currentContainer = membersContainer.get();
             if (newContainer.version.compareTo(currentContainer.version) > 0) {
                 if (membersContainer.compareAndSet(currentContainer, newContainer)) {
-                    logger.info("Replaced " + currentContainer + " with " + newContainer);
+                    logger.fine("Replaced " + currentContainer + " with " + newContainer);
                     return true;
                 }
             } else {
@@ -145,7 +146,9 @@ public class RaftInvocationContext {
             if (!setKnownLeader(groupId, getCPMember(e.getLeaderUuid()))) {
                 resetKnownLeader(groupId);
             }
-        } else if (cause instanceof TargetNotMemberException || cause instanceof MemberLeftException) {
+        } else if (cause instanceof TargetNotMemberException
+                || cause instanceof MemberLeftException
+                || cause instanceof RetryableIOException) {
             resetKnownLeader(groupId);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.cp.internal.raftop.metadata.GetRaftGroupOp;
 import com.hazelcast.cp.internal.raftop.metadata.TriggerDestroyRaftGroupOp;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
-import com.hazelcast.internal.nio.EndpointManager;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.RandomPicker;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
@@ -57,15 +56,15 @@ import java.util.concurrent.Future;
 import static com.hazelcast.cp.CPGroup.DEFAULT_GROUP_NAME;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGroupInitStatus.IN_PROGRESS;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGroupInitStatus.SUCCESSFUL;
+import static com.hazelcast.cp.internal.RaftServiceDataSerializerHook.APPEND_REQUEST_OP;
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getSnapshotEntry;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.FINALIZE_JOIN;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsToAddresses;
 import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
-import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
-import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
@@ -431,18 +430,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         HazelcastInstance leader = getInstance(leaderEndpoint);
         HazelcastInstance follower = getRandomFollowerInstance(instances, getMetadataGroupId(instances[0]));
 
-        // Ensure other nodes have an active connection to the follower
-        // Otherwise blockCommunicationBetween(..) can cause a split-brain.
-        assertTrueEventually(() -> {
-            for (HazelcastInstance instance : instances) {
-                if (follower == instance) {
-                    continue;
-                }
-                EndpointManager endpointManager = getEndpointManager(instance);
-                assertNotNull(endpointManager.getOrConnect(getAddress(follower)));
-            }
-        });
-        blockCommunicationBetween(leader, follower);
+        dropOperationsBetween(leader, follower, RaftServiceDataSerializerHook.F_ID, singletonList(APPEND_REQUEST_OP));
 
         List<CPGroupId> groupIds = new ArrayList<>();
         for (int i = 0; i < commitCountToSnapshot; i++) {
@@ -451,8 +439,6 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         }
 
         assertTrueEventually(() -> assertTrue(getSnapshotEntry(getRaftNode(leader, getMetadataGroupId(leader))).index() > 0));
-
-        unblockCommunicationBetween(leader, follower);
 
         assertTrueEventually(() -> {
             for (CPGroupId groupId : groupIds) {


### PR DESCRIPTION
- *Fix MetadataRaftGroupTest snapshotting test*: Instead of blocking network communication completely, just drop append requests to force installing snapshot on follower. Otherwise, we should handle various network split scenarios in the test.

- *Reset known CP group leader when `RetryableIOException` is received*:  `RetryableIOException` is thrown when an invocation packet cannot be sent to target. In that case, we should reset the known leader, because it might not be the leader anymore.

Fixes #15622