### PR TITLE
Several migration fixes 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -1287,7 +1287,8 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
         if (event.getReplicaIndex() > getBackupCount()) {
             return null;
         }
-        return new UnsafeStateReplicationOp(unsafeModeStates[event.getPartitionId()]);
+        UnsafeModePartitionState state = unsafeModeStates[event.getPartitionId()];
+        return state.commitIndex() == 0 ? null : new UnsafeStateReplicationOp(state);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/UnsafeModePartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/UnsafeModePartitionState.java
@@ -43,6 +43,10 @@ public class UnsafeModePartitionState implements IdentifiedDataSerializable {
         return ++commitIndex;
     }
 
+    long commitIndex() {
+        return commitIndex;
+    }
+
     boolean registerWaitingOp(long commitIndex, Operation op) {
         return waitingOperations.putIfAbsent(commitIndex, op) == null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
@@ -62,7 +62,7 @@ public class DurableExecutorPartitionContainer {
             }
             map.put(executorContainer.getName(), executorContainer);
         }
-        return new ReplicationOperation(map);
+        return map.isEmpty() ? null : new ReplicationOperation(map);
     }
 
     public void clearRingBuffersHavingLesserBackupCountThan(int thresholdReplicaIndex) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -96,6 +96,7 @@ import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEM
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_SERVICE_MAX_BACKUP_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_SERVICE_MIGRATION_QUEUE_SIZE;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_PREFIX;
+import static com.hazelcast.internal.partition.impl.MigrationManager.applyMigration;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
@@ -453,7 +454,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
 
             int partitionId = migrationInfo.getPartitionId();
             InternalPartitionImpl partition = (InternalPartitionImpl) partitions[partitionId];
-            migrationManager.applyMigration(partition, migrationInfo);
+            applyMigration(partition, migrationInfo);
 
             migrationInfo.setStatus(MigrationStatus.SUCCESS);
             completedMigrations.add(migrationInfo);
@@ -486,7 +487,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             for (MigrationInfo migrationInfo : migrationInfos) {
                 int partitionId = migrationInfo.getPartitionId();
                 InternalPartitionImpl partition = (InternalPartitionImpl) partitions[partitionId];
-                migrationManager.applyMigration(partition, migrationInfo);
+                applyMigration(partition, migrationInfo);
                 migrationInfo.setStatus(MigrationStatus.SUCCESS);
             }
 
@@ -622,24 +623,21 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
     }
 
     private boolean validateSenderIsMaster(Address sender, String messageType) {
-        Address master = latestMaster;
         Address thisAddress = node.getThisAddress();
-        if (thisAddress.equals(master) && !thisAddress.equals(sender)) {
+        if (thisAddress.equals(latestMaster) && !thisAddress.equals(sender)) {
             logger.warning("This is the master node and received " + messageType + " from " + sender
                     + ". Ignoring incoming state! ");
             return false;
         } else {
-            if (sender == null || !sender.equals(master)) {
+            if (!isMemberMaster(sender)) {
                 if (node.clusterService.getMember(sender) == null) {
                     logger.severe("Received " + messageType + " from an unknown member!"
-                            + " => Sender: " + sender + ", Master: " + master + "! ");
-                    return false;
+                            + " => Sender: " + sender + "! ");
                 } else {
                     logger.warning("Received " + messageType + ", but its sender doesn't seem to be master!"
-                            + " => Sender: " + sender + ", Master: " + master + "! "
-                            + "(Ignore if master node has changed recently.)");
-                    return false;
+                            + " => Sender: " + sender + "! (Ignore if master node has changed recently.)");
                 }
+                return false;
             }
         }
         return true;
@@ -811,7 +809,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                         logger.fine("Applying completed migration " + migration);
                     }
                     InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(migration.getPartitionId());
-                    migrationManager.applyMigration(partition, migration);
+                    applyMigration(partition, migration);
                 }
                 migrationManager.scheduleActiveMigrationFinalization(migration);
             }
@@ -1195,12 +1193,31 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
      * This method should be used instead of {@code node.isMaster()}
      * when the logic relies on being master.
      */
-    boolean isLocalMemberMaster() {
-        Address master = latestMaster;
-        if (master == null && node.getClusterService().getSize() == 1) {
-            master = node.getClusterService().getMasterAddress();
+    public boolean isLocalMemberMaster() {
+        return isMemberMaster(node.getThisAddress());
+    }
+
+    /**
+     * Returns true only if the member is the last known master by
+     * {@code InternalPartitionServiceImpl} and {@code ClusterServiceImpl}.
+     * <p>
+     * Last known master is updated under partition service lock,
+     * when the former master leaves the cluster.
+     */
+    public boolean isMemberMaster(Address address) {
+        if (address == null) {
+            return false;
         }
-        return node.getThisAddress().equals(master);
+        Address master = latestMaster;
+        ClusterServiceImpl clusterService = node.getClusterService();
+
+        // If this is the only node, we can rely on ClusterService only.
+        if (master == null && clusterService.getSize() == 1) {
+            master = clusterService.getMasterAddress();
+        }
+
+        // address should be the known master by both PartitionService and ClusterService.
+        return address.equals(master) && address.equals(clusterService.getMasterAddress());
     }
 
     @SuppressWarnings("checkstyle:npathcomplexity")
@@ -1240,7 +1257,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(migration.getPartitionId());
             boolean added = migrationManager.addCompletedMigration(migration);
             assert added : "Could not add completed migration on destination: " + migration;
-            migrationManager.applyMigration(partition, migration);
+            applyMigration(partition, migration);
             partitionStateManager.setVersion(finalVersion);
             activeMigration.setStatus(migration.getStatus());
             migrationManager.finalizeMigration(migration);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -601,7 +601,7 @@ public class MigrationManager {
     }
 
     /** Mutates the partition state and applies the migration. */
-    void applyMigration(InternalPartitionImpl partition, MigrationInfo migrationInfo) {
+    static void applyMigration(InternalPartitionImpl partition, MigrationInfo migrationInfo) {
         final PartitionReplica[] members = Arrays.copyOf(partition.getReplicas(), InternalPartition.MAX_REPLICA_COUNT);
         if (migrationInfo.getSourceCurrentReplicaIndex() > -1) {
             members[migrationInfo.getSourceCurrentReplicaIndex()] = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -284,7 +284,7 @@ public class MigrationManager {
         }
     }
 
-    MigrationInfo getActiveMigration() {
+    public MigrationInfo getActiveMigration() {
         return activeMigrationInfo;
     }
 
@@ -818,10 +818,11 @@ public class MigrationManager {
                 if (migrationCollector.lostPartitionDestination != null) {
                     lostPartitions.put(partitionId, migrationCollector.lostPartitionDestination);
                 }
-                migrations.add(migrationCollector.migrations);
-                migrationCount += migrationCollector.migrations.size();
+                if (!migrationCollector.migrations.isEmpty()) {
+                    migrations.add(migrationCollector.migrations);
+                    migrationCount += migrationCollector.migrations.size();
+                }
             }
-            migrationCount += lostPartitions.size();
 
             stats.markNewRepartition(migrationCount);
             if (migrationCount > 0) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
@@ -42,12 +42,11 @@ public final class FetchPartitionStateOperation extends AbstractPartitionOperati
     @Override
     public void run() {
         Address caller = getCallerAddress();
-        NodeEngine nodeEngine = getNodeEngine();
-        Address master = nodeEngine.getMasterAddress();
-        if (!caller.equals(master)) {
-            String msg = caller + " requested our partition table but it's not our known master. " + "Master: " + master;
+        InternalPartitionServiceImpl service = getService();
+        if (!service.isMemberMaster(caller)) {
+            String msg = caller + " requested our partition table but it's not our known master.";
             getLogger().warning(msg);
-            throw new IllegalStateException(msg);
+            throw new RetryableHazelcastException(msg);
         }
         InternalPartitionServiceImpl service = getService();
         partitionState = service.createPartitionStateInternal();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
@@ -16,17 +16,26 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.spi.impl.operationservice.ExceptionAction;
-import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.CallerNotMemberException;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.spi.impl.operationservice.CallStatus;
+import com.hazelcast.spi.impl.operationservice.ExceptionAction;
+import com.hazelcast.spi.impl.operationservice.Offload;
+import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Operation sent by the master to the cluster members to fetch their partition state.
@@ -34,22 +43,73 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 public final class FetchPartitionStateOperation extends AbstractPartitionOperation
         implements MigrationCycleOperation {
 
-    private PartitionRuntimeState partitionState;
-
     public FetchPartitionStateOperation() {
     }
 
     @Override
-    public void run() {
+    public void beforeRun() {
         Address caller = getCallerAddress();
+        Address masterAddress = getNodeEngine().getMasterAddress();
+        ILogger logger = getLogger();
+        if (!caller.equals(masterAddress)) {
+            String msg = caller + " requested our partition table but it's not our known master. " + "Master: " + masterAddress;
+            logger.warning(msg);
+            // Master address should be already updated after mastership claim.
+            throw new IllegalStateException(msg);
+        }
+
         InternalPartitionServiceImpl service = getService();
         if (!service.isMemberMaster(caller)) {
-            String msg = caller + " requested our partition table but it's not our known master.";
-            getLogger().warning(msg);
+            String msg = caller + " requested our partition table but it's not the master known by migration system.";
+            logger.warning(msg);
+            // PartitionService has not received result of mastership claim process yet.
+            // It will learn eventually.
             throw new RetryableHazelcastException(msg);
         }
-        InternalPartitionServiceImpl service = getService();
-        partitionState = service.createPartitionStateInternal();
+    }
+
+    @Override
+    public CallStatus call() {
+        return new OffloadImpl();
+    }
+
+    private final class OffloadImpl extends Offload {
+        private OffloadImpl() {
+            super(FetchPartitionStateOperation.this);
+        }
+
+        @Override
+        public void start() {
+            NodeEngine nodeEngine = getNodeEngine();
+            OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+            OperationExecutor executor = operationService.getOperationExecutor();
+
+            int partitionThreadCount = executor.getPartitionThreadCount();
+            SendPartitionStateTask barrierTask = new SendPartitionStateTask(partitionThreadCount);
+            executor.executeOnPartitionThreads(barrierTask);
+        }
+    }
+
+    /**
+     * SendPartitionStateTask is executed on all partition operation threads
+     * and sends local partition state to the caller (the master) after
+     * ensuring all pending/running migration operations are completed.
+     */
+    private final class SendPartitionStateTask implements Runnable, UrgentSystemOperation {
+        private final AtomicInteger remaining = new AtomicInteger();
+
+        private SendPartitionStateTask(int partitionThreadCount) {
+            remaining.set(partitionThreadCount);
+        }
+
+        @Override
+        public void run() {
+            if (remaining.decrementAndGet() == 0) {
+                InternalPartitionServiceImpl service = getService();
+                PartitionRuntimeState partitionState = service.createPartitionStateInternal();
+                sendResponse(partitionState);
+            }
+        }
     }
 
     @Override
@@ -60,11 +120,6 @@ public final class FetchPartitionStateOperation extends AbstractPartitionOperati
             return ExceptionAction.THROW_EXCEPTION;
         }
         return super.onInvocationException(throwable);
-    }
-
-    @Override
-    public Object getResponse() {
-        return partitionState;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
@@ -16,16 +16,18 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.internal.cluster.impl.operations.JoinOperation;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 
 import java.io.IOException;
 
@@ -35,8 +37,7 @@ import java.io.IOException;
  * @see InternalPartitionServiceImpl#publishPartitionRuntimeState
  * @see InternalPartitionServiceImpl#syncPartitionRuntimeState
  */
-public final class PartitionStateOperation extends AbstractPartitionOperation
-        implements MigrationCycleOperation, JoinOperation {
+public final class PartitionStateOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
 
     private PartitionRuntimeState partitionState;
     private boolean sync;
@@ -78,6 +79,15 @@ public final class PartitionStateOperation extends AbstractPartitionOperation
     @Override
     public String getServiceName() {
         return InternalPartitionService.SERVICE_NAME;
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException
+                || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -106,10 +106,14 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
         }
 
         Address masterAddress = nodeEngine.getMasterAddress();
-        Address callerAddress = getCallerAddress();
-        if (!callerAddress.equals(masterAddress)) {
-            throw new IllegalStateException("Caller is not master node! Caller: " + callerAddress
-                + ", Master: " + masterAddress);
+        Address caller = getCallerAddress();
+        if (!caller.equals(masterAddress)) {
+            throw new IllegalStateException("Caller is not master node! Caller: " + caller + ", Master: " + masterAddress);
+        }
+
+        InternalPartitionServiceImpl partitionService = getService();
+        if (!partitionService.isMemberMaster(caller)) {
+            throw new RetryableHazelcastException("Caller is not master node known by migration system! Caller: " + caller);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -23,8 +24,6 @@ import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.spi.impl.NodeEngine;
 
 public class ShutdownRequestOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
 
@@ -34,13 +33,11 @@ public class ShutdownRequestOperation extends AbstractPartitionOperation impleme
     @Override
     public void run() {
         InternalPartitionServiceImpl partitionService = getService();
-        final ILogger logger = getLogger();
-        final Address caller = getCallerAddress();
+        ILogger logger = getLogger();
+        Address caller = getCallerAddress();
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final ClusterService clusterService = nodeEngine.getClusterService();
-
-        if (clusterService.isMaster()) {
+        if (partitionService.isLocalMemberMaster()) {
+            ClusterService clusterService = getNodeEngine().getClusterService();
             Member member = clusterService.getMember(caller);
             if (member != null) {
                 if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
@@ -16,13 +16,12 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.impl.NodeEngine;
 
 public class ShutdownResponseOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
@@ -33,26 +32,22 @@ public class ShutdownResponseOperation extends AbstractPartitionOperation implem
     @Override
     public void run() {
         InternalPartitionServiceImpl partitionService = getService();
-        final ILogger logger = getLogger();
-        final Address caller = getCallerAddress();
+        ILogger logger = getLogger();
+        Address caller = getCallerAddress();
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final ClusterService clusterService = nodeEngine.getClusterService();
-        final Address masterAddress = clusterService.getMasterAddress();
-
+        NodeEngine nodeEngine = getNodeEngine();
         if (nodeEngine.isRunning()) {
             logger.severe("Received a shutdown response from " + caller + ", but this node is not shutting down!");
             return;
         }
 
-        boolean fromMaster = masterAddress.equals(caller);
-        if (fromMaster) {
+        if (partitionService.isMemberMaster(caller)) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Received shutdown response from " + caller);
             }
             partitionService.onShutdownResponse();
         } else {
-            logger.warning("Received shutdown response from " + caller + " but known master is: " + masterAddress);
+            logger.warning("Received shutdown response from " + caller + " but it's not the known master");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
@@ -70,7 +70,7 @@ public class ScheduledExecutorPartition extends AbstractScheduledExecutorContain
             map.put(container.getName(), container.prepareForReplication());
         }
 
-        return new ReplicationOperation(map);
+        return map.isEmpty() ? null : new ReplicationOperation(map);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -386,9 +386,10 @@ public final class OperationExecutorImpl implements OperationExecutor, StaticMet
     @Override
     public void executeOnPartitionThreads(Runnable task) {
         checkNotNull(task, "task can't be null");
+        boolean priority = task instanceof UrgentSystemOperation;
 
         for (OperationThread partitionThread : partitionThreads) {
-            partitionThread.queue.add(task, true);
+            partitionThread.queue.add(task, priority);
         }
     }
 


### PR DESCRIPTION
Several fixes in migration system. See individual commits for more details:

* PartitionStateOperation should not be sent to unknown members
* Migration operations should rely master member observed by PartitionService
* Fix race between fetching the most recent partition table and ongoing migration
* Only first migration fragment should set active migration in MigrationOperation
* Avoid unnecessary empty replication operations

Backport of https://github.com/hazelcast/hazelcast/pull/16627
Fixes #16601