### PR TITLE
Fix client listener registry leaks

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -146,6 +146,7 @@
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]client[\\/]connection[\\/]nio[\\/]ClientConnection"/>
     <suppress checks="MethodCount|ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]ClientEngineImpl"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]client[\\/]impl[\\/]ClientEndpointImpl"/>
     <suppress checks="CyclomaticComplexity|ClassDataAbstractionCoupling|ClassFanOutComplexity|MethodCount"
               files="com[\\/]hazelcast[\\/]client[\\/]config[\\/]ClientDomConfigProcessor"/>
     <suppress checks="CyclomaticComplexity" files="com[\\/]hazelcast[\\/]client[\\/]config[\\/]YamlClientDomConfigProcessor"/>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -254,4 +254,17 @@ public class ListenerLeakTest extends HazelcastTestSupport {
             }
         });
     }
+
+    @Test
+    public void testListenerLeakOnMember_whenClientDestroyed() {
+        Collection<Node> nodes = createNodes();
+
+        for (int i = 0; i < 100; i++) {
+            newHazelcastClient().shutdown();
+        }
+
+        for (Node node : nodes) {
+            assertEquals(0, node.getClientEngine().getPartitionListenerService().getPartitionListeningEndpoints().size());
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientPartitionListenerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientPartitionListenerService.java
@@ -124,4 +124,9 @@ public class ClientPartitionListenerService {
             return null;
         }
     }
+
+    //for test purpose only
+    public Map<ClientEndpoint, Long> getPartitionListeningEndpoints() {
+        return partitionListeningEndpoints;
+    }
 }


### PR DESCRIPTION
Background:
When a listener is added from an endpoint, we also register a
destroyAction. A destroyAction is a function to deregister the listener.
It is used when endpoint is removed. When endpoint is removed, we call
 all the registered destroy actions.

Racy scenario is as follows:
1. A listener is added, but not registered the destroy action.
2. Endpoint is removed because the client is disconnected.
All the destroy actions currently registered are called.
3. DestroyAction is registered to endpoint after it is destroyed.
4. After this point, there is no one to call the last destroyAction,
hence the leak.

As fix, we have added a second check if endpoint is destroyed after
a destroy action is put.

fixes https://github.com/hazelcast/hazelcast/issues/16429

(cherry picked from commit 600502cd5ed258ca4f44a9a7a796e2ebe806990f)