### PR TITLE
Correct forgotten places for client invoke on UUID 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
@@ -31,7 +31,6 @@ public class ConnectionRetryConfig {
     private double multiplier = 1;
     private long connectTimeoutMillis = CLUSTER_CONNECT_TIMEOUT_MILLIS;
     private double jitter = JITTER;
-    private boolean enabled;
 
     public ConnectionRetryConfig() {
     }
@@ -42,7 +41,6 @@ public class ConnectionRetryConfig {
         multiplier = connectionRetryConfig.multiplier;
         connectTimeoutMillis = connectionRetryConfig.connectTimeoutMillis;
         jitter = connectionRetryConfig.jitter;
-        enabled = connectionRetryConfig.enabled;
     }
 
     /**
@@ -171,10 +169,7 @@ public class ConnectionRetryConfig {
         if (connectTimeoutMillis != that.connectTimeoutMillis) {
             return false;
         }
-        if (Double.compare(that.jitter, jitter) != 0) {
-            return false;
-        }
-        return enabled == that.enabled;
+        return Double.compare(that.jitter, jitter) == 0;
     }
 
     @Override
@@ -188,14 +183,12 @@ public class ConnectionRetryConfig {
         result = 31 * result + (int) (connectTimeoutMillis ^ (connectTimeoutMillis >>> 32));
         temp = Double.doubleToLongBits(jitter);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
-        result = 31 * result + (enabled ? 1 : 0);
         return result;
     }
 
     @Override
     public String toString() {
         return "ConnectionRetryConfig{"
-                + "enabled=" + enabled
                 + ", initialBackoffMillis=" + initialBackoffMillis
                 + ", maxBackoffMillis=" + maxBackoffMillis
                 + ", multiplier=" + multiplier

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnectionManager.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.connection;
 
 import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.client.impl.connection.nio.ClientConnection;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListenable;
 
@@ -41,10 +40,10 @@ public interface ClientConnectionManager extends ConnectionListenable {
     boolean isAlive();
 
     /**
-     * @param address to be connected
+     * @param uuid UUID of the member to get connection of
      * @return connection if available, null otherwise
      */
-    Connection getConnection(@Nonnull Address address);
+    Connection getConnection(@Nonnull UUID uuid);
 
     /**
      * Check the connected state and user connection strategy configuration to see if an invocation is allowed at the moment

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnection.java
@@ -40,6 +40,7 @@ import java.nio.channels.CancelledKeyException;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -78,6 +79,7 @@ public class ClientConnection implements Connection {
     private volatile Throwable closeCause;
     private volatile String closeReason;
     private String connectedServerVersion;
+    private volatile UUID remoteUuid;
 
     public ClientConnection(HazelcastClientInstanceImpl client, int connectionId, Channel channel) {
         this.client = client;
@@ -114,9 +116,21 @@ public class ClientConnection implements Connection {
         return false;
     }
 
+    public void setRemoteEndpoint(Address remoteEndpoint) {
+        this.remoteEndpoint = remoteEndpoint;
+    }
+
     @Override
     public Address getEndPoint() {
         return remoteEndpoint;
+    }
+
+    public UUID getRemoteUuid() {
+        return remoteUuid;
+    }
+
+    public void setRemoteUuid(UUID remoteUuid) {
+        this.remoteUuid = remoteUuid;
     }
 
     @Override
@@ -171,10 +185,6 @@ public class ClientConnection implements Connection {
 
     public ClientConnectionManager getConnectionManager() {
         return connectionManager;
-    }
-
-    public void setRemoteEndpoint(Address remoteEndpoint) {
-        this.remoteEndpoint = remoteEndpoint;
     }
 
     public InetSocketAddress getLocalSocketAddress() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -46,7 +46,6 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.networking.Channel;
@@ -798,7 +797,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         }
         switch (authenticationStatus) {
             case AUTHENTICATED:
-                checkMemberUuid(response);
                 handleSuccessfulAuth(connection, response);
                 break;
             case CREDENTIALS_FAILED:
@@ -815,22 +813,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         new AuthenticationException("Authentication status code not supported. status: " + authenticationStatus);
                 connection.close("Failed to authenticate connection", exception);
                 throw exception;
-        }
-    }
-
-    private void checkMemberUuid(ClientAuthenticationCodec.ResponseParameters response) {
-        Collection<Member> memberList = client.getClientClusterService().getMemberList();
-        for (Member member : memberList) {
-            assert response.address != null;
-            assert response.uuid != null;
-            if (response.address.equals(member.getAddress())) {
-                if (!response.uuid.equals(member.getUuid())) {
-                    throw new HazelcastException("Members uuid is not the one in member list"
-                            + ", Address " + response.address
-                            + ", Connected members uuid : " + response.uuid
-                            + ", Uuid in the current member list : " + member.getUuid());
-                }
-            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -821,7 +821,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             checkPartitionCount(response.partitionCount);
             connection.setConnectedServerVersion(response.serverHazelcastVersion);
             connection.setRemoteEndpoint(response.address);
-            connection.setRemoteUuid(response.uuid);
+            connection.setRemoteUuid(response.memberUuid);
 
             UUID newClusterId = response.clusterId;
 
@@ -836,7 +836,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 client.onClusterRestart();
             }
 
-            activeConnections.put(response.uuid, connection);
+            activeConnections.put(response.memberUuid, connection);
 
             if (initialConnection) {
                 clusterId = newClusterId;
@@ -849,7 +849,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 }
             }
 
-            logger.info("Authenticated with server " + response.address + ":" + response.uuid
+            logger.info("Authenticated with server " + response.address + ":" + response.memberUuid
                     + ", server version: " + response.serverHazelcastVersion
                     + ", local address: " + connection.getLocalSocketAddress());
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Makes an authentication request to the cluster.
  */
-@Generated("137799a124f35d8a428988a4823b6a49")
+@Generated("168c048476e3d4fe1d8ac3e9fea8ad63")
 public final class ClientAuthenticationCodec {
     //hex: 0x000100
     public static final int REQUEST_MESSAGE_TYPE = 256;
@@ -46,8 +46,8 @@ public final class ClientAuthenticationCodec {
     private static final int REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
     private static final int RESPONSE_STATUS_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
-    private static final int RESPONSE_UUID_FIELD_OFFSET = RESPONSE_STATUS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
-    private static final int RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET = RESPONSE_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
+    private static final int RESPONSE_MEMBER_UUID_FIELD_OFFSET = RESPONSE_STATUS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
+    private static final int RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET = RESPONSE_MEMBER_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_PARTITION_COUNT_FIELD_OFFSET = RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
     private static final int RESPONSE_CLUSTER_ID_FIELD_OFFSET = RESPONSE_PARTITION_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_FAILOVER_SUPPORTED_FIELD_OFFSET = RESPONSE_CLUSTER_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
@@ -158,9 +158,9 @@ public final class ClientAuthenticationCodec {
         public @Nullable com.hazelcast.cluster.Address address;
 
         /**
-         * Unique string identifying the connected client uniquely.
+         * UUID of the Hazelcast member which sends the authentication response.
          */
-        public @Nullable java.util.UUID uuid;
+        public @Nullable java.util.UUID memberUuid;
 
         /**
          * client side supported version to inform server side
@@ -188,12 +188,12 @@ public final class ClientAuthenticationCodec {
         public boolean failoverSupported;
     }
 
-    public static ClientMessage encodeResponse(byte status, @Nullable com.hazelcast.cluster.Address address, @Nullable java.util.UUID uuid, byte serializationVersion, java.lang.String serverHazelcastVersion, int partitionCount, java.util.UUID clusterId, boolean failoverSupported) {
+    public static ClientMessage encodeResponse(byte status, @Nullable com.hazelcast.cluster.Address address, @Nullable java.util.UUID memberUuid, byte serializationVersion, java.lang.String serverHazelcastVersion, int partitionCount, java.util.UUID clusterId, boolean failoverSupported) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
         encodeByte(initialFrame.content, RESPONSE_STATUS_FIELD_OFFSET, status);
-        encodeUUID(initialFrame.content, RESPONSE_UUID_FIELD_OFFSET, uuid);
+        encodeUUID(initialFrame.content, RESPONSE_MEMBER_UUID_FIELD_OFFSET, memberUuid);
         encodeByte(initialFrame.content, RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET, serializationVersion);
         encodeInt(initialFrame.content, RESPONSE_PARTITION_COUNT_FIELD_OFFSET, partitionCount);
         encodeUUID(initialFrame.content, RESPONSE_CLUSTER_ID_FIELD_OFFSET, clusterId);
@@ -210,7 +210,7 @@ public final class ClientAuthenticationCodec {
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.status = decodeByte(initialFrame.content, RESPONSE_STATUS_FIELD_OFFSET);
-        response.uuid = decodeUUID(initialFrame.content, RESPONSE_UUID_FIELD_OFFSET);
+        response.memberUuid = decodeUUID(initialFrame.content, RESPONSE_MEMBER_UUID_FIELD_OFFSET);
         response.serializationVersion = decodeByte(initialFrame.content, RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET);
         response.partitionCount = decodeInt(initialFrame.content, RESPONSE_PARTITION_COUNT_FIELD_OFFSET);
         response.clusterId = decodeUUID(initialFrame.content, RESPONSE_CLUSTER_ID_FIELD_OFFSET);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Makes an authentication request to the cluster using custom credentials.
  */
-@Generated("788a55538db73b880cd7dad646a5273f")
+@Generated("a48e7f1fa47b4544c641d9c24df36702")
 public final class ClientAuthenticationCustomCodec {
     //hex: 0x000200
     public static final int REQUEST_MESSAGE_TYPE = 512;
@@ -46,8 +46,8 @@ public final class ClientAuthenticationCustomCodec {
     private static final int REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET = REQUEST_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_SERIALIZATION_VERSION_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
     private static final int RESPONSE_STATUS_FIELD_OFFSET = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
-    private static final int RESPONSE_UUID_FIELD_OFFSET = RESPONSE_STATUS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
-    private static final int RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET = RESPONSE_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
+    private static final int RESPONSE_MEMBER_UUID_FIELD_OFFSET = RESPONSE_STATUS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
+    private static final int RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET = RESPONSE_MEMBER_UUID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
     private static final int RESPONSE_PARTITION_COUNT_FIELD_OFFSET = RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
     private static final int RESPONSE_CLUSTER_ID_FIELD_OFFSET = RESPONSE_PARTITION_COUNT_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int RESPONSE_FAILOVER_SUPPORTED_FIELD_OFFSET = RESPONSE_CLUSTER_ID_FIELD_OFFSET + UUID_SIZE_IN_BYTES;
@@ -149,9 +149,9 @@ public final class ClientAuthenticationCustomCodec {
         public @Nullable com.hazelcast.cluster.Address address;
 
         /**
-         * Unique string identifying the connected client uniquely.
+         * UUID of the Hazelcast member which sends the authentication response.
          */
-        public @Nullable java.util.UUID uuid;
+        public @Nullable java.util.UUID memberUuid;
 
         /**
          * client side supported version to inform server side
@@ -179,12 +179,12 @@ public final class ClientAuthenticationCustomCodec {
         public boolean failoverSupported;
     }
 
-    public static ClientMessage encodeResponse(byte status, @Nullable com.hazelcast.cluster.Address address, @Nullable java.util.UUID uuid, byte serializationVersion, java.lang.String serverHazelcastVersion, int partitionCount, java.util.UUID clusterId, boolean failoverSupported) {
+    public static ClientMessage encodeResponse(byte status, @Nullable com.hazelcast.cluster.Address address, @Nullable java.util.UUID memberUuid, byte serializationVersion, java.lang.String serverHazelcastVersion, int partitionCount, java.util.UUID clusterId, boolean failoverSupported) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
         encodeByte(initialFrame.content, RESPONSE_STATUS_FIELD_OFFSET, status);
-        encodeUUID(initialFrame.content, RESPONSE_UUID_FIELD_OFFSET, uuid);
+        encodeUUID(initialFrame.content, RESPONSE_MEMBER_UUID_FIELD_OFFSET, memberUuid);
         encodeByte(initialFrame.content, RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET, serializationVersion);
         encodeInt(initialFrame.content, RESPONSE_PARTITION_COUNT_FIELD_OFFSET, partitionCount);
         encodeUUID(initialFrame.content, RESPONSE_CLUSTER_ID_FIELD_OFFSET, clusterId);
@@ -201,7 +201,7 @@ public final class ClientAuthenticationCustomCodec {
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.status = decodeByte(initialFrame.content, RESPONSE_STATUS_FIELD_OFFSET);
-        response.uuid = decodeUUID(initialFrame.content, RESPONSE_UUID_FIELD_OFFSET);
+        response.memberUuid = decodeUUID(initialFrame.content, RESPONSE_MEMBER_UUID_FIELD_OFFSET);
         response.serializationVersion = decodeByte(initialFrame.content, RESPONSE_SERIALIZATION_VERSION_FIELD_OFFSET);
         response.partitionCount = decodeInt(initialFrame.content, RESPONSE_PARTITION_COUNT_FIELD_OFFSET);
         response.clusterId = decodeUUID(initialFrame.content, RESPONSE_CLUSTER_ID_FIELD_OFFSET);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -194,9 +194,10 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
         logger.info("Received auth from " + connection + ", successfully authenticated" + ", clientUuid: " + clientUuid
                 + ", client version: " + clientVersion);
         final Address thisAddress = clientEngine.getThisAddress();
+        UUID uuid = clientEngine.getClusterService().getLocalMember().getUuid();
         byte status = AUTHENTICATED.getId();
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
-        return encodeAuth(status, thisAddress, clientUuid, serializationService.getVersion(),
+        return encodeAuth(status, thisAddress, uuid, serializationService.getVersion(),
                 clientEngine.getPartitionService().getPartitionCount(), clusterId, clientFailoverSupported);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
@@ -39,14 +39,6 @@ public interface ClientClusterService {
     Client getLocalClient();
 
     /**
-     * Gets the member for the given address.
-     *
-     * @param address The address of the member to look up.
-     * @return The member that was found, or null if not found. If address is null, null is returned.
-     */
-    Member getMember(Address address);
-
-    /**
      * Gets the member with the given UUID.
      *
      * @param uuid The UUID of the member.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -41,7 +41,6 @@ import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import javax.annotation.Nonnull;
@@ -115,9 +114,6 @@ public class ClientClusterServiceImpl implements ClientClusterService {
             }
             if (listener instanceof MembershipListener) {
                 addMembershipListenerWithoutInit((MembershipListener) listener);
-            }
-            if (listener instanceof PartitionLostListener) {
-                client.getPartitionService().addPartitionLostListener((PartitionLostListener) listener);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -77,11 +77,12 @@ public class ClientClusterServiceImpl implements ClientClusterService {
 
     private final AtomicReference<MemberListSnapshot> memberListSnapshot = new AtomicReference<>(EMPTY_SNAPSHOT);
     private final ConcurrentMap<UUID, MembershipListener> listeners = new ConcurrentHashMap<>();
-    private final Object clusterViewLock = new Object();
     private final Set<String> labels;
     private final ILogger logger;
     private final ClientConnectionManager connectionManager;
-    private volatile CountDownLatch initialListFetchedLatch = new CountDownLatch(1);
+    private final Object clusterViewLock = new Object();
+    //read and written under clusterViewLock
+    private CountDownLatch initialListFetchedLatch = new CountDownLatch(1);
 
     private static final class MemberListSnapshot {
         private final int version;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientPartitionServiceImpl.java
@@ -50,7 +50,7 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
     private final ILogger logger;
     private final AtomicReference<PartitionTable> partitionTable =
             new AtomicReference<>(new PartitionTable(null, -1, new Int2ObjectHashMap<>()));
-    private volatile AtomicInteger partitionCount = new AtomicInteger(0);
+    private final AtomicInteger partitionCount = new AtomicInteger(0);
 
     public ClientPartitionServiceImpl(HazelcastClientInstanceImpl client) {
         this.client = client;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/SmartClientInvocationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/SmartClientInvocationService.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientLocalBackupListenerCodec;
 import com.hazelcast.client.impl.spi.ClientListenerService;
 import com.hazelcast.client.impl.spi.EventHandler;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.nio.Connection;
 
@@ -116,14 +115,14 @@ public class SmartClientInvocationService extends AbstractClientInvocationServic
             invokeOnRandomTarget(invocation);
             return;
         }
-        Connection connection = getConnection(member.getAddress());
+        Connection connection = getConnection(member.getUuid());
         invokeOnConnection(invocation, (ClientConnection) connection);
     }
 
-    private Connection getConnection(Address target) throws IOException {
+    private Connection getConnection(UUID target) throws IOException {
         Connection connection = connectionManager.getConnection(target);
         if (connection == null) {
-            throw new IOException("No available connection to address " + target);
+            throw new IOException("No available connection to member " + target);
         }
         return connection;
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -39,6 +39,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -143,8 +144,8 @@ public class ClientConnectionTest extends ClientTestSupport {
 
         connectionManager.addConnectionListener(listener);
 
-        final Address serverAddress = server.getCluster().getLocalMember().getAddress();
-        final Connection connectionToServer = connectionManager.getConnection(serverAddress);
+        UUID serverUuid = server.getCluster().getLocalMember().getUuid();
+        final Connection connectionToServer = connectionManager.getConnection(serverUuid);
 
         ReconnectListener reconnectListener = new ReconnectListener();
         clientImpl.getLifecycleService().addLifecycleListener(reconnectListener);

--- a/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -298,6 +298,12 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
             assertEquals(expectedMembers, actualMembers);
         });
 
-        map.get(1);
+        assertTrueEventually(() -> {
+            try {
+                map.get(1);
+            } catch (HazelcastClientOfflineException e) {
+                fail();
+            }
+        });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerTranslateTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.client.impl.connection.Addresses;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.Connection;
@@ -57,7 +58,7 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
         clientConnectionManager = new ClientConnectionManagerImpl(clientInstanceImpl);
         clientConnectionManager.start();
         clientConnectionManager.reset();
-        clientConnectionManager.getOrConnect(new Address("127.0.0.1", 5701));
+        clientConnectionManager.getOrConnect(new MemberImpl(new Address("127.0.0.1", 5701), null, false));
 
         provider.shouldTranslate = true;
 
@@ -98,14 +99,8 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
     }
 
     @Test
-    public void testTranslatorIsNotUsedGetActiveConnection() {
-        Connection connection = clientConnectionManager.getConnection(privateAddress);
-        assertNotNull(connection);
-    }
-
-    @Test
     public void testTranslatorIsNotUsedOnGetConnection() {
-        Connection connection = clientConnectionManager.getOrConnect(privateAddress);
+        Connection connection = clientConnectionManager.getOrConnect(new MemberImpl(privateAddress, null, false));
         assertNotNull(connection);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ConnectMemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ConnectMemberListTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.client.impl.clientside.ClusterDiscoveryService;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -70,12 +70,12 @@ public class ConnectMemberListTest extends ClientTestSupport {
         config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
         HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
 
-        Collection<Address> possibleMemberAddresses = getPossibleMemberAddresses(client);
+        Collection<Member> possibleMemberAddresses = getPossibleMemberAddresses(client);
         //make sure last known member list is used. otherwise it returns 3
         assertEquals(4, possibleMemberAddresses.size());
     }
 
-    private Collection<Address> getPossibleMemberAddresses(HazelcastInstance client) {
+    private Collection<Member> getPossibleMemberAddresses(HazelcastInstance client) {
         HazelcastClientInstanceImpl instanceImpl = getHazelcastClientInstanceImpl(client);
         ClusterDiscoveryService clusterDiscoveryService = instanceImpl.getClusterDiscoveryService();
         CandidateClusterContext clusterContext = clusterDiscoveryService.current();

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
@@ -224,7 +224,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
 
         assertEquals(2, parameters.status);
         assertEquals(new Address("127.0.0.1", 5701), parameters.address);
-        assertEquals(uuid, parameters.uuid);
+        assertEquals(uuid, parameters.memberUuid);
         assertEquals(1, parameters.serializationVersion);
         assertEquals("3.12", parameters.serverHazelcastVersion);
         assertEquals(271, parameters.partitionCount);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
@@ -77,7 +77,7 @@ public class ClientCompatibilityNullTest_2_0 {
         ClientAuthenticationCodec.ResponseParameters parameters = ClientAuthenticationCodec.decodeResponse(fromFile);
         assertTrue(isEqual(aByte, parameters.status));
         assertTrue(isEqual(null, parameters.address));
-        assertTrue(isEqual(null, parameters.uuid));
+        assertTrue(isEqual(null, parameters.memberUuid));
         assertTrue(isEqual(aByte, parameters.serializationVersion));
         assertTrue(isEqual(aString, parameters.serverHazelcastVersion));
         assertTrue(isEqual(anInt, parameters.partitionCount));
@@ -100,7 +100,7 @@ public class ClientCompatibilityNullTest_2_0 {
         ClientAuthenticationCustomCodec.ResponseParameters parameters = ClientAuthenticationCustomCodec.decodeResponse(fromFile);
         assertTrue(isEqual(aByte, parameters.status));
         assertTrue(isEqual(null, parameters.address));
-        assertTrue(isEqual(null, parameters.uuid));
+        assertTrue(isEqual(null, parameters.memberUuid));
         assertTrue(isEqual(aByte, parameters.serializationVersion));
         assertTrue(isEqual(aString, parameters.serverHazelcastVersion));
         assertTrue(isEqual(anInt, parameters.partitionCount));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
@@ -77,7 +77,7 @@ public class ClientCompatibilityTest_2_0 {
         ClientAuthenticationCodec.ResponseParameters parameters = ClientAuthenticationCodec.decodeResponse(fromFile);
         assertTrue(isEqual(aByte, parameters.status));
         assertTrue(isEqual(anAddress, parameters.address));
-        assertTrue(isEqual(aUUID, parameters.uuid));
+        assertTrue(isEqual(aUUID, parameters.memberUuid));
         assertTrue(isEqual(aByte, parameters.serializationVersion));
         assertTrue(isEqual(aString, parameters.serverHazelcastVersion));
         assertTrue(isEqual(anInt, parameters.partitionCount));
@@ -100,7 +100,7 @@ public class ClientCompatibilityTest_2_0 {
         ClientAuthenticationCustomCodec.ResponseParameters parameters = ClientAuthenticationCustomCodec.decodeResponse(fromFile);
         assertTrue(isEqual(aByte, parameters.status));
         assertTrue(isEqual(anAddress, parameters.address));
-        assertTrue(isEqual(aUUID, parameters.uuid));
+        assertTrue(isEqual(aUUID, parameters.memberUuid));
         assertTrue(isEqual(aByte, parameters.serializationVersion));
         assertTrue(isEqual(aString, parameters.serverHazelcastVersion));
         assertTrue(isEqual(anInt, parameters.partitionCount));


### PR DESCRIPTION
Initial pr was #16404. This pr, fixes more places related to invoke
on uuid usages.

Make getting a member with uuid faster in ClientClusterService
Refactored ClientClusterService so that getting a member with uuid
is a hash table lookup instead of iterating all the member-list.

Invocations are using the getMember(uuid) method.
ClientClusterService.getMember(address) has no longer used internally.

Getting connection from connection manager is also with uuid instead
of address.

related to https://github.com/hazelcast/hazelcast-client-protocol/pull/301
fixes https://github.com/hazelcast/hazelcast/issues/16519