### PR TITLE
[BACKPORT] Preserve vote when Raft leader demotes to the follower role

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/RaftState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/RaftState.java
@@ -435,8 +435,10 @@ public final class RaftState {
 
     private void setTerm(int newTerm) {
         assert newTerm >= term : "New term: " + newTerm + ", current term: " + term;
-        term = newTerm;
-        votedFor = null;
+        if (newTerm > term) {
+            term = newTerm;
+            votedFor = null;
+        }
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
@@ -49,7 +49,9 @@ import java.util.concurrent.TimeoutException;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getCommitIndex;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLastLogOrSnapshotEntry;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getRole;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getTerm;
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getVotedFor;
 import static com.hazelcast.cp.internal.raft.impl.testing.LocalRaftGroup.LocalRaftGroupBuilder.newGroup;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
@@ -761,7 +763,7 @@ public class LocalRaftTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void when_thereAreTooManyInflightAppendedEntries_then_newAppendsAreRejected() throws ExecutionException, InterruptedException {
+    public void when_thereAreTooManyInflightAppendedEntries_then_newAppendsAreRejected() {
         int uncommittedEntryCount = 10;
         RaftAlgorithmConfig config = new RaftAlgorithmConfig().setUncommittedEntryCountToRejectNewAppends(uncommittedEntryCount);
         group = newGroup(2, config);
@@ -783,7 +785,7 @@ public class LocalRaftTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void when_leaderStaysInMinority_then_itDemotesItselfToFollower() throws ExecutionException, InterruptedException {
+    public void when_leaderStaysInMinority_then_itDemotesItselfToFollower() {
         group = newGroup(3);
         group.start();
 
@@ -797,6 +799,22 @@ public class LocalRaftTest extends HazelcastTestSupport {
             fail();
         } catch (StaleAppendRequestException ignored) {
         }
+    }
+
+    @Test
+    public void when_leaderDemotesToFollower_then_itShouldNotDeleteItsVote() {
+        group = newGroup(3);
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        assertEquals(leader.getLocalMember(), getVotedFor(leader));
+
+        group.split(leader.getLocalMember());
+
+        assertTrueEventually(() -> assertEquals(RaftRole.FOLLOWER,  getRole(leader)));
+
+        assertEquals(leader.getLocalMember(), getVotedFor(leader));
     }
 
     private static RaftAlgorithmConfig newRaftConfigWithNoSnapshotting(int maxEntryCount) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/RaftUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/RaftUtil.java
@@ -44,12 +44,7 @@ public class RaftUtil {
     }
 
     public static <T extends RaftEndpoint> T getLeaderMember(final RaftNodeImpl node) {
-        Callable<RaftEndpoint> task = new Callable<RaftEndpoint>() {
-            @Override
-            public RaftEndpoint call() {
-                return node.state().leader();
-            }
-        };
+        Callable<RaftEndpoint> task = () -> node.state().leader();
         return (T) readRaftState(node, task);
     }
 
@@ -72,12 +67,7 @@ public class RaftUtil {
     }
 
     public static long getLastApplied(final RaftNodeImpl node) {
-        Callable<Long> task = new Callable<Long>() {
-            @Override
-            public Long call() {
-                return node.state().lastApplied();
-            }
-        };
+        Callable<Long> task = () -> node.state().lastApplied();
         return readRaftState(node, task);
     }
 
@@ -120,6 +110,12 @@ public class RaftUtil {
 
     public static RaftGroupMembers getCommittedGroupMembers(RaftNodeImpl node) {
         Callable<RaftGroupMembers> task = () -> node.state().committedGroupMembers();
+
+        return readRaftState(node, task);
+    }
+
+    public static RaftEndpoint getVotedFor(RaftNodeImpl node) {
+        Callable<RaftEndpoint> task = () -> node.state().votedFor();
 
         return readRaftState(node, task);
     }


### PR DESCRIPTION
When a Raft leader stops receiving heartbeats from the majority, it switches
to the follower role in the same term. However, during this switch, it also
deletes its own vote in the term. This is a faulty behaviour because once
a vote is given in any term it should not be deleted, otherwise another leader
could be elected in the same term.

Backport of #16643