### PR TITLE
Fixes client opening redundant connections

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerTranslateTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.client.impl.connection.Addresses;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.cluster.Address;
-import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.Connection;
@@ -58,7 +57,7 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
         clientConnectionManager = new ClientConnectionManagerImpl(clientInstanceImpl);
         clientConnectionManager.start();
         clientConnectionManager.reset();
-        clientConnectionManager.getOrConnect(new MemberImpl(new Address("127.0.0.1", 5701), null, false));
+        clientConnectionManager.getOrConnect(new Address("127.0.0.1", 5701));
 
         provider.shouldTranslate = true;
 
@@ -100,7 +99,7 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
 
     @Test
     public void testTranslatorIsNotUsedOnGetConnection() {
-        Connection connection = clientConnectionManager.getOrConnect(new MemberImpl(privateAddress, null, false));
+        Connection connection = clientConnectionManager.getOrConnect(privateAddress);
         assertNotNull(connection);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ConnectMemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/nio/ConnectMemberListTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.client.impl.clientside.ClusterDiscoveryService;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -70,12 +70,12 @@ public class ConnectMemberListTest extends ClientTestSupport {
         config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
         HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
 
-        Collection<Member> possibleMemberAddresses = getPossibleMemberAddresses(client);
+        Collection<Address> possibleMemberAddresses = getPossibleMemberAddresses(client);
         //make sure last known member list is used. otherwise it returns 3
         assertEquals(4, possibleMemberAddresses.size());
     }
 
-    private Collection<Member> getPossibleMemberAddresses(HazelcastInstance client) {
+    private Collection<Address> getPossibleMemberAddresses(HazelcastInstance client) {
         HazelcastClientInstanceImpl instanceImpl = getHazelcastClientInstanceImpl(client);
         ClusterDiscoveryService clusterDiscoveryService = instanceImpl.getClusterDiscoveryService();
         CandidateClusterContext clusterContext = clusterDiscoveryService.current();


### PR DESCRIPTION
After changes #16502, `getOrConnect` become broken. getOrConnect
was checking with uuid to determine a connection is there, which is
wrong because uuid it remembers belongs to old member
(member has restarted on the same address)

Uuid should be used only when doing invocations to lookup. When opening
a new connection `address` should be used

partially reverts #16502
fixes https://github.com/hazelcast/hazelcast/issues/16540