### PR TITLE
Make member metrics JMX exposure to respect JMX sysprop

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -31,6 +31,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.LiveOperations;
 import com.hazelcast.spi.impl.operationservice.LiveOperationsTracker;
+import com.hazelcast.spi.properties.ClusterProperty;
 
 import java.util.Map;
 import java.util.Properties;
@@ -91,13 +92,14 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
+        boolean jmxEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.ENABLE_JMX);
         if (config.isEnabled()) {
 
             if (config.getManagementCenterConfig().isEnabled()) {
                 publishers.add(createMcPublisher());
             }
 
-            if (config.getJmxConfig().isEnabled()) {
+            if (jmxEnabled && config.getJmxConfig().isEnabled()) {
                 publishers.add(createJmxPublisher());
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.JmxLeakHelper;
@@ -112,6 +113,7 @@ public class MetricsServiceTest extends HazelcastTestSupport {
         when(nodeEngineMock.getLogger(any(Class.class))).thenReturn(loggerMock);
         when(nodeEngineMock.getMetricsRegistry()).thenReturn(metricsRegistry);
         when(nodeEngineMock.getHazelcastInstance()).thenReturn(hzMock);
+        when(nodeEngineMock.getProperties()).thenReturn(new HazelcastProperties(System.getProperties()));
         when(hzMock.getName()).thenReturn("mockInstance");
 
         executionService = new ExecutionServiceImpl(nodeEngineMock);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -205,7 +205,6 @@ public class JmxPublisherTest {
 
     private void when_badCharacters_then_escaped(String badText) throws Exception {
         // we must be able to work with any crazy user input
-        System.out.println("badText: " + badText);
         jmxPublisher.publishLong(newDescriptor()
                 .withPrefix(badText)
                 .withMetric("metric"), 1L);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
@@ -46,6 +46,7 @@ public class MemberJmxMetricsTest {
 
     @Before
     public void setUp() throws Exception {
+        System.clearProperty(ClusterProperty.ENABLE_JMX.getName());
         helper = new JmxPublisherTestHelper(DOMAIN_PREFIX);
         helper.assertNoMBeans();
     }


### PR DESCRIPTION
This change makes metrics and other MBean exposures consistent. Before, metrics MBeans did not respect the `hazelcast.jmx` property, and those MBeans were exposed even if JMX was not enabled. Now, both the JMX config and the `hazelcast.jmx` property needs to be set to expose the metrics.

On the client side there is no such property, therefore, enabling JMX exposure for metrics in the config is still enough.