### PR TITLE
Improve naming in LocalQueueStats

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/LocalQueueStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/LocalQueueStats.java
@@ -57,7 +57,7 @@ public interface LocalQueueStats extends LocalInstanceStats {
      *
      * @return average age of the items in this member
      */
-    long getAvgAge();
+    long getAverageAge();
 
     /**
      * Returns the number of offer/put/add operations.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -993,7 +993,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
         stats.setMinAge(minAge);
         stats.setMaxAge(maxAge);
         long totalAgedCountVal = Math.max(totalAgedCount, 1);
-        stats.setAveAge(totalAge / totalAgedCountVal);
+        stats.setAverageAge(totalAge / totalAgedCountVal);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/QueueMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/QueueMBean.java
@@ -62,10 +62,10 @@ public class QueueMBean extends HazelcastMBean<IQueue> {
         return localQueueStatsDelegate.getLocalStats().getMaxAge();
     }
 
-    @ManagedAnnotation("localAvgAge")
+    @ManagedAnnotation("localAverageAge")
     @ManagedDescription("the average age of the items in this member.")
-    public long getLocalAvgAge() {
-        return localQueueStatsDelegate.getLocalStats().getAvgAge();
+    public long getLocalAverageAge() {
+        return localQueueStatsDelegate.getLocalStats().getAverageAge();
     }
 
     @ManagedAnnotation("localOfferOperationCount")

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImpl.java
@@ -52,7 +52,7 @@ public class LocalQueueStatsImpl implements LocalQueueStats, JsonSerializable {
     @Probe
     private long maxAge;
     @Probe
-    private long aveAge;
+    private long averageAge;
     @Probe
     private long creationTime;
 
@@ -93,12 +93,12 @@ public class LocalQueueStatsImpl implements LocalQueueStats, JsonSerializable {
     }
 
     @Override
-    public long getAvgAge() {
-        return aveAge;
+    public long getAverageAge() {
+        return averageAge;
     }
 
-    public void setAveAge(long aveAge) {
-        this.aveAge = aveAge;
+    public void setAverageAge(long averageAge) {
+        this.averageAge = averageAge;
     }
 
     @Override
@@ -191,7 +191,7 @@ public class LocalQueueStatsImpl implements LocalQueueStats, JsonSerializable {
         root.add("backupItemCount", backupItemCount);
         root.add("minAge", minAge);
         root.add("maxAge", maxAge);
-        root.add("aveAge", aveAge);
+        root.add("averageAge", averageAge);
         root.add("creationTime", creationTime);
         root.add("numberOfOffers", numberOfOffers);
         root.add("numberOfPolls", numberOfPolls);
@@ -208,7 +208,7 @@ public class LocalQueueStatsImpl implements LocalQueueStats, JsonSerializable {
         backupItemCount = getInt(json, "backupItemCount", -1);
         minAge = getLong(json, "minAge", -1L);
         maxAge = getLong(json, "maxAge", -1L);
-        aveAge = getLong(json, "aveAge", -1L);
+        averageAge = getLong(json, "averageAge", -1L);
         creationTime = getLong(json, "creationTime", -1L);
         NUMBER_OF_OFFERS.set(this, getLong(json, "numberOfOffers", -1L));
         NUMBER_OF_POLLS.set(this, getLong(json, "numberOfPolls", -1L));
@@ -225,7 +225,7 @@ public class LocalQueueStatsImpl implements LocalQueueStats, JsonSerializable {
                 + ", backupItemCount=" + backupItemCount
                 + ", minAge=" + minAge
                 + ", maxAge=" + maxAge
-                + ", aveAge=" + aveAge
+                + ", averageAge=" + averageAge
                 + ", creationTime=" + creationTime
                 + ", numberOfOffers=" + numberOfOffers
                 + ", numberOfRejectedOffers=" + numberOfRejectedOffers

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStatisticsTest.java
@@ -166,7 +166,7 @@ public class QueueStatisticsTest extends HazelcastTestSupport {
         long maxAge = stats.getMaxAge();
         long minAge = stats.getMinAge();
         long testAge = (maxAge + minAge) / 2;
-        long avgAge = stats.getAvgAge();
+        long avgAge = stats.getAverageAge();
         assertEquals(testAge, avgAge);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImplTest.java
@@ -37,14 +37,14 @@ public class LocalQueueStatsImplTest {
         LocalQueueStatsImpl localQueueStats = new LocalQueueStatsImpl();
         localQueueStats.setMinAge(13);
         localQueueStats.setMaxAge(28);
-        localQueueStats.setAveAge(18);
+        localQueueStats.setAverageAge(18);
         localQueueStats.setOwnedItemCount(1234);
         localQueueStats.setBackupItemCount(15124);
 
         assertTrue(localQueueStats.getCreationTime() > 0);
         assertEquals(13, localQueueStats.getMinAge());
         assertEquals(28, localQueueStats.getMaxAge());
-        assertEquals(18, localQueueStats.getAvgAge());
+        assertEquals(18, localQueueStats.getAverageAge());
         assertEquals(1234, localQueueStats.getOwnedItemCount());
         assertEquals(15124, localQueueStats.getBackupItemCount());
         assertNotNull(localQueueStats.toString());


### PR DESCRIPTION
* Fixes misprint in `LocalQueueStatsImpl#getAvgAge` (was `aveAge` in JSON, setter and field name) and renames to `averageAge`, in a manner consistent with other stats classes (e.g. `OnDemandIndexStats#getAverageHitLatency` or `CacheStatisticsImpl#getAverageGetTime`)
* Involves corresponding rename in `QueueMBean`

Ref manual counterpart PR: https://github.com/hazelcast/hazelcast-reference-manual/pull/800