### PR TITLE
Several migration fixes 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -100,6 +100,7 @@ import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEM
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.partition.impl.MigrationManager.applyMigration;
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -503,7 +504,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
 
             int partitionId = migrationInfo.getPartitionId();
             InternalPartitionImpl partition = (InternalPartitionImpl) partitions[partitionId];
-            migrationManager.applyMigration(partition, migrationInfo);
+            applyMigration(partition, migrationInfo);
 
             migrationInfo.setStatus(MigrationStatus.SUCCESS);
             completedMigrations.add(migrationInfo);
@@ -536,7 +537,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             for (MigrationInfo migrationInfo : migrationInfos) {
                 int partitionId = migrationInfo.getPartitionId();
                 InternalPartitionImpl partition = (InternalPartitionImpl) partitions[partitionId];
-                migrationManager.applyMigration(partition, migrationInfo);
+                applyMigration(partition, migrationInfo);
                 migrationInfo.setStatus(MigrationStatus.SUCCESS);
             }
 
@@ -724,24 +725,21 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
     }
 
     private boolean validateSenderIsMaster(Address sender, String messageType) {
-        Address master = latestMaster;
         Address thisAddress = node.getThisAddress();
-        if (thisAddress.equals(master) && !thisAddress.equals(sender)) {
+        if (thisAddress.equals(latestMaster) && !thisAddress.equals(sender)) {
             logger.warning("This is the master node and received " + messageType + " from " + sender
                     + ". Ignoring incoming state! ");
             return false;
         } else {
-            if (sender == null || !sender.equals(master)) {
+            if (!isMemberMaster(sender)) {
                 if (node.clusterService.getMember(sender) == null) {
                     logger.severe("Received " + messageType + " from an unknown member!"
-                            + " => Sender: " + sender + ", Master: " + master + "! ");
-                    return false;
+                            + " => Sender: " + sender + "! ");
                 } else {
                     logger.warning("Received " + messageType + ", but its sender doesn't seem to be master!"
-                            + " => Sender: " + sender + ", Master: " + master + "! "
-                            + "(Ignore if master node has changed recently.)");
-                    return false;
+                            + " => Sender: " + sender + "! (Ignore if master node has changed recently.)");
                 }
+                return false;
             }
         }
         return true;
@@ -950,7 +948,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                         logger.fine("Applying completed migration " + migration);
                     }
                     InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(migration.getPartitionId());
-                    migrationManager.applyMigration(partition, migration);
+                    applyMigration(partition, migration);
                 }
                 migrationManager.scheduleActiveMigrationFinalization(migration);
             }
@@ -1337,12 +1335,31 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
      * This method should be used instead of {@code node.isMaster()}
      * when the logic relies on being master.
      */
-    boolean isLocalMemberMaster() {
-        Address master = latestMaster;
-        if (master == null && node.getClusterService().getSize() == 1) {
-            master = node.getClusterService().getMasterAddress();
+    public boolean isLocalMemberMaster() {
+        return isMemberMaster(node.getThisAddress());
+    }
+
+    /**
+     * Returns true only if the member is the last known master by
+     * {@code InternalPartitionServiceImpl} and {@code ClusterServiceImpl}.
+     * <p>
+     * Last known master is updated under partition service lock,
+     * when the former master leaves the cluster.
+     */
+    public boolean isMemberMaster(Address address) {
+        if (address == null) {
+            return false;
         }
-        return node.getThisAddress().equals(master);
+        Address master = latestMaster;
+        ClusterServiceImpl clusterService = node.getClusterService();
+
+        // If this is the only node, we can rely on ClusterService only.
+        if (master == null && clusterService.getSize() == 1) {
+            master = clusterService.getMasterAddress();
+        }
+
+        // address should be the known master by both PartitionService and ClusterService.
+        return address.equals(master) && address.equals(clusterService.getMasterAddress());
     }
 
     @SuppressWarnings("checkstyle:npathcomplexity")
@@ -1382,7 +1399,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(migration.getPartitionId());
             boolean added = migrationManager.addCompletedMigration(migration);
             assert added : "Could not add completed migration on destination: " + migration;
-            migrationManager.applyMigration(partition, migration);
+            applyMigration(partition, migration);
             partitionStateManager.setVersion(finalVersion);
             activeMigration.setStatus(migration.getStatus());
             migrationManager.finalizeMigration(migration);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -645,7 +645,7 @@ public class MigrationManager {
     }
 
     /** Mutates the partition state and applies the migration. */
-    void applyMigration(InternalPartitionImpl partition, MigrationInfo migrationInfo) {
+    static void applyMigration(InternalPartitionImpl partition, MigrationInfo migrationInfo) {
         final PartitionReplica[] members = Arrays.copyOf(partition.getReplicas(), InternalPartition.MAX_REPLICA_COUNT);
         if (migrationInfo.getSourceCurrentReplicaIndex() > -1) {
             members[migrationInfo.getSourceCurrentReplicaIndex()] = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -291,7 +291,7 @@ public class MigrationManager {
         }
     }
 
-    MigrationInfo getActiveMigration() {
+    public MigrationInfo getActiveMigration() {
         return activeMigrationInfo;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -144,13 +144,18 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
     /** Verifies that the local master is equal to the migration master. */
     final void verifyMaster() {
         NodeEngine nodeEngine = getNodeEngine();
+        InternalPartitionServiceImpl service = getService();
         Address masterAddress = nodeEngine.getMasterAddress();
 
         if (!migrationInfo.getMaster().equals(masterAddress)) {
             throw new IllegalStateException("Migration initiator is not master node! => " + toString());
         }
 
-        if (getMigrationParticipantType() == MigrationParticipant.SOURCE && !masterAddress.equals(getCallerAddress())) {
+        if (!service.isMemberMaster(migrationInfo.getMaster())) {
+            throw new RetryableHazelcastException("Migration initiator is not the master node known by migration system!");
+        }
+
+        if (getMigrationParticipantType() == MigrationParticipant.SOURCE && !service.isMemberMaster(getCallerAddress())) {
             throw new IllegalStateException("Caller is not master node! => " + toString());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
@@ -22,11 +22,20 @@ import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Offload;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.exception.CallerNotMemberException;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Operation sent by the master to the cluster members to fetch their partition state.
@@ -34,22 +43,73 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 public final class FetchPartitionStateOperation extends AbstractPartitionOperation
         implements MigrationCycleOperation {
 
-    private PartitionRuntimeState partitionState;
-
     public FetchPartitionStateOperation() {
     }
 
     @Override
-    public void run() {
+    public void beforeRun() {
         Address caller = getCallerAddress();
+        Address masterAddress = getNodeEngine().getMasterAddress();
+        ILogger logger = getLogger();
+        if (!caller.equals(masterAddress)) {
+            String msg = caller + " requested our partition table but it's not our known master. " + "Master: " + masterAddress;
+            logger.warning(msg);
+            // Master address should be already updated after mastership claim.
+            throw new IllegalStateException(msg);
+        }
+
         InternalPartitionServiceImpl service = getService();
         if (!service.isMemberMaster(caller)) {
-            String msg = caller + " requested our partition table but it's not our known master.";
-            getLogger().warning(msg);
+            String msg = caller + " requested our partition table but it's not the master known by migration system.";
+            logger.warning(msg);
+            // PartitionService has not received result of mastership claim process yet.
+            // It will learn eventually.
             throw new RetryableHazelcastException(msg);
         }
-        InternalPartitionServiceImpl service = getService();
-        partitionState = service.createPartitionStateInternal();
+    }
+
+    @Override
+    public CallStatus call() {
+        return new OffloadImpl();
+    }
+
+    private final class OffloadImpl extends Offload {
+        private OffloadImpl() {
+            super(FetchPartitionStateOperation.this);
+        }
+
+        @Override
+        public void start() {
+            NodeEngine nodeEngine = getNodeEngine();
+            OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+            OperationExecutor executor = operationService.getOperationExecutor();
+
+            int partitionThreadCount = executor.getPartitionThreadCount();
+            SendPartitionStateTask barrierTask = new SendPartitionStateTask(partitionThreadCount);
+            executor.executeOnPartitionThreads(barrierTask);
+        }
+    }
+
+    /**
+     * SendPartitionStateTask is executed on all partition operation threads
+     * and sends local partition state to the caller (the master) after
+     * ensuring all pending/running migration operations are completed.
+     */
+    private final class SendPartitionStateTask implements Runnable, UrgentSystemOperation {
+        private final AtomicInteger remaining = new AtomicInteger();
+
+        private SendPartitionStateTask(int partitionThreadCount) {
+            remaining.set(partitionThreadCount);
+        }
+
+        @Override
+        public void run() {
+            if (remaining.decrementAndGet() == 0) {
+                InternalPartitionServiceImpl service = getService();
+                PartitionRuntimeState partitionState = service.createPartitionStateInternal();
+                sendResponse(partitionState);
+            }
+        }
     }
 
     @Override
@@ -60,11 +120,6 @@ public final class FetchPartitionStateOperation extends AbstractPartitionOperati
             return ExceptionAction.THROW_EXCEPTION;
         }
         return super.onInvocationException(throwable);
-    }
-
-    @Override
-    public Object getResponse() {
-        return partitionState;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
@@ -42,12 +42,11 @@ public final class FetchPartitionStateOperation extends AbstractPartitionOperati
     @Override
     public void run() {
         Address caller = getCallerAddress();
-        NodeEngine nodeEngine = getNodeEngine();
-        Address master = nodeEngine.getMasterAddress();
-        if (!caller.equals(master)) {
-            String msg = caller + " requested our partition table but it's not our known master. " + "Master: " + master;
+        InternalPartitionServiceImpl service = getService();
+        if (!service.isMemberMaster(caller)) {
+            String msg = caller + " requested our partition table but it's not our known master.";
             getLogger().warning(msg);
-            throw new IllegalStateException(msg);
+            throw new RetryableHazelcastException(msg);
         }
         InternalPartitionServiceImpl service = getService();
         partitionState = service.createPartitionStateInternal();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -93,10 +93,14 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
         }
 
         Address masterAddress = nodeEngine.getMasterAddress();
-        Address callerAddress = getCallerAddress();
-        if (!callerAddress.equals(masterAddress)) {
-            throw new IllegalStateException("Caller is not master node! Caller: " + callerAddress
-                + ", Master: " + masterAddress);
+        Address caller = getCallerAddress();
+        if (!caller.equals(masterAddress)) {
+            throw new IllegalStateException("Caller is not master node! Caller: " + caller + ", Master: " + masterAddress);
+        }
+
+        InternalPartitionServiceImpl partitionService = getService();
+        if (!partitionService.isMemberMaster(caller)) {
+            throw new RetryableHazelcastException("Caller is not master node known by migration system! Caller: " + caller);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -24,7 +24,6 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.NodeEngine;
 
 public class ShutdownRequestOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
 
@@ -34,13 +33,11 @@ public class ShutdownRequestOperation extends AbstractPartitionOperation impleme
     @Override
     public void run() {
         InternalPartitionServiceImpl partitionService = getService();
-        final ILogger logger = getLogger();
-        final Address caller = getCallerAddress();
+        ILogger logger = getLogger();
+        Address caller = getCallerAddress();
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final ClusterService clusterService = nodeEngine.getClusterService();
-
-        if (clusterService.isMaster()) {
+        if (partitionService.isLocalMemberMaster()) {
+            ClusterService clusterService = getNodeEngine().getClusterService();
             Member member = clusterService.getMember(caller);
             if (member != null) {
                 if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
@@ -33,26 +32,22 @@ public class ShutdownResponseOperation extends AbstractPartitionOperation implem
     @Override
     public void run() {
         InternalPartitionServiceImpl partitionService = getService();
-        final ILogger logger = getLogger();
-        final Address caller = getCallerAddress();
+        ILogger logger = getLogger();
+        Address caller = getCallerAddress();
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final ClusterService clusterService = nodeEngine.getClusterService();
-        final Address masterAddress = clusterService.getMasterAddress();
-
+        NodeEngine nodeEngine = getNodeEngine();
         if (nodeEngine.isRunning()) {
             logger.severe("Received a shutdown response from " + caller + ", but this node is not shutting down!");
             return;
         }
 
-        boolean fromMaster = masterAddress.equals(caller);
-        if (fromMaster) {
+        if (partitionService.isMemberMaster(caller)) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Received shutdown response from " + caller);
             }
             partitionService.onShutdownResponse();
         } else {
-            logger.warning("Received shutdown response from " + caller + " but known master is: " + masterAddress);
+            logger.warning("Received shutdown response from " + caller + " but it's not the known master");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -388,9 +388,10 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     @Override
     public void executeOnPartitionThreads(Runnable task) {
         checkNotNull(task, "task can't be null");
+        boolean priority = task instanceof UrgentSystemOperation;
 
         for (OperationThread partitionThread : partitionThreads) {
-            partitionThread.queue.add(task, true);
+            partitionThread.queue.add(task, priority);
         }
     }
 


### PR DESCRIPTION
Several fixes in migration system. See individual commits for more details:

* PartitionStateOperation should not be sent to unknown members
* Migration operations should rely master member observed by PartitionService
* Fix race between fetching the most recent partition table and ongoing migration
* Only first migration fragment should set active migration in MigrationOperation

Backport of #16627