### PR TITLE
Operation supplier should create new operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -39,6 +39,7 @@ import com.hazelcast.config.TopicConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.ClusterVersionListener;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.CoreService;
 import com.hazelcast.internal.services.ManagedService;
@@ -46,12 +47,12 @@ import com.hazelcast.internal.services.PreJoinAwareService;
 import com.hazelcast.internal.services.SplitBrainHandlerService;
 import com.hazelcast.internal.util.FutureUtil;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.version.Version;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -167,7 +168,7 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
     }
 
     private IdentifiedDataSerializable[] collectAllDynamicConfigs() {
-        List<IdentifiedDataSerializable> all = new ArrayList<IdentifiedDataSerializable>();
+        List<IdentifiedDataSerializable> all = new ArrayList<>();
         for (Map<?, ? extends IdentifiedDataSerializable> entry : allConfigurations) {
             Collection<? extends IdentifiedDataSerializable> values = entry.values();
             all.addAll(values);
@@ -508,6 +509,7 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
         private final NodeEngine nodeEngine;
         private final IdentifiedDataSerializable[] allConfigurations;
 
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
         public Merger(NodeEngine nodeEngine, IdentifiedDataSerializable[] allConfigurations) {
             this.nodeEngine = nodeEngine;
             this.allConfigurations = allConfigurations;


### PR DESCRIPTION
Operations should not be reused for different
invocations. The supplier for `invokeOnStableCluster` 
in `ClusterWideConfigurationService$Merger` must
create a new operation for each subsequent invocation.

Fixes #12555 