### PR TITLE
Fix listener leak test when client destroyed

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -272,8 +272,10 @@ public class ListenerLeakTest extends ClientTestSupport {
             newHazelcastClient().shutdown();
         }
 
-        for (Node node : nodes) {
-            assertEquals(0, node.getClientEngine().getClusterListenerService().getClusterListeningEndpoints().size());
-        }
+        assertTrueEventually(() -> {
+            for (Node node : nodes) {
+                assertEquals(0, node.getClientEngine().getClusterListenerService().getClusterListeningEndpoints().size());
+            }
+        });
     }
 }


### PR DESCRIPTION
Test should have check the condition as eventually.
Corrected the test.
fixes https://github.com/hazelcast/hazelcast/issues/16512