### PR TITLE
Remove obsolete hazelcast.diagnostics.metric.level sys prop from tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFileTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFileTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -31,6 +30,7 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -49,7 +49,6 @@ public class DiagnosticsLogFileTest extends HazelcastTestSupport {
         File diagnosticsFolder = new File(parentFolder, "newdir");
 
         config.setProperty("hazelcast.diagnostics.enabled", "true");
-        config.setProperty("hazelcast.diagnostics.metric.level", "DEBUG");
         config.setProperty("hazelcast.diagnostics.directory", diagnosticsFolder.getAbsolutePath());
 
         createHazelcastInstance(config);
@@ -62,7 +61,6 @@ public class DiagnosticsLogFileTest extends HazelcastTestSupport {
         File diagnosticsFolder = folder.newFolder();
 
         config.setProperty("hazelcast.diagnostics.enabled", "true");
-        config.setProperty("hazelcast.diagnostics.metric.level", "DEBUG");
         config.setProperty("hazelcast.diagnostics.directory", diagnosticsFolder.getAbsolutePath());
 
         createHazelcastInstance(config);
@@ -71,15 +69,13 @@ public class DiagnosticsLogFileTest extends HazelcastTestSupport {
     }
 
     private void assertContainsFileEventually(final File dir) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertTrue(dir.exists());
-                assertTrue(dir.isDirectory());
+        assertTrueEventually(() -> {
+            assertTrue(dir.exists());
+            assertTrue(dir.isDirectory());
 
-                File[] files = dir.listFiles();
-                assertTrue(files.length > 0);
-            }
+            File[] files = dir.listFiles();
+            assertNotNull(files);
+            assertTrue(files.length > 0);
         });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkStatsIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkStatsIntegrationTest.java
@@ -52,7 +52,6 @@ public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetwork
     public void testStats_advancedNetworkEnabledAndConnectionActive_readFromEMs() {
         Config config = createCompleteMultiSocketConfig();
         configureTcpIpConfig(config);
-        enableMetrics(config);
         instance1 = newHazelcastInstance(config);
         instance2 = startSecondInstance();
 
@@ -71,7 +70,6 @@ public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetwork
     public void testStats_advancedNetworkEnabledAndConnectionActive_readFromMetrics() {
         Config config = createCompleteMultiSocketConfig();
         configureTcpIpConfig(config);
-        enableMetrics(config);
         instance1 = newHazelcastInstance(config);
         instance2 = startSecondInstance();
 
@@ -90,7 +88,6 @@ public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetwork
     public void testStats_advancedNetworkEnabledAndConnectionClosed_readFromEMs() {
         Config config = createCompleteMultiSocketConfig();
         configureTcpIpConfig(config);
-        enableMetrics(config);
         instance1 = newHazelcastInstance(config);
         instance2 = startSecondInstance();
         assertClusterSizeEventually(2, instance1, instance2);
@@ -110,7 +107,6 @@ public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetwork
     public void testStats_advancedNetworkEnabledAndConnectionClosed_readFromMetrics() {
         Config config = createCompleteMultiSocketConfig();
         configureTcpIpConfig(config);
-        enableMetrics(config);
         instance1 = newHazelcastInstance(config);
         instance2 = startSecondInstance();
         assertClusterSizeEventually(2, instance1, instance2);
@@ -209,12 +205,6 @@ public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetwork
         return registry.newLongGauge("tcp.bytesSend." + protocolType.name()).read();
     }
 
-    private void enableMetrics(Config config) {
-        config.setProperty("hazelcast.diagnostics.enabled", "true");
-        config.setProperty("hazelcast.diagnostics.metric.level", "Info");
-        config.setProperty("hazelcast.diagnostics.metrics.period.seconds", "5");
-    }
-
     private void assertAllNetworkStatsNotRegisteredAsMetrics(HazelcastInstance instance) {
         MetricsRegistry registry = getNode(instance).nodeEngine.getMetricsRegistry();
         for (ProtocolType protocolType : ProtocolType.values()) {
@@ -225,7 +215,6 @@ public class AdvancedNetworkStatsIntegrationTest extends AbstractAdvancedNetwork
 
     private HazelcastInstance startSecondInstance() {
         Config config = prepareJoinConfigForSecondMember(MEMBER_PORT);
-        enableMetrics(config);
         HazelcastInstance newHzInstance = newHazelcastInstance(config);
         int clusterSize = newHzInstance.getCluster().getMembers().size();
         assertEquals(2, clusterSize);


### PR DESCRIPTION
* Removes obsolete `hazelcast.diagnostics.metric.level` sys prop from tests
* Also removes redundant diagnostics configuration from `AdvancedNetworkStatsIntegrationTest`