### PR TITLE
Fix flaky ManagementCenterServiceIntegrationTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -87,9 +87,11 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
 
     @Test
     public void testTimedMemberState_usesCache_shortTimeFrame() {
-        String responseOne = mcs.getTimedMemberStateJson().orElse(null);
-        String responseTwo = mcs.getTimedMemberStateJson().orElse(null);
-        assertSame(responseOne, responseTwo);
+        assertTrueEventually(() -> {
+            String responseOne = mcs.getTimedMemberStateJson().orElse(null);
+            String responseTwo = mcs.getTimedMemberStateJson().orElse(null);
+            assertSame(responseOne, responseTwo);
+        });
     }
 
     @Test


### PR DESCRIPTION
* Fixes #16548
* The problem was in a long potential time difference (>1 sec) between `mcs.getTimedMemberStateJson()` calls. That may happen when machine which runs tests experiences high load.