### PR TITLE
[BACKPORT] Allow blocking Raft invocations to op-timeout after wait timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
@@ -230,8 +230,9 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
 
     @Override
     public final void populate(LiveOperations liveOperations) {
+        long now = Clock.currentTimeMillis();
         for (RR registry : registries.values()) {
-            registry.populate(liveOperations);
+            registry.populate(liveOperations, now);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/ResourceRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/ResourceRegistry.java
@@ -16,22 +16,22 @@
 
 package com.hazelcast.cp.internal.datastructures.spi.blocking;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.internal.util.BiTuple;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.spi.impl.operationservice.LiveOperations;
-import com.hazelcast.spi.impl.operationservice.LiveOperationsTracker;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
-import com.hazelcast.internal.util.Clock;
+import com.hazelcast.spi.impl.operationservice.LiveOperations;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,11 +39,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.UUIDSerializationUtil.readUUID;
 import static com.hazelcast.internal.util.UUIDSerializationUtil.writeUUID;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
-import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.unmodifiableMap;
 
 /**
@@ -57,11 +57,30 @@ import static java.util.Collections.unmodifiableMap;
  * @param <R> concrete type of the resource
  */
 public abstract class ResourceRegistry<W extends WaitKey, R extends BlockingResource<W>>
-        implements LiveOperationsTracker, DataSerializable {
+        implements DataSerializable {
+
+    // If the wait key of a blocking call times out, it is still reported
+    // as a live operation. This cloud lead to hang the caller side when
+    // the majority is lost because the Raft invocation does not fail with
+    // operation timeout. To prevent this problem, we don't report a wait
+    // key as a live operation if it is not expired on the CP group after
+    // its wait timeout occurs. However, if we stop reporting a wait key
+    // immediately after its timeout, then the caller might receive
+    // an operation timeout prematurely, even though the majority is alive
+    // and the wait key is expired on the CP group gracefully. In order to
+    // prevent this problem, we extend the wait key timeout a few more seconds
+    // so that the expiration logic could kick in and expire the key gracefully
+    // when the CP group majority is healthy.
+    private static final long OPERATION_TIMEOUT_EXTENSION_MS = TimeUnit.SECONDS.toMillis(5);
+
+    // If no timeout is given for a blocking call, then we will use
+    // this constant to not to expire its wait key
+    private static final long NO_WAIT_KEY_DEADLINE = Long.MAX_VALUE;
 
     protected CPGroupId groupId;
     protected final Map<String, R> resources = new ConcurrentHashMap<>();
     protected final Set<String> destroyedNames = new HashSet<>();
+
     // key.element1: name, key.element2: invocation uid
     // value.element1: timeout duration (persisted in the snapshot), value.element2: deadline timestamp (transient)
     protected final ConcurrentMap<BiTuple<String, UUID>, BiTuple<Long, Long>> waitTimeouts = new ConcurrentHashMap<>();
@@ -70,9 +89,12 @@ public abstract class ResourceRegistry<W extends WaitKey, R extends BlockingReso
     // Currently, only Raft ops that create a wait key are tracked as live operations,
     // and it is sufficiently to report them only through the leader. Although followers
     // populate live operations as well, they can miss some entries if they install a snapshot
-    // instead of applying Raft log entries. If a follower becomes later, callers will
+    // instead of applying Raft log entries. If a follower becomes leader later on, callers will
     // retry and commit their waiting Raft ops.
-    private final Set<BiTuple<Address, Long>> liveOperationsSet = newSetFromMap(new ConcurrentHashMap<>());
+    // The values are the deadlines of the wait keys plus the OPERATION_TIMEOUT_EXTENSION_MS value.
+    // If a wait key times out but still not expired on the CP group for any reason, such as lost majority,
+    // it is no longer reported as a live operation so that the caller could give up on waiting.
+    private final Map<BiTuple<Address, Long>, Long> liveOperationMap = new ConcurrentHashMap<>();
 
     protected ResourceRegistry() {
     }
@@ -110,12 +132,17 @@ public abstract class ResourceRegistry<W extends WaitKey, R extends BlockingReso
     }
 
     protected final void addWaitKey(String name, W key, long timeoutMs) {
+        long deadline;
         if (timeoutMs > 0) {
-            long deadline = Clock.currentTimeMillis() + timeoutMs;
+            long now = Clock.currentTimeMillis();
+            deadline = Long.MAX_VALUE - now >= timeoutMs ? now + timeoutMs : Long.MAX_VALUE;
             waitTimeouts.putIfAbsent(BiTuple.of(name, key.invocationUid), BiTuple.of(timeoutMs, deadline));
+        } else {
+            deadline = NO_WAIT_KEY_DEADLINE;
         }
+
         if (timeoutMs != 0) {
-            addLiveOperation(key);
+            addLiveOperation(key, deadline);
         }
     }
 
@@ -217,29 +244,44 @@ public abstract class ResourceRegistry<W extends WaitKey, R extends BlockingReso
         return indices;
     }
 
-    @Override
-    public void populate(LiveOperations liveOperations) {
-        for (BiTuple<Address, Long> t : liveOperationsSet) {
-            liveOperations.add(t.element1, t.element2);
+    public void populate(LiveOperations liveOperations, long now) {
+        Iterator<Entry<BiTuple<Address, Long>, Long>> it = liveOperationMap.entrySet().iterator();
+        while (it.hasNext()) {
+            Entry<BiTuple<Address, Long>, Long> e = it.next();
+            long deadline = e.getValue();
+            if (deadline >= now) {
+                BiTuple<Address, Long> t = e.getKey();
+                liveOperations.add(t.element1, t.element2);
+            } else {
+                it.remove();
+            }
         }
     }
 
-    private void addLiveOperation(W key) {
-        liveOperationsSet.add(BiTuple.of(key.callerAddress(), key.callId()));
+    private void addLiveOperation(W key, long deadline) {
+        // if deadline is NO_WAIT_KEY_DEADLINE, it is already Long.MAX_VALUE
+        // and no need to extend it further.
+        if (Long.MAX_VALUE - deadline >= OPERATION_TIMEOUT_EXTENSION_MS) {
+            deadline += OPERATION_TIMEOUT_EXTENSION_MS;
+        }
+
+        liveOperationMap.put(BiTuple.of(key.callerAddress(), key.callId()), deadline);
     }
 
     final void removeLiveOperation(W key) {
-        liveOperationsSet.remove(BiTuple.of(key.callerAddress(), key.callId()));
+        liveOperationMap.remove(BiTuple.of(key.callerAddress(), key.callId()));
     }
 
     public final Collection<BiTuple<Address, Long>> getLiveOperations() {
-        return liveOperationsSet;
+        return liveOperationMap.keySet();
     }
 
     final void onSnapshotRestore() {
         for (R resource : resources.values()) {
             for (W key : resource.getAllWaitKeys()) {
-                addLiveOperation(key);
+                BiTuple<Long, Long> t = waitTimeouts.get(BiTuple.of(resource.getName(), key.invocationUid));
+                long deadline = t != null ? t.element1 : NO_WAIT_KEY_DEADLINE;
+                addLiveOperation(key, deadline);
             }
         }
     }


### PR DESCRIPTION
If the wait key of a blocking call times out, it is still reported
as a live operation. This cloud lead to hang the caller side when
the majority is lost because the Raft invocation does not fail with
operation timeout.

To prevent this problem, we don't report a wait key as a live operation
if it is not expired on the CP group after its wait timeout occurs.

Backport of #16614 