### PR TITLE
Revert "Make member metrics JMX exposure to respect JMX sysprop (#16521)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -31,7 +31,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.LiveOperations;
 import com.hazelcast.spi.impl.operationservice.LiveOperationsTracker;
-import com.hazelcast.spi.properties.ClusterProperty;
 
 import java.util.Map;
 import java.util.Properties;
@@ -92,14 +91,13 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
-        boolean jmxEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.ENABLE_JMX);
         if (config.isEnabled()) {
 
             if (config.getManagementCenterConfig().isEnabled()) {
                 publishers.add(createMcPublisher());
             }
 
-            if (jmxEnabled && config.getJmxConfig().isEnabled()) {
+            if (config.getJmxConfig().isEnabled()) {
                 publishers.add(createJmxPublisher());
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl;
-import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.JmxLeakHelper;
@@ -113,7 +112,6 @@ public class MetricsServiceTest extends HazelcastTestSupport {
         when(nodeEngineMock.getLogger(any(Class.class))).thenReturn(loggerMock);
         when(nodeEngineMock.getMetricsRegistry()).thenReturn(metricsRegistry);
         when(nodeEngineMock.getHazelcastInstance()).thenReturn(hzMock);
-        when(nodeEngineMock.getProperties()).thenReturn(new HazelcastProperties(System.getProperties()));
         when(hzMock.getName()).thenReturn("mockInstance");
 
         executionService = new ExecutionServiceImpl(nodeEngineMock);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -205,7 +205,6 @@ public class JmxPublisherTest {
 
     private void when_badCharacters_then_escaped(String badText) throws Exception {
         // we must be able to work with any crazy user input
-        System.out.println("badText: " + badText);
         jmxPublisher.publishLong(newDescriptor()
                 .withPrefix(badText)
                 .withMetric("metric"), 1L);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTest.java
@@ -205,6 +205,7 @@ public class JmxPublisherTest {
 
     private void when_badCharacters_then_escaped(String badText) throws Exception {
         // we must be able to work with any crazy user input
+        System.out.println("badText: " + badText);
         jmxPublisher.publishLong(newDescriptor()
                 .withPrefix(badText)
                 .withMetric("metric"), 1L);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.metrics.jmx;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -28,13 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.CountDownLatch;
-
-import static com.hazelcast.test.HazelcastTestSupport.assertFalseEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -46,20 +40,16 @@ public class MemberJmxMetricsTest {
 
     @Before
     public void setUp() throws Exception {
-        System.clearProperty(ClusterProperty.ENABLE_JMX.getName());
         helper = new JmxPublisherTestHelper(DOMAIN_PREFIX);
-        helper.assertNoMBeans();
     }
 
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
-        helper.assertNoMBeans();
     }
 
     @Test
     public void testNoMBeanLeak() {
-        System.setProperty(ClusterProperty.ENABLE_JMX.getName(), "true");
         helper.assertNoMBeans();
 
         Config config = smallInstanceConfig();
@@ -69,69 +59,6 @@ public class MemberJmxMetricsTest {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
         String expectedObjectName = DOMAIN_PREFIX + ":type=Metrics,instance=" + member.getName() + ",prefix=os";
         assertTrueEventually(() -> helper.assertMBeanContains(expectedObjectName));
-
-        member.shutdown();
-        helper.assertNoMBeans();
-    }
-
-    @Test
-    public void testMetricsExposedOverJmxIfSysPropIsSet() {
-        System.setProperty(ClusterProperty.ENABLE_JMX.getName(), "true");
-        helper.assertNoMBeans();
-
-        Config config = smallInstanceConfig();
-        config.getMetricsConfig()
-              .setCollectionFrequencySeconds(1);
-
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
-        String expectedObjectName = DOMAIN_PREFIX + ":type=Metrics,instance=" + member.getName() + ",prefix=os";
-        assertTrueEventually(() -> helper.assertMBeanContains(expectedObjectName));
-
-        member.shutdown();
-        helper.assertNoMBeans();
-    }
-
-    @Test
-    public void testMetricsNotExposedOverJmxIfSysPropIsNotSet() throws Exception {
-        helper.assertNoMBeans();
-
-        Config config = smallInstanceConfig();
-        config.getMetricsConfig()
-              .setCollectionFrequencySeconds(1);
-
-        // we wait for two metrics collections before assert on JMX exposure
-        CountDownLatch collectionLatch = new CountDownLatch(2);
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
-        getNodeEngineImpl(member).getMetricsRegistry()
-                                 .registerDynamicMetricsProvider((descriptor, context) -> collectionLatch.countDown());
-
-        collectionLatch.await(2, SECONDS);
-
-        helper.assertNoMBeans();
-        member.shutdown();
-    }
-
-    @Test
-    public void testMetricsNotExposedOverJmxIfSysPropIsSetButJmxConfigDisabled() throws Exception {
-        System.setProperty(ClusterProperty.ENABLE_JMX.getName(), "true");
-        helper.assertNoMBeans();
-
-        Config config = smallInstanceConfig();
-        config.getMetricsConfig()
-              .setCollectionFrequencySeconds(1)
-              .getJmxConfig().setEnabled(false);
-
-        // we wait for two metrics collections before assert on JMX exposure
-        CountDownLatch collectionLatch = new CountDownLatch(2);
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
-        getNodeEngineImpl(member).getMetricsRegistry()
-                                 .registerDynamicMetricsProvider((descriptor, context) -> collectionLatch.countDown());
-
-        collectionLatch.await(5, SECONDS);
-
-        // we can't use helper.assertNoMBeans() here because there are some, but no metrics related is expected
-        String expectedObjectName = DOMAIN_PREFIX + ":type=Metrics,instance=" + member.getName() + ",prefix=os";
-        assertFalseEventually(() -> helper.assertMBeanContains(expectedObjectName));
 
         member.shutdown();
         helper.assertNoMBeans();


### PR DESCRIPTION
We revert this change so that users can separately control whether read-only metrics MBeans and the other MBeans with write operations are enabled. The revert was requested by Jet since the change affected them badly.

Added the original reviewers as well as reviewers.