### PR TITLE
Renamed MultiMap proxy implementation to follow established naming convention

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
@@ -49,7 +49,7 @@ import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
 
 @SuppressWarnings("checkstyle:methodcount")
-public class ObjectMultiMapProxy<K, V>
+public class MultiMapProxyImpl<K, V>
         extends MultiMapProxySupport
         implements MultiMap<K, V>, InitializingObject {
 
@@ -57,7 +57,7 @@ public class ObjectMultiMapProxy<K, V>
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
     protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
 
-    public ObjectMultiMapProxy(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
+    public MultiMapProxyImpl(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
         super(config, service, nodeEngine, name);
     }
 
@@ -179,7 +179,7 @@ public class ObjectMultiMapProxy<K, V>
     public Set<Map.Entry<K, V>> entrySet() {
         NodeEngine nodeEngine = getNodeEngine();
         Map map = entrySetInternal();
-        Set<Map.Entry<K, V>> entrySet = new HashSet<Map.Entry<K, V>>();
+        Set<Map.Entry<K, V>> entrySet = new HashSet<>();
         for (Object obj : map.values()) {
             if (obj == null) {
                 continue;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -206,7 +206,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         MultiMapConfig multiMapConfig = nodeEngine.getConfig().findMultiMapConfig(name);
         checkMultiMapConfig(multiMapConfig, nodeEngine.getSplitBrainMergePolicyProvider());
 
-        return new ObjectMultiMapProxy(multiMapConfig, this, nodeEngine, name);
+        return new MultiMapProxyImpl(multiMapConfig, this, nodeEngine, name);
     }
 
     @Override


### PR DESCRIPTION
All distributed data structures follow a certain naming pattern `{ds}ProxyImpl` and `Client{ds}Proxy`, like for example:
- `IMap` has `MapProxyImpl` and `ClientMapProxy`
- `IList` has `ListProxyImpl` and `ClientListProxy`

MultiMap on the other hand brakes this pattern by having `ObjectMultiMapProxy` instead `MultiMapProxyImpl` name. This PR renames this class name to follow the correct pattern.

@mmedenjak and @pveentjer confirmed that there is no meaningful reason for choosing the current name for the mentioned implementation.

Besides that, in the renamed class, removed unnecessary type arguments when newing up a HashSet<>, utilizing the diamond operator.