### PR TITLE
Make sure that the client is connected to all members before listener registrations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -51,7 +51,6 @@ import com.hazelcast.client.impl.spi.impl.listener.LazyDistributedObjectEvent;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.set.SetService;
-import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
@@ -117,15 +116,6 @@ public final class ProxyManager implements DistributedObjectListener {
     @SuppressWarnings("checkstyle:methodlength")
     public void init(ClientConfig config, ClientContext clientContext) {
         addDistributeObjectListenerInternal(this, true);
-
-        List<ListenerConfig> listenerConfigs = client.getClientConfig().getListenerConfigs();
-        if (listenerConfigs != null && !listenerConfigs.isEmpty()) {
-            for (ListenerConfig listenerConfig : listenerConfigs) {
-                if (listenerConfig.getImplementation() instanceof DistributedObjectListener) {
-                    addDistributedObjectListener((DistributedObjectListener) listenerConfig.getImplementation());
-                }
-            }
-        }
 
         context = clientContext;
         // register defaults

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientPartitionServiceImpl.java
@@ -22,19 +22,15 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientTriggerPartitionAssignmentCodec;
 import com.hazelcast.client.impl.spi.ClientPartitionService;
 import com.hazelcast.cluster.Member;
-import com.hazelcast.config.ListenerConfig;
-import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.HashUtil;
 import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.partition.Partition;
-import com.hazelcast.partition.PartitionLostListener;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
-import java.util.EventListener;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -55,27 +51,6 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
     public ClientPartitionServiceImpl(HazelcastClientInstanceImpl client) {
         this.client = client;
         this.logger = client.getLoggingService().getLogger(ClientPartitionService.class);
-    }
-
-    public void start() {
-        ClassLoader classLoader = client.getClientConfig().getClassLoader();
-        final List<ListenerConfig> listenerConfigs = client.getClientConfig().getListenerConfigs();
-        if (listenerConfigs != null && !listenerConfigs.isEmpty()) {
-            for (ListenerConfig listenerConfig : listenerConfigs) {
-                EventListener implementation = listenerConfig.getImplementation();
-                if (implementation == null) {
-                    try {
-                        implementation = ClassLoaderUtil.newInstance(classLoader, listenerConfig.getClassName());
-                    } catch (Exception e) {
-                        logger.severe(e);
-                    }
-                }
-
-                if (implementation instanceof PartitionLostListener) {
-                    client.getPartitionService().addPartitionLostListener((PartitionLostListener) implementation);
-                }
-            }
-        }
     }
 
     private static class PartitionTable {


### PR DESCRIPTION
Client makes sure that the smart client is connected to all members of the cluster before registering any listeners including the internally used listeners.

Also, refactored the user `ClientConfig` registered listeners in a single place instead of each individual service in `HazelcastClientInstanceImpl.start` as one of the last steps.

fixes https://github.com/hazelcast/hazelcast/issues/16396
