### PR TITLE
Made ScheduledExecutorServiceBasicTest more reliable

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
@@ -54,15 +54,33 @@ public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTe
         double expectedResult = 169.4;
 
         HazelcastInstance[] instances = createClusterWithCount(2);
-        ICountDownLatch runsCountLatch = instances[0].getCPSubsystem().getCountDownLatch("runsCountLatchName");
-        runsCountLatch.trySetCount(1);
+
+        ICountDownLatch initCountLatch = instances[0].getCPSubsystem().getCountDownLatch("initCountLatchName");
+        initCountLatch.trySetCount(1);
+
+        ICountDownLatch waitCountLatch = instances[0].getCPSubsystem().getCountDownLatch("waitCountLatchName");
+        waitCountLatch.trySetCount(1);
+
+        ICountDownLatch doneCountLatch = instances[0].getCPSubsystem().getCountDownLatch("doneCountLatchName");
+        doneCountLatch.trySetCount(1);
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.schedule(
-                new ICountdownLatchCallableTask("runsCountLatchName", 15000), delay, SECONDS);
+                new ICountdownLatchCallableTask(initCountLatch.getName(), waitCountLatch.getName(), doneCountLatch.getName()), delay, SECONDS);
+
+        assertOpenEventually(initCountLatch);
+
+        int sleepPeriod = 10000;
+        long start = System.currentTimeMillis();
+        new Thread(() -> {
+            sleepAtLeastMillis(sleepPeriod);
+            waitCountLatch.countDown();
+        }).start();
 
         double result = future.get();
 
+        assertTrue(System.currentTimeMillis() - start > sleepPeriod);
+        assertTrue(doneCountLatch.await(0, SECONDS));
         assertEquals(expectedResult, result, 0);
         assertTrue(future.isDone());
         assertFalse(future.isCancelled());

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceTestSupport.java
@@ -116,25 +116,23 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
 
     static class ICountdownLatchCallableTask implements Callable<Double>, Serializable, HazelcastInstanceAware {
 
-        final String runLatchName;
-        final int sleepPeriod;
+        final String initLatchName;
+        final String waitLatchName;
+        final String doneLatchName;
 
         transient HazelcastInstance instance;
 
-        ICountdownLatchCallableTask(String runLatchName, int sleepPeriod) {
-            this.runLatchName = runLatchName;
-            this.sleepPeriod = sleepPeriod;
+        ICountdownLatchCallableTask(String initLatchName, String waitLatchName, String doneLatchName) {
+            this.initLatchName = initLatchName;
+            this.waitLatchName = waitLatchName;
+            this.doneLatchName = doneLatchName;
         }
 
         @Override
         public Double call() {
-            try {
-                sleep(sleepPeriod);
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-            }
-
-            instance.getCPSubsystem().getCountDownLatch(runLatchName).countDown();
+            instance.getCPSubsystem().getCountDownLatch(initLatchName).countDown();
+            assertOpenEventually(instance.getCPSubsystem().getCountDownLatch(waitLatchName));
+            instance.getCPSubsystem().getCountDownLatch(doneLatchName).countDown();
             return 77 * 2.2;
         }
 


### PR DESCRIPTION
Namely, rewrote schedule_withLongSleepingCallable_cancelledAndGet
to use latches instead of sleeps which are unreliable.

Fixes https://github.com/hazelcast/hazelcast/issues/16530