### PR TITLE
Fixed an old incorrect merge in EntryProcessorTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -250,7 +250,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         // make sure there are no entries left
-        IMap<String, TestData> map2 = newPrimary.getMap("test");
+        IMap<String, TestData> map2 = newPrimary.getMap(MAP_NAME);
         Map<String, Boolean> executedEntries = map2.executeOnEntries(new TestLoggingEntryProcessor());
         assertEquals(0, executedEntries.size());
     }
@@ -285,7 +285,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         // make sure there are no entries left
-        IMap<String, TestData> map2 = newPrimary.getMap("test");
+        IMap<String, TestData> map2 = newPrimary.getMap(MAP_NAME);
         Map<String, Boolean> executedEntries = map2.executeOnEntries(new TestLoggingEntryProcessor());
         assertEquals(0, executedEntries.size());
     }
@@ -483,7 +483,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
                 instance2.shutdown();
                 newPrimary = instance1;
             }
-            IMap<String, TestData> map2 = newPrimary.getMap("test");
+            IMap<String, TestData> map2 = newPrimary.getMap(MAP_NAME);
             assertFalse(map2.containsKey("a"));
         } finally {
             instance1.shutdown();


### PR DESCRIPTION
Some test methods were, incorrectly, checking the (used previously)
"test" map after updating MAP_NAME, effectively testing nothing.