### PR TITLE
[BACKPORT] Avoid using on-heap indexes while indexing is in progress

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -110,7 +110,8 @@ public class QueryRunner {
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
 
         // then we try to run using an index, but if that doesn't work, we'll try a full table scan
-        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer, migrationStamp);
+        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
+                migrationStamp, initialPartitions.size());
 
         Result result;
         if (entries == null) {
@@ -157,7 +158,8 @@ public class QueryRunner {
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
 
         // then we try to run using an index
-        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer, migrationStamp);
+        Collection<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
+                migrationStamp, initialPartitions.size());
 
         Result result;
         if (entries == null) {
@@ -183,7 +185,7 @@ public class QueryRunner {
         Collection<QueryableEntry> entries = null;
         Indexes indexes = mapContainer.getIndexes(partitionId);
         if (indexes != null && !indexes.isGlobal()) {
-            entries = indexes.query(predicate);
+            entries = indexes.query(predicate, partitions.size());
         }
 
         Result result;
@@ -225,7 +227,7 @@ public class QueryRunner {
     }
 
     protected Collection<QueryableEntry> runUsingGlobalIndexSafely(Predicate predicate, MapContainer mapContainer,
-                                                                   int migrationStamp) {
+                                                                   int migrationStamp, int ownedPartitionCount) {
 
         // If a migration is in progress or migration ownership changes,
         // do not attempt to use an index as they may have not been created yet.
@@ -243,7 +245,7 @@ public class QueryRunner {
             // leverage index on this node in a global way.
             return null;
         }
-        Collection<QueryableEntry> entries = indexes.query(predicate);
+        Collection<QueryableEntry> entries = indexes.query(predicate, ownedPartitionCount);
         if (entries == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -60,6 +60,7 @@ import static com.hazelcast.map.impl.querycache.subscriber.AbstractQueryCacheEnd
 import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.publishEntryEvent;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest.newQueryCacheRequest;
 import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -334,7 +335,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<K> resultingSet = new HashSet<K>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
+        Set<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 K key = toObject(entry.getKeyData());
@@ -353,7 +354,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<Map.Entry<K, V>> resultingSet = new HashSet<Map.Entry<K, V>>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
+        Set<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 Map.Entry<K, V> copyEntry = new CachedQueryEntry<K, V>(serializationService, entry.getKeyData(),
@@ -376,7 +377,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         List<Data> resultingList = new ArrayList<Data>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
+        Set<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 resultingList.add(entry.getValueData());

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -329,6 +329,11 @@ public class AttributeIndexRegistry {
         }
 
         @Override
+        public boolean allPartitionsIndexed(int ownedPartitionCount) {
+            return delegate.allPartitionsIndexed(ownedPartitionCount);
+        }
+
+        @Override
         public void markPartitionAsIndexed(int partitionId) {
             throw newUnsupportedException();
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.TypeConverter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
 
 /**
@@ -111,7 +112,8 @@ public final class ConverterCache {
         }
 
         // try non-composite index first, if any
-        InternalIndex nonCompositeIndex = indexes.matchIndex(attribute, QueryContext.IndexMatchHint.NONE);
+        InternalIndex nonCompositeIndex = indexes.matchIndex(attribute, QueryContext.IndexMatchHint.NONE,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (nonCompositeIndex != null) {
             TypeConverter converter = nonCompositeIndex.getConverter();
             if (isNull(converter)) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
@@ -29,9 +29,9 @@ public class GlobalQueryContextProvider implements QueryContextProvider {
     };
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
         QueryContext queryContext = QUERY_CONTEXT.get();
-        queryContext.attachTo(indexes);
+        queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
@@ -29,9 +29,9 @@ public class GlobalQueryContextProviderWithStats implements QueryContextProvider
     };
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
         GlobalQueryContextWithStats queryContext = QUERY_CONTEXT.get();
-        queryContext.attachTo(indexes);
+        queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -36,8 +36,8 @@ public class GlobalQueryContextWithStats extends QueryContext {
     private final HashSet<QueryTrackingIndex> trackedIndexes = new HashSet<QueryTrackingIndex>(8);
 
     @Override
-    void attachTo(Indexes indexes) {
-        super.attachTo(indexes);
+    void attachTo(Indexes indexes, int ownedPartitionCount) {
+        super.attachTo(indexes, ownedPartitionCount);
         for (QueryTrackingIndex trackedIndex : trackedIndexes) {
             trackedIndex.resetPerQueryStats();
         }
@@ -53,7 +53,7 @@ public class GlobalQueryContextWithStats extends QueryContext {
 
     @Override
     public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        InternalIndex delegate = indexes.matchIndex(pattern, matchHint);
+        InternalIndex delegate = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (delegate == null) {
             return null;
         }
@@ -183,6 +183,11 @@ public class GlobalQueryContextWithStats extends QueryContext {
         @Override
         public boolean hasPartitionIndexed(int partitionId) {
             return delegate.hasPartitionIndexed(partitionId);
+        }
+
+        @Override
+        public boolean allPartitionsIndexed(int ownedPartitionCount) {
+            return delegate.allPartitionsIndexed(ownedPartitionCount);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -58,6 +58,14 @@ public class IndexImpl extends AbstractIndex {
     }
 
     @Override
+    public boolean allPartitionsIndexed(int ownedPartitionCount) {
+        // This check guarantees that all partitions are indexed
+        // only if there is no concurrent migrations. Check migration stamp
+        // to detect concurrent migrations if needed.
+        return ownedPartitionCount < 0 || indexedPartitions.size() == ownedPartitionCount;
+    }
+
+    @Override
     public void markPartitionAsIndexed(int partitionId) {
         assert !indexedPartitions.contains(partitionId);
         indexedPartitions.add(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -42,6 +42,21 @@ public interface InternalIndex extends Index {
     boolean hasPartitionIndexed(int partitionId);
 
     /**
+     * Returns {@code true} if all {@code queryPartitions} are indexed,
+     * {@code false} otherwise.
+     * <p>
+     * The method is used to check whether a global index is still being constructed concurrently
+     * so that some partitions are not indexed and query may suffer from entry misses.
+     * If the index construction is still in progress, a query optimizer ignores the index.
+     * <p>
+     * The aforementioned race condition is not relevant to local off-heap indexes,
+     * since index construction is performed in partition-threads.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     * Negative value indicates that the value is not defined.
+     */
+    boolean allPartitionsIndexed(int ownedPartitionCount);
+
+    /**
      * Marks the given partition as indexed by this index.
      *
      * @param partitionId the ID of the partition to mark as indexed.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
@@ -29,12 +29,13 @@ public class PartitionQueryContextProvider implements QueryContextProvider {
      * @param indexes the indexes to construct the new query context for.
      */
     public PartitionQueryContextProvider(Indexes indexes) {
-        queryContext = new QueryContext(indexes);
+        queryContext = new QueryContext(indexes, 1);
     }
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
         assert indexes == queryContext.indexes;
+        assert queryContext.ownedPartitionCount == 1 && ownedPartitionCount == 1;
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
@@ -34,8 +34,9 @@ public class PartitionQueryContextProviderWithStats implements QueryContextProvi
     }
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
-        queryContext.attachTo(indexes);
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
+        assert queryContext.ownedPartitionCount == 1 && ownedPartitionCount == 1;
+        queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -34,12 +34,13 @@ public class PartitionQueryContextWithStats extends QueryContext {
      * @param indexes the indexes to construct the new query context for.
      */
     public PartitionQueryContextWithStats(Indexes indexes) {
-        super(indexes);
+        super(indexes, 1);
     }
 
     @Override
-    void attachTo(Indexes indexes) {
+    void attachTo(Indexes indexes, int ownedPartitionCount) {
         assert indexes == this.indexes;
+        assert ownedPartitionCount == 1 && this.ownedPartitionCount == 1;
         for (PerIndexStats stats : trackedStats) {
             stats.resetPerQueryStats();
         }
@@ -55,7 +56,7 @@ public class PartitionQueryContextWithStats extends QueryContext {
 
     @Override
     public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        InternalIndex index = indexes.matchIndex(pattern, matchHint);
+        InternalIndex index = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (index == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -22,14 +22,16 @@ package com.hazelcast.query.impl;
 public class QueryContext {
 
     protected Indexes indexes;
+    protected int ownedPartitionCount = -1;
 
     /**
      * Creates a new query context with the given available indexes.
      *
      * @param indexes the indexes available for the query context.
      */
-    public QueryContext(Indexes indexes) {
+    public QueryContext(Indexes indexes, int ownedPartitionCount) {
         this.indexes = indexes;
+        this.ownedPartitionCount = ownedPartitionCount;
     }
 
     /**
@@ -39,12 +41,31 @@ public class QueryContext {
     }
 
     /**
+     * @return a count of owned partitions a query runs on.
+     */
+    public int getOwnedPartitionCount() {
+        return ownedPartitionCount;
+    }
+
+    /**
+     * Sets owned partitions count a query runs on.
+     * @param ownedPartitionCount a count of owned partitions.
+     */
+    public void setOwnedPartitionCount(int ownedPartitionCount) {
+        this.ownedPartitionCount = ownedPartitionCount;
+    }
+
+    /**
      * Attaches this index context to the given indexes.
      *
      * @param indexes the indexes to attach to.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
+     *
      */
-    void attachTo(Indexes indexes) {
+    void attachTo(Indexes indexes, int ownedPartitionCount) {
         this.indexes = indexes;
+        this.ownedPartitionCount = ownedPartitionCount;
     }
 
     /**
@@ -76,7 +97,7 @@ public class QueryContext {
      * @see QueryContext.IndexMatchHint
      */
     public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        return indexes.matchIndex(pattern, matchHint);
+        return indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
@@ -27,9 +27,11 @@ public interface QueryContextProvider {
      * The returned query context instance is valid for a duration of a single
      * query and should be re-obtained for every query.
      *
-     * @param indexes the indexes to obtain the query context for.
+     * @param indexes             the indexes to obtain the query context for.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
      * @return the obtained query context.
      */
-    QueryContext obtainContextFor(Indexes indexes);
+    QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -71,6 +71,9 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate implements Vis
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(from, true, to, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
@@ -67,6 +67,9 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
@@ -83,6 +83,9 @@ public class CompositeEqualPredicate implements Predicate, IndexAwarePredicate {
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
@@ -118,6 +118,9 @@ public class CompositeRangePredicate implements Predicate, IndexAwarePredicate {
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -63,6 +63,9 @@ public class EqualPredicate extends AbstractIndexAwarePredicate
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluatePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluatePredicate.java
@@ -74,12 +74,15 @@ public final class EvaluatePredicate implements Predicate, IndexAwarePredicate {
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (index == null) {
+            return null;
+        }
         return index.evaluate(predicate);
     }
 
     @Override
     public boolean isIndexed(QueryContext queryContext) {
-        return true;
+        return queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME) != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+
 /**
  * Tries to divide the predicate tree into isolated subtrees every of which can
  * be evaluated by {@link Index#evaluate} method in a single go.
@@ -51,7 +53,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(andPredicate.getClass())) {
                 continue;
             }
@@ -85,7 +87,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(andPredicate.getClass())) {
                 output.add(subPredicate);
             }
@@ -128,7 +130,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(orPredicate.getClass())) {
                 continue;
             }
@@ -162,7 +164,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(orPredicate.getClass())) {
                 output.add(subPredicate);
             }
@@ -198,7 +200,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
         EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
         String indexName = evaluatePredicate.getIndexName();
-        Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
         if (!index.canEvaluate(notPredicate.getClass())) {
             return notPredicate;
         }
@@ -208,7 +210,8 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @Override
     public Predicate visit(EqualPredicate predicate, Indexes indexes) {
-        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
             return predicate;
         }
@@ -227,7 +230,8 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @Override
     public Predicate visit(NotEqualPredicate predicate, Indexes indexes) {
-        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
             return predicate;
         }
@@ -246,7 +250,8 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @Override
     public Predicate visit(InPredicate predicate, Indexes indexes) {
-        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
             return predicate;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -70,6 +70,9 @@ public final class GreaterLessPredicate extends AbstractIndexAwarePredicate impl
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+        if (index == null) {
+            return null;
+        }
         final Comparison comparison;
         if (less) {
             comparison = equal ? Comparison.LESS_OR_EQUAL : Comparison.LESS;

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -122,7 +122,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
 
     @Override
     public Config getConfig() {
-        Config config = super.getConfig();
+        Config config = smallInstanceConfig();
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(inMemoryFormat);
         config.addMapConfig(mapConfig);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -38,9 +38,9 @@ import org.junit.runner.RunWith;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AbstractIndexConcurrencyTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runners.Parameterized;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public abstract class AbstractIndexConcurrencyTest extends HazelcastTestSupport {
+
+    private static final int QUERY_THREADS_NUM = 5;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Parameterized.Parameter
+    public String indexDefinition;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> parameters() {
+        // @formatter:off
+        return asList(new Object[][]{
+                {"age"},
+                {"BITMAP(age)"},
+                {"name"}
+        });
+        // @formatter:on
+    }
+
+    @Before
+    public void setUp() {
+        // by default disable awaiting on latch
+        Person.accessCountDown = null;
+        Person.indexerLatch = new CountDownLatch(1);
+        Person.queryLatch = new CountDownLatch(1);
+    }
+
+    @Test
+    public void testIndexCreationAndQueryConcurrency() throws InterruptedException {
+        Config config = getConfig();
+
+        HazelcastInstance node = createHazelcastInstance(config);
+        final IMap<Integer, Person> map = node.getMap(randomMapName());
+
+        // put some data
+        for (int i = 0; i < 10000; ++i) {
+            map.put(i, new Person(i));
+        }
+
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+
+        // run index creation and queries concurrently
+        Thread[] threads = new Thread[QUERY_THREADS_NUM + 1];
+
+        threads[0] = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    boolean ordered = indexDefinition.contains("BITMAP") ? false : true;
+                    map.addIndex("age", ordered);
+                } catch (Throwable t) {
+                    exception.compareAndSet(null, t);
+                }
+            }
+        });
+
+        threads[0].start();
+
+        for (int i = 1; i < threads.length; i++) {
+            threads[i] = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        Collection<Person> persons = map.values(new SqlPredicate("age >= 5000"));
+                        assertEquals(5000, persons.size());
+                    } catch (Throwable t) {
+                        exception.compareAndSet(null, t);
+                    }
+
+                }
+            });
+            threads[i].start();
+        }
+
+        // wait for for all threads to finish
+        for (int i = 0; i < threads.length; ++i) {
+            threads[i].join();
+        }
+
+        // assert no unexpected exceptions
+        assertNull(exception.get());
+    }
+
+    static class Person implements Serializable {
+
+        static AtomicLong accessCountDown;
+        static CountDownLatch indexerLatch;
+        static CountDownLatch queryLatch;
+
+        public final Integer age;
+        public final String name;
+
+        Person(Integer value) {
+            this.age = value;
+            this.name = value.toString();
+        }
+
+        public Integer getAge() {
+            updateCounter();
+            return age;
+        }
+
+        public String getName() {
+            updateCounter();
+            return name;
+        }
+
+        private void updateCounter() {
+            if (accessCountDown != null && accessCountDown.decrementAndGet() <= 0) {
+                queryLatch.countDown();
+                assertOpenEventually(indexerLatch);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.like;
+import static com.hazelcast.query.Predicates.greaterThan;
+import static com.hazelcast.query.Predicates.lessThan;
+import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.Predicates.greaterEqual;
+import static com.hazelcast.query.Predicates.lessEqual;
+import static com.hazelcast.query.Predicates.between;
+import static com.hazelcast.query.Predicates.in;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IndexConcurrencyTest extends AbstractIndexConcurrencyTest {
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
+    @Test
+    public void testIndexCreationAndQueryDeterministicConcurrency() {
+        Config config = getConfig();
+
+        HazelcastInstance node = createHazelcastInstance(config);
+        final IMap<Integer, Person> map = node.getMap(randomMapName());
+
+        // put some data
+        for (int i = 0; i < 10000; ++i) {
+            map.put(i, new Person(i));
+        }
+
+        // initialize age field access counter
+        Person.accessCountDown = new AtomicLong(5000);
+
+        // start indexer, it will await for latch in the middle
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        Thread indexer = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    boolean ordered = indexDefinition.contains("BITMAP") ? false : true;
+                    map.addIndex(indexDefinition, ordered);
+                } catch (Throwable t) {
+                    exception.compareAndSet(null, t);
+                }
+            }
+        });
+        indexer.start();
+
+        // await for query latch
+        assertOpenEventually(Person.queryLatch);
+        Person.accessCountDown = null;
+
+        // run checking query
+        assertQuery(map, new SqlPredicate("age >= 5000"), 5000);
+        assertQuery(map, equal("age", "6000"), 1);
+        assertQuery(map, greaterThan("age", "6000"), 3999);
+        assertQuery(map, and(greaterThan("age", 6000), lessThan("age", 7000)), 999);
+        assertQuery(map, or(equal("age", 6000), equal("age", 7000)), 2);
+        assertQuery(map, greaterEqual("age", 5000), 5000);
+        assertQuery(map, lessThan("age", 9000), 9000);
+        assertQuery(map, lessEqual("age", 9000), 9001);
+        assertQuery(map, between("age", 9000, 10000), 1000);
+        assertQuery(map, in("age", 5000, 6000, 7000, 11111), 3);
+        assertQuery(map, equal("age", "6000"), 1);
+        assertQuery(map, like("name", "9999"), 1);
+
+        // open indexer latch
+        Person.indexerLatch.countDown();
+
+        // wait for indexer to finish
+        assertJoinable(indexer);
+
+        // assert no unexpected exceptions
+        assertNull(exception.get());
+    }
+
+    private void assertQuery(IMap<Integer, Person> map, Predicate predicate, int expected) {
+        Collection<Person> persons = map.values(predicate);
+        assertEquals(expected, persons.size());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -38,6 +38,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -78,9 +79,9 @@ public class IndexJsonTest {
         assertEquals(0, numberIndex.getRecords(-1).size());
         assertEquals(1001, stringIndex.getRecords("sancar").size());
         assertEquals(501, boolIndex.getRecords(true).size());
-        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true"))).size());
-        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true))).size());
-        assertEquals(1001, is.query(new SqlPredicate("name == sancar")).size());
+        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true")), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true)), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(1001, is.query(new SqlPredicate("name == sancar"), SKIP_PARTITIONS_COUNT_CHECK).size());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.instance.TestUtil.toData;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -183,9 +184,9 @@ public class IndexTest {
         assertEquals(401, dIndex.getRecords(Comparison.GREATER_OR_EQUAL, 600d).size());
         assertEquals(9, dIndex.getRecords(Comparison.LESS, 10d).size());
         assertEquals(10, dIndex.getRecords(Comparison.LESS_OR_EQUAL, 10d).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false"))).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE))).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false))).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)), SKIP_PARTITIONS_COUNT_CHECK).size());
     }
 
     private void clearIndexes(Index... indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.instance.TestUtil.toData;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -84,7 +85,7 @@ public class IndexesTest {
         EntryObject entryObject = new PredicateBuilder().getEntryObject();
         PredicateBuilder predicate =
                 entryObject.get("name").equal("0Name").and(entryObject.get("age").in(ages.toArray(new String[0])));
-        Set<QueryableEntry> results = indexes.query(predicate);
+        Set<QueryableEntry> results = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         assertEquals(1, results.size());
     }
 
@@ -102,7 +103,7 @@ public class IndexesTest {
 
         for (int i = 0; i < 10; i++) {
             SqlPredicate predicate = new SqlPredicate("salary=161 and age >20 and age <23");
-            Set<QueryableEntry> results = new HashSet<QueryableEntry>(indexes.query(predicate));
+            Set<QueryableEntry> results = new HashSet<QueryableEntry>(indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK));
             assertEquals(5, results.size());
         }
     }
@@ -129,7 +130,7 @@ public class IndexesTest {
                 Index.OperationSource.USER);
         indexes.putEntry(new QueryEntry(serializationService, toData(9), new Value("qwx"), newExtractor()), null,
                 Index.OperationSource.USER);
-        assertEquals(8, new HashSet<QueryableEntry>(indexes.query(new SqlPredicate("name > 'aac'"))).size());
+        assertEquals(8, new HashSet<QueryableEntry>(indexes.query(new SqlPredicate("name > 'aac'"), SKIP_PARTITIONS_COUNT_CHECK)).size());
     }
 
     protected Extractors newExtractor() {
@@ -163,7 +164,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "));
+        Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "), SKIP_PARTITIONS_COUNT_CHECK);
 
         assertNull("There should be no result", query);
     }
@@ -179,7 +180,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "));
+        Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "), SKIP_PARTITIONS_COUNT_CHECK);
 
         assertEquals(89, query.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
@@ -46,6 +46,7 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.not;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -86,8 +87,8 @@ public class EvaluateVisitorTest {
         });
         when(bitmapA.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
         when(bitmapA.getName()).thenReturn("a");
-        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapA);
-        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapA);
+        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapA);
+        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapA);
 
         InternalIndex bitmapB = mock(InternalIndex.class);
         when(bitmapB.canEvaluate((Class<? extends Predicate>) any())).then(new Answer<Boolean>() {
@@ -98,14 +99,13 @@ public class EvaluateVisitorTest {
         });
         when(bitmapB.getConverter()).thenReturn(TypeConverters.STRING_CONVERTER);
         when(bitmapB.getName()).thenReturn("b");
-        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapB);
-        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapB);
+        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapB);
+        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapB);
 
         InternalIndex regular = mock(InternalIndex.class);
         when(regular.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
         when(regular.canEvaluate((Class<? extends Predicate>) any())).thenReturn(false);
-        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(regular);
-        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(regular);
+        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(regular);        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(regular);
 
         InternalIndex bitmapNoConverter = mock(InternalIndex.class);
         when(bitmapNoConverter.getName()).thenReturn("nc");
@@ -116,8 +116,8 @@ public class EvaluateVisitorTest {
                 return EVALUABLE_PREDICATES.contains(invocation.getArgument(0));
             }
         });
-        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapNoConverter);
-        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapNoConverter);
+        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoConverter);
+        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoConverter);
 
         InternalIndex bitmapNoSubPredicates = mock(InternalIndex.class);
         when(bitmapNoSubPredicates.getName()).thenReturn("ns");
@@ -129,8 +129,8 @@ public class EvaluateVisitorTest {
                 return !(clazz == AndPredicate.class || clazz == OrPredicate.class || clazz == NotPredicate.class);
             }
         });
-        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.EXACT_NAME)).thenReturn(bitmapNoSubPredicates);
-        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.PREFER_UNORDERED)).thenReturn(bitmapNoSubPredicates);
+        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoSubPredicates);
+        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoSubPredicates);
 
         visitor = new EvaluateVisitor();
     }


### PR DESCRIPTION
Fixed the race condition checking that all partitions are indexed
before using an index for query. In combination with migration stamp
check which guarantees there is no concurrent partition migration,
the using of incomplete index is avoided and query engine falls back to
the full partitions scan algorithm.

Fixes: https://github.com/hazelcast/hazelcast/issues/16311