### PR TITLE
Fix DurableExecutorServiceTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/TaskRingBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/TaskRingBuffer.java
@@ -193,6 +193,13 @@ public class TaskRingBuffer {
         return Math.abs(sequence % ringItems.length);
     }
 
+    /**
+     * Returns the number of currently running tasks in this ringbuffer.
+     */
+    public int getTaskSize() {
+        return callableCounter;
+    }
+
     public void write(ObjectDataOutput out) throws IOException {
         out.writeInt(head);
         out.writeInt(ringItems.length);

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -48,7 +47,8 @@ public class DurableLongRunningTaskTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        Config config = new Config().setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + CALL_TIMEOUT);
+        Config config = smallInstanceConfig()
+                .setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + CALL_TIMEOUT);
         hz = createHazelcastInstance(config);
     }
 
@@ -57,12 +57,9 @@ public class DurableLongRunningTaskTest extends HazelcastTestSupport {
         final String response = "foobar";
         SleepingCallable task = new SleepingCallable(response, 6 * CALL_TIMEOUT);
         final Future<String> f = hz.getDurableExecutorService("e").submit(task);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertTrue(f.isDone());
-                assertEquals(response, f.get());
-            }
+        assertTrueEventually(() -> {
+            assertTrue(f.isDone());
+            assertEquals(response, f.get());
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
@@ -43,13 +43,13 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     @Test
     public void testRetrieveResult_WhenNewNodesJoin() throws ExecutionException, InterruptedException {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(smallInstanceConfig());
 
         DurableExecutorService executorService = instance1.getDurableExecutorService(randomString());
         SleepingTask task = new SleepingTask(5);
         DurableExecutorServiceFuture<Boolean> future = executorService.submit(task);
-        factory.newHazelcastInstance();
-        factory.newHazelcastInstance();
+        factory.newHazelcastInstance(smallInstanceConfig());
+        factory.newHazelcastInstance(smallInstanceConfig());
         assertTrue(future.get());
         Future<Boolean> retrievedFuture = executorService.retrieveAndDisposeResult(future.getTaskId());
         assertTrue(retrievedFuture.get());
@@ -59,7 +59,7 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     public void testDisposeResult() throws Exception {
         String key = randomString();
         String name = randomString();
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createHazelcastInstance(smallInstanceConfig());
         DurableExecutorService executorService = instance.getDurableExecutorService(name);
         BasicTestCallable task = new BasicTestCallable();
         DurableExecutorServiceFuture<String> future = executorService.submitToKeyOwner(task, key);
@@ -73,9 +73,9 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     public void testRetrieveAndDispose_WhenSubmitterMemberDown() throws Exception {
         String name = randomString();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
-        factory.newHazelcastInstance();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(smallInstanceConfig());
+        HazelcastInstance instance2 = factory.newHazelcastInstance(smallInstanceConfig());
+        factory.newHazelcastInstance(smallInstanceConfig());
         String key = generateKeyOwnedBy(instance2);
 
         DurableExecutorService executorService = instance1.getDurableExecutorService(name);
@@ -96,9 +96,9 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     public void testRetrieveAndDispose_WhenOwnerMemberDown() throws Exception {
         String name = randomString();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
-        factory.newHazelcastInstance();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(smallInstanceConfig());
+        HazelcastInstance instance2 = factory.newHazelcastInstance(smallInstanceConfig());
+        factory.newHazelcastInstance(smallInstanceConfig());
         String key = generateKeyOwnedBy(instance1);
 
         DurableExecutorService executorService = instance1.getDurableExecutorService(name);
@@ -119,7 +119,7 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     public void testSingleExecution_WhenMigratedAfterCompletion_WhenOwnerMemberKilled() throws Exception {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
 
-        HazelcastInstance[] instances = factory.newInstances();
+        HazelcastInstance[] instances = factory.newInstances(smallInstanceConfig());
         HazelcastInstance first = instances[0];
         HazelcastInstance second = instances[1];
 
@@ -133,7 +133,7 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
         String name = randomString();
         DurableExecutorService executorService = first.getDurableExecutorService(name);
         IncrementAtomicLongRunnable task = new IncrementAtomicLongRunnable(runCounterName);
-        DurableExecutorServiceFuture future = executorService.submitToKeyOwner(task, key);
+        DurableExecutorServiceFuture<?> future = executorService.submitToKeyOwner(task, key);
 
         future.get(); // Wait for it to finish
 
@@ -153,9 +153,9 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     public void testRetrieve_WhenSubmitterMemberDown() throws Exception {
         String name = randomString();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
-        factory.newHazelcastInstance();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(smallInstanceConfig());
+        HazelcastInstance instance2 = factory.newHazelcastInstance(smallInstanceConfig());
+        factory.newHazelcastInstance(smallInstanceConfig());
         String key = generateKeyOwnedBy(instance2);
 
         DurableExecutorService executorService = instance1.getDurableExecutorService(name);
@@ -173,9 +173,9 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     public void testRetrieve_WhenOwnerMemberDown() throws Exception {
         String name = randomString();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
-        factory.newHazelcastInstance();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(smallInstanceConfig());
+        HazelcastInstance instance2 = factory.newHazelcastInstance(smallInstanceConfig());
+        factory.newHazelcastInstance(smallInstanceConfig());
         String key = generateKeyOwnedBy(instance1);
 
         DurableExecutorService executorService = instance1.getDurableExecutorService(name);
@@ -192,7 +192,7 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     @Test
     public void testRetrieve_WhenResultOverwritten() throws Exception {
         String name = randomString();
-        Config config = new Config();
+        Config config = smallInstanceConfig();
         config.getDurableExecutorConfig(name).setCapacity(1).setDurability(0);
         HazelcastInstance instance = createHazelcastInstance(config);
         DurableExecutorService executorService = instance.getDurableExecutorService(name);

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSingleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSingleNodeTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -73,7 +72,7 @@ public class DurableSingleNodeTest extends ExecutorServiceTestSupport {
     @Test
     public void submitBasicTask() throws Exception {
         Callable<String> task = new BasicTestCallable();
-        Future future = executor.submit(task);
+        Future<String> future = executor.submit(task);
         assertEquals(future.get(), BasicTestCallable.RESULT);
     }
 
@@ -100,7 +99,7 @@ public class DurableSingleNodeTest extends ExecutorServiceTestSupport {
     @Test
     public void isDoneAfterGet() throws Exception {
         Callable<String> task = new BasicTestCallable();
-        Future future = executor.submit(task);
+        Future<String> future = executor.submit(task);
         assertEquals(future.get(), BasicTestCallable.RESULT);
         assertTrue(future.isDone());
     }
@@ -121,10 +120,8 @@ public class DurableSingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test
     public void issue292() throws Exception {
-        final BlockingQueue<Member> responseQueue = new ArrayBlockingQueue<Member>(1);
-        executor.submit(new MemberCheck()).toCompletableFuture().thenAccept(response -> {
-            responseQueue.offer(response);
-        });
+        final BlockingQueue<Member> responseQueue = new ArrayBlockingQueue<>(1);
+        executor.submit(new MemberCheck()).toCompletableFuture().thenAccept(responseQueue::offer);
         assertNotNull(responseQueue.poll(10, TimeUnit.SECONDS));
     }
 
@@ -217,14 +214,4 @@ public class DurableSingleNodeTest extends ExecutorServiceTestSupport {
     //        }
     //    });
     //}
-
-    static class LatchRunnable implements Runnable, Serializable {
-
-        static CountDownLatch latch;
-
-        @Override
-        public void run() {
-            latch.countDown();
-        }
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSmallClusterTest.java
@@ -49,7 +49,7 @@ public class DurableSmallClusterTest extends ExecutorServiceTestSupport {
 
     @Before
     public void setup() {
-        instances = createHazelcastInstanceFactory(NODE_COUNT).newInstances();
+        instances = createHazelcastInstanceFactory(NODE_COUNT).newInstances(smallInstanceConfig());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class DurableSmallClusterTest extends ExecutorServiceTestSupport {
 
     @Test
     public void submitToKeyOwner_runnable() {
-        NullResponseCountingCallback callback = new NullResponseCountingCallback(instances.length);
+        NullResponseCountingCallback<Object> callback = new NullResponseCountingCallback<>(instances.length);
 
         for (HazelcastInstance instance : instances) {
             DurableExecutorService service = instance.getDurableExecutorService("testSubmitToKeyOwnerRunnable");
@@ -99,26 +99,26 @@ public class DurableSmallClusterTest extends ExecutorServiceTestSupport {
     public void submitToSeveralNodes_callable() throws Exception {
         for (int i = 0; i < instances.length; i++) {
             DurableExecutorService service = instances[i].getDurableExecutorService("testSubmitMultipleNode");
-            Future future = service.submit(new IncrementAtomicLongCallable("testSubmitMultipleNode"));
-            assertEquals((long) (i + 1), future.get());
+            Future<Long> future = service.submit(new IncrementAtomicLongCallable("testSubmitMultipleNode"));
+            assertEquals(i + 1, (long) future.get());
         }
     }
 
     @Test(timeout = TEST_TIMEOUT)
     public void submitToKeyOwner_callable() throws Exception {
-        List<Future> futures = new ArrayList<>();
+        List<Future<Boolean>> futures = new ArrayList<>();
 
         for (HazelcastInstance instance : instances) {
             DurableExecutorService service = instance.getDurableExecutorService("testSubmitToKeyOwnerCallable");
             Member localMember = instance.getCluster().getLocalMember();
             int key = findNextKeyForMember(instance, localMember);
 
-            Future future = service.submitToKeyOwner(new MemberUUIDCheckCallable(localMember.getUuid()), key);
+            Future<Boolean> future = service.submitToKeyOwner(new MemberUUIDCheckCallable(localMember.getUuid()), key);
             futures.add(future);
         }
 
-        for (Future future : futures) {
-            assertTrue((Boolean) future.get(60, TimeUnit.SECONDS));
+        for (Future<Boolean> future : futures) {
+            assertTrue(future.get(60, TimeUnit.SECONDS));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/MemberDurableExecutorNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/MemberDurableExecutorNullTest.java
@@ -37,7 +37,7 @@ public class MemberDurableExecutorNullTest extends AbstractDurableExecutorNullTe
     @Before
     public void setup() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        instance = factory.newHazelcastInstance();
+        instance = factory.newHazelcastInstance(smallInstanceConfig());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
@@ -19,10 +19,9 @@ package com.hazelcast.executor;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.core.IExecutorService;
+import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.partition.PartitionAware;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -35,7 +34,6 @@ import org.junit.runner.RunWith;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -54,15 +52,15 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
     @Before
     public void setup() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        localHz = factory.newHazelcastInstance();
-        remoteHz = factory.newHazelcastInstance();
+        localHz = factory.newHazelcastInstance(smallInstanceConfig());
+        remoteHz = factory.newHazelcastInstance(smallInstanceConfig());
         taskStartedLatchName = randomName();
         taskStartedLatch = localHz.getCPSubsystem().getCountDownLatch(taskStartedLatchName);
         taskStartedLatch.trySetCount(1);
     }
 
     @Test
-    public void testCancel_submitRandom() throws Exception {
+    public void testCancel_submitRandom() {
         IExecutorService executorService = localHz.getExecutorService(randomString());
         Future<Boolean> future = executorService.submit(new SleepingTask(Integer.MAX_VALUE, taskStartedLatchName));
         awaitTaskStart();
@@ -73,12 +71,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
     }
 
     public void awaitTaskStart() {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEquals(0, taskStartedLatch.getCount());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(0, taskStartedLatch.getCount()));
     }
 
     @Test(expected = CancellationException.class)
@@ -93,12 +86,12 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
     }
 
     @Test
-    public void testCancel_submitToLocalMember() throws Exception {
+    public void testCancel_submitToLocalMember() {
         testCancel_submitToMember(localHz, localHz.getCluster().getLocalMember());
     }
 
     @Test
-    public void testCancel_submitToRemoteMember() throws Exception {
+    public void testCancel_submitToRemoteMember() {
         testCancel_submitToMember(localHz, remoteHz.getCluster().getLocalMember());
     }
 
@@ -112,7 +105,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
         testGetValueAfterCancel_submitToMember(localHz, remoteHz.getCluster().getLocalMember());
     }
 
-    private void testCancel_submitToMember(HazelcastInstance instance, Member member) throws Exception {
+    private void testCancel_submitToMember(HazelcastInstance instance, Member member) {
         IExecutorService executorService = instance.getExecutorService(randomString());
         Future<Boolean> future
                 = executorService.submitToMember(new SleepingTask(Integer.MAX_VALUE, taskStartedLatchName), member);
@@ -132,7 +125,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
     }
 
     @Test
-    public void testCancel_submitToKeyOwner() throws ExecutionException, InterruptedException {
+    public void testCancel_submitToKeyOwner() {
         IExecutorService executorService = localHz.getExecutorService(randomString());
         Future<Boolean> future
                 = executorService.submitToKeyOwner(new SleepingTask(Integer.MAX_VALUE, taskStartedLatchName), randomString());
@@ -154,7 +147,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
         future.get(10, TimeUnit.SECONDS);
     }
 
-    static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware, HazelcastInstanceAware {
+    static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware<String>, HazelcastInstanceAware {
         private final String taskStartedLatchName;
         private long sleepSeconds;
         private HazelcastInstance hz;
@@ -178,7 +171,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
         }
 
         @Override
-        public Object getPartitionKey() {
+        public String getPartitionKey() {
             return "key";
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceLiteMemberTest.java
@@ -16,12 +16,11 @@
 
 package com.hazelcast.executor;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.map.IMap;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -45,12 +44,12 @@ import static org.junit.Assert.assertTrue;
 public class ExecutorServiceLiteMemberTest
         extends ExecutorServiceTestSupport {
 
-    private Config liteConfig = new Config().setLiteMember(true);
+    private Config liteConfig = smallInstanceConfig().setLiteMember(true);
 
     @Test(expected = RejectedExecutionException.class)
     public void test_executeRunnable_failsWhenNoLiteMemberExists() {
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
-        final HazelcastInstance instance = factory.newHazelcastInstance();
+        final HazelcastInstance instance = factory.newHazelcastInstance(smallInstanceConfig());
         final String name = randomString();
         final IExecutorService executor = instance.getExecutorService(name);
         executor.execute(new ResultSettingRunnable(name), LITE_MEMBER_SELECTOR);
@@ -61,23 +60,19 @@ public class ExecutorServiceLiteMemberTest
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        final HazelcastInstance other = factory.newHazelcastInstance(smallInstanceConfig());
 
         final String name = randomString();
         final IExecutorService executor = other.getExecutorService(name);
         executor.execute(new ResultSettingRunnable(name), LITE_MEMBER_SELECTOR);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                final IMap<Object, Object> results = lite1.getMap(name);
-                assertEquals(1, results.size());
-                final boolean executedOnLite1 = results.containsKey(lite1.getCluster().getLocalMember());
-                final boolean executedOnLite2 = results.containsKey(lite2.getCluster().getLocalMember());
+        assertTrueEventually(() -> {
+            final IMap<Object, Object> results = lite1.getMap(name);
+            assertEquals(1, results.size());
+            final boolean executedOnLite1 = results.containsKey(lite1.getCluster().getLocalMember());
+            final boolean executedOnLite2 = results.containsKey(lite2.getCluster().getLocalMember());
 
-                assertTrue(executedOnLite1 || executedOnLite2);
-            }
+            assertTrue(executedOnLite1 || executedOnLite2);
         });
     }
 
@@ -86,21 +81,17 @@ public class ExecutorServiceLiteMemberTest
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        final HazelcastInstance other = factory.newHazelcastInstance(smallInstanceConfig());
 
         final String name = randomString();
         final IExecutorService executor = other.getExecutorService(name);
         executor.executeOnMembers(new ResultSettingRunnable(name), LITE_MEMBER_SELECTOR);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                final IMap<Object, Object> results = lite1.getMap(name);
-                assertEquals(2, results.size());
-                assertTrue(results.containsKey(lite1.getCluster().getLocalMember()));
-                assertTrue(results.containsKey(lite2.getCluster().getLocalMember()));
-            }
+        assertTrueEventually(() -> {
+            final IMap<Object, Object> results = lite1.getMap(name);
+            assertEquals(2, results.size());
+            assertTrue(results.containsKey(lite1.getCluster().getLocalMember()));
+            assertTrue(results.containsKey(lite2.getCluster().getLocalMember()));
         });
 
     }
@@ -108,7 +99,7 @@ public class ExecutorServiceLiteMemberTest
     @Test(expected = RejectedExecutionException.class)
     public void test_submitCallable_failsWhenNoLiteMemberExists() {
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
-        final HazelcastInstance instance = factory.newHazelcastInstance();
+        final HazelcastInstance instance = factory.newHazelcastInstance(smallInstanceConfig());
         final IExecutorService executor = instance.getExecutorService(randomString());
         executor.submit(new LocalMemberReturningCallable(), LITE_MEMBER_SELECTOR);
     }
@@ -119,7 +110,7 @@ public class ExecutorServiceLiteMemberTest
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        final HazelcastInstance other = factory.newHazelcastInstance(smallInstanceConfig());
 
         final IExecutorService executor = other.getExecutorService(randomString());
         final Future<Member> future = executor.submit(new LocalMemberReturningCallable(), LITE_MEMBER_SELECTOR);
@@ -136,7 +127,7 @@ public class ExecutorServiceLiteMemberTest
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        final HazelcastInstance other = factory.newHazelcastInstance(smallInstanceConfig());
 
         final IExecutorService executor = other.getExecutorService(randomString());
         final Map<Member, Future<Member>> results = executor
@@ -156,9 +147,9 @@ public class ExecutorServiceLiteMemberTest
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        final HazelcastInstance other = factory.newHazelcastInstance(smallInstanceConfig());
 
-        final CountingDownExecutionCallback<Member> callback = new CountingDownExecutionCallback<Member>(1);
+        final CountingDownExecutionCallback<Member> callback = new CountingDownExecutionCallback<>(1);
         final IExecutorService executor = other.getExecutorService(randomString());
         executor.submit(new LocalMemberReturningCallable(), LITE_MEMBER_SELECTOR, callback);
 
@@ -174,24 +165,20 @@ public class ExecutorServiceLiteMemberTest
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        final HazelcastInstance other = factory.newHazelcastInstance(smallInstanceConfig());
 
         final ResultHoldingMultiExecutionCallback callback = new ResultHoldingMultiExecutionCallback();
         final IExecutorService executor = other.getExecutorService(randomString());
         executor.submitToMembers(new LocalMemberReturningCallable(), LITE_MEMBER_SELECTOR, callback);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                final Map<Member, Object> results = callback.getResults();
+        assertTrueEventually(() -> {
+            final Map<Member, Object> results = callback.getResults();
 
-                assertNotNull(results);
-                final Member liteMember1 = lite1.getCluster().getLocalMember();
-                final Member liteMember2 = lite2.getCluster().getLocalMember();
-                assertEquals(liteMember1, results.get(liteMember1));
-                assertEquals(liteMember2, results.get(liteMember2));
-            }
+            assertNotNull(results);
+            final Member liteMember1 = lite1.getCluster().getLocalMember();
+            final Member liteMember2 = lite2.getCluster().getLocalMember();
+            assertEquals(liteMember1, results.get(liteMember1));
+            assertEquals(liteMember2, results.get(liteMember2));
         });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -17,7 +17,6 @@
 package com.hazelcast.executor;
 
 import com.hazelcast.cluster.Member;
-import com.hazelcast.config.Config;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.core.ExecutionCallback;
@@ -65,13 +64,13 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
     IExecutorService createSingleNodeExecutorService(String name, int poolSize, boolean statsEnabled) {
         ExecutorConfig executorConfig = new ExecutorConfig(name, poolSize).setStatisticsEnabled(statsEnabled);
-        HazelcastInstance instance = createHazelcastInstance(new Config().addExecutorConfig(executorConfig));
+        HazelcastInstance instance = createHazelcastInstance(smallInstanceConfig().addExecutorConfig(executorConfig));
         return instance.getExecutorService(name);
     }
 
     protected DurableExecutorService createSingleNodeDurableExecutorService(String name, int poolSize) {
         DurableExecutorConfig executorConfig = new DurableExecutorConfig(name).setPoolSize(poolSize);
-        HazelcastInstance instance = createHazelcastInstance(new Config().addDurableExecutorConfig(executorConfig));
+        HazelcastInstance instance = createHazelcastInstance(smallInstanceConfig().addDurableExecutorConfig(executorConfig));
         return instance.getDurableExecutorService(name);
     }
 
@@ -106,7 +105,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
     public static class CountingDownExecutionCallback<T> implements BiConsumer<T, Throwable>, ExecutionCallback<T> {
 
-        private final AtomicReference<Object> result = new AtomicReference<Object>();
+        private final AtomicReference<Object> result = new AtomicReference<>();
         private final CountDownLatch latch;
 
         public CountingDownExecutionCallback(int count) {
@@ -153,7 +152,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
-    public static class BasicTestCallable implements Callable<String>, Serializable, PartitionAware {
+    public static class BasicTestCallable implements Callable<String>, Serializable, PartitionAware<String> {
 
         public static final String RESULT = "Task completed";
 
@@ -163,7 +162,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
 
         @Override
-        public Object getPartitionKey() {
+        public String getPartitionKey() {
             return "key";
         }
     }
@@ -200,7 +199,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
-    public static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware {
+    public static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware<String> {
 
         long sleepSeconds;
 
@@ -215,7 +214,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
 
         @Override
-        public Object getPartitionKey() {
+        public String getPartitionKey() {
             return "key";
         }
     }
@@ -226,8 +225,8 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
         @Override
         public String call() throws Exception {
-            Future future = instance.getExecutorService("NestedExecutorTask").submit(new BasicTestCallable());
-            return (String) future.get();
+            Future<String> future = instance.getExecutorService("NestedExecutorTask").submit(new BasicTestCallable());
+            return future.get();
         }
 
         @Override
@@ -301,7 +300,6 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
-    @SuppressWarnings("unused")
     public static class NullResponseCountingCallback<T> implements Consumer<T>, ExecutionCallback<T> {
 
         private final AtomicInteger nullResponseCount = new AtomicInteger(0);

--- a/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.executor;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.IExecutorService;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.cluster.MemberSelector;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -80,19 +78,14 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     @Test
     public void submitBasicTask() throws Exception {
         Callable<String> task = new BasicTestCallable();
-        Future future = executor.submit(task);
+        Future<String> future = executor.submit(task);
         assertEquals(future.get(), BasicTestCallable.RESULT);
     }
 
     @Test(expected = RejectedExecutionException.class)
     public void alwaysFalseMemberSelector_expectRejection() {
         HazelcastInstanceAwareRunnable task = new HazelcastInstanceAwareRunnable();
-        executor.execute(task, new MemberSelector() {
-            @Override
-            public boolean select(Member member) {
-                return false;
-            }
-        });
+        executor.execute(task, member -> false);
     }
 
     @Test
@@ -130,7 +123,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     @Test(expected = CancellationException.class)
     public void timeOut_thenCancel() throws ExecutionException, InterruptedException {
         SleepingTask task = new SleepingTask(1);
-        Future future = executor.submit(task);
+        Future<?> future = executor.submit(task);
         try {
             future.get(1, TimeUnit.MILLISECONDS);
             fail("Should throw TimeoutException!");
@@ -146,13 +139,13 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test(expected = CancellationException.class)
     public void cancelWhileQueued() throws ExecutionException, InterruptedException {
-        Callable task1 = new SleepingTask(100);
-        Future inProgressFuture = executor.submit(task1);
+        Callable<?> task1 = new SleepingTask(100);
+        Future<?> inProgressFuture = executor.submit(task1);
 
-        Callable task2 = new BasicTestCallable();
+        Callable<?> task2 = new BasicTestCallable();
         // this future should not be an instance of CompletedFuture,
         // because even if we get an exception, isDone is returning true
-        Future queuedFuture = executor.submit(task2);
+        Future<?> queuedFuture = executor.submit(task2);
 
         try {
             assertFalse(queuedFuture.isDone());
@@ -169,7 +162,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     @Test
     public void isDoneAfterGet() throws Exception {
         Callable<String> task = new BasicTestCallable();
-        Future future = executor.submit(task);
+        Future<String> future = executor.submit(task);
         assertEquals(future.get(), BasicTestCallable.RESULT);
         assertTrue(future.isDone());
     }
@@ -190,7 +183,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test
     public void issue292() throws Exception {
-        final BlockingQueue<Member> qResponse = new ArrayBlockingQueue<Member>(1);
+        final BlockingQueue<Member> qResponse = new ArrayBlockingQueue<>(1);
         executor.submit(new MemberCheck(), new ExecutionCallback<Member>() {
             public void onResponse(Member response) {
                 qResponse.offer(response);
@@ -221,7 +214,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     @Test
     public void invokeAll() throws Exception {
         // only one task
-        ArrayList<Callable<String>> tasks = new ArrayList<Callable<String>>();
+        ArrayList<Callable<String>> tasks = new ArrayList<>();
         tasks.add(new BasicTestCallable());
         List<Future<String>> futures = executor.invokeAll(tasks);
         assertEquals(futures.size(), 1);
@@ -245,7 +238,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
         assertEquals(futures.size(), 1);
         assertEquals(futures.get(0).get(), Boolean.TRUE);
 
-        List<Callable<Boolean>> tasks = new ArrayList<Callable<Boolean>>();
+        List<Callable<Boolean>> tasks = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             tasks.add(new SleepingTask(i < 2 ? 0 : 20));
         }
@@ -268,7 +261,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     @Test
     public void invokeAllTimeoutSuccess() throws Exception {
         // only one task
-        ArrayList<Callable<String>> tasks = new ArrayList<Callable<String>>();
+        ArrayList<Callable<String>> tasks = new ArrayList<>();
         tasks.add(new BasicTestCallable());
         List<Future<String>> futures = executor.invokeAll(tasks, 5, TimeUnit.SECONDS);
         assertEquals(futures.size(), 1);
@@ -345,15 +338,12 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
         } catch (CancellationException ignored) {
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                LocalExecutorStats stats = executor.getLocalExecutorStats();
-                assertEquals(iterations + 1, stats.getStartedTaskCount());
-                assertEquals(iterations, stats.getCompletedTaskCount());
-                assertEquals(0, stats.getPendingTaskCount());
-                assertEquals(1, stats.getCancelledTaskCount());
-            }
+        assertTrueEventually(() -> {
+            LocalExecutorStats stats = executor.getLocalExecutorStats();
+            assertEquals(iterations + 1, stats.getStartedTaskCount());
+            assertEquals(iterations, stats.getCompletedTaskCount());
+            assertEquals(0, stats.getPendingTaskCount());
+            assertEquals(1, stats.getCancelledTaskCount());
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.executor;
 
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.MultiExecutionCallback;
@@ -63,7 +62,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
 
     @Before
     public void setUp() {
-        instances = createHazelcastInstanceFactory(NODE_COUNT).newInstances(new Config());
+        instances = createHazelcastInstanceFactory(NODE_COUNT).newInstances(smallInstanceConfig());
         warmUpPartitions(instances);
     }
 
@@ -73,7 +72,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
         BasicTestCallable task = new BasicTestCallable();
         String key = generateKeyOwnedBy(instances[0]);
         InternalCompletableFuture<String> future = (InternalCompletableFuture<String>) executorService.submitToKeyOwner(task, key);
-        CountingDownExecutionCallback<String> callback = new CountingDownExecutionCallback<String>(1);
+        CountingDownExecutionCallback<String> callback = new CountingDownExecutionCallback<>(1);
         future.whenCompleteAsync(callback);
         future.get();
         assertOpenEventually(callback.getLatch(), 10);
@@ -94,7 +93,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
 
     @Test
     public void submitToKeyOwner_runnable() {
-        NullResponseCountingCallback callback = new NullResponseCountingCallback(instances.length);
+        NullResponseCountingCallback<Object> callback = new NullResponseCountingCallback<>(instances.length);
 
         for (HazelcastInstance instance : instances) {
             IExecutorService service = instance.getExecutorService("testSubmitToKeyOwnerRunnable");
@@ -112,7 +111,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
 
     @Test
     public void submitToMember_runnable() {
-        NullResponseCountingCallback callback = new NullResponseCountingCallback(instances.length);
+        NullResponseCountingCallback<Object> callback = new NullResponseCountingCallback<>(instances.length);
 
         for (HazelcastInstance instance : instances) {
             IExecutorService service = instance.getExecutorService("testSubmitToMemberRunnable");
@@ -169,8 +168,8 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
     public void submitToSeveralNodes_callable() throws Exception {
         for (int i = 0; i < instances.length; i++) {
             IExecutorService service = instances[i].getExecutorService("testSubmitMultipleNode");
-            Future future = service.submit(new IncrementAtomicLongCallable("testSubmitMultipleNode"));
-            assertEquals((long) (i + 1), future.get());
+            Future<Long> future = service.submit(new IncrementAtomicLongCallable("testSubmitMultipleNode"));
+            assertEquals((i + 1), (long) future.get());
         }
     }
 
@@ -263,19 +262,19 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
 
     @Test(timeout = TEST_TIMEOUT)
     public void submitToKeyOwner_callable() throws Exception {
-        List<Future> futures = new ArrayList<Future>();
+        List<Future<Boolean>> futures = new ArrayList<>();
 
         for (HazelcastInstance instance : instances) {
             IExecutorService service = instance.getExecutorService("testSubmitToKeyOwnerCallable");
             Member localMember = instance.getCluster().getLocalMember();
             int key = findNextKeyForMember(instance, localMember);
 
-            Future future = service.submitToKeyOwner(new MemberUUIDCheckCallable(localMember.getUuid()), key);
+            Future<Boolean> future = service.submitToKeyOwner(new MemberUUIDCheckCallable(localMember.getUuid()), key);
             futures.add(future);
         }
 
-        for (Future future : futures) {
-            assertTrue((Boolean) future.get(60, TimeUnit.SECONDS));
+        for (Future<Boolean> future : futures) {
+            assertTrue(future.get(60, TimeUnit.SECONDS));
         }
     }
 
@@ -296,18 +295,19 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
 
     @Test(timeout = TEST_TIMEOUT)
     public void submitToMember_callable() throws Exception {
-        List<Future> futures = new ArrayList<Future>();
+        List<Future<Boolean>> futures = new ArrayList<>();
 
         for (HazelcastInstance instance : instances) {
             IExecutorService service = instance.getExecutorService("testSubmitToMemberCallable");
             Member localMember = instance.getCluster().getLocalMember();
 
-            Future future = service.submitToMember(new MemberUUIDCheckCallable(localMember.getUuid()), localMember);
+            Future<Boolean> future = service.submitToMember(
+                    new MemberUUIDCheckCallable(localMember.getUuid()), localMember);
             futures.add(future);
         }
 
-        for (Future future : futures) {
-            assertTrue((Boolean) future.get());
+        for (Future<Boolean> future : futures) {
+            assertTrue(future.get());
         }
     }
 
@@ -432,7 +432,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
         assertEquals(1, responseCount.get());
     }
 
-    private static class NonSerializableResponseCallable implements Callable, Serializable {
+    private static class NonSerializableResponseCallable implements Callable<Object>, Serializable {
 
         @Override
         public Object call() throws Exception {


### PR DESCRIPTION
Task execution result is propagated concurrently to other partition
operations. It may happen that we fetch the execution result and call
destroy on the executor before the backup execution result operation is
executed. The backup execution operation will recreate the executor
container after it has been destroyed.

This is a lifecycle issue similar to the ones we have with other data
structures. So not fixing it here but instead introducing more
synchronization in the test. We now additionally wait until none
containers contain a running task before calling destroy. This means
that all executions have completed and backup operations have been
applied.

Also, cleaned up the tests from warnings and made all tests use small
instances to use less resources.

Fixes: https://github.com/hazelcast/hazelcast/issues/15736