### PR TITLE
Make logging of version, cluster name and ip optional

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
@@ -44,12 +44,16 @@ public class ClientLoggingService implements LoggingService {
     private final LoggerFactory loggerFactory;
     private final BuildInfo buildInfo;
     private final String instanceName;
+    private final boolean detailsEnabled;
     private volatile String versionMessage;
 
-    public ClientLoggingService(String clusterName, String loggingType, BuildInfo buildInfo, String instanceName) {
+    public ClientLoggingService(
+            String clusterName, String loggingType, BuildInfo buildInfo, String instanceName, boolean detailsEnabled
+    ) {
         this.loggerFactory = Logger.newLoggerFactory(loggingType);
         this.buildInfo = buildInfo;
         this.instanceName = instanceName;
+        this.detailsEnabled = detailsEnabled;
         updateClusterName(clusterName);
     }
 
@@ -100,7 +104,7 @@ public class ClientLoggingService implements LoggingService {
         @Override
         public void log(Level level, String message, Throwable thrown) {
             if (logger.isLoggable(level)) {
-                String logMessage = versionMessage + message;
+                String logMessage = detailsEnabled ? versionMessage + message : message;
                 logger.log(level, logMessage, thrown);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -212,9 +212,12 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         this.clientFailoverConfig = clientFailoverConfig;
         this.instanceName = instanceName;
 
-        String loggingType = config.getProperty(ClusterProperty.LOGGING_TYPE.getName());
+
+        HazelcastProperties props = new HazelcastProperties(config.getProperties());
+        String loggingType = props.getString(ClusterProperty.LOGGING_TYPE);
+        boolean detailsEnabled = props.getBoolean(ClusterProperty.LOGGING_ENABLE_DETAILS);
         this.loggingService = new ClientLoggingService(config.getClusterName(),
-                loggingType, BuildInfoProvider.getBuildInfo(), instanceName);
+                loggingType, BuildInfoProvider.getBuildInfo(), instanceName, detailsEnabled);
 
         if (clientConfig != null) {
             MetricsConfigHelper.overrideClientMetricsConfig(clientConfig,

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -127,6 +127,7 @@ import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
 import static com.hazelcast.spi.properties.ClusterProperty.DISCOVERY_SPI_ENABLED;
 import static com.hazelcast.spi.properties.ClusterProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED;
 import static com.hazelcast.spi.properties.ClusterProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
+import static com.hazelcast.spi.properties.ClusterProperty.LOGGING_ENABLE_DETAILS;
 import static com.hazelcast.spi.properties.ClusterProperty.LOGGING_TYPE;
 import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_ENABLED;
 import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_POLICY;
@@ -210,7 +211,8 @@ public class Node {
         this.version = MemberVersion.of(buildInfo.getVersion());
 
         String loggingType = properties.getString(LOGGING_TYPE);
-        loggingService = new LoggingServiceImpl(config.getClusterName(), loggingType, buildInfo);
+        boolean detailsEnabled = properties.getBoolean(LOGGING_ENABLE_DETAILS);
+        loggingService = new LoggingServiceImpl(config.getClusterName(), loggingType, buildInfo, detailsEnabled);
         MetricsConfigHelper.overrideMemberMetricsConfig(staticConfig, getLogger(MetricsConfigHelper.class));
 
         checkAdvancedNetworkConfig(config);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -570,6 +570,12 @@ public final class ClusterProperty {
     public static final HazelcastProperty LOGGING_TYPE
             = new HazelcastProperty("hazelcast.logging.type", "jdk");
 
+    /**
+     * Controls whether cluster name, ip and version should be included in all log messages
+     */
+    public static final HazelcastProperty LOGGING_ENABLE_DETAILS
+            = new HazelcastProperty("hazelcast.logging.details.enabled", true);
+
     public static final HazelcastProperty ENABLE_JMX
             = new HazelcastProperty("hazelcast.jmx", false);
     public static final HazelcastProperty JMX_UPDATE_INTERVAL_SECONDS

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientExecutionServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientExecutionServiceImplTest.java
@@ -48,7 +48,9 @@ public class ClientExecutionServiceImplTest {
         String name = "ClientExecutionServiceImplTest";
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         HazelcastProperties properties = new HazelcastProperties(new Config());
-        ClientLoggingService loggingService = new ClientLoggingService(name, "jdk", BuildInfoProvider.getBuildInfo(), name);
+        ClientLoggingService loggingService = new ClientLoggingService(
+                name, "jdk", BuildInfoProvider.getBuildInfo(), name, true
+        );
 
         executionService = new ClientExecutionServiceImpl(name, classLoader, properties, loggingService);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
@@ -85,7 +85,7 @@ public class LocalRaftIntegration implements RaftIntegration {
         this.groupId = groupId;
         this.service = service;
         this.appendNopEntryOnLeaderElection = appendNopEntryOnLeaderElection;
-        this.loggingService = new LoggingServiceImpl("dev", "log4j2", BuildInfoProvider.getBuildInfo());
+        this.loggingService = new LoggingServiceImpl("dev", "log4j2", BuildInfoProvider.getBuildInfo(), true);
         loggingService.setThisMember(getThisMember(localEndpoint));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class IOBalancerTest {
-    private final LoggingService loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
+    private final LoggingService loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo(), true);
 
     // https://github.com/hazelcast/hazelcast/issues/11501
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
@@ -74,7 +74,7 @@ public class MockIOService implements IOService {
     private final ILogger logger;
 
     public MockIOService(int port) throws Exception {
-        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
+        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo(), true);
         logger = loggingService.getLogger(MockIOService.class);
         serverSocketChannel = ServerSocketChannel.open();
         ServerSocket serverSocket = serverSocketChannel.socket();

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -72,7 +72,7 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
     @Before
     public void setup() throws Exception {
 
-        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
+        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo(), true);
         logger = loggingService.getLogger(TcpIpConnection_AbstractTest.class);
 
         metricsRegistryA = newMetricsRegistry();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -71,7 +71,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
 
     @Before
     public void setup() throws Exception {
-        loggingService = new LoggingServiceImpl("foo", "jdk", new BuildInfo("1", "1", "1", 1, false, (byte) 1, "1"));
+        loggingService = new LoggingServiceImpl("foo", "jdk", new BuildInfo("1", "1", "1", 1, false, (byte) 1, "1"), true);
 
         serializationService = new DefaultSerializationServiceBuilder().build();
         config = smallInstanceConfig();


### PR DESCRIPTION
Currently these are always logged, creating a lot of noise in logs. If you just have a single node running, this information isn’t useful but makes the logs much harder to read, obscuring important messages.

This PR introduces the “hazelcast.logging.details.enabled” property which 
makes this optional.

Backport of #16622 