### PR TITLE
Fix WanCustomPublisherMapTest.mapPutTransientTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/AbstractWanCustomPublisherMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/AbstractWanCustomPublisherMapTest.java
@@ -145,7 +145,7 @@ public class AbstractWanCustomPublisherMapTest extends HazelcastTestSupport {
     public void mapPutTransientTest() {
         initInstancesAndMap("wan-replication-test-put-transient");
         for (int i = 0; i < 10; i++) {
-            map.putTransient(i, i, 1, TimeUnit.SECONDS);
+            map.putTransient(i, i, 30, TimeUnit.SECONDS);
         }
 
         assertQueueContents(10, map);


### PR DESCRIPTION
The test puts entries with a short TTL and asserts the contents of the
map were replicated. The TTL is not important here so we increase it.

Failed on several PR builds but not reported yet, e.g.:
http://jenkins.hazelcast.com/job/Hazelcast-pr-builder/5474/