### PR TITLE
Take serializeKeys into account in containsKey at ClientMapProxy

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -39,6 +39,7 @@ import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
@@ -106,11 +107,11 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     private void initNearCache() {
         NearCacheConfig nearCacheConfig = getContext().getClientConfig().getNearCacheConfig(name);
         if (nearCacheConfig != null) {
-            NearCacheConfig copyNearCacheConfig = new NearCacheConfig(nearCacheConfig);
-            //We don't have serializeKeys support on replicated map nearcache
-            copyNearCacheConfig.setSerializeKeys(false);
+            if (nearCacheConfig.isSerializeKeys()) {
+                throw new InvalidConfigurationException("ReplicatedMap doesn't support serializeKeys option of NearCacheConfig");
+            }
 
-            nearCache = getContext().getNearCacheManager().getOrCreateNearCache(name, copyNearCacheConfig);
+            nearCache = getContext().getNearCacheManager().getOrCreateNearCache(name, nearCacheConfig);
             if (nearCacheConfig.isInvalidateOnChange()) {
                 registerInvalidationListener();
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -106,7 +106,11 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     private void initNearCache() {
         NearCacheConfig nearCacheConfig = getContext().getClientConfig().getNearCacheConfig(name);
         if (nearCacheConfig != null) {
-            nearCache = getContext().getNearCacheManager().getOrCreateNearCache(name, nearCacheConfig);
+            NearCacheConfig copyNearCacheConfig = new NearCacheConfig(nearCacheConfig);
+            //We don't have serializeKeys support on replicated map nearcache
+            copyNearCacheConfig.setSerializeKeys(false);
+
+            nearCache = getContext().getNearCacheManager().getOrCreateNearCache(name, copyNearCacheConfig);
             if (nearCacheConfig.isInvalidateOnChange()) {
                 registerInvalidationListener();
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -106,6 +106,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     @Override
     protected boolean containsKeyInternal(Object key) {
+        key = toNearCacheKey(key);
         Object cached = getCachedValue(key, false);
         if (cached != NOT_CACHED) {
             return cached != null;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.nearcache.NearCacheTestSupport;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.nio.serialization.Data;
@@ -1095,7 +1096,8 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
                 .setImplementation(new SimpleMapStore());
 
         // populate Near Cache
-        final IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(config, newNearCacheConfig(), 2);
+        final NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        final IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(config, nearCacheConfig, 2);
         populateMap(clientMap, 1000);
         populateNearCache(clientMap, 1000);
 
@@ -1104,12 +1106,18 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
         IMap<Object, Object> anotherClientMap = anotherClient.getMap(clientMap.getName());
         anotherClientMap.loadAll(true);
 
+        final InternalSerializationService serializationService =
+                getSerializationService(hazelcastFactory.getAllHazelcastInstances().iterator().next());
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
                 NearCache<Object, Object> nearCache = ((NearCachedClientMapProxy<Integer, Integer>) clientMap).getNearCache();
                 for (int i = 0; i < 1000; i++) {
-                    assertNull("Near Cache should be empty", nearCache.get(i));
+                    Object key = i;
+                    if (nearCacheConfig.isSerializeKeys()) {
+                        key = serializationService.toData(i);
+                    }
+                    assertNull("Near Cache should be empty", nearCache.get(key));
                 }
             }
         });
@@ -1124,21 +1132,26 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
                 .setImplementation(new SimpleMapStore());
 
         // populate Near Cache
-        final IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(config, newNearCacheConfig(), 2);
+        final NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        final IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(config, nearCacheConfig, 2);
         populateMap(clientMap, 1000);
         populateNearCache(clientMap, 1000);
 
-        // create a new client to send events
         HazelcastInstance member = hazelcastFactory.getAllHazelcastInstances().iterator().next();
         IMap<Object, Object> memberMap = member.getMap(clientMap.getName());
         memberMap.loadAll(true);
 
+        final InternalSerializationService serializationService = getSerializationService(member);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
                 NearCache<Object, Object> nearCache = ((NearCachedClientMapProxy<Integer, Integer>) clientMap).getNearCache();
                 for (int i = 0; i < 1000; i++) {
-                    assertNull("Near Cache should be empty", nearCache.get(i));
+                    Object key = i;
+                    if (nearCacheConfig.isSerializeKeys()) {
+                        key = serializationService.toData(i);
+                    }
+                    assertNull("Near Cache should be empty", nearCache.get(key));
                 }
             }
         });

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -21,6 +21,8 @@ import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
@@ -37,6 +39,7 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -70,7 +73,7 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true);
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, false);
     }
 
     @After
@@ -112,6 +115,19 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
                 .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
 
         return config;
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testSerializeKeys_notSupported() {
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setSerializeKeys(true).setInMemoryFormat(inMemoryFormat);
+        nearCacheConfig.setName("test");
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        client.getReplicatedMap("test");
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheLeakTest.java
@@ -67,7 +67,7 @@ public class ClientReplicatedMapNearCacheLeakTest extends AbstractNearCacheLeakT
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true)
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, false)
                 .setInvalidateOnChange(true);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -84,26 +84,19 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
     @Parameter(value = 6)
     public InMemoryFormat nearCacheInMemoryFormat;
 
-    @Parameter(value = 7)
-    public Boolean serializeKeys;
-
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Parameters(name = "method:{0} replicatedMapFormat:{5} nearCacheFormat:{6} serializeKeys:{7}")
+    @Parameters(name = "method:{0} replicatedMapFormat:{5} nearCacheFormat:{6}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {GET, newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null},
-                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(0, 1, 1), BINARY, BINARY, true},
-                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(0, 1, 1), BINARY, BINARY, false},
-                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true},
-                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
+                {GET, newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null},
+                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(0, 1, 1), BINARY, BINARY},
+                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT},
 
                 // FIXME: we should not serialize the value twice
-                {GET, newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
+                {GET, newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null},
+                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY},
+                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT},
         });
     }
 
@@ -115,7 +108,7 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, serializeKeys)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, false)
                     // we have to disable invalidations, otherwise there will be an non-deterministic serialization in a listener
                     .setInvalidateOnChange(false);
         }
@@ -131,7 +124,6 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
         configBuilder.append(method);
         configBuilder.append(replicatedMapInMemoryFormat);
         configBuilder.append(nearCacheInMemoryFormat);
-        configBuilder.append(serializeKeys);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
+import static com.hazelcast.util.Preconditions.checkInstanceOf;
 import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
 
 public class DefaultNearCache<K, V> implements NearCache<K, V> {
@@ -208,6 +209,8 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     private void checkKeyFormat(K key) {
         if (!serializeKeys) {
             checkNotInstanceOf(Data.class, key, "key cannot be of type Data!");
+        } else {
+            checkInstanceOf(Data.class, key, "key must be of type Data!");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -207,10 +207,10 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     }
 
     private void checkKeyFormat(K key) {
-        if (!serializeKeys) {
-            checkNotInstanceOf(Data.class, key, "key cannot be of type Data!");
-        } else {
+        if (serializeKeys) {
             checkInstanceOf(Data.class, key, "key must be of type Data!");
+        } else {
+            checkNotInstanceOf(Data.class, key, "key cannot be of type Data!");
         }
     }
 


### PR DESCRIPTION
fixes #16472


Note that after adding the check to `checkKeyFormat` ,
ClientMapNearCacheBasicSlowTest starts to fail. It has tests
for containsKey. With the fix, it is passing now. So no new test is
needed.

related to https://github.com/hazelcast/hazelcast/issues/16458
backport of https://github.com/hazelcast/hazelcast/pull/16462
(cherry picked from commit 15a0322816e5a745cca13c8ab94c4bce1531f78b)