### PR TITLE
Add serialization benchmark.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/serialization/DataSerializableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/DataSerializableObject.java
@@ -1,0 +1,55 @@
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+
+import java.io.IOException;
+
+class DataSerializableObject {
+
+    static DataSerializable object() {
+        return new Person("Joe", "Doe", 28, 66.92f);
+    }
+
+    static InternalSerializationService serializationService() {
+        return new DefaultSerializationServiceBuilder().build();
+    }
+
+    public static class Person implements DataSerializable {
+
+        private String firstName;
+        private String lastName;
+        private int age;
+        private float height;
+
+        @SuppressWarnings("unused")
+        public Person() {
+        }
+
+        public Person(String firstName, String lastName, int age, float height) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+            this.height = height;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeUTF(firstName);
+            out.writeUTF(lastName);
+            out.writeInt(age);
+            out.writeFloat(height);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            this.firstName = in.readUTF();
+            this.lastName = in.readUTF();
+            this.age = in.readInt();
+            this.height = in.readFloat();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/DataSerializableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/DataSerializableObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.serialization;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -26,10 +42,10 @@ class DataSerializableObject {
         private float height;
 
         @SuppressWarnings("unused")
-        public Person() {
+        Person() {
         }
 
-        public Person(String firstName, String lastName, int age, float height) {
+        Person(String firstName, String lastName, int age, float height) {
             this.firstName = firstName;
             this.lastName = lastName;
             this.age = age;

--- a/hazelcast/src/test/java/com/hazelcast/serialization/ExternalizableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/ExternalizableObject.java
@@ -1,0 +1,54 @@
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class ExternalizableObject {
+
+    static Externalizable object() {
+        return new Person("Joe", "Doe", 28, 66.92f);
+    }
+
+    static InternalSerializationService serializationService() {
+        return new DefaultSerializationServiceBuilder().build();
+    }
+
+    static class Person implements Externalizable {
+
+        private String firstName;
+        private String lastName;
+        private int age;
+        private float height;
+
+        public Person() {
+        }
+
+        public Person(String firstName, String lastName, int age, float height) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+            this.height = height;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeUTF(firstName);
+            out.writeUTF(lastName);
+            out.writeInt(age);
+            out.writeFloat(height);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException {
+            this.firstName = in.readUTF();
+            this.lastName = in.readUTF();
+            this.age = in.readInt();
+            this.height = in.readFloat();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/ExternalizableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/ExternalizableObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.serialization;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -25,10 +41,11 @@ public class ExternalizableObject {
         private int age;
         private float height;
 
-        public Person() {
+        @SuppressWarnings({"unused"})
+        Person() {
         }
 
-        public Person(String firstName, String lastName, int age, float height) {
+        Person(String firstName, String lastName, int age, float height) {
             this.firstName = firstName;
             this.lastName = lastName;
             this.age = age;

--- a/hazelcast/src/test/java/com/hazelcast/serialization/IdentifiedDataSerializableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/IdentifiedDataSerializableObject.java
@@ -1,0 +1,83 @@
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+class IdentifiedDataSerializableObject {
+
+    static IdentifiedDataSerializable object() {
+        return new Person("Joe", "Doe", 28, 66.92f);
+    }
+
+    static InternalSerializationService serializationService() {
+        return new DefaultSerializationServiceBuilder()
+                .addDataSerializableFactory(IdentifiedDataSerializableFactory.FACTORY_ID, new IdentifiedDataSerializableFactory())
+                .build();
+    }
+
+    public static class Person implements IdentifiedDataSerializable {
+
+        private static final int CLASS_ID = 2;
+
+        private String firstName;
+        private String lastName;
+        private int age;
+        private float height;
+
+        @SuppressWarnings("unused")
+        public Person() {
+        }
+
+        public Person(String firstName, String lastName, int age, float height) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+            this.height = height;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return IdentifiedDataSerializableFactory.FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return CLASS_ID;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeUTF(firstName);
+            out.writeUTF(lastName);
+            out.writeInt(age);
+            out.writeFloat(height);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            this.firstName = in.readUTF();
+            this.lastName = in.readUTF();
+            this.age = in.readInt();
+            this.height = in.readFloat();
+        }
+    }
+
+    private static class IdentifiedDataSerializableFactory implements DataSerializableFactory {
+
+        public static final int FACTORY_ID = 1;
+
+        @Override
+        public IdentifiedDataSerializable create(int id) {
+            if (id == Person.CLASS_ID) {
+                return new Person();
+            }
+            throw new IllegalArgumentException("unknown id");
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/IdentifiedDataSerializableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/IdentifiedDataSerializableObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.serialization;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -31,10 +47,10 @@ class IdentifiedDataSerializableObject {
         private float height;
 
         @SuppressWarnings("unused")
-        public Person() {
+        Person() {
         }
 
-        public Person(String firstName, String lastName, int age, float height) {
+        Person(String firstName, String lastName, int age, float height) {
             this.firstName = firstName;
             this.lastName = lastName;
             this.age = age;

--- a/hazelcast/src/test/java/com/hazelcast/serialization/PortableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/PortableObject.java
@@ -1,0 +1,82 @@
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+
+import java.io.IOException;
+
+class PortableObject {
+
+    static Portable object() {
+        return new Person("Joe", "Doe", 28, 66.92f);
+    }
+
+    static InternalSerializationService serializationService() {
+        return new DefaultSerializationServiceBuilder()
+                .addPortableFactory(PortableFactory.FACTORY_ID, new PortableFactory())
+                .build();
+    }
+
+    public static class Person implements Portable {
+
+        private static final int CLASS_ID = 2;
+
+        private String firstName;
+        private String lastName;
+        private int age;
+        private float height;
+
+        @SuppressWarnings("unused")
+        public Person() {
+        }
+
+        public Person(String firstName, String lastName, int age, float height) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+            this.height = height;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return PortableFactory.FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return CLASS_ID;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeUTF("firstName", firstName);
+            writer.writeUTF("lastName", lastName);
+            writer.writeInt("age", age);
+            writer.writeFloat("height", height);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            this.firstName = reader.readUTF("firstName");
+            this.lastName = reader.readUTF("firstName");
+            this.age = reader.readInt("age");
+            this.height = reader.readFloat("height");
+        }
+    }
+
+    static class PortableFactory implements com.hazelcast.nio.serialization.PortableFactory {
+
+        public static final int FACTORY_ID = 2;
+
+        @Override
+        public Portable create(int id) {
+            if (id == Person.CLASS_ID) {
+                return new Person();
+            }
+            throw new IllegalArgumentException("unknown id");
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/PortableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/PortableObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.serialization;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -30,10 +46,10 @@ class PortableObject {
         private float height;
 
         @SuppressWarnings("unused")
-        public Person() {
+        Person() {
         }
 
-        public Person(String firstName, String lastName, int age, float height) {
+        Person(String firstName, String lastName, int age, float height) {
             this.firstName = firstName;
             this.lastName = lastName;
             this.age = age;

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializableObject.java
@@ -1,0 +1,33 @@
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+
+import java.io.Serializable;
+
+class SerializableObject {
+
+    static Serializable object() {
+        return new Person("Joe", "Doe", 28, 66.92f);
+    }
+
+    static InternalSerializationService serializationService() {
+        return new DefaultSerializationServiceBuilder().build();
+    }
+
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    static class Person implements Serializable {
+
+        private final String firstName;
+        private final String lastName;
+        private final int age;
+        private final float height;
+
+        private Person(String firstName, String lastName, int age, float height) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+            this.height = height;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializableObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializableObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.serialization;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
@@ -129,7 +129,7 @@ public class SerializationBenchmark {
 
         private final InternalSerializationService serializationService;
 
-        public Serializer(InternalSerializationService serializationService) {
+        Serializer(InternalSerializationService serializationService) {
             this.serializationService = serializationService;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -159,6 +160,8 @@ public class SerializationBenchmark {
     public static void main(String[] args) throws Exception {
         Options options = new OptionsBuilder()
                 .include(SerializationBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                //.resultFormat(JSON)
                 .build();
 
         new Runner(options).run();

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
@@ -46,8 +46,8 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(value = 1, warmups = 0)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 3, time = 1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @OperationsPerInvocation(SerializationBenchmark.BATCH_SIZE)
 public class SerializationBenchmark {
 

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.nio.BufferObjectDataOutput;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.Portable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
+public class SerializationBenchmark {
+
+    Serializable serializable;
+    Serializer serializableSerializer;
+
+    Externalizable externalizable;
+    Serializer externalizableSerializer;
+
+    DataSerializable dataSerializable;
+    Serializer dataSerializableSerializer;
+
+    IdentifiedDataSerializable identifiedDataSerializable;
+    Serializer identifiedDataSerializableSerializer;
+
+    Portable portable;
+    Serializer portableSerializer;
+
+    Object object;
+    Serializer streamSerializer;
+
+    @Setup
+    public void setup() {
+        serializable = SerializableObject.object();
+        serializableSerializer = new Serializer(SerializableObject.serializationService());
+
+        externalizable = ExternalizableObject.object();
+        externalizableSerializer = new Serializer(ExternalizableObject.serializationService());
+
+        dataSerializable = DataSerializableObject.object();
+        dataSerializableSerializer = new Serializer(DataSerializableObject.serializationService());
+
+        identifiedDataSerializable = IdentifiedDataSerializableObject.object();
+        identifiedDataSerializableSerializer = new Serializer(IdentifiedDataSerializableObject.serializationService());
+
+        portable = PortableObject.object();
+        portableSerializer = new Serializer(PortableObject.serializationService());
+
+        object = StreamObject.object();
+        streamSerializer = new Serializer(StreamObject.serializationService());
+    }
+
+    @Benchmark
+    public void serializable(Blackhole blackhole) throws Exception {
+        byte[] serialized = serializableSerializer.serialize(serializable);
+        blackhole.consume(serializableSerializer.deserialize(serialized));
+    }
+
+    @Benchmark
+    public void externalizable(Blackhole blackhole) throws Exception {
+        byte[] serialized = externalizableSerializer.serialize(externalizable);
+        blackhole.consume(externalizableSerializer.deserialize(serialized));
+    }
+
+    @Benchmark
+    public void dataSerializable(Blackhole blackhole) throws Exception {
+        byte[] serialized = dataSerializableSerializer.serialize(dataSerializable);
+        blackhole.consume(dataSerializableSerializer.deserialize(serialized));
+    }
+
+    @Benchmark
+    public void identifiedDataSerializable(Blackhole blackhole) throws Exception {
+        byte[] serialized = identifiedDataSerializableSerializer.serialize(identifiedDataSerializable);
+        blackhole.consume(identifiedDataSerializableSerializer.deserialize(serialized));
+    }
+
+    @Benchmark
+    public void portable(Blackhole blackhole) throws Exception {
+        byte[] serialized = portableSerializer.serialize(portable);
+        blackhole.consume(portableSerializer.deserialize(serialized));
+    }
+
+    @Benchmark
+    public void stream(Blackhole blackhole) throws Exception {
+        byte[] serialized = streamSerializer.serialize(object);
+        blackhole.consume(streamSerializer.deserialize(serialized));
+    }
+
+    private static class Serializer {
+
+        private final InternalSerializationService serializationService;
+
+        public Serializer(InternalSerializationService serializationService) {
+            this.serializationService = serializationService;
+        }
+
+        byte[] serialize(Object object) throws IOException {
+            try (BufferObjectDataOutput output = serializationService.createObjectDataOutput()) {
+                serializationService.writeObject(output, object);
+                return output.toByteArray();
+            }
+        }
+
+        <T> T deserialize(byte[] bytes) throws IOException {
+            try (BufferObjectDataInput input = serializationService.createObjectDataInput(bytes)) {
+                return serializationService.readObject(input);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options options = new OptionsBuilder()
+                .include(SerializationBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/SerializationBenchmark.java
@@ -33,7 +33,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -51,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 3, time = 1)
 @OperationsPerInvocation(SerializationBenchmark.BATCH_SIZE)
 public class SerializationBenchmark {
+
     static final int BATCH_SIZE = 1_000;
 
     Serializable serializable;
@@ -93,39 +93,39 @@ public class SerializationBenchmark {
     }
 
     @Benchmark
-    public void serializable(Blackhole blackhole) throws Exception {
+    public Object[] serializable() throws Exception {
         byte[] serialized = serializableSerializer.serialize(serializable);
-        blackhole.consume(serializableSerializer.deserialize(serialized));
+        return serializableSerializer.deserialize(serialized);
     }
 
     @Benchmark
-    public void externalizable(Blackhole blackhole) throws Exception {
+    public Object[] externalizable() throws Exception {
         byte[] serialized = externalizableSerializer.serialize(externalizable);
-        blackhole.consume(externalizableSerializer.deserialize(serialized));
+        return externalizableSerializer.deserialize(serialized);
     }
 
     @Benchmark
-    public void dataSerializable(Blackhole blackhole) throws Exception {
+    public Object[] dataSerializable() throws Exception {
         byte[] serialized = dataSerializableSerializer.serialize(dataSerializable);
-        blackhole.consume(dataSerializableSerializer.deserialize(serialized));
+        return dataSerializableSerializer.deserialize(serialized);
     }
 
     @Benchmark
-    public void identifiedDataSerializable(Blackhole blackhole) throws Exception {
+    public Object[] identifiedDataSerializable() throws Exception {
         byte[] serialized = identifiedDataSerializableSerializer.serialize(identifiedDataSerializable);
-        blackhole.consume(identifiedDataSerializableSerializer.deserialize(serialized));
+        return identifiedDataSerializableSerializer.deserialize(serialized);
     }
 
     @Benchmark
-    public void portable(Blackhole blackhole) throws Exception {
+    public Object[] portable() throws Exception {
         byte[] serialized = portableSerializer.serialize(portable);
-        blackhole.consume(portableSerializer.deserialize(serialized));
+        return portableSerializer.deserialize(serialized);
     }
 
     @Benchmark
-    public void stream(Blackhole blackhole) throws Exception {
+    public Object[] stream() throws Exception {
         byte[] serialized = streamSerializer.serialize(object);
-        blackhole.consume(streamSerializer.deserialize(serialized));
+        return streamSerializer.deserialize(serialized);
     }
 
     private static class Serializer {

--- a/hazelcast/src/test/java/com/hazelcast/serialization/StreamObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/StreamObject.java
@@ -1,0 +1,66 @@
+package com.hazelcast.serialization;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+
+import java.io.IOException;
+
+class StreamObject {
+
+    static Object object() {
+        return new Person("Joe", "Doe", 28, 66.92f);
+    }
+
+    static InternalSerializationService serializationService() {
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder()
+                .build();
+        ((AbstractSerializationService) serializationService).register(Person.class, new PersonSerializer());
+        return serializationService;
+    }
+
+    static class Person {
+
+        private final String firstName;
+        private final String lastName;
+        private final int age;
+        private final float height;
+
+        public Person(String firstName, String lastName, int age, float height) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+            this.height = height;
+        }
+    }
+
+    static class PersonSerializer implements StreamSerializer<Person> {
+
+        private static final int TYPE_ID = 1;
+
+        @Override
+        public int getTypeId() {
+            return TYPE_ID;
+        }
+
+        @Override
+        public void write(ObjectDataOutput out, Person object) throws IOException {
+            out.writeUTF(object.firstName);
+            out.writeUTF(object.lastName);
+            out.writeInt(object.age);
+            out.writeFloat(object.height);
+        }
+
+        @Override
+        public Person read(ObjectDataInput in) throws IOException {
+            return new Person(in.readUTF(), in.readUTF(), in.readInt(), in.readFloat());
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/serialization/StreamObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serialization/StreamObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.serialization;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -29,7 +45,7 @@ class StreamObject {
         private final int age;
         private final float height;
 
-        public Person(String firstName, String lastName, int age, float height) {
+        Person(String firstName, String lastName, int age, float height) {
             this.firstName = firstName;
             this.lastName = lastName;
             this.age = age;


### PR DESCRIPTION
We would like to post some serialization benchmark results on Jet website to help users choose the most appropriate serialization strategy for their application. Here is some straightforward code to backup to-be-published numbers and maybe even allow users to play with it and test particular use cases.