### PR TITLE
Update Hazelcast Kubernetes plugin to 2.0.1

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-kubernetes</artifactId>
-            <version>2.0</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Update Hazelcast Kubernetes version to 2.0.1.

The change is effectively a patch change to fix the bug discovered by IBM Cloud Pak: https://github.com/hazelcast/hazelcast-kubernetes/pull/191