### PR TITLE
remove unnecessary null check from Frame#getSize

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -436,11 +436,7 @@ public final class ClientMessage implements OutboundFrame {
         }
 
         public int getSize() {
-            if (content == null) {
-                return SIZE_OF_FRAME_LENGTH_AND_FLAGS;
-            } else {
-                return SIZE_OF_FRAME_LENGTH_AND_FLAGS + content.length;
-            }
+            return SIZE_OF_FRAME_LENGTH_AND_FLAGS + content.length;
         }
 
         @Override


### PR DESCRIPTION
We have an assertion on the constructor of the `Frame` that prevents it from having a null content. Throughout the code base, byte array with the size of 0 is used instead of the null content. So, there is no need to perform a null check here. 