### PR TITLE
Fixed ClientClusterRestartEventTest.testMultiMemberRestart

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -19,11 +19,13 @@ package com.hazelcast.client;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -44,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertContains;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.spawn;
 import static org.junit.Assert.assertEquals;
 
@@ -148,7 +151,17 @@ public class ClientClusterRestartEventTest {
             }
         });
 
-        instance1.getCluster().shutdown();
+        final Cluster cluster = instance1.getCluster();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                try {
+                    cluster.shutdown();
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            }
+        });
 
         Future<HazelcastInstance> f1 = spawn(new Callable<HazelcastInstance>() {
             @Override


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/commit/d7e9b4362f0d6910105b3324b43cf1ffcb104178

The test initiates cluster shutdown right after starting
the members. It can happen that the non-master members
don't have up-to-date partition table version yet
(PartitionStateOperation delayed or not arrived at all)
at the moment when shutdown/changeClusterState is called.
As a result, calling shutdown() may fail which is a known
design limitation (see the javadoc of Cluster#shutdown).

Since partition state on members is eventually consistent,
this commit introduces retry until shutdown() succeeds.

Fixes https://github.com/hazelcast/hazelcast/issues/16217