### PR TITLE
Fix ClientReliableTopicOnClusterRestartTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableTopicProxy.java
@@ -162,10 +162,9 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     }
 
     //for testing
-    public boolean isListenerCancelled(UUID registrationID) {
+    public boolean isListenerCancelled(@Nonnull UUID registrationID) {
         checkNotNull(registrationID, "registrationId can't be null");
-
-        MessageRunner runner = runnersMap.get(registrationID);
+        MessageRunner<?> runner = runnersMap.get(registrationID);
         if (runner == null) {
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
@@ -47,19 +47,19 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
     protected final ILogger logger;
     protected final ReliableMessageListener<E> listener;
     protected final String topicName;
-    protected long sequence;
+    protected volatile long sequence;
     private final SerializationService serializationService;
     private final ConcurrentMap<UUID, MessageRunner<E>> runnersMap;
     private final UUID id;
     private final Executor executor;
-    private final int batchSze;
+    private final int batchSize;
     private volatile boolean cancelled;
 
     public MessageRunner(UUID id,
                          ReliableMessageListener<E> listener,
                          Ringbuffer<ReliableTopicMessage> ringbuffer,
                          String topicName,
-                         int batchSze,
+                         int batchSize,
                          SerializationService serializationService,
                          Executor executor,
                          ConcurrentMap<UUID, MessageRunner<E>> runnersMap,
@@ -70,7 +70,7 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
         this.topicName = topicName;
         this.serializationService = serializationService;
         this.logger = logger;
-        this.batchSze = batchSze;
+        this.batchSize = batchSize;
         this.executor = executor;
         this.runnersMap = runnersMap;
 
@@ -86,7 +86,7 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
         if (cancelled) {
             return;
         }
-        ringbuffer.readManyAsync(sequence, 1, batchSze, null)
+        ringbuffer.readManyAsync(sequence, 1, batchSize, null)
                   .whenCompleteAsync(this, executor);
     }
 


### PR DESCRIPTION
Fixes the test testing behaviour of a loss tolerant listener when the
instance is restarted. This test failure is similar to the one described
in https://github.com/hazelcast/hazelcast/issues/16430#issuecomment-571947692 and the [fix PR](https://github.com/hazelcast/hazelcast/pull/16440).

Basically, it might happen that the new item is added to the restarted
member before the listener sends a read operation to the new member.
Since it was previously on a higher sequence, the sequence will be
reset to the currently highest, which is one after the latest added item.

In the case when the item is added to the ringbuffer before the read
operation is executed, the listener will simply ignore the added item
and wait for a new one.

The test asserts that the listener is able to continue after the cluster
restarts so we modify the test so that we add new items until we
eventually get an item.

Also, made some minor modifications like using small instances in the
test and made the sequence field volatile since it is accessed from
different threads.

Fixes: https://github.com/hazelcast/hazelcast/issues/16623