### PR TITLE
Fix default class loader for client user code deployment service

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientUserCodeDeploymentService.java
@@ -55,7 +55,7 @@ public class ClientUserCodeDeploymentService {
     public ClientUserCodeDeploymentService(ClientUserCodeDeploymentConfig clientUserCodeDeploymentConfig,
                                            ClassLoader configClassLoader) {
         this.clientUserCodeDeploymentConfig = clientUserCodeDeploymentConfig;
-        this.configClassLoader = configClassLoader != null ? configClassLoader : ClassLoader.getSystemClassLoader();
+        this.configClassLoader = configClassLoader != null ? configClassLoader : Thread.currentThread().getContextClassLoader();
     }
 
     public void start() throws IOException, ClassNotFoundException {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentConfigTest.java
@@ -27,6 +27,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import usercodedeployment.IncrementingEntryProcessor;
 
 import java.io.File;
@@ -191,6 +192,26 @@ public class ClientUserCodeDeploymentConfigTest extends HazelcastTestSupport {
         assertClassLoaded(list, "usercodedeployment.EntryProcessorWithAnonymousAndInner");
         assertClassLoaded(list, "usercodedeployment.EntryProcessorWithAnonymousAndInner$1");
         assertClassLoaded(list, "usercodedeployment.EntryProcessorWithAnonymousAndInner$Test");
+    }
+
+    private static class CustomClassLoader extends ClassLoader {
+    }
+
+    @Test
+    public void testUserCodeDeploymentUsesCurrentThreadContextClassLoader() throws ClassNotFoundException, IOException {
+        ClientUserCodeDeploymentConfig config = new ClientUserCodeDeploymentConfig();
+        CustomClassLoader classLoader = Mockito.spy(new CustomClassLoader());
+
+        config.setEnabled(true);
+        config.addClass(IncrementingEntryProcessor.class);
+
+        Thread.currentThread().setContextClassLoader(classLoader);
+        ClientUserCodeDeploymentService service = new ClientUserCodeDeploymentService(config, null);
+        service.start();
+        List<Map.Entry<String, byte[]>> list = service.getClassDefinitionList();
+        assertClassLoaded(list, IncrementingEntryProcessor.class.getName());
+
+        Mockito.verify(classLoader, Mockito.times(1)).getResourceAsStream((String) Mockito.any());
     }
 
 


### PR DESCRIPTION
Problem detected on tomcat. Usage of system class loader was wrong
in that context. The application codes are not accesible from
system class loader. The default class loader is aligned with
what serialization service uses by default, which is
Thread.currentThread().getContextClassLoader()

fixes https://github.com/hazelcast/hazelcast/issues/16421