### PR TITLE
Fix HD ICache iterator consistency issue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCachePartitionsIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCachePartitionsIterator.java
@@ -128,16 +128,13 @@ public abstract class AbstractCachePartitionsIterator<K, V> implements Iterator<
 
     @Override
     public Cache.Entry<K, V> next() {
-        while (hasNext()) {
+        if (hasNext()) {
             currentIndex = index;
             index++;
-            final Data keyData = getKey(currentIndex);
-            final K key = toObject(keyData);
-            final V value = getValue(currentIndex, key);
-            // Value might be removed or evicted
-            if (value != null) {
-                return new CacheEntry<K, V>(key, value);
-            }
+            Data keyData = getKey(currentIndex);
+            K key = toObject(keyData);
+            V value = getValue(currentIndex, key);
+            return new CacheEntry<>(key, value);
         }
         throw new NoSuchElementException();
     }
@@ -220,7 +217,7 @@ public abstract class AbstractCachePartitionsIterator<K, V> implements Iterator<
      * @param response the iteration response
      * @param pointers the pointers defining the state of iteration
      */
-    protected void setLastTableIndex(List response, IterationPointer[] pointers) {
+    protected void setIterationPointers(List response, IterationPointer[] pointers) {
         if (response != null && response.size() > 0) {
             this.pointers = pointers;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionsIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionsIterator.java
@@ -70,25 +70,22 @@ public class CachePartitionsIterator<K, V>
         final OperationService operationService = cacheProxy.getNodeEngine().getOperationService();
         if (prefetchValues) {
             Operation operation = cacheProxy.operationProvider.createFetchEntriesOperation(pointers, fetchSize);
-            InternalCompletableFuture<CacheEntriesWithCursor> f = operationService
-                    .invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionIndex);
-            CacheEntriesWithCursor iteratorResult = f.joinInternal();
-            if (iteratorResult != null) {
-                setLastTableIndex(iteratorResult.getEntries(), iteratorResult.getPointers());
-                return iteratorResult.getEntries();
-            }
+            CacheEntriesWithCursor iteratorResult = invoke(operationService, operation);
+            setIterationPointers(iteratorResult.getEntries(), iteratorResult.getPointers());
+            return iteratorResult.getEntries();
         } else {
             Operation operation = cacheProxy.operationProvider.createFetchKeysOperation(pointers, fetchSize);
-            InternalCompletableFuture<CacheKeysWithCursor> f = operationService
-                    .invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionIndex);
-            CacheKeysWithCursor iteratorResult = f.joinInternal();
-            if (iteratorResult != null) {
-                setLastTableIndex(iteratorResult.getKeys(), iteratorResult.getPointers());
-                return iteratorResult.getKeys();
-            }
+            CacheKeysWithCursor iteratorResult = invoke(operationService, operation);
+            setIterationPointers(iteratorResult.getKeys(), iteratorResult.getPointers());
+            return iteratorResult.getKeys();
         }
-        return null;
 
+    }
+
+    private <T> T invoke(OperationService operationService, Operation operation) {
+        InternalCompletableFuture<T> f = operationService
+                .invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionIndex);
+        return f.joinInternal();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionsIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionsIterator.java
@@ -85,7 +85,7 @@ public class ClientCachePartitionsIterator<K, V> extends AbstractCachePartitions
                 CacheIterateEntriesCodec.ResponseParameters responseParameters = CacheIterateEntriesCodec.decodeResponse(
                         future.get());
                 IterationPointer[] pointers = decodePointers(responseParameters.iterationPointers);
-                setLastTableIndex(responseParameters.entries, pointers);
+                setIterationPointers(responseParameters.entries, pointers);
                 return responseParameters.entries;
             } catch (Exception e) {
                 throw rethrow(e);
@@ -97,7 +97,7 @@ public class ClientCachePartitionsIterator<K, V> extends AbstractCachePartitions
                 ClientInvocationFuture future = clientInvocation.invoke();
                 CacheIterateCodec.ResponseParameters responseParameters = CacheIterateCodec.decodeResponse(future.get());
                 IterationPointer[] pointers = decodePointers(responseParameters.iterationPointers);
-                setLastTableIndex(responseParameters.keys, pointers);
+                setIterationPointers(responseParameters.keys, pointers);
                 return responseParameters.keys;
             } catch (Exception e) {
                 throw rethrow(e);

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -18,11 +18,10 @@ package com.hazelcast.cache;
 
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.internal.iteration.IterationPointer;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.util.SampleableConcurrentHashMap;
-import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.test.AssertTask;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -121,13 +120,11 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         final String key = "key";
 
         cache.put(key, "value1");
-        CompletionStage future = cache.getAsync(key);
+        CompletionStage<?> future = cache.getAsync(key);
         assertEquals("value1", future.toCompletableFuture().get());
 
         cache.putAsync(key, "value2");
-        assertTrueEventually(() -> {
-            assertEquals("value2", cache.get(key));
-        });
+        assertTrueEventually(() -> assertEquals("value2", cache.get(key)));
 
         future = cache.getAndPutAsync(key, "value3");
         assertEquals("value2", future.toCompletableFuture().get());
@@ -171,12 +168,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         HazelcastExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1);
 
         cache.putIfAbsentAsync(key, randomString(), expiryPolicy);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertNull(cache.get(key));
-            }
-        });
+        assertTrueEventually(() -> assertNull(cache.get(key)));
     }
 
     @Test
@@ -195,7 +187,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     @Test
     public void testGetAll_withEmptySet() {
         ICache<String, String> cache = createCache();
-        Map<String, String> map = cache.getAll(Collections.<String>emptySet());
+        Map<String, String> map = cache.getAll(Collections.emptySet());
         assertEquals(0, map.size());
     }
 
@@ -225,43 +217,24 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         final String key = "key";
         cache.put(key, "value1", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
 
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertNull(cache.get(key));
-            }
-        });
+        assertTrueEventually(() -> assertNull(cache.get(key)));
         assertEquals(0, cache.size());
 
         cache.putAsync(key, "value1", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertNull(cache.get(key));
-            }
-        });
+        assertTrueEventually(() -> assertNull(cache.get(key)));
         assertEquals(0, cache.size());
 
         cache.put(key, "value2");
         String value = cache.getAndPut(key, "value3", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
         assertEquals("value2", value);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertNull(cache.get(key));
-            }
-        });
+        assertTrueEventually(() -> assertNull(cache.get(key)));
         assertEquals(0, cache.size());
 
         cache.put(key, "value4");
-        CompletionStage stage = cache.getAndPutAsync(key, "value5", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
+        CompletionStage<String> stage = cache.getAndPutAsync(key, "value5", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
         assertEquals("value4", stage.toCompletableFuture().get());
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertNull(cache.get(key));
-            }
-        });
+        assertTrueEventually(() -> assertNull(cache.get(key)));
         assertEquals(0, cache.size());
     }
 
@@ -300,10 +273,10 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
     @Test
     public void testExpiration() {
-        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
-        final SimpleExpiryListener<Integer, String> listener = new SimpleExpiryListener<Integer, String>();
+        CacheConfig<Integer, String> config = new CacheConfig<>();
+        final SimpleExpiryListener<Integer, String> listener = new SimpleExpiryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
-                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                new MutableCacheEntryListenerConfiguration<>(
                         FactoryBuilder.factoryOf(listener), null, true, true);
 
         config.addCacheEntryListenerConfiguration(listenerConfiguration);
@@ -313,22 +286,16 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
         instanceCache.put(1, "value");
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(1, listener.expired.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, listener.expired.get()));
     }
 
     @Test
     public void testExpiration_entryWithOwnTtl() {
-        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
-        final SimpleExpiryListener<Integer, String> listener = new SimpleExpiryListener<Integer, String>();
+        CacheConfig<Integer, String> config = new CacheConfig<>();
+        final SimpleExpiryListener<Integer, String> listener = new SimpleExpiryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration
-                = new MutableCacheEntryListenerConfiguration<Integer, String>(
-                        FactoryBuilder.factoryOf(listener), null, true, true);
+                = new MutableCacheEntryListenerConfiguration<>(
+                FactoryBuilder.factoryOf(listener), null, true, true);
 
         config.addCacheEntryListenerConfiguration(listenerConfiguration);
         config.setExpiryPolicyFactory(FactoryBuilder.factoryOf(new HazelcastExpiryPolicy(Duration.ETERNAL, Duration.ETERNAL,
@@ -338,13 +305,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
         instanceCache.put(1, "value", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(1, listener.expired.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, listener.expired.get()));
     }
 
     @Test
@@ -418,7 +379,12 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
                 Cache.Entry<Integer, Integer> e = iterator.next();
                 Integer key = e.getKey();
                 Integer value = e.getValue();
-                assertEquals(key, value);
+                if (value != null) {
+                    // value can be null in case prefetchValues is false
+                    // and the entry expired between the time the key was fetched
+                    // and the value was fetched
+                    assertEquals(key, value);
+                }
                 i++;
             }
             if (withoutEviction) {
@@ -472,8 +438,13 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
             while (iterator.hasNext()) {
                 Cache.Entry<Integer, Integer> e = iterator.next();
                 int key = e.getKey();
-                int value = e.getValue();
-                assertEquals("key: " + key + ", value: " + value, key, Math.abs(value));
+                Integer value = e.getValue();
+                if (value != null) {
+                    // value can be null in case prefetchValues is false
+                    // and the entry expired between the time the key was fetched
+                    // and the value was fetched
+                    assertEquals("key: " + key + ", value: " + value, key, Math.abs(value));
+                }
                 i++;
             }
             if (withoutEviction) {
@@ -528,7 +499,12 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
                 Cache.Entry<Integer, Integer> e = iterator.next();
                 Integer key = e.getKey();
                 Integer value = e.getValue();
-                assertEquals(key, value);
+                if (value != null) {
+                    // value can be null in case prefetchValues is false
+                    // and the entry expired between the time the key was fetched
+                    // and the value was fetched
+                    assertEquals(key, value);
+                }
                 i++;
             }
             if (withoutEviction) {
@@ -577,7 +553,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     }
 
     @Test
-    public void testRemoveAsyncWhenEntryNotFound_withOldValue() throws Exception {
+    public void testRemoveAsyncWhenEntryNotFound_withOldValue() {
         ICache<String, String> cache = createCache();
 
         cache.removeAsync(randomString(), randomString())
@@ -596,9 +572,9 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
         CacheConfig<Integer, String> config = createCacheConfig();
         final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener
-                = new CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String>();
+                = new CacheFromDifferentNodesTest.SimpleEntryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration
-                = new MutableCacheEntryListenerConfiguration<Integer, String>(
+                = new MutableCacheEntryListenerConfiguration<>(
                 FactoryBuilder.factoryOf(listener), null, true, true);
 
         config.addCacheEntryListenerConfiguration(listenerConfiguration);
@@ -609,22 +585,12 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         Integer key = 1;
         String value = "value";
         cache.put(key, value);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertEquals(1, listener.created.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, listener.created.get()));
 
         cache.removeAll();
         cache.removeAll();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertEquals(1, listener.removed.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, listener.removed.get()));
     }
 
     @Test
@@ -633,9 +599,9 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
         CacheConfig<Integer, String> config = createCacheConfig();
         final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener
-                = new CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String>();
+                = new CacheFromDifferentNodesTest.SimpleEntryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration
-                = new MutableCacheEntryListenerConfiguration<Integer, String>(
+                = new MutableCacheEntryListenerConfiguration<>(
                 FactoryBuilder.factoryOf(listener), null, true, true);
 
         config.addCacheEntryListenerConfiguration(listenerConfiguration);
@@ -646,33 +612,18 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         Integer key1 = 1;
         String value1 = "value1";
         cache.put(key1, value1);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertEquals(1, listener.created.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, listener.created.get()));
 
         Integer key2 = 2;
         String value2 = "value2";
         cache.put(key2, value2);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertEquals(2, listener.created.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(2, listener.created.get()));
 
-        Set<Integer> keys = new HashSet<Integer>();
+        Set<Integer> keys = new HashSet<>();
         keys.add(key1);
         keys.add(key2);
         cache.removeAll(keys);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertEquals(2, listener.removed.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(2, listener.removed.get()));
     }
 
     @Test
@@ -681,7 +632,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
         assertNull(cacheManager.getCache(cacheName));
 
-        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> config = new CacheConfig<>();
         Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
         assertNotNull(cache);
 
@@ -703,8 +654,8 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
     @Test
     public void testCaches_NotEmpty() {
-        ArrayList<String> expected = new ArrayList<String>();
-        ArrayList<String> real = new ArrayList<String>();
+        ArrayList<String> expected = new ArrayList<>();
+        ArrayList<String> real = new ArrayList<>();
         cacheManager.createCache("c1", new MutableConfiguration());
         cacheManager.createCache("c2", new MutableConfiguration());
         cacheManager.createCache("c3", new MutableConfiguration());
@@ -725,7 +676,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         int testSize = 3007;
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
         for (int fetchSize = 1; fetchSize < 102; fetchSize++) {
-            SampleableConcurrentHashMap<Data, String> map = new SampleableConcurrentHashMap<Data, String>(1000);
+            SampleableConcurrentHashMap<Data, String> map = new SampleableConcurrentHashMap<>(1000);
             for (int i = 0; i < testSize; i++) {
                 Integer key = i;
                 Data data = serializationService.toData(key);
@@ -737,8 +688,8 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
             int total = 0;
             int remaining = testSize;
             while (remaining > 0 && pointers[pointers.length - 1].getIndex() > 0) {
-                int size = (remaining > fetchSize ? fetchSize : remaining);
-                List<Data> keys = new ArrayList<Data>(size);
+                int size = (Math.min(remaining, fetchSize));
+                List<Data> keys = new ArrayList<>(size);
                 pointers = map.fetchKeys(pointers, size, keys);
                 remaining -= keys.size();
                 total += keys.size();
@@ -821,7 +772,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     public void testEntryProcessor_invokeAll() {
         ICache<String, String> cache = createCache();
         int entryCount = 10;
-        Map<String, String> localMap = new HashMap<String, String>();
+        Map<String, String> localMap = new HashMap<>();
         for (int i = 0; i < entryCount; i++) {
             localMap.put(randomString(), randomString());
         }
@@ -909,7 +860,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         final int createdExpiryTimeMillis = 100;
 
         Duration duration = new Duration(TimeUnit.MILLISECONDS, createdExpiryTimeMillis);
-        CacheConfig<Integer, String> cacheConfig = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> cacheConfig = new CacheConfig<>();
         cacheConfig.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(duration));
 
         Cache<Integer, String> cache = createCache(cacheConfig);
@@ -946,7 +897,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     public void testRecordExpiryPolicyTakesPrecedenceOverCachePolicy() {
         final int updatedTtlMillis = 1000;
 
-        CacheConfig<Integer, String> cacheConfig = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> cacheConfig = new CacheConfig<>();
         cacheConfig.setExpiryPolicyFactory(TouchedExpiryPolicy.factoryOf(Duration.ONE_DAY));
 
         ICache<Integer, String> cache = createCache(cacheConfig);
@@ -1013,14 +964,14 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
 
     @Test
     public void removeCacheFromOwnerCacheManagerWhenCacheIsDestroyed() {
-        ICache cache = createCache();
+        ICache<?, ?> cache = createCache();
         assertTrue("Expected the cache to be found in the CacheManager", cacheExistsInCacheManager(cache));
 
         cache.destroy();
         assertFalse("Expected the cache not to be found in the CacheManager", cacheExistsInCacheManager(cache));
     }
 
-    private boolean cacheExistsInCacheManager(ICache cache) {
+    private boolean cacheExistsInCacheManager(ICache<?, ?> cache) {
         for (String cacheName : cacheManager.getCacheNames()) {
             if (cacheName.equals(cache.getName())) {
                 return true;
@@ -1032,7 +983,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     @Test
     public void entryShouldNotBeExpiredWhenTimeUnitIsNullAndDurationIsZero() {
         Duration duration = new Duration(null, 0);
-        CacheConfig<Integer, String> cacheConfig = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> cacheConfig = new CacheConfig<>();
         cacheConfig.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(duration));
 
         Cache<Integer, String> cache = createCache(cacheConfig);
@@ -1049,13 +1000,13 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         CacheManager cacheManagerFooURI = cachingProvider.getCacheManager(new URI("foo"), null, properties);
         CacheManager cacheManagerFooClassLoader = cachingProvider.getCacheManager(null,
                 new MaliciousClassLoader(CacheBasicAbstractTest.class.getClassLoader()), properties);
-        CacheConfig cacheConfig = new CacheConfig("the-cache");
-        Cache cache1 = cacheManagerFooURI.createCache("the-cache", cacheConfig);
+        CacheConfig<?, ?> cacheConfig = new CacheConfig<>("the-cache");
+        Cache<?, ?> cache1 = cacheManagerFooURI.createCache("the-cache", cacheConfig);
         // cache1.cacheManager is cacheManagerFooURI
         assertEquals(cacheManagerFooURI, cache1.getCacheManager());
 
         // assert one can still get the cache
-        Cache cache2 = cacheManagerFooURI.getCache("the-cache");
+        Cache<?, ?> cache2 = cacheManagerFooURI.getCache("the-cache");
         assertEquals(cache1, cache2);
 
         // attempt to overwrite existing cache1's CacheManager -> fails with IllegalStateException
@@ -1071,19 +1022,11 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         final CacheManager cacheManagerFooURI = cachingProvider.getCacheManager(new URI("foo"), null, properties);
         final CacheManager cacheManagerFooClassLoader = cachingProvider.getCacheManager(null,
                 new MaliciousClassLoader(CacheBasicAbstractTest.class.getClassLoader()), properties);
-        Future createCacheFromFooURI = spawn(new Runnable() {
-            @Override
-            public void run() {
-                createCacheConcurrently(latch, cacheManagerFooURI, illegalStateExceptionCount);
-            }
-        });
+        Future<?> createCacheFromFooURI = spawn(
+                () -> createCacheConcurrently(latch, cacheManagerFooURI, illegalStateExceptionCount));
 
-        Future createCacheFromFooClassLoader = spawn(new Runnable() {
-            @Override
-            public void run() {
-                createCacheConcurrently(latch, cacheManagerFooClassLoader, illegalStateExceptionCount);
-            }
-        });
+        Future<?> createCacheFromFooClassLoader = spawn(
+                () -> createCacheConcurrently(latch, cacheManagerFooClassLoader, illegalStateExceptionCount));
 
         latch.countDown();
 
@@ -1106,7 +1049,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
                                                 AtomicInteger illegalStateExceptionCount) {
         try {
             latch.await();
-            CacheConfig cacheConfig = new CacheConfig("the-cache");
+            CacheConfig<?, ?> cacheConfig = new CacheConfig<>("the-cache");
             cacheManager.createCache("the-cache", cacheConfig);
         } catch (IllegalStateException e) {
             illegalStateExceptionCount.incrementAndGet();
@@ -1139,7 +1082,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         @Override
         public void onExpired(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+            for (CacheEntryEvent<? extends K, ? extends V> ignored : cacheEntryEvents) {
                 expired.incrementAndGet();
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorBouncingTest.java
@@ -55,7 +55,7 @@ public class CachePartitionIteratorBouncingTest extends HazelcastTestSupport {
     private static final int CONCURRENCY = 2;
     public static final int FETCH_SIZE = 100;
     public static final int MUTATION_ENTRY_FACTOR = 10;
-    public AtomicInteger successfulIterations = new AtomicInteger();
+    public AtomicInteger successfullIterations = new AtomicInteger();
 
     @Rule
     public BounceMemberRule bounceMemberRule =
@@ -121,7 +121,7 @@ public class CachePartitionIteratorBouncingTest extends HazelcastTestSupport {
                 assertTrue("Missing stable entry " + i + " - " + cache.get(i), all.contains(i));
             }
 
-            logger.info("Successfully finished iteration " + successfulIterations.incrementAndGet());
+            logger.info("Successfully finished iteration " + successfullIterations.incrementAndGet());
         }
 
         private HashSet<Integer> getAll() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorBouncingTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration.DriverType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.Cache.Entry;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import static com.hazelcast.config.EvictionConfig.DEFAULT_MAX_SIZE_POLICY;
+import static com.hazelcast.config.MaxSizePolicy.USED_NATIVE_MEMORY_SIZE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class CachePartitionIteratorBouncingTest extends HazelcastTestSupport {
+
+    private final Logger logger = Logger.getLogger(getClass().getName());
+    private static final String TEST_CACHE_NAME = "testCache";
+    private static final int STABLE_ENTRY_COUNT = 10000;
+    private static final int CONCURRENCY = 2;
+    public static final int FETCH_SIZE = 100;
+    public static final int MUTATION_ENTRY_FACTOR = 10;
+    public AtomicInteger successfulIterations = new AtomicInteger();
+
+    @Rule
+    public BounceMemberRule bounceMemberRule =
+            BounceMemberRule.with(getConfig())
+                            .clusterSize(4)
+                            .driverCount(4)
+                            .driverType(isClientDriver() ? DriverType.CLIENT : DriverType.MEMBER)
+                            .build();
+
+    @Override
+    protected Config getConfig() {
+        Config config = smallInstanceConfig();
+        MaxSizePolicy maxSizePolicy = getInMemoryFormat() == InMemoryFormat.NATIVE
+                ? USED_NATIVE_MEMORY_SIZE
+                : DEFAULT_MAX_SIZE_POLICY;
+        config.getCacheConfig(TEST_CACHE_NAME)
+              .setInMemoryFormat(getInMemoryFormat())
+              .getEvictionConfig()
+              .setMaxSizePolicy(maxSizePolicy)
+              .setSize(Integer.MAX_VALUE);
+
+        return config;
+    }
+
+    @Test
+    public void test() {
+        ICache<Integer, Integer> cache = bounceMemberRule.getSteadyMember()
+                                                         .getCacheManager()
+                                                         .getCache(TEST_CACHE_NAME);
+        populateCache(cache);
+
+        Runnable[] testTasks = new Runnable[CONCURRENCY];
+        for (int i = 0; i < CONCURRENCY; ) {
+            HazelcastInstance driver = bounceMemberRule.getNextTestDriver();
+            testTasks[i++] = new IterationRunnable(driver);
+            testTasks[i++] = new MutationRunnable(driver, i / 2);
+        }
+        bounceMemberRule.testRepeatedly(testTasks, MINUTES.toSeconds(3));
+    }
+
+    private void populateCache(ICache<Integer, Integer> cache) {
+        for (int i = 0; i < STABLE_ENTRY_COUNT; i++) {
+            cache.put(i, i);
+        }
+    }
+
+    public class IterationRunnable implements Runnable {
+
+        private final HazelcastInstance hazelcastInstance;
+        private ICache<Integer, Integer> cache;
+
+        public IterationRunnable(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+        }
+
+        @Override
+        public void run() {
+            if (cache == null) {
+                cache = hazelcastInstance.getCacheManager().getCache(TEST_CACHE_NAME);
+            }
+            HashSet<Integer> all = getAll();
+            for (int i = 0; i < STABLE_ENTRY_COUNT; i++) {
+                assertTrue("Missing stable entry " + i + " - " + cache.get(i), all.contains(i));
+            }
+
+            logger.info("Successfully finished iteration " + successfulIterations.incrementAndGet());
+        }
+
+        private HashSet<Integer> getAll() {
+            HashSet<Integer> keys = new HashSet<>();
+            int partitionCount = hazelcastInstance.getPartitionService().getPartitions().size();
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                Iterator<Cache.Entry<Integer, Integer>> iterator = createIterator(cache, FETCH_SIZE, partitionId, false);
+                while (iterator.hasNext()) {
+                    Entry<Integer, Integer> e = iterator.next();
+                    assertTrue("Got the same key twice", keys.add(e.getKey()));
+                }
+            }
+            return keys;
+        }
+
+    }
+
+    private Iterator<Cache.Entry<Integer, Integer>> createIterator(
+            ICache<Integer, Integer> cache, int fetchSize, int partitionId, boolean prefetchValues) {
+        return isClientDriver()
+                ? ((ClientCacheProxy<Integer, Integer>) cache).iterator(fetchSize, partitionId, prefetchValues)
+                : ((CacheProxy<Integer, Integer>) cache).iterator(fetchSize, partitionId, prefetchValues);
+    }
+
+    protected boolean isClientDriver() {
+        return false;
+    }
+
+    protected InMemoryFormat getInMemoryFormat() {
+        return CacheSimpleConfig.DEFAULT_IN_MEMORY_FORMAT;
+    }
+
+    public static class MutationRunnable implements Runnable {
+        private final HazelcastInstance hazelcastInstance;
+        private final int startIndex;
+        private final int endIndex;
+        private ICache<Integer, Integer> cache;
+
+        public MutationRunnable(HazelcastInstance hazelcastInstance, int runnableIndex) {
+            this.hazelcastInstance = hazelcastInstance;
+            this.startIndex = runnableIndex * MUTATION_ENTRY_FACTOR * STABLE_ENTRY_COUNT;
+            this.endIndex = startIndex + MUTATION_ENTRY_FACTOR * STABLE_ENTRY_COUNT;
+        }
+
+        @Override
+        public void run() {
+            if (cache == null) {
+                cache = hazelcastInstance.getCacheManager().getCache(TEST_CACHE_NAME);
+            }
+
+            for (int i = startIndex; i < endIndex; i++) {
+                cache.put(i, i);
+            }
+
+            for (int i = startIndex; i < endIndex; i++) {
+                cache.remove(i, i);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorBouncingTest.java
@@ -49,7 +49,7 @@ public class MapPartitionIteratorBouncingTest extends HazelcastTestSupport {
     private static final int CONCURRENCY = 2;
     public static final int FETCH_SIZE = 100;
     public static final int MUTATION_ENTRY_FACTOR = 10;
-    public AtomicInteger successfulIterations = new AtomicInteger();
+    public AtomicInteger successfullIterations = new AtomicInteger();
 
     @Rule
     public BounceMemberRule bounceMemberRule =
@@ -102,7 +102,7 @@ public class MapPartitionIteratorBouncingTest extends HazelcastTestSupport {
                 assertTrue("Missing stable entry", all.contains(i));
             }
 
-            logger.info("Successfully finished iteration " + successfulIterations.incrementAndGet());
+            logger.info("Successfully finished iteration " + successfullIterations.incrementAndGet());
         }
 
         private HashSet<Integer> getAll() {


### PR DESCRIPTION
The hasNotBeenObserved method had an issue which might cause stable
entries to be skipped.

Also:
- added bouncing tests for on-heap and off-heap ICache
- moved the hasNotBeenObserved method for a common parent class for both
off-heap ICache and IMap
- made it possible for ICache iterator to return an entry with a null
value in case prefetchValues is false. This is the same way it is in the
 IMap iterator.
- further aligned the ICache and IMap code

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3494