### PR TITLE
Fix client listener registry leaks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
@@ -78,8 +78,6 @@ public interface ClientEndpoint extends Client, DynamicMetricsProvider {
 
     Subject getSubject();
 
-    void clearAllListeners();
-
     Connection getConnection();
 
     void setLoginContext(LoginContext lc);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClusterViewListenerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClusterViewListenerService.java
@@ -181,4 +181,8 @@ public class ClusterViewListenerService {
         return partitionsMap;
     }
 
+    //for test purpose only
+    public Map<ClientEndpoint, Long> getClusterListeningEndpoints() {
+        return clusterListeningEndpoints;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -263,4 +263,17 @@ public class ListenerLeakTest extends ClientTestSupport {
         Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
         assertTrueEventually(() -> assertEquals(0, backupListeners.size()));
     }
+
+    @Test
+    public void testListenerLeakOnMember_whenClientDestroyed() {
+        Collection<Node> nodes = createNodes();
+
+        for (int i = 0; i < 100; i++) {
+            newHazelcastClient().shutdown();
+        }
+
+        for (Node node : nodes) {
+            assertEquals(0, node.getClientEngine().getClusterListenerService().getClusterListeningEndpoints().size());
+        }
+    }
 }


### PR DESCRIPTION
Background:
When a listener is added from an endpoint, we also register a
destroyAction. A destroyAction is a function to deregister the listener.
It is used when endpoint is removed. When endpoint is removed, we call
 all the registered destroy actions.

Racy scenario is as follows:
1. A listener is added, but not registered the destroy action.
2. Endpoint is removed because the client is disconnected.
All the destroy actions currently registered are called.
3. DestroyAction is registered to endpoint after it is destroyed.
4. After this point, there is no one to call the last destroyAction,
hence the leak.

As fix, we have added a second check if endpoint is destroyed after
a destroy action is put.

fixes https://github.com/hazelcast/hazelcast/issues/16429