### PR TITLE
Small improvements on map and cache iterators

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -437,6 +437,7 @@ public interface ICacheRecordStore {
     /**
      * Fetch minimally {@code size} keys from the {@code pointers} position.
      * The key is fetched on-heap.
+     * The method may return less keys if iteration has completed.
      * <p>
      * NOTE: The implementation is free to return more than {@code size} items.
      * This can happen if we cannot easily resume from the last returned item
@@ -446,7 +447,7 @@ public interface ICacheRecordStore {
      * the requested {@code size}.
      *
      * @param pointers the pointers defining the state of iteration
-     * @param size     the minimal count of returned items
+     * @param size     the minimal count of returned items, unless iteration has completed
      * @return fetched keys and the new iteration state
      */
     CacheKeysWithCursor fetchKeys(IterationPointer[] pointers, int size);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordMap.java
@@ -44,6 +44,7 @@ public interface CacheRecordMap<K extends Data, V extends CacheRecord>
     /**
      * Fetch minimally {@code size} keys from the {@code pointers} position.
      * The key is fetched on-heap.
+     * The method may return less keys if iteration has completed.
      * <p>
      * NOTE: The implementation is free to return more than {@code size} items.
      * This can happen if we cannot easily resume from the last returned item
@@ -53,7 +54,7 @@ public interface CacheRecordMap<K extends Data, V extends CacheRecord>
      * the requested {@code size}.
      *
      * @param pointers the pointers defining the state of iteration
-     * @param size     the minimal count of returned items
+     * @param size     the minimal count of returned items, unless iteration has completed
      * @return fetched keys and the new iteration state
      */
     CacheKeysWithCursor fetchKeys(IterationPointer[] pointers, int size);

--- a/hazelcast/src/main/java/com/hazelcast/internal/iteration/IterationPointer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/iteration/IterationPointer.java
@@ -40,6 +40,11 @@ public class IterationPointer {
         this.size = size;
     }
 
+    public IterationPointer(IterationPointer other) {
+        this.index = other.index;
+        this.size = other.size;
+    }
+
     /**
      * Returns the iteration index representing the position of the iteration
      * in the backing structure.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -306,6 +306,7 @@ public interface RecordStore<R extends Record> {
     /**
      * Fetch minimally {@code size} keys from the {@code pointers} position.
      * The key is fetched on-heap.
+     * The method may return less keys if iteration has completed.
      * <p>
      * NOTE: The implementation is free to return more than {@code size} items.
      * This can happen if we cannot easily resume from the last returned item
@@ -315,7 +316,7 @@ public interface RecordStore<R extends Record> {
      * the requested {@code size}.
      *
      * @param pointers the pointers defining the state of iteration
-     * @param size     the minimal count of returned items
+     * @param size     the minimal count of returned items, unless iteration has completed
      * @return fetched keys and the new iteration state
      */
     MapKeysWithCursor fetchKeys(IterationPointer[] pointers, int size);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -98,6 +98,7 @@ public interface Storage<K, R> {
     /**
      * Fetch minimally {@code size} keys from the {@code pointers} position.
      * The key is fetched on-heap.
+     * The method may return less keys if iteration has completed.
      * <p>
      * NOTE: The implementation is free to return more than {@code size} items.
      * This can happen if we cannot easily resume from the last returned item
@@ -107,7 +108,7 @@ public interface Storage<K, R> {
      * the requested {@code size}.
      *
      * @param pointers the pointers defining the state of iteration
-     * @param size     the minimal count of returned items
+     * @param size     the minimal count of returned items, unless iteration has completed
      * @return fetched keys and the new iteration state
      */
     MapKeysWithCursor fetchKeys(IterationPointer[] pointers, int size);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
@@ -113,28 +113,28 @@ public class MapPartitionIteratorTest extends HazelcastTestSupport {
     @Test
     public void test_Next_Returns_Value_On_NonEmptyPartition() {
         HazelcastInstance instance = createHazelcastInstance();
-        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+        MapProxyImpl<String, String> proxy = (MapProxyImpl<String, String>) instance.<String, String>getMap(randomMapName());
 
         String key = generateKeyForPartition(instance, 1);
         String value = randomString();
         proxy.put(key, value);
 
-        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
-        Map.Entry entry = iterator.next();
+        Iterator<Map.Entry<String, String>> iterator = proxy.iterator(10, 1, prefetchValues);
+        Map.Entry<String, String> entry = iterator.next();
         assertEquals(value, entry.getValue());
     }
 
     @Test
     public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() {
         HazelcastInstance instance = createHazelcastInstance();
-        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+        MapProxyImpl<String, String> proxy = (MapProxyImpl<String, String>) instance.<String, String>getMap(randomMapName());
 
         String key = generateKeyForPartition(instance, 1);
         String value = randomString();
         proxy.put(key, value);
 
-        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
-        Map.Entry entry = iterator.next();
+        Iterator<Map.Entry<String, String>> iterator = proxy.iterator(10, 1, prefetchValues);
+        Map.Entry<String, String> entry = iterator.next();
         assertEquals(value, entry.getValue());
         boolean hasNext = iterator.hasNext();
         assertFalse(hasNext);
@@ -143,16 +143,16 @@ public class MapPartitionIteratorTest extends HazelcastTestSupport {
     @Test
     public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() {
         HazelcastInstance instance = createHazelcastInstance();
-        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+        MapProxyImpl<String, String> proxy = (MapProxyImpl<String, String>) instance.<String, String>getMap(randomMapName());
 
         String value = randomString();
         for (int i = 0; i < 100; i++) {
             String key = generateKeyForPartition(instance, 1);
             proxy.put(key, value);
         }
-        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
+        Iterator<Map.Entry<String, String>> iterator = proxy.iterator(10, 1, prefetchValues);
         for (int i = 0; i < 100; i++) {
-            Map.Entry entry = iterator.next();
+            Map.Entry<String, String> entry = iterator.next();
             assertEquals(value, entry.getValue());
         }
     }


### PR DESCRIPTION
- cloned the iterator pointers before iterating so local operations
don't get their pointers mutated
- improved javadoc to say there can be less than the minimum requested
entries, in case the iterator was exhausted
- swapped places for checks for expiration and observation. Observation
check can be more CPU intensive than the expiration check.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3488