### PR TITLE
EntryProcessor: added support for direct backups

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/EntryProcessorUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryProcessorUtil.java
@@ -14,30 +14,14 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.listener;
+package com.hazelcast.map;
 
-import com.hazelcast.map.EntryProcessor;
-
-import java.util.Map;
+import com.hazelcast.map.impl.DirectBackupEntryProcessor;
 
 /**
  * Utility class for {@link EntryProcessor}.
  */
 public final class EntryProcessorUtil {
-
-    private static final DirectBackupEntryProcessor DIRECT_BACKUP_ENTRY_PROCESSOR = new DirectBackupEntryProcessor();
-
-    private static final class DirectBackupEntryProcessor<K, V, R> implements EntryProcessor<Object, Object, Object> {
-
-        @Override
-        public Object process(Map.Entry<Object, Object> entry) {
-            return null;
-        }
-
-        private Object readResolve() {
-            return DIRECT_BACKUP_ENTRY_PROCESSOR;
-        }
-    }
 
     private EntryProcessorUtil() {
     }
@@ -50,10 +34,11 @@ public final class EntryProcessorUtil {
      * This may be useful in cases when loading the backup entries and/or applying
      * the backup entry processor is costly and direct copy of the modifications
      * is more efficient.
+     *
      * @return the direct backup processor singleton.
      */
     @SuppressWarnings("unchecked")
     public static <K, V, R> EntryProcessor<K, V, R> directBackupProcessor() {
-        return (EntryProcessor<K, V, R>) DIRECT_BACKUP_ENTRY_PROCESSOR;
+        return (EntryProcessor<K, V, R>) DirectBackupEntryProcessor.DIRECT_BACKUP_PROCESSOR;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DirectBackupEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DirectBackupEntryProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.util.Map;
+
+public class DirectBackupEntryProcessor implements EntryProcessor<Object, Object, Object>, IdentifiedDataSerializable {
+
+    public static final DirectBackupEntryProcessor DIRECT_BACKUP_PROCESSOR = new DirectBackupEntryProcessor();
+
+    public DirectBackupEntryProcessor() {
+    }
+
+    @Override
+    public Object process(Map.Entry<Object, Object> entry) {
+        return null;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return MapDataSerializerHook.DIRECT_BACKUP_ENTRY_PROCESSOR;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -312,8 +312,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int PUT_IF_ABSENT_WITH_EXPIRY = 146;
     public static final int PUT_TRANSIENT_BACKUP = 147;
     public static final int PUT_ALL_DELETE_ALL_BACKUP = 148;
+    public static final int DIRECT_BACKUP_ENTRY_PROCESSOR = 149;
 
-    private static final int LEN = PUT_ALL_DELETE_ALL_BACKUP + 1;
+    private static final int LEN = DIRECT_BACKUP_ENTRY_PROCESSOR + 1;
 
     @Override
     public int getFactoryId() {
@@ -470,6 +471,7 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[PUT_IF_ABSENT_WITH_EXPIRY] = arg -> new PutIfAbsentWithExpiryOperation();
         constructors[PUT_TRANSIENT_BACKUP] = arg -> new PutTransientBackupOperation();
         constructors[PUT_ALL_DELETE_ALL_BACKUP] = arg -> new PutAllDeleteAllBackupOperation();
+        constructors[DIRECT_BACKUP_ENTRY_PROCESSOR] = arg -> DirectBackupEntryProcessor.DIRECT_BACKUP_PROCESSOR;
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -86,6 +86,7 @@ import com.hazelcast.map.impl.operation.MultipleEntryOperationFactory;
 import com.hazelcast.map.impl.operation.MultipleEntryWithPredicateBackupOperation;
 import com.hazelcast.map.impl.operation.MultipleEntryWithPredicateOperation;
 import com.hazelcast.map.impl.operation.NotifyMapFlushOperation;
+import com.hazelcast.map.impl.operation.PutAllDeleteAllBackupOperation;
 import com.hazelcast.map.impl.operation.PartitionWideEntryBackupOperation;
 import com.hazelcast.map.impl.operation.PartitionWideEntryOperation;
 import com.hazelcast.map.impl.operation.PartitionWideEntryOperationFactory;
@@ -310,8 +311,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int PUT_TRANSIENT_WITH_EXPIRY = 145;
     public static final int PUT_IF_ABSENT_WITH_EXPIRY = 146;
     public static final int PUT_TRANSIENT_BACKUP = 147;
+    public static final int PUT_ALL_DELETE_ALL_BACKUP = 148;
 
-    private static final int LEN = PUT_TRANSIENT_BACKUP + 1;
+    private static final int LEN = PUT_ALL_DELETE_ALL_BACKUP + 1;
 
     @Override
     public int getFactoryId() {
@@ -467,6 +469,7 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[PUT_TRANSIENT_WITH_EXPIRY] = arg -> new PutTransientWithExpiryOperation();
         constructors[PUT_IF_ABSENT_WITH_EXPIRY] = arg -> new PutIfAbsentWithExpiryOperation();
         constructors[PUT_TRANSIENT_BACKUP] = arg -> new PutTransientBackupOperation();
+        constructors[PUT_ALL_DELETE_ALL_BACKUP] = arg -> new PutAllDeleteAllBackupOperation();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -35,8 +35,8 @@ import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
 import java.io.IOException;
 import java.util.UUID;
 
+import static com.hazelcast.map.impl.DirectBackupEntryProcessor.DIRECT_BACKUP_PROCESSOR;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
-import static com.hazelcast.map.listener.EntryProcessorUtil.directBackupProcessor;
 
 /**
  * Set &amp; Unlock processing for the EntryOperation
@@ -114,7 +114,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
 
     @Override
     public Operation getBackupOperation() {
-        if (entryBackupProcessor == directBackupProcessor()) {
+        if (entryBackupProcessor == DIRECT_BACKUP_PROCESSOR) {
             return backupRecord == null ? new RemoveBackupOperation(name, dataKey, false) : new PutBackupOperation(name, dataKey,
                     backupRecord, backupValue);
         }
@@ -127,7 +127,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
     }
 
     private boolean shouldUseDirectBackup() {
-        return mapContainer.getTotalBackupCount() > 0 && entryBackupProcessor == directBackupProcessor();
+        return mapContainer.getTotalBackupCount() > 0 && entryBackupProcessor == DIRECT_BACKUP_PROCESSOR;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -51,8 +51,8 @@ import java.util.UUID;
 import static com.hazelcast.core.Offloadable.NO_OFFLOADING;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
+import static com.hazelcast.map.impl.DirectBackupEntryProcessor.DIRECT_BACKUP_PROCESSOR;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
-import static com.hazelcast.map.listener.EntryProcessorUtil.directBackupProcessor;
 import static com.hazelcast.spi.impl.executionservice.ExecutionService.OFFLOADABLE_EXECUTOR;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.WAIT;
@@ -280,7 +280,7 @@ public class EntryOperation extends LockAwareOperation
             return null;
         }
         EntryProcessor backupProcessor = entryProcessor.getBackupProcessor();
-        if (backupProcessor == directBackupProcessor()) {
+        if (backupProcessor == DIRECT_BACKUP_PROCESSOR) {
             return backupRecord == null ? new RemoveBackupOperation(name, dataKey, false) : new PutBackupOperation(name, dataKey,
                     backupRecord, backupValue);
         }
@@ -300,7 +300,7 @@ public class EntryOperation extends LockAwareOperation
             return false;
         }
         return mapContainer.getTotalBackupCount() > 0
-                && entryProcessor.getBackupProcessor() == directBackupProcessor();
+                && entryProcessor.getBackupProcessor() == DIRECT_BACKUP_PROCESSOR;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -203,6 +203,10 @@ public final class EntryOperator {
         return entry.getByPrioritizingDataValue();
     }
 
+    public Data getValueData() {
+        return entry.getValueData();
+    }
+
     public Object getOldValue() {
         return oldValue;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -41,8 +41,8 @@ import java.util.List;
 import java.util.Set;
 
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
+import static com.hazelcast.map.impl.DirectBackupEntryProcessor.DIRECT_BACKUP_PROCESSOR;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
-import static com.hazelcast.map.listener.EntryProcessorUtil.directBackupProcessor;
 
 public class MultipleEntryOperation extends MapOperation
         implements MutatingOperation, PartitionAwareOperation, BackupAwareOperation {
@@ -119,7 +119,7 @@ public class MultipleEntryOperation extends MapOperation
     }
 
     private boolean shouldUseDirectBackup() {
-        return entryProcessor.getBackupProcessor() == directBackupProcessor()
+        return entryProcessor.getBackupProcessor() == DIRECT_BACKUP_PROCESSOR
                 && mapContainer.getTotalBackupCount() > 0;
     }
 
@@ -137,7 +137,7 @@ public class MultipleEntryOperation extends MapOperation
     public Operation getBackupOperation() {
         EntryProcessor backupProcessor = entryProcessor.getBackupProcessor();
         Operation backupOperation = null;
-        if (backupProcessor == directBackupProcessor()) {
+        if (backupProcessor == DIRECT_BACKUP_PROCESSOR) {
             backupOperation = getDirectBackupOperation();
         } else if (backupProcessor != null) {
             backupOperation = getMultipleEntryBackupOperation(backupProcessor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateOperation.java
@@ -16,13 +16,12 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.io.IOException;
 import java.util.Set;
@@ -48,8 +47,7 @@ public class MultipleEntryWithPredicateOperation extends MultipleEntryOperation 
     }
 
     @Override
-    public Operation getBackupOperation() {
-        EntryProcessor backupProcessor = entryProcessor.getBackupProcessor();
+    protected MultipleEntryBackupOperation getMultipleEntryBackupOperation(EntryProcessor backupProcessor) {
         return new MultipleEntryWithPredicateBackupOperation(name, keys, backupProcessor, predicate);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -46,8 +46,8 @@ import java.util.Queue;
 import java.util.Set;
 
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
+import static com.hazelcast.map.impl.DirectBackupEntryProcessor.DIRECT_BACKUP_PROCESSOR;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
-import static com.hazelcast.map.listener.EntryProcessorUtil.directBackupProcessor;
 
 /**
  * GOTCHA: This operation does NOT load missing keys from map-store for now.
@@ -237,7 +237,7 @@ public class PartitionWideEntryOperation extends MapOperation
     }
 
     private boolean shouldUseDirectBackup() {
-        return entryProcessor.getBackupProcessor() == directBackupProcessor()
+        return entryProcessor.getBackupProcessor() == DIRECT_BACKUP_PROCESSOR
                 && mapContainer.getTotalBackupCount() > 0;
     }
 
@@ -255,7 +255,7 @@ public class PartitionWideEntryOperation extends MapOperation
     public Operation getBackupOperation() {
         EntryProcessor backupProcessor = entryProcessor.getBackupProcessor();
         Operation backupOperation = null;
-        if (backupProcessor == directBackupProcessor()) {
+        if (backupProcessor == DIRECT_BACKUP_PROCESSOR) {
             // direct copy backup
             backupOperation = getDirectBackupOperation();
         } else if (backupProcessor != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -44,21 +43,8 @@ public class PartitionWideEntryWithPredicateOperation extends PartitionWideEntry
     }
 
     @Override
-    @SuppressFBWarnings(
-            value = {"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"},
-            justification = "backupProcessor can indeed be null so check is not redundant")
-    public Operation getBackupOperation() {
-        EntryProcessor backupProcessor = entryProcessor.getBackupProcessor();
-        if (backupProcessor == null) {
-            return null;
-        }
-        if (keysFromIndex != null) {
-            // if we used index we leverage it for the backup too
-            return new MultipleEntryBackupOperation(name, keysFromIndex, backupProcessor);
-        } else {
-            // if no index used we will do a full partition-scan on backup too
-            return new PartitionWideEntryWithPredicateBackupOperation(name, backupProcessor, getPredicate());
-        }
+    protected Operation getPartitionWideEntryBackupOperation(EntryProcessor backupProcessor) {
+        return new PartitionWideEntryWithPredicateBackupOperation(name, backupProcessor, getPredicate());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllDeleteAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllDeleteAllBackupOperation.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+public class PutAllDeleteAllBackupOperation extends PutAllBackupOperation {
+
+    private Set<Data> deletions;
+
+    public PutAllDeleteAllBackupOperation(String name, List<Object> dataKeyDataValueRecord, Set<Data> deletions,
+                                          boolean disableWanReplicationEvent) {
+        super(name, dataKeyDataValueRecord, disableWanReplicationEvent);
+        this.deletions = deletions;
+    }
+
+    public PutAllDeleteAllBackupOperation() {
+    }
+
+    @Override
+    protected void runInternal() {
+        super.runInternal();
+        if (deletions != null) {
+            Iterator<Data> it = deletions.iterator();
+            while (it.hasNext()) {
+                Data deletion = it.next();
+                removeBackup(deletion);
+                it.remove();
+            }
+        }
+    }
+
+    private void removeBackup(Data key) {
+        recordStore.removeBackup(key, getCallerProvenance());
+        publishWanRemove(key);
+        evict(key);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(deletions.size());
+        for (Data data : deletions) {
+            IOUtil.writeData(out, data);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        deletions = new HashSet<>(size);
+        for (int i = 0; i < size; i++) {
+            deletions.add(IOUtil.readData(in));
+        }
+    }
+
+    @Override
+    public int getClassId() {
+        return MapDataSerializerHook.PUT_ALL_DELETE_ALL_BACKUP;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryProcessorUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryProcessorUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.map.EntryProcessor;
+
+import java.util.Map;
+
+/**
+ * Utility class for {@link EntryProcessor}.
+ */
+public final class EntryProcessorUtil {
+
+    private static final DirectBackupEntryProcessor DIRECT_BACKUP_ENTRY_PROCESSOR = new DirectBackupEntryProcessor();
+
+    private static final class DirectBackupEntryProcessor<K, V, R> implements EntryProcessor<Object, Object, Object> {
+
+        @Override
+        public Object process(Map.Entry<Object, Object> entry) {
+            return null;
+        }
+
+        private Object readResolve() {
+            return DIRECT_BACKUP_ENTRY_PROCESSOR;
+        }
+    }
+
+    private EntryProcessorUtil() {
+    }
+
+    /**
+     * This method provides a special (singleton) backup {@link EntryProcessor}
+     * that can be returned by {@link EntryProcessor#getBackupProcessor()}
+     * to indicate that backups are to be made by transmitting all modifications
+     * to the backup replicas instead of applying the backup entry processor there.
+     * This may be useful in cases when loading the backup entries and/or applying
+     * the backup entry processor is costly and direct copy of the modifications
+     * is more efficient.
+     * @return the direct backup processor singleton.
+     */
+    @SuppressWarnings("unchecked")
+    public static <K, V, R> EntryProcessor<K, V, R> directBackupProcessor() {
+        return (EntryProcessor<K, V, R>) DIRECT_BACKUP_ENTRY_PROCESSOR;
+    }
+}


### PR DESCRIPTION
Introduced `EntryProcessorUtil#directBackupProcessor()` that provides
a special (singleton) backup `EntryProcessor` that can be returned
by `EntryProcessor#getBackupProcessor()` to indicate that backups
are to be made by transmitting all modifications to the backup
replicas instead of applying the backup entry processor there.
This may be useful in cases when loading the backup entries and/or
applying the backup entry processor is costly and direct copy of
the modifications is more efficient.

Resolves https://github.com/hazelcast/hazelcast/issues/16101