### PR TITLE
Ensure cache is created in test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.executor.ExecutorServiceTestSupport;
@@ -120,7 +121,15 @@ public class ClientCacheCreationTest extends CacheCreationTest {
         HazelcastClientCachingProvider cachingProvider = createClientCachingProvider(client);
         final CacheManager cacheManager = cachingProvider.getCacheManager();
         MutableConfiguration configuration = new MutableConfiguration();
-        cacheManager.createCache("xmlCache", configuration);
+        // ensure cache is created despite the low concurrent invocation limit
+        while (true) {
+            try {
+                cacheManager.createCache("xmlCache", configuration);
+                break;
+            } catch (HazelcastOverloadException e) {
+                sleepMillis(30);
+            }
+        }
 
         IExecutorService executorService = client.getExecutorService("exec");
         //keep the slot for one invocation to test if client can reconnect even if all slots are kept

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -122,14 +122,14 @@ public class ClientCacheCreationTest extends CacheCreationTest {
         final CacheManager cacheManager = cachingProvider.getCacheManager();
         MutableConfiguration configuration = new MutableConfiguration();
         // ensure cache is created despite the low concurrent invocation limit
-        while (true) {
+        assertTrueEventually(() -> {
             try {
                 cacheManager.createCache("xmlCache", configuration);
-                break;
             } catch (HazelcastOverloadException e) {
-                sleepMillis(30);
+                throw new AssertionError("Could not create cache due to "
+                        + "low concurrent invocation count.");
             }
-        }
+        });
 
         IExecutorService executorService = client.getExecutorService("exec");
         //keep the slot for one invocation to test if client can reconnect even if all slots are kept


### PR DESCRIPTION
In ClientCacheCreationTest cache recreation is
tested with a low concurrent invocation limit.
With unlucky timing, the limit obstructs even the
original cache creation during test setup.

(cherry picked from commit 94d9f8643caf30f2834849978fd775298f9a9343)

Backport of #16598 to `4.0.z` branch