### PR TITLE
Javadoc fixes

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -69,7 +69,7 @@ import static org.springframework.util.Assert.isTrue;
 
 /**
  * Base class of all Hazelcast BeanDefinitionParser implementations.
- * <p/>
+ * <p>
  * <ul>
  * <li>{@link HazelcastClientBeanDefinitionParser}</li>
  * <li>{@link HazelcastConfigBeanDefinitionParser}</li>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastFailoverClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastFailoverClientBeanDefinitionParser.java
@@ -31,6 +31,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
 
 /**
  * BeanDefinitionParser for Hazelcast Client Configuration.
+ * <pre>{@code
  *     <hz:client-failover id="blueGreenClient" try-count="5">
  *         <hz:client>
  *             <hz:cluster-name>${cluster.name}</hz:cluster-name>
@@ -49,6 +50,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  *         </hz:client>
  *
  *     </hz:client-failover>
+ * }</pre>
  */
 public class HazelcastFailoverClientBeanDefinitionParser extends  AbstractHazelcastBeanDefinitionParser {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -56,7 +56,6 @@ import java.util.Properties;
  *     provider, while value {@code client} selects the client-side provider. Other values
  *     result in a {@link CacheException} being thrown.</li>
  * </ul>
- * </p>
  * <p>When using one of {@code Caching#getCachingProvider} variants with an explicit
  * class name argument, then:
  * <ul>
@@ -69,7 +68,6 @@ import java.util.Properties;
  *     <li>using {@value #CLIENT_CACHING_PROVIDER} as
  *     class name will return a client-side caching provider</li>
  * </ul>
- * </p>
  * <h3>Creating or reusing HazelcastInstances with CacheManagers</h3>
  * Arguments used with {@link CachingProvider#getCacheManager(URI, ClassLoader, Properties)}
  * and its variants control whether a {@code HazelcastInstance} will be created or reused
@@ -123,7 +121,6 @@ import java.util.Properties;
  * cache.put("a", "b");
  * </pre>
  * </blockquote>
- * </p>
  * <p><b>Obtain a client-side caching provider, starting a default client {@code HazelcastInstance}</b>
  * In this example the client-side caching provider is selected as default option. A new
  * client-side {@code HazelcastInstance} is created with default configuration once
@@ -141,7 +138,6 @@ import java.util.Properties;
  * cache.put("a", "b");
  * </pre>
  * </blockquote>
- * </p>
  *
  * @since 3.4
  */

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -107,7 +107,7 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.client.invocation.backoff.timeout.millis", -1, MILLISECONDS);
 
     /**
-     * <p>Enables the Discovery SPI/p>
+     * <p>Enables the Discovery SPI</p>
      * <p>Discovery SPI is <b>disabled</b> by default</p>
      */
     public static final HazelcastProperty DISCOVERY_SPI_ENABLED
@@ -240,9 +240,9 @@ public final class ClientProperty {
     /**
      * Enables/disables metrics collection altogether. This is a master
      * switch for all metrics related functionality.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link ClientMetricsConfig#isEnabled()}.
-     * <p/>
+     * <p>
      * Using {@link ClientMetricsConfig#setEnabled(boolean)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is
@@ -255,9 +255,9 @@ public final class ClientProperty {
 
     /**
      * Enables/disables exposing metrics on JMX.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link MetricsJmxConfig#isEnabled()}.
-     * <p/>
+     * <p>
      * Using {@link MetricsJmxConfig#setEnabled(boolean)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is
@@ -277,9 +277,9 @@ public final class ClientProperty {
 
     /**
      * Sets the metrics collection frequency in seconds.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link ClientMetricsConfig#getCollectionFrequencySeconds()}.
-     * <p/>
+     * <p>
      * Using {@link ClientMetricsConfig#setCollectionFrequencySeconds(int)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is

--- a/hazelcast/src/main/java/com/hazelcast/config/BaseMetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/BaseMetricsConfig.java
@@ -52,7 +52,7 @@ public abstract class BaseMetricsConfig<T extends BaseMetricsConfig> {
      * Sets whether metrics collection should be enabled for the node. If
      * enabled, Hazelcast Management Center will be able to connect to this
      * member. It's enabled by default.
-     * <p/>
+     * <p>
      * May be overridden by {@link ClusterProperty#METRICS_ENABLED}
      * system property.
      */
@@ -84,7 +84,7 @@ public abstract class BaseMetricsConfig<T extends BaseMetricsConfig> {
      * Sets the metrics collection frequency in seconds. The same interval is
      * used for collection for Management Center and for JMX publisher. By default,
      * metrics are collected every 5 seconds.
-     * <p/>
+     * <p>
      * May be overridden by {@link ClusterProperty#METRICS_COLLECTION_FREQUENCY}
      * system property.
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -43,7 +43,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
  * <ul>
  * <li>{@link EvictionPolicy#LRU} as eviction policy</li>
  * <li>{@link MaxSizePolicy#ENTRY_COUNT} as max size policy</li>
- * <li>{@value MapConfig#DEFAULT_MAX_SIZE as maximum
+ * <li>{@value MapConfig#DEFAULT_MAX_SIZE} as maximum
  * size for on-heap {@link com.hazelcast.map.IMap}</li>
  * <li>{@value DEFAULT_MAX_ENTRY_COUNT} as maximum size
  *      for all other data structures and configurations</li>

--- a/hazelcast/src/main/java/com/hazelcast/config/MetricsJmxConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetricsJmxConfig.java
@@ -38,7 +38,7 @@ public class MetricsJmxConfig {
     /**
      * Returns whether metrics will be exposed through JMX MBeans. It's
      * enabled by default.
-     * <p/>
+     * <p>
      * This configuration acts as a fine-tuning option beyond
      * enabling/disabling the Metrics collection entirely via the
      * {@link MetricsConfig#isEnabled()} master switch.
@@ -54,11 +54,11 @@ public class MetricsJmxConfig {
      * Enables metrics exposure through JMX. It's enabled by default. Metric
      * values are collected in the {@link MetricsConfig#getCollectionFrequencySeconds()}
      * metric collection interval} and written to a set of MBeans.
-     * <p/>
+     * <p>
      * This configuration acts as a fine-tuning option beyond
      * enabling/disabling the Metrics collection entirely via the {@link #enabled}
      * master switch.
-     * <p/>
+     * <p>
      * May be overridden by {@link ClusterProperty#METRICS_JMX_ENABLED}
      * system property.
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/MetricsManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetricsManagementCenterConfig.java
@@ -47,7 +47,7 @@ public class MetricsManagementCenterConfig {
      * Returns whether metrics will be exposed to Hazelcast Management
      * Center. If enabled, Hazelcast Management Center will be able to read
      * out the collected metrics from this member. It's enabled by default.
-     * <p/>
+     * <p>
      * This configuration acts as a fine-tuning option beyond
      * enabling/disabling the Metrics collection entirely via the
      * {@link MetricsConfig#isEnabled()} master switch.
@@ -63,11 +63,11 @@ public class MetricsManagementCenterConfig {
      * Enables exposing metrics to Hazelcast Management Center. If enabled,
      * Hazelcast Management Center will be able to read out the recorded
      * metrics from this member. It's enabled by default.
-     * <p/>
+     * <p>
      * This configuration acts as a fine-tuning option beyond
      * enabling/disabling the Metrics collection entirely via the {@link #enabled}
      * master switch.
-     * <p/>
+     * <p>
      * May be overridden by {@link ClusterProperty#METRICS_MC_ENABLED}
      * system property.
      *
@@ -95,7 +95,7 @@ public class MetricsManagementCenterConfig {
      * is used). More retention means more heap memory, but allows for longer
      * client hiccups without losing a value (for example to restart the
      * Management Center).
-     * <p/>
+     * <p>
      * May be overridden by {@link ClusterProperty#METRICS_MC_RETENTION}
      * system property.
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
@@ -125,7 +125,7 @@ public class UserCodeDeploymentConfig {
      * Default: {@code null}
      *
      * @return this instance of UserCodeDeploymentConfig for easy method-chaining
-     * @see Member#setAttribute(String, String)
+     * @see Member#getAttribute(String)
      */
     public UserCodeDeploymentConfig setProviderFilter(String providerFilter) {
         this.providerFilter = providerFilter;

--- a/hazelcast/src/main/java/com/hazelcast/core/Offloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Offloadable.java
@@ -29,7 +29,6 @@ import com.hazelcast.spi.impl.executionservice.ExecutionService;
  * <ul>
  *     <li>{@link IMap#executeOnKey(Object, EntryProcessor)}</li>
  *     <li>{@link IMap#submitToKey(Object, EntryProcessor)} </li>
- *     <li>{@link IMap#submitToKey(Object, EntryProcessor, ExecutionCallback)} </li>
  * </ul>
  */
 @FunctionalInterface

--- a/hazelcast/src/main/java/com/hazelcast/core/ReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ReadOnly.java
@@ -29,7 +29,6 @@ import com.hazelcast.map.IMap;
  * <ul>
  * <li>{@link EntryProcessor} passed to {@link IMap#executeOnKey(Object, EntryProcessor)}</li>
  * <li>{@link EntryProcessor} passed to {@link IMap#submitToKey(Object, EntryProcessor)} </li>
- * <li>{@link EntryProcessor} passed to {@link IMap#submitToKey(Object, EntryProcessor, ExecutionCallback)} </li>
  * </ul>
  *
  * @see Offloadable

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1005,9 +1005,9 @@ public final class ClusterProperty {
     /**
      * Enables/disables metrics collection altogether. This is a master
      * switch for all metrics related functionality.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link MetricsConfig#isEnabled()}.
-     * <p/>
+     * <p>
      * Using {@link MetricsConfig#setEnabled(boolean)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is
@@ -1021,9 +1021,9 @@ public final class ClusterProperty {
     /**
      * Enables/disables collecting metrics for Management Center. If disabled,
      * Management Center can't consume the metrics from this member.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link MetricsManagementCenterConfig#isEnabled()}.
-     * <p/>
+     * <p>
      * Using {@link MetricsManagementCenterConfig#setEnabled(boolean)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is
@@ -1037,9 +1037,9 @@ public final class ClusterProperty {
     /**
      * Sets the duration in seconds for which the collected metrics are retained
      * and Management Center can consume them.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link MetricsManagementCenterConfig#getRetentionSeconds()}.
-     * <p/>
+     * <p>
      * Using {@link MetricsManagementCenterConfig#setRetentionSeconds(int)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is
@@ -1052,9 +1052,9 @@ public final class ClusterProperty {
 
     /**
      * Enables/disables exposing metrics on JMX.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link MetricsJmxConfig#isEnabled()}.
-     * <p/>
+     * <p>
      * Using {@link MetricsJmxConfig#setEnabled(boolean)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is
@@ -1081,9 +1081,9 @@ public final class ClusterProperty {
 
     /**
      * Sets the metrics collection frequency in seconds.
-     * <p/>
+     * <p>
      * NOTE: This property overrides {@link MetricsConfig#getCollectionFrequencySeconds()}.
-     * <p/>
+     * <p>
      * Using {@link MetricsConfig#setCollectionFrequencySeconds(int)} and the declarative
      * counterparts are preferred over using this property. The main purpose
      * of making metrics collection configurable from properties too is


### PR DESCRIPTION
Fixed ill-formed markup and non-existent references