### PR TITLE
[WIP] use getOrCreateLocalProxy in the LazyDistributedObjectEvent

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/LazyDistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/LazyDistributedObjectEvent.java
@@ -47,7 +47,7 @@ public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
     public DistributedObject getDistributedObject() {
         distributedObject = super.getDistributedObject();
         if (distributedObject == null) {
-            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName());
+            distributedObject = proxyManager.getOrCreateLocalProxy(getServiceName(), (String) getObjectName());
         }
         return distributedObject;
     }


### PR DESCRIPTION
Since the proxy may be destroyed on the member side in between the arrival of the  distributed object event and the `getDistributedObject` method is called, making a remote getOrCreateProxy request may recreate the deleted proxy. Hence, the `LazyDistributedObjectEvent` makes a local call instead of a remote call in its `getDistributedObject` method.