### PR TITLE
Fail MigrationOperation when TargetNotMemberException is thrown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -289,7 +289,7 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
 
     @Override
     public ExceptionAction onInvocationException(Throwable throwable) {
-        if (throwable instanceof MemberLeftException) {
+        if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
         if (!migrationInfo.isValid()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -32,7 +32,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.CallStatus;
-import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.FragmentedMigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Offload;
@@ -41,7 +40,6 @@ import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.UrgentSystemOperation;
-import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.SimpleExecutionCallback;
@@ -276,14 +274,6 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
     private Level getLogLevel(Throwable e) {
         return (e instanceof MemberLeftException || e instanceof InterruptedException)
                 || !getNodeEngine().isRunning() ? Level.INFO : Level.WARNING;
-    }
-
-    @Override
-    public ExceptionAction onInvocationException(Throwable throwable) {
-        if (throwable instanceof TargetNotMemberException) {
-            return ExceptionAction.THROW_EXCEPTION;
-        }
-        return super.onInvocationException(throwable);
     }
 
     @Override


### PR DESCRIPTION
`MigrationRequestOperation` checks for existence of migration destination
in `verifyExistingDestination()` method and fails the migration
with `TargetNotMemberException` if destination doesn't exist.

But if destination leaves the cluster while `MigrationOperation` is being invoked,
`MigrationOperation` is retried with `TargetNotMemberException` until retries timeout.

`MigrationOperation` should fail when `TargetNotMemberException` is thrown
after it's invoked, because it's known that if `MigrationOperation` is invoked
destination was there but left in the meantime.

(cherry picked from commit 367e2cafbc407bfa2520af424ed8e6bc33802b8e)

Backport of https://github.com/hazelcast/hazelcast/pull/16451

Fixes #16433