### PR TITLE
Prevent unneeded map container creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -17,6 +17,8 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.monitor.LocalRecordStoreStats;
 import com.hazelcast.internal.monitor.impl.IndexesStats;
@@ -32,12 +34,12 @@ import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nearcache.NearCacheStats;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.proxyservice.ProxyService;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -143,15 +145,21 @@ public class LocalMapStatsProvider {
     }
 
     /**
-     * Some maps may have a proxy but no data has been put yet. Think of one created a proxy but not put any data in it.
-     * By calling this method we are returning an empty stats object for those maps. This is helpful to monitor those kind
-     * of maps.
+     * Some maps may have a proxy but no data has been put yet.
+     * Think of one created a proxy but not put any data in it. By
+     * calling this method we are returning an empty stats object for
+     * those maps. This is helpful to monitor those kind of maps.
      */
     private void addStatsOfNoDataIncludedMaps(Map statsPerMap) {
-        ProxyService proxyService = nodeEngine.getProxyService();
-        Collection<String> mapNames = proxyService.getDistributedObjectNames(SERVICE_NAME);
-        for (String mapName : mapNames) {
-            if (!statsPerMap.containsKey(mapName) && mapServiceContext.getMapContainer(mapName).mapConfig.isStatisticsEnabled()) {
+        Collection<DistributedObject> distributedObjects = nodeEngine.getProxyService()
+                .getDistributedObjects(SERVICE_NAME);
+
+        for (DistributedObject distributedObject : distributedObjects) {
+            MapProxyImpl mapProxy = (MapProxyImpl) distributedObject;
+            MapConfig mapConfig = mapProxy.getMapConfig();
+            String mapName = mapProxy.getName();
+
+            if (mapConfig.isStatisticsEnabled() && !statsPerMap.containsKey(mapName)) {
                 statsPerMap.put(mapName, EMPTY_LOCAL_MAP_STATS);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -26,16 +26,15 @@ import com.hazelcast.config.MapPartitionLostListenerConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.ReadOnly;
-import com.hazelcast.executor.impl.ExecutionCallbackAdapter;
 import com.hazelcast.internal.locksupport.LockProxySupport;
 import com.hazelcast.internal.locksupport.LockSupportServiceImpl;
 import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.IterableUtil;
@@ -72,7 +71,6 @@ import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.PartitionPredicate;
@@ -244,6 +242,10 @@ abstract class MapProxySupport<K, V>
     @Override
     public final String getServiceName() {
         return SERVICE_NAME;
+    }
+
+    public MapConfig getMapConfig() {
+        return mapConfig;
     }
 
     @Override
@@ -1385,18 +1387,6 @@ abstract class MapProxySupport<K, V>
             if (throwable == null) {
                 mapServiceContext.incrementOperationStats(startTime, localMapStats, name, operation);
             }
-        }
-    }
-
-    private class MapExecutionCallbackAdapter<T> extends ExecutionCallbackAdapter<T> {
-
-        MapExecutionCallbackAdapter(ExecutionCallback<T> executionCallback) {
-            super(executionCallback);
-        }
-
-        @Override
-        protected Object interceptResponse(Object o) {
-            return toObject(o);
         }
     }
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/16543

Removed `mapServiceContext.getMapContainer(mapName)` 