### PR TITLE
Avoid NPE on not-yet-built indexes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -65,6 +65,8 @@ import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest.newQueryCacheRequest;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+
 
 /**
  * Default implementation of {@link com.hazelcast.map.QueryCache QueryCache} interface which holds actual data.
@@ -333,7 +335,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<K> resultingSet = new HashSet<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate, -1);
+        Set<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 K key = toObject(entry.getKeyData());
@@ -352,7 +354,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         Set<Map.Entry<K, V>> resultingSet = new HashSet<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate, -1);
+        Set<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 Map.Entry<K, V> copyEntry = new CachedQueryEntry<>(serializationService, entry.getKeyData(),
@@ -375,7 +377,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         List<Data> resultingList = new ArrayList<>();
 
-        Set<QueryableEntry> query = indexes.query(predicate, -1);
+        Set<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query != null) {
             for (QueryableEntry entry : query) {
                 resultingList.add(entry.getValueData());

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
@@ -29,9 +29,9 @@ public class GlobalQueryContextProvider implements QueryContextProvider {
     };
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
         QueryContext queryContext = QUERY_CONTEXT.get();
-        queryContext.attachTo(indexes);
+        queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
@@ -29,9 +29,9 @@ public class GlobalQueryContextProviderWithStats implements QueryContextProvider
     };
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
         GlobalQueryContextWithStats queryContext = QUERY_CONTEXT.get();
-        queryContext.attachTo(indexes);
+        queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -37,8 +37,8 @@ public class GlobalQueryContextWithStats extends QueryContext {
     private final HashSet<QueryTrackingIndex> trackedIndexes = new HashSet<>(8);
 
     @Override
-    void attachTo(Indexes indexes) {
-        super.attachTo(indexes);
+    void attachTo(Indexes indexes, int ownedPartitionCount) {
+        super.attachTo(indexes, ownedPartitionCount);
         for (QueryTrackingIndex trackedIndex : trackedIndexes) {
             trackedIndex.resetPerQueryStats();
         }
@@ -53,7 +53,7 @@ public class GlobalQueryContextWithStats extends QueryContext {
     }
 
     @Override
-    public Index matchIndex(String pattern, IndexMatchHint matchHint, int ownedPartitionCount) {
+    public Index matchIndex(String pattern, IndexMatchHint matchHint) {
         InternalIndex delegate = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (delegate == null) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -45,6 +45,12 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 @SuppressWarnings("checkstyle:finalclass")
 public class Indexes {
 
+    /**
+     * The partitions count check detects a race condition when a
+     * query is executed on the index which is under (re)construction.
+     * The negative value means the check should be skipped.
+     */
+    public static final int SKIP_PARTITIONS_COUNT_CHECK = -1;
     private static final InternalIndex[] EMPTY_INDEXES = {};
 
     private final boolean global;
@@ -317,12 +323,12 @@ public class Indexes {
         }
 
         IndexAwarePredicate indexAwarePredicate = (IndexAwarePredicate) predicate;
-        QueryContext queryContext = queryContextProvider.obtainContextFor(this);
-        if (!indexAwarePredicate.isIndexed(queryContext, ownedPartitionCount)) {
+        QueryContext queryContext = queryContextProvider.obtainContextFor(this, ownedPartitionCount);
+        if (!indexAwarePredicate.isIndexed(queryContext)) {
             return null;
         }
 
-        Set<QueryableEntry> result = indexAwarePredicate.filter(queryContext, ownedPartitionCount);
+        Set<QueryableEntry> result = indexAwarePredicate.filter(queryContext);
         if (result != null) {
             stats.incrementIndexedQueryCount();
             queryContext.applyPerQueryStats();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
@@ -29,12 +29,13 @@ public class PartitionQueryContextProvider implements QueryContextProvider {
      * @param indexes the indexes to construct the new query context for.
      */
     public PartitionQueryContextProvider(Indexes indexes) {
-        queryContext = new QueryContext(indexes);
+        queryContext = new QueryContext(indexes, 1);
     }
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
         assert indexes == queryContext.indexes;
+        assert queryContext.ownedPartitionCount == 1 && ownedPartitionCount == 1;
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
@@ -34,8 +34,9 @@ public class PartitionQueryContextProviderWithStats implements QueryContextProvi
     }
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes) {
-        queryContext.attachTo(indexes);
+    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
+        assert queryContext.ownedPartitionCount == 1 && ownedPartitionCount == 1;
+        queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -34,12 +34,13 @@ public class PartitionQueryContextWithStats extends QueryContext {
      * @param indexes the indexes to construct the new query context for.
      */
     public PartitionQueryContextWithStats(Indexes indexes) {
-        super(indexes);
+        super(indexes, 1);
     }
 
     @Override
-    void attachTo(Indexes indexes) {
+    void attachTo(Indexes indexes, int ownedPartitionCount) {
         assert indexes == this.indexes;
+        assert ownedPartitionCount == 1 && this.ownedPartitionCount == 1;
         for (PerIndexStats stats : trackedStats) {
             stats.resetPerQueryStats();
         }
@@ -54,7 +55,7 @@ public class PartitionQueryContextWithStats extends QueryContext {
     }
 
     @Override
-    public Index matchIndex(String pattern, IndexMatchHint matchHint, int ownedPartitionCount) {
+    public Index matchIndex(String pattern, IndexMatchHint matchHint) {
         InternalIndex index = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (index == null) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
@@ -109,19 +109,19 @@ public class PredicateBuilderImpl
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
         Predicate p = lsPredicates.get(0);
         if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).filter(queryContext, ownedPartitionCount);
+            return ((IndexAwarePredicate) p).filter(queryContext);
         }
         return null;
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+    public boolean isIndexed(QueryContext queryContext) {
         Predicate p = lsPredicates.get(0);
         if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).isIndexed(queryContext, ownedPartitionCount);
+            return ((IndexAwarePredicate) p).isIndexed(queryContext);
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -22,14 +22,16 @@ package com.hazelcast.query.impl;
 public class QueryContext {
 
     protected Indexes indexes;
+    protected int ownedPartitionCount = -1;
 
     /**
      * Creates a new query context with the given available indexes.
      *
      * @param indexes the indexes available for the query context.
      */
-    public QueryContext(Indexes indexes) {
+    public QueryContext(Indexes indexes, int ownedPartitionCount) {
         this.indexes = indexes;
+        this.ownedPartitionCount = ownedPartitionCount;
     }
 
     /**
@@ -39,12 +41,31 @@ public class QueryContext {
     }
 
     /**
+     * @return a count of owned partitions a query runs on.
+     */
+    public int getOwnedPartitionCount() {
+        return ownedPartitionCount;
+    }
+
+    /**
+     * Sets owned partitions count a query runs on.
+     * @param ownedPartitionCount a count of owned partitions.
+     */
+    public void setOwnedPartitionCount(int ownedPartitionCount) {
+        this.ownedPartitionCount = ownedPartitionCount;
+    }
+
+    /**
      * Attaches this index context to the given indexes.
      *
      * @param indexes the indexes to attach to.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
+     *
      */
-    void attachTo(Indexes indexes) {
+    void attachTo(Indexes indexes, int ownedPartitionCount) {
         this.indexes = indexes;
+        this.ownedPartitionCount = ownedPartitionCount;
     }
 
     /**
@@ -59,13 +80,11 @@ public class QueryContext {
      * context.
      *
      * @param attribute the attribute to obtain the index for.
-     * @param ownedPartitionCount a count of owned partitions a query runs on.
-     * Negative value indicates that the value is not defined.
      * @return the obtained index or {@code null} if there is no index available
      * for the given attribute.
      */
-    public Index getIndex(String attribute, int ownedPartitionCount) {
-        return matchIndex(attribute, IndexMatchHint.NONE, ownedPartitionCount);
+    public Index getIndex(String attribute) {
+        return matchIndex(attribute, IndexMatchHint.NONE);
     }
 
     /**
@@ -74,12 +93,10 @@ public class QueryContext {
      * @param pattern   the pattern to match an index for. May be either an
      *                  attribute name or an exact index name.
      * @param matchHint the match hint.
-     * @param ownedPartitionCount a count of owned partitions a query runs on.
-     * Negative value indicates that the value is not defined.
      * @return the matched index or {@code null} if nothing matched.
      * @see QueryContext.IndexMatchHint
      */
-    public Index matchIndex(String pattern, IndexMatchHint matchHint, int ownedPartitionCount) {
+    public Index matchIndex(String pattern, IndexMatchHint matchHint) {
         return indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
@@ -27,9 +27,11 @@ public interface QueryContextProvider {
      * The returned query context instance is valid for a duration of a single
      * query and should be re-obtained for every query.
      *
-     * @param indexes the indexes to obtain the query context for.
+     * @param indexes             the indexes to obtain the query context for.
+     * @param ownedPartitionCount a count of owned partitions a query runs on.
+     *                            Negative value indicates that the value is not defined.
      * @return the obtained query context.
      */
-    QueryContext obtainContextFor(Indexes indexes);
+    QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -30,17 +30,17 @@ public abstract class AbstractIndexAwarePredicate<K, V> extends AbstractPredicat
         super(attributeName);
     }
 
-    protected Index getIndex(QueryContext queryContext, int ownedPartitionCount) {
-        return matchIndex(queryContext, QueryContext.IndexMatchHint.NONE, ownedPartitionCount);
+    protected Index getIndex(QueryContext queryContext) {
+        return matchIndex(queryContext, QueryContext.IndexMatchHint.NONE);
     }
 
-    protected Index matchIndex(QueryContext queryContext, QueryContext.IndexMatchHint matchHint, int ownedPartitionCount) {
-        return queryContext.matchIndex(attributeName, matchHint, ownedPartitionCount);
+    protected Index matchIndex(QueryContext queryContext, QueryContext.IndexMatchHint matchHint) {
+        return queryContext.matchIndex(attributeName, matchHint);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
-        return getIndex(queryContext, ownedPartitionCount) != null;
+    public boolean isIndexed(QueryContext queryContext) {
+        return getIndex(queryContext) != null;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -68,8 +68,11 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate implements Vis
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(from, true, to, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
@@ -65,8 +65,11 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeEqualPredicate.java
@@ -80,8 +80,11 @@ public class CompositeEqualPredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(value);
     }
 
@@ -91,7 +94,7 @@ public class CompositeEqualPredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+    public boolean isIndexed(QueryContext queryContext) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeRangePredicate.java
@@ -115,13 +115,16 @@ public class CompositeRangePredicate implements IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(from, fromInclusive, to, toInclusive);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+    public boolean isIndexed(QueryContext queryContext) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -61,8 +61,11 @@ public class EqualPredicate extends AbstractIndexAwarePredicate
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED);
+        if (index == null) {
+            return null;
+        }
         return index.getRecords(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluatePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluatePredicate.java
@@ -71,14 +71,17 @@ public final class EvaluatePredicate implements Predicate, IndexAwarePredicate {
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, ownedPartitionCount);
-        return index == null ? null : index.evaluate(predicate);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME);
+        if (index == null) {
+            return null;
+        }
+        return index.evaluate(predicate);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
-        return true;
+    public boolean isIndexed(QueryContext queryContext) {
+        return queryContext.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME) != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+
 /**
  * Tries to divide the predicate tree into isolated subtrees every of which can
  * be evaluated by {@link Index#evaluate} method in a single go.
@@ -51,7 +53,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, -1);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(andPredicate.getClass())) {
                 continue;
             }
@@ -85,7 +87,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, -1);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(andPredicate.getClass())) {
                 output.add(subPredicate);
             }
@@ -128,7 +130,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, -1);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(orPredicate.getClass())) {
                 continue;
             }
@@ -162,7 +164,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
             EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
             String indexName = evaluatePredicate.getIndexName();
-            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, -1);
+            Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
             if (!index.canEvaluate(orPredicate.getClass())) {
                 output.add(subPredicate);
             }
@@ -198,7 +200,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
         EvaluatePredicate evaluatePredicate = (EvaluatePredicate) subPredicate;
         String indexName = evaluatePredicate.getIndexName();
-        Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, -1);
+        Index index = indexes.matchIndex(indexName, QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK);
         if (!index.canEvaluate(notPredicate.getClass())) {
             return notPredicate;
         }
@@ -208,7 +210,8 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @Override
     public Predicate visit(EqualPredicate predicate, Indexes indexes) {
-        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED, -1);
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
             return predicate;
         }
@@ -227,7 +230,8 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @Override
     public Predicate visit(NotEqualPredicate predicate, Indexes indexes) {
-        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED, -1);
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
             return predicate;
         }
@@ -246,7 +250,8 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @Override
     public Predicate visit(InPredicate predicate, Indexes indexes) {
-        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED, -1);
+        Index index = indexes.matchIndex(predicate.attributeName, QueryContext.IndexMatchHint.PREFER_UNORDERED,
+                SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
             return predicate;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FalsePredicate.java
@@ -54,12 +54,12 @@ public class FalsePredicate<K, V> implements IdentifiedDataSerializable, IndexAw
     }
 
     @Override
-    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
         return Collections.emptySet();
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+    public boolean isIndexed(QueryContext queryContext) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -68,8 +68,11 @@ public final class GreaterLessPredicate extends AbstractIndexAwarePredicate impl
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_ORDERED);
+        if (index == null) {
+            return null;
+        }
         final Comparison comparison;
         if (less) {
             comparison = equal ? Comparison.LESS_OR_EQUAL : Comparison.LESS;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -85,8 +85,8 @@ public class InPredicate extends AbstractIndexAwarePredicate implements Visitabl
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Index index = matchIndex(queryContext, QueryContext.IndexMatchHint.PREFER_UNORDERED);
         if (index != null) {
             return index.getRecords(values);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/IndexAwarePredicate.java
@@ -62,11 +62,9 @@ public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
      * @param queryContext        the query context to access the indexes. The passed
      *                            query context is valid only for a duration of a single
      *                            call to the method.
-     * @param ownedPartitionCount a count of owned partitions a query runs on.
-     *                            Negative value indicates that the value is not defined.
      * @return the produced filtered entry set.
      */
-    Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount);
+    Set<QueryableEntry<K, V>> filter(QueryContext queryContext);
 
     /**
      * Signals to the query engine that this predicate is able to utilize the
@@ -74,10 +72,8 @@ public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
      *
      * @param queryContext        the query context to consult for the available
      *                            indexes.
-     * @param ownedPartitionCount a count of owned partitions a query runs on.
-     *                            Negative value indicates that the value is not defined.
      * @return {@code true} if this predicate is able to use the indexes to
      * speed up the processing, {@code false} otherwise.
      */
-    boolean isIndexed(QueryContext queryContext, int ownedPartitionCount);
+    boolean isIndexed(QueryContext queryContext);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -183,12 +183,12 @@ public class PagingPredicateImpl<K, V>
      * @return
      */
     @Override
-    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
         if (!(predicate instanceof IndexAwarePredicate)) {
             return null;
         }
 
-        Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext, ownedPartitionCount);
+        Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext);
         if (set == null || set.isEmpty()) {
             return set;
         }
@@ -212,9 +212,9 @@ public class PagingPredicateImpl<K, V>
      * @param queryContext
      * @return
      */
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+    public boolean isIndexed(QueryContext queryContext) {
         if (predicate instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, ownedPartitionCount);
+            return ((IndexAwarePredicate) predicate).isIndexed(queryContext);
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -91,16 +91,16 @@ public class SqlPredicate
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+    public boolean isIndexed(QueryContext queryContext) {
         if (predicate instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) predicate).isIndexed(queryContext, ownedPartitionCount);
+            return ((IndexAwarePredicate) predicate).isIndexed(queryContext);
         }
         return false;
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-        return ((IndexAwarePredicate) predicate).filter(queryContext, ownedPartitionCount);
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        return ((IndexAwarePredicate) predicate).filter(queryContext);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
@@ -162,12 +162,12 @@ public class ClientEntryProcessorTest extends AbstractClientMapTest {
         static final AtomicBoolean INDEX_CALLED = new AtomicBoolean(false);
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        public Set<QueryableEntry> filter(QueryContext queryContext) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+        public boolean isIndexed(QueryContext queryContext) {
             INDEX_CALLED.set(true);
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1291,13 +1291,13 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-            Index index = queryContext.getIndex(attributeName, ownedPartitionCount);
+        public Set<QueryableEntry> filter(QueryContext queryContext) {
+            Index index = queryContext.getIndex(attributeName);
             return index.getRecords(key);
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+        public boolean isIndexed(QueryContext queryContext) {
             return true;
         }
 
@@ -1426,12 +1426,12 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry<K, V>> filter(QueryContext queryContext, int ownedPartitionCount) {
+        public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+        public boolean isIndexed(QueryContext queryContext) {
             indexCalled.set(true);
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -42,14 +42,14 @@ class TestPredicate implements IndexAwarePredicate<String, TestData> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Set<QueryableEntry<String, TestData>> filter(QueryContext queryContext, int ownedPartitionCount) {
+    public Set<QueryableEntry<String, TestData>> filter(QueryContext queryContext) {
         filtered = true;
-        return (Set) queryContext.getIndex("attr1", ownedPartitionCount).getRecords(value);
+        return (Set) queryContext.getIndex("attr1").getRecords(value);
     }
 
     @Override
-    public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
-        return queryContext.getIndex("attr1", ownedPartitionCount) != null;
+    public boolean isIndexed(QueryContext queryContext) {
+        return queryContext.getIndex("attr1") != null;
     }
 
     boolean isFilteredAndApplied(int times) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -141,8 +141,8 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
-            Index ix = queryContext.getIndex("age", ownedPartitionCount);
+        public Set<QueryableEntry> filter(QueryContext queryContext) {
+            Index ix = queryContext.getIndex("age");
             if (ix != null) {
                 return ix.getRecords(Comparison.GREATER, 50);
             } else {
@@ -151,8 +151,8 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
-            Index ix = queryContext.getIndex("age", ownedPartitionCount);
+        public boolean isIndexed(QueryContext queryContext) {
+            Index ix = queryContext.getIndex("age");
             if (ix != null) {
                 isIndexedInvocationCounter.incrementAndGet();
                 return true;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
@@ -348,12 +348,12 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+        public Set<QueryableEntry> filter(QueryContext queryContext) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public boolean isIndexed(QueryContext queryContext, int ownedPartitionCount) {
+        public boolean isIndexed(QueryContext queryContext) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -112,10 +112,10 @@ public class QueryRunnerTest extends HazelcastTestSupport {
 
         Predicate predicate = new EqualPredicate("this", value) {
             @Override
-            public Set<QueryableEntry> filter(QueryContext queryContext, int ownedPartitionCount) {
+            public Set<QueryableEntry> filter(QueryContext queryContext) {
                 // start a new migration while executing an indexed query
                 mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
-                return super.filter(queryContext, ownedPartitionCount);
+                return super.filter(queryContext);
             }
         };
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
@@ -60,14 +60,14 @@ public class FalsePredicateTest extends HazelcastTestSupport {
     public void isIndexed() {
         QueryContext queryContext = mock(QueryContext.class);
 
-        assertTrue(FalsePredicate.INSTANCE.isIndexed(queryContext, -1));
+        assertTrue(FalsePredicate.INSTANCE.isIndexed(queryContext));
     }
 
     @Test
     public void filter() {
         QueryContext queryContext = mock(QueryContext.class);
 
-        Set<QueryableEntry> result = FalsePredicate.INSTANCE.filter(queryContext, -1);
+        Set<QueryableEntry> result = FalsePredicate.INSTANCE.filter(queryContext);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexConcurrencyTest.java
@@ -17,27 +17,53 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.predicates.SqlPredicate;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.config.IndexType.BITMAP;
+import static com.hazelcast.config.IndexType.SORTED;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.greaterThan;
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.Predicates.in;
+import static com.hazelcast.query.Predicates.like;
+import static com.hazelcast.query.Predicates.between;
+import static com.hazelcast.query.Predicates.lessEqual;
+import static com.hazelcast.query.Predicates.lessThan;
+import static com.hazelcast.query.Predicates.greaterEqual;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class IndexConcurrencyTest extends AbstractIndexConcurrencyTest {
+
+    @Parameterized.Parameters(name = "indexAttribute: {0}, indexType: {1}")
+    public static Collection<Object[]> parameters() {
+        // @formatter:off
+        return asList(new Object[][]{
+                {"age", SORTED},
+                {"age", BITMAP},
+                {"name", SORTED}
+        });
+        // @formatter:on
+    }
 
     @Override
     protected Config getConfig() {
@@ -63,7 +89,7 @@ public class IndexConcurrencyTest extends AbstractIndexConcurrencyTest {
         AtomicReference<Throwable> exception = new AtomicReference<>();
         Thread indexer = new Thread(() -> {
             try {
-                map.addIndex(IndexType.SORTED, "age");
+                map.addIndex(indexType, indexAttribute);
             } catch (Throwable t) {
                 exception.compareAndSet(null, t);
             }
@@ -75,8 +101,18 @@ public class IndexConcurrencyTest extends AbstractIndexConcurrencyTest {
         Person.accessCountDown = null;
 
         // run checking query
-        Collection<Person> persons = map.values(new SqlPredicate("age >= 5000"));
-        assertEquals(5000, persons.size());
+        assertQuery(map, new SqlPredicate("age >= 5000"), 5000);
+        assertQuery(map, equal("age", "6000"), 1);
+        assertQuery(map, greaterThan("age", "6000"), 3999);
+        assertQuery(map, and(greaterThan("age", 6000), lessThan("age", 7000)), 999);
+        assertQuery(map, or(equal("age", 6000), equal("age", 7000)), 2);
+        assertQuery(map, greaterEqual("age", 5000), 5000);
+        assertQuery(map, lessThan("age", 9000), 9000);
+        assertQuery(map, lessEqual("age", 9000), 9001);
+        assertQuery(map, between("age", 9000, 10000), 1000);
+        assertQuery(map, in("age", 5000, 6000, 7000, 11111), 3);
+        assertQuery(map, equal("age", "6000"), 1);
+        assertQuery(map, like("name", "9999"), 1);
 
         // open indexer latch
         Person.indexerLatch.countDown();
@@ -86,6 +122,11 @@ public class IndexConcurrencyTest extends AbstractIndexConcurrencyTest {
 
         // assert no unexpected exceptions
         assertNull(exception.get());
+    }
+
+    private void assertQuery(IMap<Integer, Person> map, Predicate predicate, int expected) {
+        Collection<Person> persons = map.values(predicate);
+        assertEquals(expected, persons.size());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -18,13 +18,14 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.AndPredicate;
 import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -78,9 +80,9 @@ public class IndexJsonTest {
         assertEquals(0, numberIndex.getRecords(-1).size());
         assertEquals(1001, stringIndex.getRecords("sancar").size());
         assertEquals(501, boolIndex.getRecords(true).size());
-        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true")), -1).size());
-        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true)), -1).size());
-        assertEquals(1001, is.query(Predicates.sql("name == sancar"), -1).size());
+        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true")), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true)), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(1001, is.query(new SqlPredicate("name == sancar"), SKIP_PARTITIONS_COUNT_CHECK).size());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.instance.impl.TestUtil.toData;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -184,9 +185,9 @@ public class IndexTest {
         assertEquals(401, dIndex.getRecords(Comparison.GREATER_OR_EQUAL, 600d).size());
         assertEquals(9, dIndex.getRecords(Comparison.LESS, 10d).size());
         assertEquals(10, dIndex.getRecords(Comparison.LESS_OR_EQUAL, 10d).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")), -1).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)), -1).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)), -1).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)), SKIP_PARTITIONS_COUNT_CHECK).size());
+        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)), SKIP_PARTITIONS_COUNT_CHECK).size());
     }
 
     private void clearIndexes(Index... indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -20,13 +20,13 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.PredicateBuilder.EntryObject;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
 import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.predicates.SqlPredicate;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.instance.impl.TestUtil.toData;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -87,7 +88,7 @@ public class IndexesTest {
         EntryObject entryObject = Predicates.newPredicateBuilder().getEntryObject();
         PredicateBuilder predicate =
                 entryObject.get("name").equal("0Name").and(entryObject.get("age").in(ages.toArray(new String[0])));
-        Set<QueryableEntry> results = indexes.query(predicate, -1);
+        Set<QueryableEntry> results = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         assertEquals(1, results.size());
     }
 
@@ -104,8 +105,8 @@ public class IndexesTest {
         }
 
         for (int i = 0; i < 10; i++) {
-            Predicate predicate = Predicates.sql("salary=161 and age >20 and age <23");
-            Set<QueryableEntry> results = new HashSet<>(indexes.query(predicate, -1));
+            SqlPredicate predicate = new SqlPredicate("salary=161 and age >20 and age <23");
+            Set<QueryableEntry> results = new HashSet<QueryableEntry>(indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK));
             assertEquals(5, results.size());
         }
     }
@@ -132,7 +133,7 @@ public class IndexesTest {
                 Index.OperationSource.USER);
         indexes.putEntry(new QueryEntry(serializationService, toData(9), new Value("qwx"), newExtractor()), null,
                 Index.OperationSource.USER);
-        assertEquals(8, new HashSet<>(indexes.query(Predicates.sql("name > 'aac'"), -1)).size());
+        assertEquals(8, new HashSet<QueryableEntry>(indexes.query(new SqlPredicate("name > 'aac'"), SKIP_PARTITIONS_COUNT_CHECK)).size());
     }
 
     protected Extractors newExtractor() {
@@ -166,7 +167,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), -1);
+        Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "), SKIP_PARTITIONS_COUNT_CHECK);
 
         assertNull("There should be no result", query);
     }
@@ -182,7 +183,7 @@ public class IndexesTest {
                     Index.OperationSource.USER);
         }
 
-        Set<QueryableEntry> query = indexes.query(Predicates.sql("__key > 10 "), -1);
+        Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "), SKIP_PARTITIONS_COUNT_CHECK);
 
         assertEquals(89, query.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
@@ -44,6 +44,7 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.not;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -80,30 +81,30 @@ public class EvaluateVisitorTest {
                 (Answer<Boolean>) invocation -> EVALUABLE_PREDICATES.contains(invocation.getArgument(0)));
         when(bitmapA.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
         when(bitmapA.getName()).thenReturn("a");
-        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.EXACT_NAME, -1)).thenReturn(bitmapA);
-        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.PREFER_UNORDERED, -1)).thenReturn(bitmapA);
+        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapA);
+        when(indexes.matchIndex("a", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapA);
 
         InternalIndex bitmapB = mock(InternalIndex.class);
         when(bitmapB.canEvaluate(any())).then(
                 (Answer<Boolean>) invocation -> EVALUABLE_PREDICATES.contains(invocation.getArgument(0)));
         when(bitmapB.getConverter()).thenReturn(TypeConverters.STRING_CONVERTER);
         when(bitmapB.getName()).thenReturn("b");
-        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.EXACT_NAME, -1)).thenReturn(bitmapB);
-        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.PREFER_UNORDERED, -1)).thenReturn(bitmapB);
+        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapB);
+        when(indexes.matchIndex("b", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapB);
 
         InternalIndex regular = mock(InternalIndex.class);
         when(regular.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);
         when(regular.canEvaluate(any())).thenReturn(false);
-        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.EXACT_NAME, -1)).thenReturn(regular);
-        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.PREFER_UNORDERED, -1)).thenReturn(regular);
+        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(regular);
+        when(indexes.matchIndex("r", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(regular);
 
         InternalIndex bitmapNoConverter = mock(InternalIndex.class);
         when(bitmapNoConverter.getName()).thenReturn("nc");
         when(bitmapNoConverter.getConverter()).thenReturn(null);
         when(bitmapNoConverter.canEvaluate(any())).then(
                 (Answer<Boolean>) invocation -> EVALUABLE_PREDICATES.contains(invocation.getArgument(0)));
-        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.EXACT_NAME, -1)).thenReturn(bitmapNoConverter);
-        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.PREFER_UNORDERED, -1)).thenReturn(bitmapNoConverter);
+        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoConverter);
+        when(indexes.matchIndex("nc", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoConverter);
 
         InternalIndex bitmapNoSubPredicates = mock(InternalIndex.class);
         when(bitmapNoSubPredicates.getName()).thenReturn("ns");
@@ -112,8 +113,8 @@ public class EvaluateVisitorTest {
             Object clazz = invocation.getArgument(0);
             return !(clazz == AndPredicate.class || clazz == OrPredicate.class || clazz == NotPredicate.class);
         });
-        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.EXACT_NAME, -1)).thenReturn(bitmapNoSubPredicates);
-        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.PREFER_UNORDERED, -1)).thenReturn(bitmapNoSubPredicates);
+        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.EXACT_NAME, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoSubPredicates);
+        when(indexes.matchIndex("ns", QueryContext.IndexMatchHint.PREFER_UNORDERED, SKIP_PARTITIONS_COUNT_CHECK)).thenReturn(bitmapNoSubPredicates);
 
         visitor = new EvaluateVisitor();
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -105,12 +105,12 @@ public class PredicatesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext, int ownedPartitionCount) {
+        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext) {
             return null;
         }
 
         @Override
-        public boolean isIndexed(final QueryContext queryContext, int ownedPartitionCount) {
+        public boolean isIndexed(final QueryContext queryContext) {
             return false;
         }
     }


### PR DESCRIPTION
Check that the matched index might be null in the query engine and if
so, don't try to use it. The fix is a follow-up of the
https://github.com/hazelcast/hazelcast/issues/16311 issue.

Fixes: https://github.com/hazelcast/hazelcast/issues/16466