### PR TITLE
Fix DiagnosticsLogTest.testLogFileContent

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -53,11 +52,62 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
     private DiagnosticsLogFile diagnosticsLogFile;
     private MetricsRegistry metricsRegistry;
 
-    @Before
-    public void setup() {
+    @After
+    public void teardown() {
+        cleanupDiagnosticFiles(diagnostics);
+    }
+
+    @Test
+    public void testLogFileContent() {
+        setup("10");
+        assertTrueEventually(() -> {
+            String content = loadLogfile(diagnosticsLogFile.file);
+            assertNotNull(content);
+
+            assertContains(content, "SystemProperties[");
+            assertContains(content, "BuildInfo[");
+            assertContains(content, "ConfigProperties[");
+            assertContains(content, "Metric[");
+        });
+    }
+
+    @Test
+    public void testRollover() {
+        setup("0.2");
+        // we register 50 probes to quickly fill up the diagnostics log file
+        String id = generateRandomString(10000);
+        LongProbeFunction<Object> probe = source -> 0;
+        for (int k = 0; k < 50; k++) {
+            metricsRegistry.registerStaticProbe(this, id + k, ProbeLevel.MANDATORY, probe);
+        }
+
+        // we run for some time to make sure we get enough rollovers
+        final List<File> files = new LinkedList<>();
+        while (files.size() < 3) {
+            final File file = diagnosticsLogFile.file;
+            if (file != null) {
+                if (!files.contains(file)) {
+                    files.add(file);
+                }
+
+                assertTrueEventually(() -> assertExist(file));
+            }
+
+            sleepMillis(100);
+        }
+
+        // eventually all these files should be gone
+        assertTrueEventually(() -> {
+            for (File file : files) {
+                assertNotExist(file);
+            }
+        });
+    }
+
+    private void setup(String maxFileSize) {
         Config config = new Config()
                 .setProperty(Diagnostics.ENABLED.getName(), "true")
-                .setProperty(Diagnostics.MAX_ROLLED_FILE_SIZE_MB.getName(), "0.2")
+                .setProperty(Diagnostics.MAX_ROLLED_FILE_SIZE_MB.getName(), maxFileSize)
                 .setProperty(Diagnostics.MAX_ROLLED_FILE_COUNT.getName(), "3")
                 .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
 
@@ -66,72 +116,6 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
         diagnostics = AbstractDiagnosticsPluginTest.getDiagnostics(hz);
         diagnosticsLogFile = diagnostics.diagnosticsLogFile;
         metricsRegistry = getMetricsRegistry(hz);
-    }
-
-    @After
-    public void teardown() {
-        cleanupDiagnosticFiles(diagnostics);
-    }
-
-    @Test
-    public void testLogFileContent() {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                String content = loadLogfile(diagnosticsLogFile.file);
-                assertNotNull(content);
-
-                assertContains(content, "SystemProperties[");
-                assertContains(content, "BuildInfo[");
-                assertContains(content, "ConfigProperties[");
-                assertContains(content, "Metric[");
-            }
-        });
-    }
-
-    @Test
-    public void testRollover() {
-        // we register 50 probes to quickly fill up the diagnostics log file
-        String id = generateRandomString(10000);
-        LongProbeFunction probe = new LongProbeFunction() {
-            @Override
-            public long get(Object source) {
-                return 0;
-            }
-        };
-        for (int k = 0; k < 50; k++) {
-            metricsRegistry.registerStaticProbe(this, id + k, ProbeLevel.MANDATORY, probe);
-        }
-
-        // we run for some time to make sure we get enough rollovers
-        final List<File> files = new LinkedList<File>();
-        while (files.size() < 3) {
-            final File file = diagnosticsLogFile.file;
-            if (file != null) {
-                if (!files.contains(file)) {
-                    files.add(file);
-                }
-
-                assertTrueEventually(new AssertTask() {
-                    @Override
-                    public void run() {
-                        assertExist(file);
-                    }
-                });
-            }
-
-            sleepMillis(100);
-        }
-
-        // eventually all these files should be gone
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                for (File file : files) {
-                    assertNotExist(file);
-                }
-            }
-        });
     }
 
     private static String loadLogfile(File file) {


### PR DESCRIPTION
The diagnostics files roll over as soon as 200KB is reached, which is
when we print out all of the static plugins and do a single output of
the metrics. After this, a new file is created with only the static
diagnostics plugin output until the metrics plugin kicks in again in 1
second. It might happen that the assertion just observes the new
diagnostics files without the metrics output then.
We fix this by allowing more than 200KB in a single diagnostics file.
Such a low number was used only because we want the other test in this
class to do rollovers as soon as possible. We then use different max
file sizes for each test separately.

Fixes: https://github.com/hazelcast/hazelcast/issues/16395