### PR TITLE
Fixes NPE when completing exceptionally in ExecutorService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -702,7 +702,7 @@ public class ExecutorServiceProxy
         try {
             return InternalCompletableFuture.newCompletedFuture(future.get(), serializationService);
         } catch (ExecutionException e) {
-            return InternalCompletableFuture.completedExceptionally(e.getCause());
+            return InternalCompletableFuture.completedExceptionally(e.getCause() == null ? e : e.getCause());
         } catch (CancellationException e) {
             InternalCompletableFuture cancelledFuture = new InternalCompletableFuture();
             future.cancel(true);


### PR DESCRIPTION
When a future is completed with an `ExecutionException`,
previously the assumption was that it would include a
non-null cause. However this is not true all the time;
in particular when a future is completed with a
`MemberLeftException`, there is no cause associated
resulting in a NPE being thrown. This is now fixed
and the future is completed with a non-null throwable.

Fixes #16562 