### PR TITLE
Disables scripting in default config

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1055,7 +1055,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     public void testManagementCenterConfig() {
         ManagementCenterConfig managementCenterConfig = config.getManagementCenterConfig();
         assertNotNull(managementCenterConfig);
-        assertFalse(managementCenterConfig.isScriptingEnabled());
+        assertTrue(managementCenterConfig.isScriptingEnabled());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -38,7 +38,7 @@
             <hz:instance-name>test-instance</hz:instance-name>
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
             <hz:license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</hz:license-key>
-            <hz:management-center scripting-enabled="false" />
+            <hz:management-center scripting-enabled="true" />
 
             <hz:properties>
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.instance.BuildInfoProvider;
+import java.util.Objects;
 
 /**
  * Contains the configuration for Hazelcast Management Center.
  */
-public class ManagementCenterConfig {
+public final class ManagementCenterConfig {
 
-    private boolean scriptingEnabled = ! BuildInfoProvider.getBuildInfo().isEnterprise();
+    private boolean scriptingEnabled;
 
     public ManagementCenterConfig() {
     }
@@ -57,5 +57,22 @@ public class ManagementCenterConfig {
         return "ManagementCenterConfig{"
                 + "scriptingEnabled=" + scriptingEnabled
                 + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ManagementCenterConfig that = (ManagementCenterConfig) o;
+        return scriptingEnabled == that.scriptingEnabled;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scriptingEnabled);
     }
 }

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -103,8 +103,7 @@
         The element <management-center> has the following optional attributes:
         * scripting-enabled:
         Set to true to allow scripting on the member, false to disallow.
-        Default value for this config element depends on Hazelcast edition:
-        false for Hazelcast Enterprise, true for Hazelcast (open source).
+        Default value is false.
 
         Hazelcast's Open Source edition provides the Management Center with monitoring at most 3 members
         in your cluster. To use it for more members, you need to have either a Management Center,
@@ -1955,7 +1954,7 @@
         * <epoch-start>:
             Sets the offset of timestamp component. Time unit is milliseconds, default is 1514764800000
              (1.1.2018 0:00 UTC).
-            
+
         * <node-id-offset>:
             Sets the offset that will be added to the node ID assigned to cluster member for this generator.
             Might be useful in A/B deployment scenarios where you have cluster A which you want to upgrade.
@@ -1964,13 +1963,13 @@
 
         * <bits-sequence>:
             Sets the bit-length of the sequence component, default is 6 bits.
-            
+
         * <bits-node-id>:
             Sets the bit-length of node id component. Default value is 16 bits.
-            
+
         * <allowed-future-millis>:
             Sets how far to the future is the generator allowed to go to generate IDs without blocking, default is 15 seconds.
-            
+
         * <statistics-enabled>:
             When you enable it, you can retrieve the Flake ID generators statistics. Its default value is true.
     -->

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -91,8 +91,7 @@ hazelcast:
   # The element "management-center" has the following optional attributes:
   # * scripting-enabled:
   # Set to true to allow scripting on the member, false to disallow.
-  # Default value for this config element depends on Hazelcast edition:
-  # false for Hazelcast Enterprise, true for Hazelcast (open source).
+  # Default value is false.
   #
   # Hazelcast's Open Source edition provides the Management Center with monitoring at most 3 members
   # in your cluster. To use it for more members, you need to have either a Management Center,
@@ -1934,7 +1933,7 @@ hazelcast:
   # * "epoch-start":
   #     Sets the offset of timestamp component. Time unit is milliseconds, default is 1514764800000
   #     (1.1.2018 0:00 UTC).
-  #       
+  #
   # * "node-id-offset":
   #     Sets the offset that will be added to the node ID assigned to cluster member for this generator.
   #     Might be useful in A/B deployment scenarios where you have cluster A which you want to upgrade.
@@ -1946,11 +1945,11 @@ hazelcast:
   #
   # * "bits-node-id":
   #     Sets the bit-length of node id component. Default value is 16 bits.
-  #      
+  #
   # * "allowed-future-millis":
   #     Sets how far to the future is the generator allowed to go to generate IDs without blocking, default is
   #     15 seconds.
-  #  
+  #
   # * "statistics-enabled":
   #     When you enable it, you can retrieve the Flake ID generators statistics. Its default value is true.
   #

--- a/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/management/ManagementCenterServiceTest.java
@@ -88,11 +88,11 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
     @Before
     public void setUp() {
         factory = new TestHazelcastFactory(NODE_COUNT);
-        hazelcastInstances[0] = factory.newHazelcastInstance(getConfig());
+        Config configWithScriptingEnabled = getConfig();
+        configWithScriptingEnabled.getManagementCenterConfig().setScriptingEnabled(true);
+        hazelcastInstances[0] = factory.newHazelcastInstance(configWithScriptingEnabled);
         hazelcastInstances[1] = factory.newHazelcastInstance(getConfig().setLiteMember(true));
-        Config config = getConfig();
-        config.getManagementCenterConfig().setScriptingEnabled(false);
-        hazelcastInstances[2] = factory.newHazelcastInstance(config);
+        hazelcastInstances[2] = factory.newHazelcastInstance(getConfig());
 
         members = stream(hazelcastInstances)
                 .map(instance -> instance.getCluster().getLocalMember())

--- a/hazelcast/src/test/java/com/hazelcast/config/ManagementCenterConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ManagementCenterConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ManagementCenterConfigTest extends HazelcastTestSupport {
+
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    @Test
+    public void testScriptingDisabledByDefault() {
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+    }
+
+    @Test
+    public void testScriptingDisabled_whenProgrammaticConfig() {
+        HazelcastInstance hz = factory.newHazelcastInstance(new Config());
+        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+    }
+
+    @Test
+    public void testScriptingDisabled_whenXmlConfig() {
+        InMemoryXmlConfig xmlConfig = new InMemoryXmlConfig("<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n"
+                + "<management-center />\n"
+                + "</hazelcast>");
+        HazelcastInstance hz = factory.newHazelcastInstance(xmlConfig);
+        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+    }
+
+    @Test
+    public void testScriptingDisabled_whenYamlConfig() {
+        InMemoryYamlConfig yamlConfig = new InMemoryYamlConfig("hazelcast:\n  cluster-name: name\n");
+        HazelcastInstance hz = factory.newHazelcastInstance(yamlConfig);
+        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
+        EqualsVerifier.forClass(ManagementCenterConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -803,7 +803,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(xml);
         ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(mcConfig.isScriptingEnabled());
+        assertFalse(mcConfig.isScriptingEnabled());
     }
 
     @Override
@@ -814,7 +814,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(xml);
         ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(mcConfig.isScriptingEnabled());
+        assertFalse(mcConfig.isScriptingEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -783,13 +783,13 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<management-center scripting-enabled='false' />"
+                + "<management-center scripting-enabled='true' />"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
         ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertFalse(mcConfig.isScriptingEnabled());
+        assertTrue(mcConfig.isScriptingEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -806,7 +806,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(yaml);
         ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(mcConfig.isScriptingEnabled());
+        assertFalse(mcConfig.isScriptingEnabled());
     }
 
     @Override
@@ -817,7 +817,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(yaml);
         ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertTrue(mcConfig.isScriptingEnabled());
+        assertFalse(mcConfig.isScriptingEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -788,12 +788,12 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         String yaml = ""
                 + "hazelcast:\n"
                 + "  management-center:\n"
-                + "    scripting-enabled: false\n";
+                + "    scripting-enabled: true\n";
 
         Config config = buildConfig(yaml);
         ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
 
-        assertFalse(mcConfig.isScriptingEnabled());
+        assertTrue(mcConfig.isScriptingEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
@@ -81,7 +81,7 @@ public class ScriptingProtectionTest extends HazelcastTestSupport {
      * @return true if the scripting should be enabled by default
      */
     protected boolean getScriptingEnabledDefaultValue() {
-        return true;
+        return false;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
@@ -109,7 +109,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
-        boolean expected = enabled == null ? true : enabled;
+        boolean expected = enabled == null ? false : enabled;
         assertEquals(expected, timedMemberState.scriptingEnabled);
     }
 }


### PR DESCRIPTION
Changes default of management center scripting enabled
property to false. Scripting now has to be explicitly
enabled by setting ManagementCenterConfig#scriptingEnabled
config property.

Fixes #16526 