### PR TITLE
Fix txn near cache 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
@@ -65,6 +65,16 @@ public class CollectionTransactionLogRecord implements TransactionLogRecord {
     }
 
     @Override
+    public void onCommitSuccess() {
+        // NOP
+    }
+
+    @Override
+    public void onCommitFailure() {
+        // NOP
+    }
+
+    @Override
     public Operation newRollbackOperation() {
         long[] itemIds = createItemIdArray();
         return new CollectionRollbackOperation(partitionId, name, serviceName, itemIds);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -49,7 +49,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
     }
 
     public ClusterStateTransactionLogRecord(ClusterStateChange stateChange, Address initiator, Address target,
-            String txnId, long leaseTime, int partitionStateVersion, boolean isTransient) {
+                                            String txnId, long leaseTime, int partitionStateVersion, boolean isTransient) {
         Preconditions.checkNotNull(stateChange);
         Preconditions.checkNotNull(initiator);
         Preconditions.checkNotNull(target);
@@ -83,6 +83,16 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
     @Override
     public Operation newRollbackOperation() {
         return new RollbackClusterStateOp(initiator, txnId);
+    }
+
+    @Override
+    public void onCommitSuccess() {
+        // NOP
+    }
+
+    @Override
+    public void onCommitFailure() {
+        // NOP
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCachingHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCachingHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCachingHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCachingHook.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nearcache;
+
+
+import com.hazelcast.nio.serialization.Data;
+
+/**
+ * Hook to be used by near cache enabled proxy objects.
+ *
+ * With this hook, you can implement needed logic
+ * for truly invalidate/populate local near cache.
+ */
+public interface NearCachingHook<K, V> {
+
+    NearCachingHook EMPTY_HOOK = new NearCachingHook() {
+
+        @Override
+        public void beforeRemoteCall(Object key, Data keyData,
+                                     Object value, Data valueData) {
+        }
+
+        @Override
+        public void onRemoteCallSuccess() {
+        }
+
+        @Override
+        public void onRemoteCallFailure() {
+
+        }
+    };
+
+    void beforeRemoteCall(K key, Data keyData, V value, Data valueData);
+
+    void onRemoteCallSuccess();
+
+    void onRemoteCallFailure();
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.internal.nearcache.NearCachingHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.Query;
@@ -54,7 +55,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
     private final Map<Data, TxnValueWrapper> txMap = new HashMap<Data, TxnValueWrapper>();
 
-    public TransactionalMapProxy(String name, MapService mapService, NodeEngine nodeEngine, Transaction transaction) {
+    public TransactionalMapProxy(String name, MapService mapService,
+                                 NodeEngine nodeEngine, Transaction transaction) {
         super(name, mapService, nodeEngine, transaction);
     }
 
@@ -143,19 +145,19 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
-            Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, mapServiceContext.toData(value), ttl, timeUnit));
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+        Data valueData = mapServiceContext.toData(value);
 
-            TxnValueWrapper currentValue = txMap.get(keyData);
-            Type type = valueBeforeTxn == null ? Type.NEW : Type.UPDATED;
-            TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
-            txMap.put(keyData, wrapper);
-            return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
-        } finally {
-            invalidateNearCache(nearCacheKey);
-        }
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, value, valueData);
+
+        Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, valueData, ttl, timeUnit, nearCachingHook));
+
+        TxnValueWrapper currentValue = txMap.get(keyData);
+        Type type = valueBeforeTxn == null ? Type.NEW : Type.UPDATED;
+        TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
+        txMap.put(keyData, wrapper);
+        return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
     }
 
     @Override
@@ -164,16 +166,16 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
-            Data dataBeforeTxn = putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
-            Type type = dataBeforeTxn == null ? Type.NEW : Type.UPDATED;
-            TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
-            txMap.put(keyData, wrapper);
-        } finally {
-            invalidateNearCache(nearCacheKey);
-        }
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+        Data valueData = mapServiceContext.toData(value);
+
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, value, valueData);
+
+        Data dataBeforeTxn = putInternal(keyData, valueData, -1, MILLISECONDS, nearCachingHook);
+        Type type = dataBeforeTxn == null ? Type.NEW : Type.UPDATED;
+        TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
+        txMap.put(keyData, wrapper);
     }
 
     @Override
@@ -182,27 +184,27 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
-            TxnValueWrapper wrapper = txMap.get(keyData);
-            boolean haveTxnPast = wrapper != null;
-            if (haveTxnPast) {
-                if (wrapper.type != Type.REMOVED) {
-                    return wrapper.value;
-                }
-                putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
-                txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
-                return null;
-            } else {
-                Data oldValue = putIfAbsentInternal(keyData, mapServiceContext.toData(value));
-                if (oldValue == null) {
-                    txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
-                }
-                return toObjectIfNeeded(oldValue);
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+        Data valueData = mapServiceContext.toData(value);
+
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, value, valueData);
+
+        TxnValueWrapper wrapper = txMap.get(keyData);
+        boolean haveTxnPast = wrapper != null;
+        if (haveTxnPast) {
+            if (wrapper.type != Type.REMOVED) {
+                return wrapper.value;
             }
-        } finally {
-            invalidateNearCache(nearCacheKey);
+            putInternal(keyData, valueData, -1, MILLISECONDS, nearCachingHook);
+            txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
+            return null;
+        } else {
+            Data oldValue = putIfAbsentInternal(keyData, valueData, nearCachingHook);
+            if (oldValue == null) {
+                txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
+            }
+            return toObjectIfNeeded(oldValue);
         }
     }
 
@@ -212,28 +214,27 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+        Data valueData = mapServiceContext.toData(value);
 
-            TxnValueWrapper wrapper = txMap.get(keyData);
-            boolean haveTxnPast = wrapper != null;
-            if (haveTxnPast) {
-                if (wrapper.type == Type.REMOVED) {
-                    return null;
-                }
-                putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
-                txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
-                return wrapper.value;
-            } else {
-                Data oldValue = replaceInternal(keyData, mapServiceContext.toData(value));
-                if (oldValue != null) {
-                    txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
-                }
-                return toObjectIfNeeded(oldValue);
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, value, valueData);
+
+        TxnValueWrapper wrapper = txMap.get(keyData);
+        boolean haveTxnPast = wrapper != null;
+        if (haveTxnPast) {
+            if (wrapper.type == Type.REMOVED) {
+                return null;
             }
-        } finally {
-            invalidateNearCache(nearCacheKey);
+            putInternal(keyData, valueData, -1, MILLISECONDS, nearCachingHook);
+            txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
+            return wrapper.value;
+        } else {
+            Data oldValue = replaceInternal(keyData, valueData, nearCachingHook);
+            if (oldValue != null) {
+                txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
+            }
+            return toObjectIfNeeded(oldValue);
         }
     }
 
@@ -244,29 +245,28 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(oldValue, "oldValue can't be null");
         checkNotNull(newValue, "newValue can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+        Data newValueData = mapServiceContext.toData(newValue);
 
-            TxnValueWrapper wrapper = txMap.get(keyData);
-            boolean haveTxnPast = wrapper != null;
-            if (haveTxnPast) {
-                if (!wrapper.value.equals(oldValue)) {
-                    return false;
-                }
-                putInternal(keyData, mapServiceContext.toData(newValue), -1, MILLISECONDS);
-                txMap.put(keyData, new TxnValueWrapper(wrapper.value, Type.UPDATED));
-                return true;
-            } else {
-                boolean success = replaceIfSameInternal(keyData,
-                        mapServiceContext.toData(oldValue), mapServiceContext.toData(newValue));
-                if (success) {
-                    txMap.put(keyData, new TxnValueWrapper(newValue, Type.UPDATED));
-                }
-                return success;
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, newValue, newValueData);
+
+        TxnValueWrapper wrapper = txMap.get(keyData);
+        boolean haveTxnPast = wrapper != null;
+        if (haveTxnPast) {
+            if (!wrapper.value.equals(oldValue)) {
+                return false;
             }
-        } finally {
-            invalidateNearCache(nearCacheKey);
+            putInternal(keyData, newValueData, -1, MILLISECONDS, nearCachingHook);
+            txMap.put(keyData, new TxnValueWrapper(wrapper.value, Type.UPDATED));
+            return true;
+        } else {
+            boolean success = replaceIfSameInternal(keyData,
+                    mapServiceContext.toData(oldValue), newValueData, nearCachingHook);
+            if (success) {
+                txMap.put(keyData, new TxnValueWrapper(newValue, Type.UPDATED));
+            }
+            return success;
         }
     }
 
@@ -276,33 +276,31 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-            TxnValueWrapper wrapper = txMap.get(keyData);
-            // wrapper is null which means this entry is not touched by transaction
-            if (wrapper == null) {
-                boolean removed = removeIfSameInternal(keyData, value);
-                if (removed) {
-                    txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
-                }
-                return removed;
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, null, null);
+
+        TxnValueWrapper wrapper = txMap.get(keyData);
+        // wrapper is null which means this entry is not touched by transaction
+        if (wrapper == null) {
+            boolean removed = removeIfSameInternal(keyData, value, nearCachingHook);
+            if (removed) {
+                txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
             }
-            // wrapper type is REMOVED which means entry is already removed inside the transaction
-            if (wrapper.type == Type.REMOVED) {
-                return false;
-            }
-            // wrapper value is not equal to passed value
-            if (!isEquals(wrapper.value, value)) {
-                return false;
-            }
-            // wrapper value is equal to passed value, we call removeInternal just to add delete log
-            removeInternal(keyData);
-            txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
-        } finally {
-            invalidateNearCache(nearCacheKey);
+            return removed;
         }
+        // wrapper type is REMOVED which means entry is already removed inside the transaction
+        if (wrapper.type == Type.REMOVED) {
+            return false;
+        }
+        // wrapper value is not equal to passed value
+        if (!isEquals(wrapper.value, value)) {
+            return false;
+        }
+        // wrapper value is equal to passed value, we call removeInternal just to add delete log
+        removeInternal(keyData, nearCachingHook);
+        txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
 
         return true;
     }
@@ -312,19 +310,18 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
-            Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData));
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-            TxnValueWrapper wrapper = null;
-            if (valueBeforeTxn != null || txMap.containsKey(keyData)) {
-                wrapper = txMap.put(keyData, new TxnValueWrapper(valueBeforeTxn, Type.REMOVED));
-            }
-            return wrapper == null ? valueBeforeTxn : checkIfRemoved(wrapper);
-        } finally {
-            invalidateNearCache(nearCacheKey);
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, null, null);
+
+        Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData, nearCachingHook));
+
+        TxnValueWrapper wrapper = null;
+        if (valueBeforeTxn != null || txMap.containsKey(keyData)) {
+            wrapper = txMap.put(keyData, new TxnValueWrapper(valueBeforeTxn, Type.REMOVED));
         }
+        return wrapper == null ? valueBeforeTxn : checkIfRemoved(wrapper);
     }
 
     @Override
@@ -332,15 +329,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        try {
-            Data keyData = mapServiceContext.toData(key, partitionStrategy);
-            Data data = removeInternal(keyData);
-            if (data != null || txMap.containsKey(keyData)) {
-                txMap.put(keyData, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
-            }
-        } finally {
-            invalidateNearCache(nearCacheKey);
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+
+        NearCachingHook nearCachingHook = newNearCachingHook();
+        nearCachingHook.beforeRemoteCall(key, keyData, null, null);
+
+        Data data = removeInternal(keyData, nearCachingHook);
+        if (data != null || txMap.containsKey(keyData)) {
+            txMap.put(keyData, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
         }
     }
 
@@ -449,7 +445,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     private void removeFromResultSet(Set<Map.Entry> queryResultSet, List<Object> valueSet,
                                      Set<Data> keyWontBeIncluded) {
         for (Map.Entry entry : queryResultSet) {
-            if (keyWontBeIncluded.contains((Data) entry.getKey())) {
+            if (keyWontBeIncluded.contains(entry.getKey())) {
                 continue;
             }
             valueSet.add(toObjectIfNeeded(entry.getValue()));

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
@@ -61,6 +61,16 @@ public class MultiMapTransactionLogRecord implements TransactionLogRecord {
     }
 
     @Override
+    public void onCommitSuccess() {
+        // NOP
+    }
+
+    @Override
+    public void onCommitFailure() {
+        // NOP
+    }
+
+    @Override
     public Operation newRollbackOperation() {
         return new TxnRollbackOperation(partitionId, name, key, threadId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -291,9 +291,11 @@ public class TransactionImpl implements Transaction {
                 List<Future> futures = transactionLog.commit(nodeEngine);
                 waitWithDeadline(futures, Long.MAX_VALUE, MILLISECONDS, RETHROW_TRANSACTION_EXCEPTION);
                 state = COMMITTED;
+                transactionLog.onCommitSuccess();
                 transactionManagerService.commitCount.inc();
             } catch (Throwable e) {
                 state = COMMIT_FAILED;
+                transactionLog.onCommitFailure();
                 throw rethrow(e, TransactionException.class);
             } finally {
                 purgeBackupLogs();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -105,6 +105,18 @@ public class TransactionLog {
         return futures;
     }
 
+    public void onCommitSuccess() {
+        for (TransactionLogRecord record : recordMap.values()) {
+            record.onCommitSuccess();
+        }
+    }
+
+    public void onCommitFailure() {
+        for (TransactionLogRecord record : recordMap.values()) {
+            record.onCommitFailure();
+        }
+    }
+
     public List<Future> prepare(NodeEngine nodeEngine) {
         List<Future> futures = new ArrayList<Future>(size());
         for (TransactionLogRecord record : recordList) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
@@ -43,5 +43,9 @@ public interface TransactionLogRecord extends IdentifiedDataSerializable {
 
     Operation newCommitOperation();
 
+    void onCommitSuccess();
+
+    void onCommitFailure();
+
     Operation newRollbackOperation();
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -174,16 +174,39 @@ public final class XATransaction implements Transaction {
         }
     }
 
-    public void commitAsync(ExecutionCallback callback) {
+    public void commitAsync(final ExecutionCallback callback) {
         if (state != PREPARED) {
             throw new IllegalStateException("Transaction is not prepared");
         }
         checkTimeout();
         state = COMMITTING;
-        transactionLog.commitAsync(nodeEngine, callback);
+
+        transactionLog.commitAsync(nodeEngine, wrapExecutionCallback(callback));
         // We should rethrow exception if transaction is not TWO_PHASE
 
         state = COMMITTED;
+    }
+
+    private ExecutionCallback wrapExecutionCallback(final ExecutionCallback callback) {
+        return new ExecutionCallback() {
+            @Override
+            public void onResponse(Object response) {
+                try {
+                    callback.onResponse(response);
+                } finally {
+                    transactionLog.onCommitSuccess();
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                try {
+                    callback.onFailure(t);
+                } finally {
+                    transactionLog.onCommitFailure();
+                }
+            }
+        };
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
@@ -358,6 +358,16 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
         }
 
         @Override
+        public void onCommitSuccess() {
+            // NOP
+        }
+
+        @Override
+        public void onCommitFailure() {
+            // NOP
+        }
+
+        @Override
         public Operation newRollbackOperation() {
             return newEmptyOperation();
         }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
@@ -77,6 +77,16 @@ public class MockTransactionLogRecord implements TransactionLogRecord {
     }
 
     @Override
+    public void onCommitSuccess() {
+        // NOP
+    }
+
+    @Override
+    public void onCommitFailure() {
+        // NOP
+    }
+
+    @Override
     public Operation newRollbackOperation() {
         rollbackCalled = true;
         return createOperation(failRollback);


### PR DESCRIPTION
Fixes: https://github.com/hazelcast/hazelcast/issues/16577
Backport of: https://github.com/hazelcast/hazelcast/pull/16579

ee: https://github.com/hazelcast/hazelcast-enterprise/pull/3513

__Modifications:__
Introduced `NearCachingHook` type. With it, if near caching is enabled on a map, we record the key to be invalidated at each txn operation and invalidate it in near cache at txn commit step. 
