### PR TITLE
Map/Cache/MultiMap should return Int.MAX when size overflows int32

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -894,7 +894,8 @@ public interface ICache<K, V>
     V getAndReplace(K key, V value, ExpiryPolicy expiryPolicy);
 
     /**
-     * Total entry count.
+     * Total entry count. If the cache contains more than
+     * <code>Integer.MAX_VALUE</code> elements, returns <code>Integer.MAX_VALUE</code>.
      *
      * @return total entry count
      */

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -66,6 +66,7 @@ import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrowAllowedTypeFirst;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
 import static java.util.Collections.emptyMap;
@@ -654,12 +655,11 @@ public class CacheProxy<K, V> extends CacheProxySupport<K, V>
             OperationFactory operationFactory = operationProvider.createSizeOperationFactory();
             Map<Integer, Object> results = getNodeEngine().getOperationService()
                                                           .invokeOnAllPartitions(getServiceName(), operationFactory);
-            int total = 0;
+            long total = 0;
             for (Object result : results.values()) {
-                //noinspection RedundantCast
                 total += (Integer) getNodeEngine().toObject(result);
             }
-            return total;
+            return toIntSize(total);
         } catch (Throwable t) {
             throw rethrowAllowedTypeFirst(t, CacheException.class);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSizeMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.spi.impl.operationservice.OperationFactory;
 import java.security.Permission;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
+
 /**
  * This client request specifically calls {@link CacheSizeOperationFactory} on the server side.
  *
@@ -50,13 +52,13 @@ public class CacheSizeMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        int total = 0;
+        long total = 0;
         CacheService service = getService(getServiceName());
         for (Object result : map.values()) {
             Integer size = (Integer) service.toObject(result);
             total += size;
         }
-        return total;
+        return toIntSize(total);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSizeMessageTask.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.impl.operationservice.OperationFactory;
 import java.security.Permission;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
 import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
 
 public class MapSizeMessageTask
@@ -45,14 +46,14 @@ public class MapSizeMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        int total = 0;
+        long total = 0;
         MapService mapService = getService(MapService.SERVICE_NAME);
         for (Object result : map.values()) {
             Integer size = (Integer) mapService.getMapServiceContext().toObject(result);
             total += size;
         }
         incrementOtherOperationsCount(mapService, parameters.name);
-        return total;
+        return toIntSize(total);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapSizeMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.spi.impl.operationservice.OperationFactory;
 import java.security.Permission;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
+
 /**
  * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_SIZE}
@@ -48,11 +50,11 @@ public class MultiMapSizeMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        int total = 0;
+        long total = 0;
         for (Object obj : map.values()) {
             total += (Integer) obj;
         }
-        return total;
+        return toIntSize(total);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MapUtil.java
@@ -102,4 +102,16 @@ public final class MapUtil {
         return new SimpleImmutableEntry<>(k, v);
     }
 
+    /**
+     * Converts <code>long</code> map size to <code>int</code>.
+     * If <code>size</code> is greater than <code>Integer.MAX_VALUE</code>
+     * then <code>Integer.MAX_VALUE</code> is returned.
+     *
+     * @param size map size
+     * @return map size in <code>int</code> type
+     */
+    public static int toIntSize(long size) {
+        assert size >= 0 : "Invalid size value: " + size;
+        return size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -117,6 +117,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
 import static com.hazelcast.internal.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
 import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
@@ -784,12 +785,12 @@ abstract class MapProxySupport<K, V>
             OperationFactory sizeOperationFactory = operationProvider.createMapSizeOperationFactory(name);
             Map<Integer, Object> results = operationService.invokeOnAllPartitions(SERVICE_NAME, sizeOperationFactory);
             incrementOtherOperationsStat();
-            int total = 0;
+            long total = 0;
             for (Object result : results.values()) {
                 Integer size = toObject(result);
                 total += size;
             }
-            return total;
+            return toIntSize(total);
         } catch (Throwable t) {
             throw rethrow(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -220,6 +220,8 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
 
     /**
      * Returns the number of key-value pairs in the multimap.
+     * If the multimap contains more than <tt>Integer.MAX_VALUE</tt> elements,
+     * returns <tt>Integer.MAX_VALUE</tt>.
      *
      * @return the number of key-value pairs in the multimap
      */

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
+
 public abstract class MultiMapProxySupport extends AbstractDistributedObject<MultiMapService> {
 
     protected final MultiMapConfig config;
@@ -197,7 +199,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
                             MultiMapService.SERVICE_NAME,
                             new MultiMapOperationFactory(name, OperationFactoryType.SIZE)
                     );
-            int size = 0;
+            long size = 0;
             for (Object obj : results.values()) {
                 if (obj == null) {
                     continue;
@@ -205,7 +207,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
                 Integer result = nodeEngine.toObject(obj);
                 size += result;
             }
-            return size;
+            return toIntSize(size);
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/MapUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/MapUtilTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.util;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -27,6 +28,8 @@ import org.junit.runner.RunWith;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -46,14 +49,38 @@ public class MapUtilTest {
 
     @Test
     public void isNullOrEmpty_whenEmpty() {
-        assertTrue(MapUtil.isNullOrEmpty(new HashMap()));
+        assertTrue(MapUtil.isNullOrEmpty(new HashMap<>()));
     }
 
     @Test
     public void isNullOrEmpty_whenNotEmpty() {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("a", "b");
         assertFalse(MapUtil.isNullOrEmpty(map));
     }
 
+    @Test
+    public void toIntSize_whenLessThanIntMax() {
+        long size = 123456789;
+        assertEquals((int) size, toIntSize(size));
+    }
+
+    @Test
+    public void toIntSize_whenEqualToIntMax() {
+        long size = Integer.MAX_VALUE;
+        assertEquals(Integer.MAX_VALUE, toIntSize(size));
+    }
+
+    @Test
+    public void toIntSize_whenGreaterThanIntMax() {
+        long size = Integer.MAX_VALUE + 1L;
+        assertEquals(Integer.MAX_VALUE, toIntSize(size));
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void toIntSize_whenNegative() {
+        long size = -1;
+        assertEquals((int) size, toIntSize(size));
+    }
 }


### PR DESCRIPTION
(cherry picked from commit 5eb0eba9d46d49dea29a492a9625812ad42af1ae)

Fixes #14935

Backport of https://github.com/hazelcast/hazelcast/pull/16594