### PR TITLE
Use server time for CP session creation-time

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/CPSessionInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/CPSessionInfo.java
@@ -122,7 +122,6 @@ public class CPSessionInfo implements CPSession, IdentifiedDataSerializable {
     }
 
     @Override
-    @SuppressWarnings("checkstyle:npathcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -132,33 +131,13 @@ public class CPSessionInfo implements CPSession, IdentifiedDataSerializable {
         }
 
         CPSessionInfo that = (CPSessionInfo) o;
-
-        if (id != that.id) {
-            return false;
-        }
-        if (version != that.version) {
-            return false;
-        }
-        if (creationTime != that.creationTime) {
-            return false;
-        }
-        if (!endpoint.equals(that.endpoint)) {
-            return false;
-        }
-        if (!endpointName.equals(that.endpointName)) {
-            return false;
-        }
-        return endpointType == that.endpointType;
+        return id == that.id && version == that.version;
     }
 
     @Override
     public int hashCode() {
         int result = (int) (id ^ (id >>> 32));
         result = 31 * result + (int) (version ^ (version >>> 32));
-        result = 31 * result + endpoint.hashCode();
-        result = 31 * result + endpointName.hashCode();
-        result = 31 * result + endpointType.hashCode();
-        result = 31 * result + (int) (creationTime ^ (creationTime >>> 32));
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/ProxySessionManagerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/ProxySessionManagerService.java
@@ -70,8 +70,7 @@ public class ProxySessionManagerService extends AbstractProxySessionManager impl
     @Override
     protected SessionResponse requestNewSession(RaftGroupId groupId) {
         String instanceName = nodeEngine.getConfig().getInstanceName();
-        long creationTime = System.currentTimeMillis();
-        RaftOp op = new CreateSessionOp(nodeEngine.getThisAddress(), instanceName, SERVER, creationTime);
+        RaftOp op = new CreateSessionOp(nodeEngine.getThisAddress(), instanceName, SERVER);
         ICompletableFuture<SessionResponse> future = getInvocationManager().invoke(groupId, op);
         try {
             return future.get();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
@@ -237,9 +237,9 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
     }
 
     public SessionResponse createNewSession(CPGroupId groupId, Address endpoint, String endpointName,
-                                            CPSessionOwnerType endpointType, long creationTime) {
+                                            CPSessionOwnerType endpointType) {
         RaftSessionRegistry registry = getOrInitRegistry(groupId);
-
+        long creationTime = Clock.currentTimeMillis();
         long sessionTTLMillis = getSessionTTLMillis();
         long sessionId = registry.createNewSession(sessionTTLMillis, endpoint, endpointName, endpointType, creationTime);
         logger.info("Created new session: " + sessionId + " in " + groupId + " for " + endpointType + " -> " + endpoint);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/CreateSessionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/CreateSessionMessageTask.java
@@ -44,7 +44,7 @@ public class CreateSessionMessageTask extends AbstractMessageTask<CPSessionCreat
     @Override
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        RaftOp op = new CreateSessionOp(connection.getEndPoint(), parameters.endpointName, CLIENT, System.currentTimeMillis());
+        RaftOp op = new CreateSessionOp(connection.getEndPoint(), parameters.endpointName, CLIENT);
         service.getInvocationManager()
                 .<SessionResponse>invoke(parameters.groupId, op)
                 .andThen(this);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/operation/CreateSessionOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/operation/CreateSessionOp.java
@@ -42,22 +42,22 @@ public class CreateSessionOp extends RaftOp implements IndeterminateOperationSta
 
     private CPSessionOwnerType endpointType;
 
+    // Not used, but keeping for patch compatibility
     private long creationTime;
 
     public CreateSessionOp() {
     }
 
-    public CreateSessionOp(Address endpoint, String endpointName, CPSessionOwnerType endpointType, long creationTime) {
+    public CreateSessionOp(Address endpoint, String endpointName, CPSessionOwnerType endpointType) {
         this.endpoint = endpoint;
         this.endpointName = endpointName;
         this.endpointType = endpointType;
-        this.creationTime = creationTime;
     }
 
     @Override
     public Object run(CPGroupId groupId, long commitIndex) {
         RaftSessionService service = getService();
-        return service.createNewSession(groupId, endpoint, endpointName, endpointType, creationTime);
+        return service.createNewSession(groupId, endpoint, endpointName, endpointType);
     }
 
     @Override
@@ -107,7 +107,6 @@ public class CreateSessionOp extends RaftOp implements IndeterminateOperationSta
     protected void toString(StringBuilder sb) {
         sb.append(", endpoint=").append(endpoint)
           .append(", endpointName=").append(endpointName)
-          .append(", endpointType=").append(endpointType)
-          .append(", creationTime=").append(creationTime);
+          .append(", endpointType=").append(endpointType);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/session/RaftSessionServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/session/RaftSessionServiceTest.java
@@ -52,7 +52,6 @@ import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getSnapshotEntry;
 import static com.hazelcast.cp.session.CPSession.CPSessionOwnerType.SERVER;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
-import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
@@ -376,6 +375,6 @@ public class RaftSessionServiceTest extends HazelcastRaftTestSupport {
     }
 
     private CreateSessionOp newCreateSessionOp() throws UnknownHostException {
-        return new CreateSessionOp(new Address("localhost", 1111), "server1", SERVER, currentTimeMillis());
+        return new CreateSessionOp(new Address("localhost", 1111), "server1", SERVER);
     }
 }


### PR DESCRIPTION
Used server time for CP session creation-time instead of invocation
time of the client/caller. Session creation can be delayed for many
reasons and session can be expire unexpectedly.

Fixes #15735

Backport of https://github.com/hazelcast/hazelcast/pull/16475