### PR TITLE
Do not serialize optimize-queries option in MapConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -876,7 +876,6 @@ public class ConfigXmlGenerator {
             gen.open("map", "name", m.getName())
                     .node("in-memory-format", m.getInMemoryFormat())
                     .node("statistics-enabled", m.isStatisticsEnabled())
-                    .node("optimize-queries", m.isOptimizeQueries())
                     .node("cache-deserialized-values", cacheDeserializedVal)
                     .node("backup-count", m.getBackupCount())
                     .node("async-backup-count", m.getAsyncBackupCount())

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -822,8 +822,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         if (!setCacheDeserializedValuesExplicitlyInvoked) {
             return;
         }
-        if ((cacheDeserializedValues == CacheDeserializedValues.INDEX_ONLY
-                || cacheDeserializedValues == CacheDeserializedValues.NEVER) && optimizeQueries) {
+        if (cacheDeserializedValues != CacheDeserializedValues.ALWAYS && optimizeQueries) {
             throw new ConfigurationException("Deprecated option 'optimize-queries' is being set to true, "
                     + "but 'cacheDeserializedValues' was set to NEVER or INDEX_ONLY. "
                     + "These are conflicting options. Please remove the `optimize-queries'");
@@ -864,7 +863,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
                     + " These are conflicting options. Please remove the `optimize-queries'");
         } else if (!optimizeQueryFlag && newValue == CacheDeserializedValues.ALWAYS) {
             throw new ConfigurationException("Deprecated option 'optimize-queries' is set to `false`, "
-                    + "but 'cacheDeserializedValues' is begin set to ALWAYS. These are conflicting options."
+                    + "but 'cacheDeserializedValues' is being set to ALWAYS. These are conflicting options."
                     + " Please remove the `optimize-queries'");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -822,17 +822,14 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         if (!setCacheDeserializedValuesExplicitlyInvoked) {
             return;
         }
-        if (cacheDeserializedValues == CacheDeserializedValues.INDEX_ONLY) {
-            throw new ConfigurationException("Deprecated option 'optimize-queries' is being set"
-                    + ", but 'cacheDeserializedValues' was set to INDEX_ONLY. "
-                    + "These are conflicting options. Please remove the `optimize-queries'");
-        } else if (cacheDeserializedValues == CacheDeserializedValues.NEVER && optimizeQueries) {
+        if ((cacheDeserializedValues == CacheDeserializedValues.INDEX_ONLY
+                || cacheDeserializedValues == CacheDeserializedValues.NEVER) && optimizeQueries) {
             throw new ConfigurationException("Deprecated option 'optimize-queries' is being set to true, "
-                    + "but 'cacheDeserializedValues' is set to NEVER. "
+                    + "but 'cacheDeserializedValues' was set to NEVER or INDEX_ONLY. "
                     + "These are conflicting options. Please remove the `optimize-queries'");
         } else if (cacheDeserializedValues == CacheDeserializedValues.ALWAYS && !optimizeQueries) {
             throw new ConfigurationException("Deprecated option 'optimize-queries' is being set to false, "
-                    + "but 'cacheDeserializedValues' is set to ALWAYS. "
+                    + "but 'cacheDeserializedValues' was set to ALWAYS. "
                     + "These are conflicting options. Please remove the `optimize-queries'");
         }
     }
@@ -852,7 +849,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         return this;
     }
 
-    private void validateCacheDeserializedValuesOption(CacheDeserializedValues validatedCacheDeserializedValues) {
+    private void validateCacheDeserializedValuesOption(CacheDeserializedValues newValue) {
         if (!optimizeQueryExplicitlyInvoked) {
             return;
         }
@@ -861,13 +858,13 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         // we need to be strict with validation to detect conflicts
         boolean optimizeQueryFlag = (cacheDeserializedValues == CacheDeserializedValues.ALWAYS);
 
-        if (optimizeQueryFlag && validatedCacheDeserializedValues != CacheDeserializedValues.ALWAYS) {
+        if (optimizeQueryFlag && newValue != CacheDeserializedValues.ALWAYS) {
             throw new ConfigurationException("Deprecated option 'optimize-queries' is set to `true`, "
                     + "but 'cacheDeserializedValues' is being set to NEVER or INDEX_ONLY."
                     + " These are conflicting options. Please remove the `optimize-queries'");
-        } else if (!optimizeQueryFlag && validatedCacheDeserializedValues != CacheDeserializedValues.NEVER) {
+        } else if (!optimizeQueryFlag && newValue == CacheDeserializedValues.ALWAYS) {
             throw new ConfigurationException("Deprecated option 'optimize-queries' is set to `false`, "
-                    + "but 'cacheDeserializedValues' is begin set to ALWAYS or INDEX_ONLY. These are conflicting options."
+                    + "but 'cacheDeserializedValues' is begin set to ALWAYS. These are conflicting options."
                     + " Please remove the `optimize-queries'");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -851,17 +851,19 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         if (optimizeQueryExplicitlyInvoked) {
             // deprecated {@link #setOptimizeQueries(boolean)} was explicitly invoked
             // we need to be strict with validation to detect conflicts
-            boolean optimizeQuerySet = (cacheDeserializedValues == CacheDeserializedValues.ALWAYS);
-            if (optimizeQuerySet && validatedCacheDeserializedValues == CacheDeserializedValues.NEVER) {
+            boolean optimizeQueryFlag = (cacheDeserializedValues == CacheDeserializedValues.ALWAYS);
+            if (!optimizeQueryFlag && validatedCacheDeserializedValues == CacheDeserializedValues.NEVER) {
+                // settings are compatible
+                return;
+            }
+            if (optimizeQueryFlag && validatedCacheDeserializedValues == CacheDeserializedValues.NEVER) {
                 throw new ConfigurationException("Deprecated option 'optimize-queries' is set to `true`, "
                         + "but 'cacheDeserializedValues' is set to NEVER. These are conflicting options. "
                         + "Please remove the `optimize-queries'");
             }
-
             if (cacheDeserializedValues != validatedCacheDeserializedValues) {
-                boolean optimizeQueriesFlagState = cacheDeserializedValues == CacheDeserializedValues.ALWAYS;
                 throw new ConfigurationException("Deprecated option 'optimize-queries' is set to "
-                        + optimizeQueriesFlagState + " but 'cacheDeserializedValues' is set to "
+                        + optimizeQueryFlag + " but 'cacheDeserializedValues' is set to "
                         + validatedCacheDeserializedValues + ". These are conflicting options. "
                         + "Please remove the `optimize-queries'");
             }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -851,7 +851,6 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getInMemoryFormat(), c2.getInMemoryFormat())
                     && nullSafeEqual(c1.getMetadataPolicy(), c2.getMetadataPolicy())
                     && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
-                    && nullSafeEqual(c1.isOptimizeQueries(), c2.isOptimizeQueries())
                     && nullSafeEqual(c1.getCacheDeserializedValues(), c2.getCacheDeserializedValues())
                     && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
                     && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -313,6 +313,26 @@ public class MapConfigTest {
     }
 
     @Test(expected = ConfigurationException.class)
+    public void givenCacheDeserializedValuesSetToINDEX_ONLY_whenSetOptimizeQueriesToFalse_thenThrowConfigurationException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
+
+        // when
+        mapConfig.setOptimizeQueries(false);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenCacheDeserializedValuesSetToINDEX_ONLY_whenSetOptimizeQueriesToTrue_thenThrowConfigurationException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
+
+        // when
+        mapConfig.setOptimizeQueries(true);
+    }
+
+    @Test(expected = ConfigurationException.class)
     public void givenCacheDeserializedValuesSetToNEVER_whenSetOptimizeQueriesToTrue_thenThrowConfigurationException() {
         // given
         MapConfig mapConfig = new MapConfig();
@@ -371,14 +391,24 @@ public class MapConfigTest {
         assertFalse(optimizeQueries);
     }
 
-    @Test(expected = ConfigurationException.class)
-    public void givenSetOptimizeQueryIsTrue_whenSetCacheDeserializedValuesToNEVER_thenThrowConfigurationException() {
+    @Test
+    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToNEVER_thenNoException() {
         // given
         MapConfig mapConfig = new MapConfig();
-        mapConfig.setOptimizeQueries(true);
+        mapConfig.setOptimizeQueries(false);
 
         // when
         mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToINDEX_ONLY_thenThrowConfigurationException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setOptimizeQueries(false);
+
+        // when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
     }
 
     @Test(expected = ConfigurationException.class)
@@ -392,6 +422,16 @@ public class MapConfigTest {
     }
 
     @Test(expected = ConfigurationException.class)
+    public void givenSetOptimizeQueryIsTrue_whenSetCacheDeserializedValuesToNEVER_thenThrowConfigurationException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setOptimizeQueries(true);
+
+        // when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+    }
+
+    @Test(expected = ConfigurationException.class)
     public void givenSetOptimizeQueryIsTrue_whenSetCacheDeserializedValuesToINDEX_ONLY_thenThrowConfigurationException() {
         // given
         MapConfig mapConfig = new MapConfig();
@@ -402,13 +442,13 @@ public class MapConfigTest {
     }
 
     @Test
-    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToNEVER_thenNoException() {
+    public void givenSetOptimizeQueryIsTrue_whenSetCacheDeserializedValuesToALWAYS_thenNoException() {
         // given
         MapConfig mapConfig = new MapConfig();
-        mapConfig.setOptimizeQueries(false);
+        mapConfig.setOptimizeQueries(true);
 
         // when
-        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.ALWAYS);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -402,6 +402,16 @@ public class MapConfigTest {
     }
 
     @Test
+    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToNEVER_thenNoException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setOptimizeQueries(false);
+
+        // when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+    }
+
+    @Test
     @Ignore(value = "this MapStoreConfig does not override equals/hashcode -> this cannot pass right now")
     public void givenSetCacheDeserializedValuesIsINDEX_ONLY_whenComparedWithOtherConfigWhereCacheIsINDEX_ONLY_thenReturnTrue() {
         // given

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -312,8 +312,8 @@ public class MapConfigTest {
         mapConfig.setOptimizeQueries(false);
     }
 
-    @Test(expected = ConfigurationException.class)
-    public void givenCacheDeserializedValuesSetToINDEX_ONLY_whenSetOptimizeQueriesToFalse_thenThrowConfigurationException() {
+    @Test
+    public void givenCacheDeserializedValuesSetToINDEX_ONLY_whenSetOptimizeQueriesToFalse_thenNoException() {
         // given
         MapConfig mapConfig = new MapConfig();
         mapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
@@ -401,8 +401,8 @@ public class MapConfigTest {
         mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
     }
 
-    @Test(expected = ConfigurationException.class)
-    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToINDEX_ONLY_thenThrowConfigurationException() {
+    @Test
+    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToINDEX_ONLY_thenThrowNoException() {
         // given
         MapConfig mapConfig = new MapConfig();
         mapConfig.setOptimizeQueries(false);

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -313,6 +313,16 @@ public class MapConfigTest {
     }
 
     @Test
+    public void givenCacheDeserializedValuesSetToALWAYS_whenSetOptimizeQueriesToTrue_thenNoException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.ALWAYS);
+
+        // when
+        mapConfig.setOptimizeQueries(true);
+    }
+
+    @Test
     public void givenCacheDeserializedValuesSetToINDEX_ONLY_whenSetOptimizeQueriesToFalse_thenNoException() {
         // given
         MapConfig mapConfig = new MapConfig();
@@ -330,6 +340,16 @@ public class MapConfigTest {
 
         // when
         mapConfig.setOptimizeQueries(true);
+    }
+
+    @Test
+    public void givenCacheDeserializedValuesSetToNEVER_whenSetOptimizeQueriesToFalse_thenNoException() {
+        // given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+
+        // when
+        mapConfig.setOptimizeQueries(false);
     }
 
     @Test(expected = ConfigurationException.class)


### PR DESCRIPTION
This setting is a derived value and when serializing there is no need to set it in the generated XML. Also fix the wrong conflict detection when both options are set.