### PR TITLE
Made [Single|Multi]ValueBitmapIndexTest reliable

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
@@ -203,6 +203,8 @@ public class MultiValueBitmapIndexTest extends HazelcastTestSupport {
         Config config = HazelcastTestSupport.smallInstanceConfig();
         MapConfig mapConfig = config.getMapConfig("persons");
         mapConfig.addIndexConfig(indexConfig);
+        // disable periodic metrics collection (may interfere with the test)
+        config.getMetricsConfig().setEnabled(false);
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
@@ -195,6 +195,8 @@ public class SingleValueBitmapIndexTest extends HazelcastTestSupport {
         Config config = HazelcastTestSupport.smallInstanceConfig();
         MapConfig mapConfig = config.getMapConfig("persons");
         mapConfig.addIndexConfig(indexConfig);
+        // disable periodic metrics collection (may interfere with the test)
+        config.getMetricsConfig().setEnabled(false);
         return config;
     }
 


### PR DESCRIPTION
Disabled the periodic metrics collection task because it was
interfering with the test (the query verification code relies
on index stats).

Fixes https://github.com/hazelcast/hazelcast/issues/16544