### PR TITLE
Disable metrics collection for LocalIndexStatsTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -86,6 +86,7 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         config.setProperty(PARTITION_COUNT.getName(), Integer.toString(PARTITIONS));
         config.getMapConfig(mapName).setInMemoryFormat(inMemoryFormat);
         config.getMapConfig(noStatsMapName).setStatisticsEnabled(false);
+        config.getMetricsConfig().setEnabled(false);
 
         instance = createInstance(config);
         map = instance.getMap(mapName);


### PR DESCRIPTION
The periodic metrics collection task may interfere
with getStats() that is used by the test, resulting
in the test observing skewed/incorrect statistics.

The issue occurs because the various getStats()
implementations are not thread-safe. A better fix
would be to make getStats() - namely the parts that
are calculated on demand - thread-safe but that would
require bigger changes in the statistics collection
design.

Fixes https://github.com/hazelcast/hazelcast/issues/16457