### PR TITLE
Fix ChangeClusterStateOperation for clusters in passive state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeClusterStateOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 /**
  * Operation to change a cluster's state via Management Center.
  */
-public class ChangeClusterStateOperation extends AbstractManagementOperation {
+public class ChangeClusterStateOperation extends AbstractManagementOperation implements AllowedDuringPassiveState {
     private ClusterState newState;
 
     public ChangeClusterStateOperation() {

--- a/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
@@ -109,17 +109,6 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState() throws Exception {
-        hazelcastInstances[0].getCluster().changeClusterState(PASSIVE);
-        waitClusterForSafeState(hazelcastInstances[0]);
-        assertClusterState(PASSIVE, hazelcastInstances);
-
-        resolve(managementCenterService.changeClusterState(ACTIVE));
-
-        assertClusterState(ACTIVE, hazelcastInstances);
-    }
-
-    @Test
-    public void changeClusterState_whenPassiveState() throws Exception {
         assertTrueEventually(
                 () -> assertEquals(ACTIVE, hazelcastInstances[0].getCluster().getClusterState()));
         waitClusterForSafeState(hazelcastInstances[0]);
@@ -127,6 +116,17 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
         resolve(managementCenterService.changeClusterState(PASSIVE));
 
         assertClusterState(PASSIVE, hazelcastInstances);
+    }
+
+    @Test
+    public void changeClusterState_whenPassiveState() throws Exception {
+        waitClusterForSafeState(hazelcastInstances[0]);
+        hazelcastInstances[0].getCluster().changeClusterState(PASSIVE);
+        assertClusterState(PASSIVE, hazelcastInstances);
+
+        resolve(managementCenterService.changeClusterState(ACTIVE));
+
+        assertClusterState(ACTIVE, hazelcastInstances);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
@@ -109,6 +109,17 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState() throws Exception {
+        hazelcastInstances[0].getCluster().changeClusterState(PASSIVE);
+        waitClusterForSafeState(hazelcastInstances[0]);
+        assertClusterState(PASSIVE, hazelcastInstances);
+
+        resolve(managementCenterService.changeClusterState(ACTIVE));
+
+        assertClusterState(ACTIVE, hazelcastInstances);
+    }
+
+    @Test
+    public void changeClusterState_whenPassiveState() throws Exception {
         assertTrueEventually(
                 () -> assertEquals(ACTIVE, hazelcastInstances[0].getCluster().getClusterState()));
         waitClusterForSafeState(hazelcastInstances[0]);


### PR DESCRIPTION
* Fixes the issue when MC client could not change cluster state if the cluster is in `PASSIVE` state