### PR TITLE
remove enum type from custom codecs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
@@ -30,7 +30,6 @@ public final class FixedSizeTypesCodec {
     public static final int BYTE_SIZE_IN_BYTES = Bits.BYTE_SIZE_IN_BYTES;
     public static final int LONG_SIZE_IN_BYTES = Bits.LONG_SIZE_IN_BYTES;
     public static final int INT_SIZE_IN_BYTES = Bits.INT_SIZE_IN_BYTES;
-    public static final int ENUM_SIZE_IN_BYTES = Bits.INT_SIZE_IN_BYTES;
     public static final int BOOLEAN_SIZE_IN_BYTES = Bits.BOOLEAN_SIZE_IN_BYTES;
     public static final int UUID_SIZE_IN_BYTES = Bits.BOOLEAN_SIZE_IN_BYTES + Bits.LONG_SIZE_IN_BYTES * 2;
 
@@ -45,19 +44,19 @@ public final class FixedSizeTypesCodec {
         return Bits.readIntL(buffer, pos);
     }
 
-    public static void encodeEnum(byte[] buffer, int pos, CacheEventType cacheEventType) {
+    public static void encodeInt(byte[] buffer, int pos, CacheEventType cacheEventType) {
         encodeInt(buffer, pos, cacheEventType.getType());
     }
 
-    public static void encodeEnum(byte[] buffer, int pos, IndexType indexType) {
+    public static void encodeInt(byte[] buffer, int pos, IndexType indexType) {
         encodeInt(buffer, pos, indexType.getId());
     }
 
-    public static void encodeEnum(byte[] buffer, int pos, ExpiryPolicyType expiryPolicyType) {
+    public static void encodeInt(byte[] buffer, int pos, ExpiryPolicyType expiryPolicyType) {
         encodeInt(buffer, pos, expiryPolicyType.getId());
     }
 
-    public static void encodeEnum(byte[] buffer, int pos, TimeUnit timeUnit) {
+    public static void encodeInt(byte[] buffer, int pos, TimeUnit timeUnit) {
         int timeUnitId;
         if (TimeUnit.NANOSECONDS.equals(timeUnit)) {
             timeUnitId = 0;
@@ -79,12 +78,8 @@ public final class FixedSizeTypesCodec {
         encodeInt(buffer, pos, timeUnitId);
     }
 
-    public static void encodeEnum(byte[] buffer, int pos, ClientBwListEntryDTO.Type clientBwListEntryType) {
+    public static void encodeInt(byte[] buffer, int pos, ClientBwListEntryDTO.Type clientBwListEntryType) {
         encodeInt(buffer, pos, clientBwListEntryType.getId());
-    }
-
-    public static int decodeEnum(byte[] buffer, int pos) {
-        return decodeInt(buffer, pos);
     }
 
     public static void encodeInteger(byte[] buffer, int pos, Integer value) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/CacheEventDataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/CacheEventDataCodec.java
@@ -24,10 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("c16ee5635047568db60c4ec00e62de8c")
+@Generated("9406ff10290f056c7dfe44404bf17486")
 public final class CacheEventDataCodec {
     private static final int CACHE_EVENT_TYPE_FIELD_OFFSET = 0;
-    private static final int OLD_VALUE_AVAILABLE_FIELD_OFFSET = CACHE_EVENT_TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
+    private static final int OLD_VALUE_AVAILABLE_FIELD_OFFSET = CACHE_EVENT_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int INITIAL_FRAME_SIZE = OLD_VALUE_AVAILABLE_FIELD_OFFSET + BOOLEAN_SIZE_IN_BYTES;
 
     private CacheEventDataCodec() {
@@ -37,7 +37,7 @@ public final class CacheEventDataCodec {
         clientMessage.add(BEGIN_FRAME.copy());
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
-        encodeEnum(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET, cacheEventData.getCacheEventType());
+        encodeInt(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET, cacheEventData.getCacheEventType());
         encodeBoolean(initialFrame.content, OLD_VALUE_AVAILABLE_FIELD_OFFSET, cacheEventData.isOldValueAvailable());
         clientMessage.add(initialFrame);
 
@@ -54,7 +54,7 @@ public final class CacheEventDataCodec {
         iterator.next();
 
         ClientMessage.Frame initialFrame = iterator.next();
-        int cacheEventType = decodeEnum(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET);
+        int cacheEventType = decodeInt(initialFrame.content, CACHE_EVENT_TYPE_FIELD_OFFSET);
         boolean oldValueAvailable = decodeBoolean(initialFrame.content, OLD_VALUE_AVAILABLE_FIELD_OFFSET);
 
         java.lang.String name = StringCodec.decode(iterator);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/ClientBwListEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/ClientBwListEntryCodec.java
@@ -24,10 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("0f42232b245b4a5941f65bd082e7c235")
+@Generated("59b47a13e51ca2fe48fcc41108084463")
 public final class ClientBwListEntryCodec {
     private static final int TYPE_FIELD_OFFSET = 0;
-    private static final int INITIAL_FRAME_SIZE = TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 
     private ClientBwListEntryCodec() {
     }
@@ -36,7 +36,7 @@ public final class ClientBwListEntryCodec {
         clientMessage.add(BEGIN_FRAME.copy());
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
-        encodeEnum(initialFrame.content, TYPE_FIELD_OFFSET, clientBwListEntry.getType());
+        encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, clientBwListEntry.getType());
         clientMessage.add(initialFrame);
 
         StringCodec.encode(clientMessage, clientBwListEntry.getValue());
@@ -49,7 +49,7 @@ public final class ClientBwListEntryCodec {
         iterator.next();
 
         ClientMessage.Frame initialFrame = iterator.next();
-        int type = decodeEnum(initialFrame.content, TYPE_FIELD_OFFSET);
+        int type = decodeInt(initialFrame.content, TYPE_FIELD_OFFSET);
 
         java.lang.String value = StringCodec.decode(iterator);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/DurationConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/DurationConfigCodec.java
@@ -24,11 +24,11 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("0585260927e80a1dbda4f93599ca4626")
+@Generated("1e81e25643b65eec749a06f2eb0b247c")
 public final class DurationConfigCodec {
     private static final int DURATION_AMOUNT_FIELD_OFFSET = 0;
     private static final int TIME_UNIT_FIELD_OFFSET = DURATION_AMOUNT_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
-    private static final int INITIAL_FRAME_SIZE = TIME_UNIT_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = TIME_UNIT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 
     private DurationConfigCodec() {
     }
@@ -38,7 +38,7 @@ public final class DurationConfigCodec {
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
         encodeLong(initialFrame.content, DURATION_AMOUNT_FIELD_OFFSET, durationConfig.getDurationAmount());
-        encodeEnum(initialFrame.content, TIME_UNIT_FIELD_OFFSET, durationConfig.getTimeUnit());
+        encodeInt(initialFrame.content, TIME_UNIT_FIELD_OFFSET, durationConfig.getTimeUnit());
         clientMessage.add(initialFrame);
 
         clientMessage.add(END_FRAME.copy());
@@ -50,7 +50,7 @@ public final class DurationConfigCodec {
 
         ClientMessage.Frame initialFrame = iterator.next();
         long durationAmount = decodeLong(initialFrame.content, DURATION_AMOUNT_FIELD_OFFSET);
-        int timeUnit = decodeEnum(initialFrame.content, TIME_UNIT_FIELD_OFFSET);
+        int timeUnit = decodeInt(initialFrame.content, TIME_UNIT_FIELD_OFFSET);
 
         fastForwardToEndFrame(iterator);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/IndexConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/IndexConfigCodec.java
@@ -24,10 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("b743ec3bf2f0e22cb848680560da259e")
+@Generated("2bddf94f25d9046ac7a5fa35fdfec729")
 public final class IndexConfigCodec {
     private static final int TYPE_FIELD_OFFSET = 0;
-    private static final int INITIAL_FRAME_SIZE = TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 
     private IndexConfigCodec() {
     }
@@ -36,7 +36,7 @@ public final class IndexConfigCodec {
         clientMessage.add(BEGIN_FRAME.copy());
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
-        encodeEnum(initialFrame.content, TYPE_FIELD_OFFSET, indexConfig.getType());
+        encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, indexConfig.getType());
         clientMessage.add(initialFrame);
 
         CodecUtil.encodeNullable(clientMessage, indexConfig.getName(), StringCodec::encode);
@@ -50,7 +50,7 @@ public final class IndexConfigCodec {
         iterator.next();
 
         ClientMessage.Frame initialFrame = iterator.next();
-        int type = decodeEnum(initialFrame.content, TYPE_FIELD_OFFSET);
+        int type = decodeInt(initialFrame.content, TYPE_FIELD_OFFSET);
 
         java.lang.String name = CodecUtil.decodeNullable(iterator, StringCodec::decode);
         java.util.List<java.lang.String> attributes = ListMultiFrameCodec.decode(iterator, StringCodec::decode);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/TimedExpiryPolicyFactoryConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/custom/TimedExpiryPolicyFactoryConfigCodec.java
@@ -24,10 +24,10 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
-@Generated("5047b22c005f691dbb8680f2916f6df2")
+@Generated("81ada5402a317de1c4d63c185f96d54f")
 public final class TimedExpiryPolicyFactoryConfigCodec {
     private static final int EXPIRY_POLICY_TYPE_FIELD_OFFSET = 0;
-    private static final int INITIAL_FRAME_SIZE = EXPIRY_POLICY_TYPE_FIELD_OFFSET + ENUM_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = EXPIRY_POLICY_TYPE_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 
     private TimedExpiryPolicyFactoryConfigCodec() {
     }
@@ -36,7 +36,7 @@ public final class TimedExpiryPolicyFactoryConfigCodec {
         clientMessage.add(BEGIN_FRAME.copy());
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
-        encodeEnum(initialFrame.content, EXPIRY_POLICY_TYPE_FIELD_OFFSET, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        encodeInt(initialFrame.content, EXPIRY_POLICY_TYPE_FIELD_OFFSET, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
         clientMessage.add(initialFrame);
 
         DurationConfigCodec.encode(clientMessage, timedExpiryPolicyFactoryConfig.getDurationConfig());
@@ -49,7 +49,7 @@ public final class TimedExpiryPolicyFactoryConfigCodec {
         iterator.next();
 
         ClientMessage.Frame initialFrame = iterator.next();
-        int expiryPolicyType = decodeEnum(initialFrame.content, EXPIRY_POLICY_TYPE_FIELD_OFFSET);
+        int expiryPolicyType = decodeInt(initialFrame.content, EXPIRY_POLICY_TYPE_FIELD_OFFSET);
 
         com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig durationConfig = DurationConfigCodec.decode(iterator);
 


### PR DESCRIPTION
Removed enum type from the protocol and replaced it with int.

Implementation for the enum types does not change much. One has to write the conversion method with the `encodeInt` name instead of `encodeEnum` and specify the parameter types as `int` instead of `enum` in the protocol definitions.

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/294