### PR TITLE
Fix typo in GC unknownCount metric descriptor constant

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -166,7 +166,7 @@ public final class MetricDescriptorConstants {
     public static final String GC_METRIC_MINOR_TIME = "minorTime";
     public static final String GC_METRIC_MAJOR_COUNT = "majorCount";
     public static final String GC_METRIC_MAJOR_TIME = "majorTime";
-    public static final String GC_METRIC_UNKNOWN_COUNT = "unknowsnCount";
+    public static final String GC_METRIC_UNKNOWN_COUNT = "unknownCount";
     public static final String GC_METRIC_UNKNOWN_TIME = "unknownTime";
     // ===[/GC]=========================================================
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,6 +49,11 @@ public class ClassLoadingMetricSetTest extends HazelcastTestSupport {
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
         ClassLoadingMetricSet.register(metricsRegistry);
+    }
+
+    @After
+    public void tearDown() {
+        metricsRegistry.shutdown();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,6 +42,11 @@ public class FileMetricSetTest extends HazelcastTestSupport {
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
         FileMetricSet.register(metricsRegistry);
+    }
+
+    @After
+    public void tearDown() {
+        metricsRegistry.shutdown();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
@@ -19,10 +19,10 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,6 +46,11 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
         gcStats = new GarbageCollectionMetricSet.GcStats();
     }
 
+    @After
+    public void tearDown() {
+        metricsRegistry.shutdown();
+    }
+
     @Test
     public void utilityConstructor() {
         assertUtilityConstructor(GarbageCollectionMetricSet.class);
@@ -54,48 +59,36 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
     @Test
     public void minorCount() {
         final LongGauge gauge = metricsRegistry.newLongGauge("gc.minorCount");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                gcStats.run();
-                assertEquals(gcStats.minorCount, gauge.read(), 1);
-            }
+        assertTrueEventually(() -> {
+            gcStats.run();
+            assertEquals(gcStats.minorCount, gauge.read(), 1);
         });
     }
 
     @Test
-    public void minorTime() throws InterruptedException {
+    public void minorTime() {
         final LongGauge gauge = metricsRegistry.newLongGauge("gc.minorTime");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                gcStats.run();
-                assertEquals(gcStats.minorTime, gauge.read(), SECONDS.toMillis(1));
-            }
+        assertTrueEventually(() -> {
+            gcStats.run();
+            assertEquals(gcStats.minorTime, gauge.read(), SECONDS.toMillis(1));
         });
     }
 
     @Test
     public void majorCount() {
         final LongGauge gauge = metricsRegistry.newLongGauge("gc.majorCount");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                gcStats.run();
-                assertEquals(gcStats.majorCount, gauge.read(), 1);
-            }
+        assertTrueEventually(() -> {
+            gcStats.run();
+            assertEquals(gcStats.majorCount, gauge.read(), 1);
         });
     }
 
     @Test
     public void majorTime() {
         final LongGauge gauge = metricsRegistry.newLongGauge("gc.majorTime");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                gcStats.run();
-                assertEquals(gcStats.majorTime, gauge.read(), SECONDS.toMillis(1));
-            }
+        assertTrueEventually(() -> {
+            gcStats.run();
+            assertEquals(gcStats.majorTime, gauge.read(), SECONDS.toMillis(1));
         });
     }
 
@@ -103,24 +96,18 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
     @Test
     public void unknownCount() {
         final LongGauge gauge = metricsRegistry.newLongGauge("gc.unknownCount");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                gcStats.run();
-                assertEquals(gcStats.unknownCount, gauge.read(), 1);
-            }
+        assertTrueEventually(() -> {
+            gcStats.run();
+            assertEquals(gcStats.unknownCount, gauge.read(), 1);
         });
     }
 
     @Test
     public void unknownTime() {
         final LongGauge gauge = metricsRegistry.newLongGauge("gc.unknownTime");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                gcStats.run();
-                assertEquals(gcStats.unknownTime, gauge.read(), SECONDS.toMillis(1));
-            }
+        assertTrueEventually(() -> {
+            gcStats.run();
+            assertEquals(gcStats.unknownTime, gauge.read(), SECONDS.toMillis(1));
         });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +53,11 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(getLogger(MetricsRegistryImpl.class), INFO);
         OperatingSystemMetricSet.register(metricsRegistry);
+    }
+
+    @After
+    public void tearDown() {
+        metricsRegistry.shutdown();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,6 +48,11 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), ProbeLevel.INFO);
         RuntimeMetricSet.register(metricsRegistry);
         runtime = Runtime.getRuntime();
+    }
+
+    @After
+    public void tearDown() {
+        metricsRegistry.shutdown();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,6 +46,11 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
         ThreadMetricSet.register(metricsRegistry);
+    }
+
+    @After
+    public void tearDown() {
+        metricsRegistry.shutdown();
     }
 
     @Test


### PR DESCRIPTION
`GarbageCollectionMetricSetTest.unknownCount` failed constantly, but with
J9 JRE only that reports non-zero unknown GC count. The reason for the
failure is a typo in `MetricDescriptorConstants`. Because the `unknownCount`
on the OpenJDK/Oracle buids are zero, the PR builder didn't catch this
typo, but the IBM JDK build did catch it. This change fixes the type
plus shuts down the `MetricsRegistry` in every metrics set tests to prevent
having hanging executors and "garbage" around.

BACKPORT: #16635

Fixes #16565