### PR TITLE
Disable management for CacheTypesConfigTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
@@ -43,8 +43,8 @@ import javax.cache.spi.CachingProvider;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 import static com.hazelcast.config.UserCodeDeploymentConfig.ClassCacheMode.OFF;
 import static org.junit.Assert.assertNotNull;
 
@@ -159,8 +159,8 @@ public class CacheTypesConfigTest extends HazelcastTestSupport {
 
     // overridden in another context
     CacheConfig<String, Person> createCacheConfig() {
-        CacheConfig<String, Person> cacheConfig = new CacheConfig<String, Person>();
-        cacheConfig.setTypes(String.class, Person.class).setManagementEnabled(true);
+        CacheConfig<String, Person> cacheConfig = new CacheConfig<>();
+        cacheConfig.setTypes(String.class, Person.class);
         return cacheConfig;
     }
 


### PR DESCRIPTION
Enabling cache management results in
caches being registered with the static
Cache MBean, which may fail other cache
management tests. Cache management is not
really required for `CacheTypesConfigTest`.

Fixes #15969 