### PR TITLE
Upgrade log4j2 version to 2.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,7 @@
 
         <log4j.version>1.2.17</log4j.version>
 
-        <!--- This is the last log4j2 version working with Java 6 -->
-        <log4j2.version>2.3</log4j2.version>
+        <log4j2.version>2.13.0</log4j2.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
 
         <jackson.version>2.9.7</jackson.version>


### PR DESCRIPTION
This is to fix blocking of threads inside date converter:
```
java.lang.Thread.State: BLOCKED, on lock=org.apache.logging.log4j.core.pattern.DatePatternConverter@1d084df7, owned by hz.modest_elgamal.HealthMonitor, id=470, cpu=225087565 nsecs, usr=140000000 nsecs, blocked=57 msecs, waited=60868 msecs
		at org.apache.logging.log4j.core.pattern.DatePatternConverter.format(DatePatternConverter.java:249)
		at org.apache.logging.log4j.core.pattern.PatternFormatter.format(PatternFormatter.java:36)
		at org.apache.logging.log4j.core.layout.PatternLayout.toSerializable(PatternLayout.java:196)
		at org.apache.logging.log4j.core.layout.PatternLayout.toSerializable(PatternLayout.java:55)
		at org.apache.logging.log4j.core.layout.AbstractStringLayout.toByteArray(AbstractStringLayout.java:71)
		at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.append(AbstractOutputStreamAppender.java:108)
		at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:99)
		at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:430)
		at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:409)
		at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:367)
		at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:112)
		at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:732)
		at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:700)
		at com.hazelcast.logging.Log4j2Factory$Log4j2Logger.log(Log4j2Factory.java:57)

```
