### PR TITLE
Handle network disconnections between slave nodes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -26,3 +26,6 @@ from minimal-json project (https://github.com/ralfstx/minimal-json).
 
 The class com.hazelcast.instance.impl.MobyNames contains code originating
 from The Moby Project (https://github.com/moby/moby).
+
+The class com.hazelcast.internal.util.graph.BronKerboschCliqueFinder contains code
+originating from The JGraphT Project (https://github.com/jgrapht/jgrapht).

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -57,6 +57,7 @@
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]collection[\\/]LongHashSetTest"/>
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]collection[\\/]IntHashSetTest"/>
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]collection[\\/]Long2LongHashMapTest"/>
+    <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]graph[\\/]BronKerboschCliqueFinder"/>
 
     <!-- Exclude internal, implementation and template packages from JavaDoc checks -->
     <suppress checks="Javadoc(Package|Method|Type|Variable)" files="com[\\/]hazelcast[\\/]internal[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -153,30 +153,27 @@ public class MemberInfo implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((address == null) ? 0 : address.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MemberInfo that = (MemberInfo) o;
+
+        if (!address.equals(that.address)) {
+            return false;
+        }
+        return uuid != null ? uuid.equals(that.uuid) : that.uuid == null;
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        MemberInfo other = (MemberInfo) obj;
-        if (address == null) {
-            return other.address == null;
-        } else {
-            return address.equals(other.address);
-        }
+    public int hashCode() {
+        int result = address.hashCode();
+        result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -19,9 +19,9 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.IcmpFailureDetectorConfig;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetector;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
 import com.hazelcast.internal.cluster.fd.DeadlineClusterFailureDetector;
@@ -46,11 +46,13 @@ import com.hazelcast.splitbrainprotection.impl.SplitBrainProtectionServiceImpl;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 
+import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEMBER_SELECTOR;
 import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.CLUSTER_EXECUTOR_NAME;
@@ -62,6 +64,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * ClusterHeartbeatManager manages the heartbeat sending and receiving
@@ -216,7 +219,8 @@ public class ClusterHeartbeatManager {
         }
     }
 
-    public void handleHeartbeat(MembersViewMetadata senderMembersViewMetadata, UUID receiverUuid, long timestamp) {
+    public void handleHeartbeat(MembersViewMetadata senderMembersViewMetadata, UUID receiverUuid, long timestamp,
+                                Collection<MemberInfo> suspectedMembers) {
         Address senderAddress = senderMembersViewMetadata.getMemberAddress();
         try {
             long timeout = Math.min(TimeUnit.SECONDS.toMillis(1), heartbeatIntervalMillis / 2);
@@ -249,7 +253,11 @@ public class ClusterHeartbeatManager {
             MemberImpl member = membershipManager.getMember(senderAddress, senderMembersViewMetadata.getMemberUuid());
             if (member != null) {
                 if (clusterService.getThisUuid().equals(receiverUuid)) {
-                    onHeartbeat(member, timestamp);
+                    if (onHeartbeat(member, timestamp)) {
+                        // local timestamp is used on purpose here
+                        membershipManager.handleReceivedSuspectedMembers(member, clusterClock.getClusterTime(), suspectedMembers);
+                    }
+
                     return;
                 }
 
@@ -274,14 +282,14 @@ public class ClusterHeartbeatManager {
                 clusterService.sendExplicitSuspicion(senderMembersViewMetadata);
             }
         } else {
-            Address masterAddress = clusterService.getMasterAddress();
-            if (clusterService.getMembershipManager().isMemberSuspected(masterAddress)) {
+            MemberImpl master = clusterService.getMember(clusterService.getMasterAddress());
+            if (clusterService.getMembershipManager().isMemberSuspected(master.getAddress(), master.getUuid())) {
                 logger.fine("Not sending heartbeat complaint for " + senderMembersViewMetadata
-                        + " to suspected master: " + masterAddress);
+                        + " to suspected master: " + master.getAddress());
                 return;
             }
 
-            logger.fine("Sending heartbeat complaint to master " + masterAddress + " for heartbeat "
+            logger.fine("Sending heartbeat complaint to master " + master.getAddress() + " for heartbeat "
                     + senderMembersViewMetadata + ", because it is not a member of this cluster"
                     + " or its heartbeat cannot be validated!");
             sendHeartbeatComplaintToMaster(senderMembersViewMetadata);
@@ -371,9 +379,9 @@ public class ClusterHeartbeatManager {
      * @param member    the member sending the heartbeat
      * @param timestamp the timestamp when the heartbeat was created
      */
-    public void onHeartbeat(MemberImpl member, long timestamp) {
+    public boolean onHeartbeat(MemberImpl member, long timestamp) {
         if (member == null) {
-            return;
+            return false;
         }
         long clusterTime = clusterClock.getClusterTime();
         if (logger.isFineEnabled()) {
@@ -384,7 +392,7 @@ public class ClusterHeartbeatManager {
         if (clusterTime - timestamp > maxNoHeartbeatMillis / 2) {
             logger.warning(format("Ignoring heartbeat from %s since it is expired (now: %s, timestamp: %s)", member,
                     timeToString(clusterTime), timeToString(timestamp)));
-            return;
+            return false;
         }
 
         if (isMaster(member)) {
@@ -393,8 +401,10 @@ public class ClusterHeartbeatManager {
         heartbeatFailureDetector.heartbeat(member, clusterClock.getClusterTime());
 
         MembershipManager membershipManager = clusterService.getMembershipManager();
-        membershipManager.clearMemberSuspicion(member.getAddress(), "Valid heartbeat");
+        membershipManager.clearMemberSuspicion(member.getAddress(), member.getUuid(), "Valid heartbeat");
         nodeEngine.getSplitBrainProtectionService().onHeartbeat(member, timestamp);
+
+        return true;
     }
 
     /**
@@ -476,22 +486,21 @@ public class ClusterHeartbeatManager {
      * @param now the current cluster clock time
      */
     private void heartbeatWhenMaster(long now) {
-        Collection<MemberImpl> members = clusterService.getMemberImpls();
-        for (MemberImpl member : members) {
-            if (!member.localMember()) {
-                try {
-                    logIfConnectionToEndpointIsMissing(now, member);
-                    if (suspectMemberIfNotHeartBeating(now, member)) {
-                        continue;
-                    }
-
-                    pingMemberIfRequired(now, member);
-                    sendHeartbeat(member);
-                } catch (Throwable e) {
-                    logger.severe(e);
+        for (Member member : clusterService.getMembers(NON_LOCAL_MEMBER_SELECTOR)) {
+            try {
+                logIfConnectionToEndpointIsMissing(now, member);
+                if (suspectMemberIfNotHeartBeating(now, member)) {
+                    continue;
                 }
+
+                pingMemberIfRequired(now, member);
+                sendHeartbeat(member);
+            } catch (Throwable t) {
+                logger.severe(t);
             }
         }
+
+        clusterService.getMembershipManager().checkPartialDisconnectivity(now);
     }
 
     /**
@@ -503,7 +512,7 @@ public class ClusterHeartbeatManager {
      * @return if the member has been removed
      */
     private boolean suspectMemberIfNotHeartBeating(long now, Member member) {
-        if (clusterService.getMembershipManager().isMemberSuspected(member.getAddress())) {
+        if (clusterService.getMembershipManager().isMemberSuspected(member.getAddress(), member.getUuid())) {
             return true;
         }
 
@@ -534,9 +543,8 @@ public class ClusterHeartbeatManager {
      */
     private void heartbeatWhenSlave(long now) {
         MembershipManager membershipManager = clusterService.getMembershipManager();
-        Collection<Member> members = clusterService.getMembers(MemberSelectors.NON_LOCAL_MEMBER_SELECTOR);
 
-        for (Member member : members) {
+        for (Member member : clusterService.getMembers(NON_LOCAL_MEMBER_SELECTOR)) {
             try {
                 logIfConnectionToEndpointIsMissing(now, member);
 
@@ -544,7 +552,7 @@ public class ClusterHeartbeatManager {
                     continue;
                 }
 
-                if (membershipManager.isMemberSuspected(member.getAddress())) {
+                if (membershipManager.isMemberSuspected(member.getAddress(), member.getUuid())) {
                     continue;
                 }
 
@@ -577,7 +585,7 @@ public class ClusterHeartbeatManager {
 
     private void startPeriodicPinger() {
         nodeEngine.getExecutionService().scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, () -> {
-            Collection<Member> members = clusterService.getMembers(MemberSelectors.NON_LOCAL_MEMBER_SELECTOR);
+            Collection<Member> members = clusterService.getMembers(NON_LOCAL_MEMBER_SELECTOR);
 
             for (Member member : members) {
                 try {
@@ -610,7 +618,20 @@ public class ClusterHeartbeatManager {
         }
         try {
             MembersViewMetadata membersViewMetadata = clusterService.getMembershipManager().createLocalMembersViewMetadata();
-            Operation op = new HeartbeatOp(membersViewMetadata, target.getUuid(), clusterClock.getClusterTime());
+            Collection<MemberInfo> suspectedMembers;
+            if (clusterService.getMembershipManager().isPartialDisconnectionDetectionEnabled()
+                    && !clusterService.isMaster() && target.getAddress().equals(clusterService.getMasterAddress())) {
+                suspectedMembers = clusterService.getMembershipManager()
+                                                 .getSuspectedMembers()
+                                                 .stream()
+                                                 .map(MemberInfo::new)
+                                                 .collect(toSet());
+            } else {
+                suspectedMembers = Collections.emptySet();
+            }
+
+            long clusterTime = clusterClock.getClusterTime();
+            Operation op = new HeartbeatOp(membersViewMetadata, target.getUuid(), clusterTime, suspectedMembers);
             op.setCallerUuid(clusterService.getThisUuid());
             node.nodeEngine.getOperationService().send(op, target.getAddress());
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -265,7 +265,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 throw new RetryableHazelcastException(message);
             }
 
-            if (!membershipManager.clearMemberSuspicion(candidateAddress, "Mastership claim")) {
+            if (!membershipManager.clearMemberSuspicion(candidateAddress, candidateUuid, "Mastership claim")) {
                 throw new IllegalStateException("Cannot accept mastership claim of " + candidateAddress + ". "
                         + getMasterAddress() + " is already master.");
             }
@@ -287,7 +287,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private boolean shouldAcceptMastership(MemberMap memberMap, MemberImpl candidate) {
         assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         for (MemberImpl member : memberMap.headMemberSet(candidate, false)) {
-            if (!membershipManager.isMemberSuspected(member.getAddress())) {
+            if (!membershipManager.isMemberSuspected(member.getAddress(), member.getUuid())) {
                 if (logger.isFineEnabled()) {
                     logger.fine("Should not accept mastership claim of " + candidate + ", because " + member
                             + " is not suspected at the moment and is before than " + candidate + " in the member list.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -265,7 +265,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 throw new RetryableHazelcastException(message);
             }
 
-            if (!membershipManager.clearMemberSuspicion(candidateAddress, candidateUuid, "Mastership claim")) {
+            if (!membershipManager.clearMemberSuspicion(masterCandidate, "Mastership claim")) {
                 throw new IllegalStateException("Cannot accept mastership claim of " + candidateAddress + ". "
                         + getMasterAddress() + " is already master.");
             }
@@ -287,7 +287,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private boolean shouldAcceptMastership(MemberMap memberMap, MemberImpl candidate) {
         assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         for (MemberImpl member : memberMap.headMemberSet(candidate, false)) {
-            if (!membershipManager.isMemberSuspected(member.getAddress(), member.getUuid())) {
+            if (!membershipManager.isMemberSuspected(member)) {
                 if (logger.isFineEnabled()) {
                     logger.fine("Should not accept mastership claim of " + candidate + ", because " + member
                             + " is not suspected at the moment and is before than " + candidate + " in the member list.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/PartialDisconnectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/PartialDisconnectionHandler.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.internal.util.graph.BronKerboschCliqueFinder;
+import com.hazelcast.internal.util.graph.Graph;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+class PartialDisconnectionHandler {
+    private final long detectionIntervalMs;
+    private final long algorithmTimeoutMs;
+    private Map<MemberImpl, Set<MemberImpl>> disconnections = new HashMap<>();
+    private long lastUpdated;
+
+    PartialDisconnectionHandler(long detectionIntervalMs, long algorithmTimeoutMs) {
+        this.detectionIntervalMs = detectionIntervalMs;
+        this.algorithmTimeoutMs = algorithmTimeoutMs;
+    }
+
+    boolean update(MemberImpl member, long timestamp, Collection<MemberImpl> disconnectedMembers) {
+        if (timestamp < lastUpdated) {
+            return false;
+        }
+
+        Set<MemberImpl> currentDisconnectedMembers =  disconnections.get(member);
+        if (currentDisconnectedMembers == null) {
+            if (disconnectedMembers.isEmpty()) {
+                return false;
+            }
+
+            currentDisconnectedMembers = new HashSet<>();
+            disconnections.put(member, currentDisconnectedMembers);
+        }
+
+        boolean updated = false;
+
+        for (MemberImpl disconnectedMember : disconnectedMembers) {
+            if (currentDisconnectedMembers.add(disconnectedMember)
+                    && !disconnections.getOrDefault(disconnectedMember, emptySet()).contains(member)) {
+                lastUpdated = timestamp;
+                updated = true;
+            }
+        }
+
+        if (currentDisconnectedMembers.retainAll(disconnectedMembers)) {
+            lastUpdated = timestamp;
+            updated = true;
+        }
+
+        if (currentDisconnectedMembers.isEmpty()) {
+            disconnections.remove(member);
+        }
+
+        return updated;
+    }
+
+    boolean shouldResolvePartialDisconnections(long timestamp) {
+        return !disconnections.isEmpty() && timestamp - lastUpdated >= detectionIntervalMs;
+    }
+
+    Collection<MemberImpl> resolve(Map<MemberImpl, Set<MemberImpl>> disconnections) {
+        Set<MemberImpl> members = new HashSet<>();
+        disconnections.forEach((k, v) -> {
+            members.add(k);
+            members.addAll(v);
+        });
+
+        Graph<MemberImpl> connectivityGraph = buildConnectionGraph(members, disconnections);
+        BronKerboschCliqueFinder<MemberImpl> cliqueFinder = createCliqueFinder(connectivityGraph);
+        Collection<Set<MemberImpl>> maxCliques = cliqueFinder.computeMaxCliques();
+
+        if (cliqueFinder.isTimeLimitReached()) {
+            throw new IllegalStateException("Partial disconnection resolution algorithm timed out! disconnectivity map: "
+                    + disconnections);
+        } else if (maxCliques.isEmpty()) {
+            throw new IllegalStateException("Partial disconnection resolution algorithm returned no result! "
+                    + "disconnectivity map: " + disconnections);
+        }
+
+        Collection<MemberImpl> membersToRemove = new HashSet<>(members);
+        membersToRemove.removeAll(maxCliques.iterator().next());
+
+        return membersToRemove;
+    }
+
+    private Graph<MemberImpl> buildConnectionGraph(Set<MemberImpl> members,
+                                                   Map<MemberImpl, Set<MemberImpl>> disconnections) {
+        Graph<MemberImpl> graph = new Graph<>();
+        members.forEach(graph::add);
+
+        for (MemberImpl member1 : members) {
+            for (MemberImpl member2 : members) {
+                if (!isDisconnected(disconnections, member1, member2)) {
+                    graph.connect(member1, member2);
+                }
+            }
+        }
+
+        return graph;
+    }
+
+    private boolean isDisconnected(Map<MemberImpl, Set<MemberImpl>> disconnections, MemberImpl member1, MemberImpl member2) {
+        return disconnections.getOrDefault(member1, emptySet()).contains(member2)
+                || disconnections.getOrDefault(member2, emptySet()).contains(member1);
+    }
+
+    private BronKerboschCliqueFinder<MemberImpl> createCliqueFinder(Graph<MemberImpl> graph) {
+        return new BronKerboschCliqueFinder<>(graph, algorithmTimeoutMs, MILLISECONDS);
+    }
+
+    void removeMember(MemberImpl member) {
+        disconnections.remove(member);
+        disconnections.values().forEach(members -> members.remove(member));
+    }
+
+    Map<MemberImpl, Set<MemberImpl>> reset() {
+        Map<MemberImpl, Set<MemberImpl>> disconnections = this.disconnections;
+        this.disconnections = new HashMap<>();
+        return disconnections;
+    }
+
+    Map<MemberImpl, Set<MemberImpl>> getDisconnections() {
+        return disconnections;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/PartialDisconnectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/PartialDisconnectionHandler.java
@@ -19,27 +19,66 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.internal.util.graph.BronKerboschCliqueFinder;
 import com.hazelcast.internal.util.graph.Graph;
+import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
+import static com.hazelcast.spi.properties.ClusterProperty.HEARTBEAT_INTERVAL_SECONDS;
+import static com.hazelcast.spi.properties.ClusterProperty.MAX_NO_HEARTBEAT_SECONDS;
+import static com.hazelcast.spi.properties.ClusterProperty.PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_ALGORITHM_TIMEOUT_SECONDS;
+import static com.hazelcast.spi.properties.ClusterProperty.PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT;
 import static java.util.Collections.emptySet;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
+/**
+ * Collects the disconnections that occur between the slave members in the
+ * cluster. These disconnections occur because of network issues between slave
+ * members and the master member do not encounter those network issues because
+ * otherwise the master could have already kicked those members.
+ * <p>
+ * Once a set of disconnections are collected, the master member decides on
+ * a minimum set of members to kick from the cluster so that the remaining
+ * members do not have any network problem.
+ * <p>
+ * Used only by the master member.
+ */
 class PartialDisconnectionHandler {
     private final long detectionIntervalMs;
-    private final long algorithmTimeoutMs;
+    private final long algorithmTimeoutNanos;
     private Map<MemberImpl, Set<MemberImpl>> disconnections = new HashMap<>();
     private long lastUpdated;
 
-    PartialDisconnectionHandler(long detectionIntervalMs, long algorithmTimeoutMs) {
-        this.detectionIntervalMs = detectionIntervalMs;
-        this.algorithmTimeoutMs = algorithmTimeoutMs;
+    PartialDisconnectionHandler(HazelcastProperties properties) {
+        int partialDisconnectionResolutionHeartbeatCount = properties.getInteger(
+                PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT);
+        if (partialDisconnectionResolutionHeartbeatCount > 0) {
+            long heartbeatIntervalSecs = properties.getInteger(HEARTBEAT_INTERVAL_SECONDS);
+            long detectionIntervalSecs = partialDisconnectionResolutionHeartbeatCount * heartbeatIntervalSecs;
+            long heartbeatTimeoutSecs = properties.getInteger(MAX_NO_HEARTBEAT_SECONDS);
+            if (heartbeatTimeoutSecs < detectionIntervalSecs) {
+                detectionIntervalSecs = heartbeatTimeoutSecs;
+            }
+            this.detectionIntervalMs = SECONDS.toMillis(detectionIntervalSecs);
+        } else {
+            this.detectionIntervalMs = Long.MAX_VALUE;
+        }
+
+        long algorithmTimeoutSecs = properties.getLong(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_ALGORITHM_TIMEOUT_SECONDS);
+        this.algorithmTimeoutNanos = algorithmTimeoutSecs >= 1 ? SECONDS.toNanos(algorithmTimeoutSecs) : Long.MAX_VALUE;
     }
 
+    /**
+     * Updates the disconnected members set for the given member if the given
+     * timestamp is greater than the highest observed timestamp.
+     *
+     * @return true if the internal disconnected members set is updated.
+     */
     boolean update(MemberImpl member, long timestamp, Collection<MemberImpl> disconnectedMembers) {
         if (timestamp < lastUpdated) {
             return false;
@@ -77,11 +116,26 @@ class PartialDisconnectionHandler {
         return updated;
     }
 
+    /**
+     * Returns true if there is at least 1 disconnection reported and
+     * {@code detectionIntervalMs} has passed after the last disconnection is
+     * reported.
+     */
     boolean shouldResolvePartialDisconnections(long timestamp) {
         return !disconnections.isEmpty() && timestamp - lastUpdated >= detectionIntervalMs;
     }
 
-    Collection<MemberImpl> resolve(Map<MemberImpl, Set<MemberImpl>> disconnections) {
+    /**
+     * Receives a map of disconnections and returns a minimum set of members to
+     * kick so that the remaining members are have no disconnections.
+     * <p>
+     * The key of the disconnection map is a member and the value is its
+     * disconnection reports.
+     *
+     * @throws TimeoutException if the internally-used algorithm times out without
+     *                          returning a result
+     */
+    Collection<MemberImpl> resolve(Map<MemberImpl, Set<MemberImpl>> disconnections) throws TimeoutException {
         Set<MemberImpl> members = new HashSet<>();
         disconnections.forEach((k, v) -> {
             members.add(k);
@@ -93,7 +147,7 @@ class PartialDisconnectionHandler {
         Collection<Set<MemberImpl>> maxCliques = cliqueFinder.computeMaxCliques();
 
         if (cliqueFinder.isTimeLimitReached()) {
-            throw new IllegalStateException("Partial disconnection resolution algorithm timed out! disconnectivity map: "
+            throw new TimeoutException("Partial disconnection resolution algorithm timed out! disconnectivity map: "
                     + disconnections);
         } else if (maxCliques.isEmpty()) {
             throw new IllegalStateException("Partial disconnection resolution algorithm returned no result! "
@@ -128,7 +182,7 @@ class PartialDisconnectionHandler {
     }
 
     private BronKerboschCliqueFinder<MemberImpl> createCliqueFinder(Graph<MemberImpl> graph) {
-        return new BronKerboschCliqueFinder<>(graph, algorithmTimeoutMs, MILLISECONDS);
+        return new BronKerboschCliqueFinder<>(graph, algorithmTimeoutNanos, NANOSECONDS);
     }
 
     void removeMember(MemberImpl member) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -16,38 +16,47 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.util.UUIDSerializationUtil;
+import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterHeartbeatManager;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
+import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.UUID;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-public final class HeartbeatOp extends AbstractClusterOperation {
+public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
 
     private MembersViewMetadata senderMembersViewMetadata;
     private UUID targetUuid;
     private long timestamp;
+    private Collection<MemberInfo> suspectedMembers;
 
     public HeartbeatOp() {
     }
 
-    public HeartbeatOp(MembersViewMetadata senderMembersViewMetadata, UUID targetUuid, long timestamp) {
+    public HeartbeatOp(MembersViewMetadata senderMembersViewMetadata, UUID targetUuid, long timestamp,
+                       Collection<MemberInfo> suspectedMembers) {
         this.senderMembersViewMetadata = senderMembersViewMetadata;
         this.targetUuid = targetUuid;
         this.timestamp = timestamp;
+        this.suspectedMembers = suspectedMembers;
     }
 
     @Override
     public void run() {
         ClusterServiceImpl service = getService();
         ClusterHeartbeatManager heartbeatManager = service.getClusterHeartbeatManager();
-        heartbeatManager.handleHeartbeat(senderMembersViewMetadata, targetUuid, timestamp);
+        heartbeatManager.handleHeartbeat(senderMembersViewMetadata, targetUuid, timestamp, suspectedMembers);
     }
 
     @Override
@@ -61,6 +70,12 @@ public final class HeartbeatOp extends AbstractClusterOperation {
         out.writeObject(senderMembersViewMetadata);
         UUIDSerializationUtil.writeUUID(out, targetUuid);
         out.writeLong(timestamp);
+        if (out.getVersion().isGreaterThan(Versions.V4_0)) {
+            out.writeInt(suspectedMembers.size());
+            for (MemberInfo m : suspectedMembers) {
+                out.writeObject(m);
+            }
+        }
     }
 
     @Override
@@ -69,6 +84,16 @@ public final class HeartbeatOp extends AbstractClusterOperation {
         senderMembersViewMetadata = in.readObject();
         targetUuid = UUIDSerializationUtil.readUUID(in);
         timestamp = in.readLong();
+        if (in.getVersion().isGreaterThan(Versions.V4_0)) {
+            int suspectedMemberCount = in.readInt();
+            suspectedMembers = new HashSet<>(suspectedMemberCount);
+            for (int i = 0; i < suspectedMemberCount; i++) {
+                MemberInfo m = in.readObject();
+                suspectedMembers.add(m);
+            }
+        } else {
+            suspectedMembers = Collections.emptySet();
+        }
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinder.java
@@ -22,9 +22,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
 
 public class BronKerboschCliqueFinder<V> {
 
@@ -41,16 +42,11 @@ public class BronKerboschCliqueFinder<V> {
      * @param unit    the time unit of the timeout argument
      */
     public BronKerboschCliqueFinder(Graph<V> graph, long timeout, TimeUnit unit) {
-        this.graph = Objects.requireNonNull(graph, "Graph cannot be null");
-        if (timeout == 0L) {
-            this.nanos = Long.MAX_VALUE;
-        } else {
-            this.nanos = unit.toNanos(timeout);
+        this.graph = requireNonNull(graph, "Graph cannot be null");
+        if (timeout < 1L) {
+            throw new IllegalArgumentException("Invalid timeout, must be positive!");
         }
-        if (this.nanos < 1L) {
-            throw new IllegalArgumentException("Invalid timeout, must be positive");
-        }
-        this.timeLimitReached = false;
+        this.nanos = unit.toNanos(timeout);
     }
 
     /**
@@ -59,7 +55,7 @@ public class BronKerboschCliqueFinder<V> {
      * @param graph the input graph; must be "simple".
      */
     public BronKerboschCliqueFinder(Graph<V> graph) {
-        this(graph, 0L, TimeUnit.SECONDS);
+        this(graph, Long.MAX_VALUE, TimeUnit.NANOSECONDS);
     }
 
     /**
@@ -91,11 +87,6 @@ public class BronKerboschCliqueFinder<V> {
         }
 
         maximumCliques = new ArrayList<>();
-
-        // [basri] Our Graph impl is already a simple graph.
-        //            if (!GraphTests.isSimple(graph)) {
-        //                throw new IllegalArgumentException("Graph must be simple");
-        //            }
 
         long nanosTimeLimit;
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinder.java
@@ -1,0 +1,178 @@
+/*
+*  Original work Copyright (c) 2005-2020, by Ewgenij Proschak and Contributors.
+ * Modified work Copyright (c) 2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.graph;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class BronKerboschCliqueFinder<V> {
+
+    private final Graph<V> graph;
+    private final long nanos;
+    private boolean timeLimitReached;
+    private List<Set<V>> maximumCliques;
+
+    /**
+     * Constructor
+     *
+     * @param graph   the input graph; must be simple
+     * @param timeout the maximum time to wait, if zero no timeout
+     * @param unit    the time unit of the timeout argument
+     */
+    public BronKerboschCliqueFinder(Graph<V> graph, long timeout, TimeUnit unit) {
+        this.graph = Objects.requireNonNull(graph, "Graph cannot be null");
+        if (timeout == 0L) {
+            this.nanos = Long.MAX_VALUE;
+        } else {
+            this.nanos = unit.toNanos(timeout);
+        }
+        if (this.nanos < 1L) {
+            throw new IllegalArgumentException("Invalid timeout, must be positive");
+        }
+        this.timeLimitReached = false;
+    }
+
+    /**
+     * Constructs a new clique finder.
+     *
+     * @param graph the input graph; must be "simple".
+     */
+    public BronKerboschCliqueFinder(Graph<V> graph) {
+        this(graph, 0L, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Computes and returns the maximum cliques of the given graph.
+     *
+     * @return the maximum cliques of the given graph.
+     */
+    public Collection<Set<V>> computeMaxCliques() {
+        lazyRun();
+        return maximumCliques;
+    }
+
+    /**
+     * Check the computation has stopped due to a time limit or due to computing all maximal
+     * cliques.
+     *
+     * @return true if the computation has stopped due to a time limit, false otherwise
+     */
+    public boolean isTimeLimitReached() {
+        return timeLimitReached;
+    }
+
+    /**
+     * Lazily execute the enumeration algorithm.
+     */
+    private void lazyRun() {
+        if (maximumCliques != null) {
+            return;
+        }
+
+        maximumCliques = new ArrayList<>();
+
+        // [basri] Our Graph impl is already a simple graph.
+        //            if (!GraphTests.isSimple(graph)) {
+        //                throw new IllegalArgumentException("Graph must be simple");
+        //            }
+
+        long nanosTimeLimit;
+        try {
+            nanosTimeLimit = Math.addExact(System.nanoTime(), nanos);
+        } catch (ArithmeticException e) {
+            nanosTimeLimit = Long.MAX_VALUE;
+        }
+
+        findCliques(new HashSet<>(), new HashSet<>(graph.vertexSet()), new HashSet<>(), nanosTimeLimit);
+    }
+
+    private void findCliques(Collection<V> potentialClique, Collection<V> candidates, Collection<V> alreadyFound,
+                             long nanosTimeLimit) {
+        /*
+         * Termination condition: check if any already found node is connected to all candidate
+         * nodes.
+         */
+        for (V v : alreadyFound) {
+            if (candidates.stream().allMatch(c -> graph.containsEdge(v, c))) {
+                return;
+            }
+        }
+
+        Iterator<V> it = candidates.iterator();
+        while (it.hasNext()) {
+            if (nanosTimeLimit - System.nanoTime() < 0) {
+                timeLimitReached = true;
+                return;
+            }
+
+            V candidate = it.next();
+            it.remove();
+
+            // move candidate node to potentialClique
+            potentialClique.add(candidate);
+
+            // create newCandidates by removing nodes in candidates
+            // not connected to candidate node
+            Collection<V> newCandidates = populate(candidates, candidate);
+
+            // create newAlreadyFound by removing nodes in alreadyFound
+            // not connected to candidate node
+            Collection<V> newAlreadyFound = populate(alreadyFound, candidate);
+
+            // if newCandidates and newAlreadyFound are empty
+            if (newCandidates.isEmpty() && newAlreadyFound.isEmpty()) {
+                // potential clique is maximum clique
+                addMaxClique(potentialClique);
+            } else {
+                // recursive call
+                findCliques(potentialClique, newCandidates, newAlreadyFound, nanosTimeLimit);
+            }
+
+            // move candidate node from potentialClique to alreadyFound
+            alreadyFound.add(candidate);
+            potentialClique.remove(candidate);
+        }
+    }
+
+    private Collection<V> populate(Collection<V> candidates, V candidate) {
+        Collection<V> newCandidates = new HashSet<>();
+        for (V newCandidate : candidates) {
+            if (graph.containsEdge(candidate, newCandidate)) {
+                newCandidates.add(newCandidate);
+            }
+        }
+
+        return newCandidates;
+    }
+
+    private void addMaxClique(Collection<V> potentialClique) {
+        if (maximumCliques.isEmpty() || potentialClique.size() == maximumCliques.get(0).size()) {
+            maximumCliques.add(new HashSet<>(potentialClique));
+        } else if (potentialClique.size() > maximumCliques.get(0).size()) {
+            maximumCliques.clear();
+            maximumCliques.add(new HashSet<>(potentialClique));
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/graph/Graph.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/graph/Graph.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.graph;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+
+/**
+ * A basic implementation for simple & undirected graphs.
+ * "Simple graph" means that a vertex cannot have an edge to itself
+ * and there can be at most one edge between two vertices.
+ *
+ * @param <V> Type of vertices
+ */
+public class Graph<V> {
+
+    private Map<V, Set<V>> adjacencyMap = new HashMap<>();
+
+    public void add(V v) {
+        Objects.requireNonNull(v);
+        adjacencyMap.putIfAbsent(v, new HashSet<>());
+    }
+
+    public void connect(V v1, V v2) {
+        Objects.requireNonNull(v1);
+        Objects.requireNonNull(v2);
+        if (v1.equals(v2)) {
+            return;
+        }
+
+        adjacencyMap.computeIfAbsent(v1, v -> new HashSet<>()).add(v2);
+        adjacencyMap.computeIfAbsent(v2, v -> new HashSet<>()).add(v1);
+    }
+
+    public void disconnect(V v1, V v2) {
+        Objects.requireNonNull(v1);
+        Objects.requireNonNull(v2);
+        if (v1.equals(v2)) {
+            return;
+        }
+
+        if (adjacencyMap.getOrDefault(v1, emptySet()).remove(v2)) {
+            adjacencyMap.get(v2).remove(v1);
+        }
+    }
+
+    public Set<V> vertexSet() {
+        return Collections.unmodifiableSet(adjacencyMap.keySet());
+    }
+
+    public boolean containsEdge(V v1, V v2) {
+        Objects.requireNonNull(v1);
+        Objects.requireNonNull(v2);
+        return adjacencyMap.getOrDefault(v1, emptySet()).contains(v2);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -264,7 +264,6 @@ public final class ClusterProperty {
             return RuntimeAvailableProcessors.get() >= 20 ? 4 : 3;
         }
     });
-    ;
 
     /**
      * Controls the number of socket input threads. By default it is the same as {@link #IO_THREAD_COUNT}.
@@ -486,6 +485,37 @@ public final class ClusterProperty {
      */
     public static final HazelcastProperty MAX_NO_HEARTBEAT_SECONDS
             = new HazelcastProperty("hazelcast.max.no.heartbeat.seconds", 60, SECONDS);
+
+    /**
+     * The master member, i.e, the first member in the cluster member list administrates the cluster
+     * and kicks unreachable members with the heartbeat mechanism. It means that a non-master member (i.e,
+     * any member other than the master) does not send heartbeats to the master for the "heartbeat timeout"
+     * duration, it is kicked from the cluster. However, there can be heartbeat problems between non-master
+     * members as well. Since the master member is the single authority to update the cluster member list,
+     * non-master members report their heartbeat problems to the master so that the master can update
+     * the cluster member list.
+     * <p>
+     * When the master receives a heartbeat problem report from another member, it first waits for a number
+     * of heartbeat rounds to allow other members to report their problems if there is any. After that,
+     * it takes all reports received so far and checks if it can update the cluster member in a way that
+     * the minimum number of members will be kicked from the cluster and there won't be any heartbeat problem
+     * between the remaining members.
+     * <p>
+     * If this configuration option is set to 0, this functionality is disabled. It is recommended to be
+     * set to at least 3 or 5 so that the master will wait long enough to collect heartbeat problem reports.
+     * Otherwise, the master member can make sub-optimal decisions.
+     */
+    public static final HazelcastProperty PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT
+            = new HazelcastProperty("hazelcast.partial.member.disconnection.resolution.heartbeat.count", 0);
+
+    /**
+     * The partial member disconnection resolution mechanism uses a graph algorithm that finds a max-clique
+     * in non-polynomial time. Since it could take a lot of time to find a max-clique in a large graph, i.e,
+     * in a large cluster with lots of random network disconnections, we use a timeout mechanism to stop
+     * execution of the algorithm.
+     */
+    public static final HazelcastProperty PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_ALGORITHM_TIMEOUT_SECONDS
+            = new HazelcastProperty("hazelcast.partial.member.disconnection.resolution.algorithm.timeout.seconds", 5);
 
     /**
      * Heartbeat failure detector type. Available options are:

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetectorTest.java
@@ -81,13 +81,13 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void member_isNotAlive_whenNoHeartbeat() throws Exception {
+    public void member_isNotAlive_whenNoHeartbeat() {
         Member member = newMember(5000);
         assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
     }
 
     @Test
-    public void member_isAlive_whenHeartbeat() throws Exception {
+    public void member_isAlive_whenHeartbeat() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -95,7 +95,7 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void member_isAlive_beforeHeartbeatTimeout() throws Exception {
+    public void member_isAlive_beforeHeartbeatTimeout() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -103,7 +103,7 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void member_isNotAlive_afterHeartbeatTimeout() throws Exception {
+    public void member_isNotAlive_afterHeartbeatTimeout() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -113,14 +113,14 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void lastHeartbeat_whenNoHeartbeat() throws Exception {
+    public void lastHeartbeat_whenNoHeartbeat() {
         Member member = newMember(5000);
         long lastHeartbeat = failureDetector.lastHeartbeat(member);
         assertEquals(0L, lastHeartbeat);
     }
 
     @Test
-    public void lastHeartbeat() throws Exception {
+    public void lastHeartbeat() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -130,7 +130,7 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void suspicionLevel_whenNoHeartbeat() throws Exception {
+    public void suspicionLevel_whenNoHeartbeat() {
         Member member = newMember(5000);
         double suspicionLevel = failureDetector.suspicionLevel(member, Clock.currentTimeMillis());
 
@@ -139,7 +139,7 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void suspicionLevel_whenHeartbeat() throws Exception {
+    public void suspicionLevel_whenHeartbeat() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -149,7 +149,7 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void suspicionLevel_beforeHeartbeatTimeout() throws Exception {
+    public void suspicionLevel_beforeHeartbeatTimeout() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -161,7 +161,7 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void suspicionLevel_afterHeartbeatTimeout() throws Exception {
+    public void suspicionLevel_afterHeartbeatTimeout() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -183,14 +183,14 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void remove_whenNoHeartbeat() throws Exception {
+    public void remove_whenNoHeartbeat() {
         Member member = newMember(5000);
         failureDetector.remove(member);
         assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
     }
 
     @Test
-    public void remove_afterHeartbeat() throws Exception {
+    public void remove_afterHeartbeat() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);
@@ -200,14 +200,14 @@ public class ClusterFailureDetectorTest {
     }
 
     @Test
-    public void reset_whenNoHeartbeat() throws Exception {
+    public void reset_whenNoHeartbeat() {
         Member member = newMember(5000);
         failureDetector.reset();
         assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
     }
 
     @Test
-    public void reset_afterHeartbeat() throws Exception {
+    public void reset_afterHeartbeat() {
         Member member = newMember(5000);
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(member, timestamp);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetectorTest.java
@@ -43,26 +43,26 @@ public class PhiAccrualFailureDetectorTest {
             acceptableHeartbeatPause, minStdDev);
 
     @Test
-    public void member_isAssumedAlive_beforeFirstHeartbeat() throws Exception {
+    public void member_isAssumedAlive_beforeFirstHeartbeat() {
         assertTrue(failureDetector.isAlive(Clock.currentTimeMillis()));
     }
 
     @Test
-    public void member_isAlive_whenHeartbeat() throws Exception {
+    public void member_isAlive_whenHeartbeat() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
         assertTrue(failureDetector.isAlive(timestamp));
     }
 
     @Test
-    public void member_isAlive_beforeHeartbeatTimeout() throws Exception {
+    public void member_isAlive_beforeHeartbeatTimeout() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
         assertTrue(failureDetector.isAlive(timestamp + acceptableHeartbeatPause / 2));
     }
 
     @Test
-    public void member_isNotAlive_afterHeartbeatTimeout() throws Exception {
+    public void member_isNotAlive_afterHeartbeatTimeout() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
 
@@ -71,13 +71,13 @@ public class PhiAccrualFailureDetectorTest {
     }
 
     @Test
-    public void lastHeartbeat_whenNoHeartbeat() throws Exception {
+    public void lastHeartbeat_whenNoHeartbeat() {
         long lastHeartbeat = failureDetector.lastHeartbeat();
         assertEquals(PhiAccrualFailureDetector.NO_HEARTBEAT_TIMESTAMP, lastHeartbeat);
     }
 
     @Test
-    public void lastHeartbeat() throws Exception {
+    public void lastHeartbeat() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
 
@@ -86,14 +86,14 @@ public class PhiAccrualFailureDetectorTest {
     }
 
     @Test
-    public void nonSuspected_beforeFirstHeartbeat() throws Exception {
+    public void nonSuspected_beforeFirstHeartbeat() {
         double suspicionLevel = failureDetector.suspicionLevel(Clock.currentTimeMillis());
 
         assertEquals(0, suspicionLevel, 0d);
     }
 
     @Test
-    public void suspicionLevel_whenHeartbeat() throws Exception {
+    public void suspicionLevel_whenHeartbeat() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
 
@@ -102,7 +102,7 @@ public class PhiAccrualFailureDetectorTest {
     }
 
     @Test
-    public void suspicionLevel_beforeHeartbeatTimeout() throws Exception {
+    public void suspicionLevel_beforeHeartbeatTimeout() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
 
@@ -112,7 +112,7 @@ public class PhiAccrualFailureDetectorTest {
     }
 
     @Test
-    public void suspicionLevel_afterHeartbeatTimeout() throws Exception {
+    public void suspicionLevel_afterHeartbeatTimeout() {
         long timestamp = Clock.currentTimeMillis();
         failureDetector.heartbeat(timestamp);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PingFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PingFailureDetectorTest.java
@@ -41,21 +41,21 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PingFailureDetectorTest {
 
-    private PingFailureDetector failureDetector;
+    private PingFailureDetector<Member> failureDetector;
 
     @Before
     public void setup() {
-        failureDetector = new PingFailureDetector(3);
+        failureDetector = new PingFailureDetector<>(3);
     }
 
     @Test
-    public void member_isNotAlive_whenNoHeartbeat() throws Exception {
+    public void member_isNotAlive_whenNoHeartbeat() {
         Member member = newMember(5000);
         assertFalse(failureDetector.isAlive(member));
     }
 
     @Test
-    public void member_isNotAlive_afterThreeAttempts() throws Exception {
+    public void member_isNotAlive_afterThreeAttempts() {
         Member member = newMember(5000);
         failureDetector.logAttempt(member);
         failureDetector.logAttempt(member);
@@ -64,7 +64,7 @@ public class PingFailureDetectorTest {
     }
 
     @Test
-    public void member_isAlive_afterThreeAttempts_afterHeartbeat() throws Exception {
+    public void member_isAlive_afterThreeAttempts_afterHeartbeat() {
         Member member = newMember(5000);
         failureDetector.logAttempt(member);
         failureDetector.logAttempt(member);
@@ -74,28 +74,28 @@ public class PingFailureDetectorTest {
     }
 
     @Test
-    public void member_isAlive_whenHeartbeat() throws Exception {
+    public void member_isAlive_whenHeartbeat() {
         Member member = newMember(5000);
         failureDetector.heartbeat(member);
         assertTrue(failureDetector.isAlive(member));
     }
 
     @Test
-    public void member_isAlive_beforeHeartbeatTimeout() throws Exception {
+    public void member_isAlive_beforeHeartbeatTimeout() {
         Member member = newMember(5000);
         failureDetector.heartbeat(member);
         assertTrue(failureDetector.isAlive(member));
     }
 
     @Test
-    public void remove_whenNoHeartbeat() throws Exception {
+    public void remove_whenNoHeartbeat() {
         Member member = newMember(5000);
         failureDetector.remove(member);
         assertFalse(failureDetector.isAlive(member));
     }
 
     @Test
-    public void remove_afterHeartbeat() throws Exception {
+    public void remove_afterHeartbeat() {
         Member member = newMember(5000);
         failureDetector.heartbeat(member);
 
@@ -104,14 +104,14 @@ public class PingFailureDetectorTest {
     }
 
     @Test
-    public void reset_whenNoHeartbeat() throws Exception {
+    public void reset_whenNoHeartbeat() {
         Member member = newMember(5000);
         failureDetector.reset();
         assertFalse(failureDetector.isAlive(member));
     }
 
     @Test
-    public void reset_afterHeartbeat() throws Exception {
+    public void reset_afterHeartbeat() {
         Member member = newMember(5000);
         failureDetector.heartbeat(member);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -35,7 +35,6 @@ import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -89,7 +88,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_whenMemberAdded_duringTx() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance[] instances = new HazelcastInstance[3];
         for (int i = 0; i < 3; i++) {
             instances[i] = factory.newHazelcastInstance();
@@ -126,8 +125,8 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_whenMemberRemoved_duringTx() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        final HazelcastInstance[] instances = new HazelcastInstance[3];
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = new HazelcastInstance[3];
         for (int i = 0; i < 3; i++) {
             instances[i] = factory.newHazelcastInstance();
         }
@@ -163,23 +162,23 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_whenStateIsAlreadyLocked() {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[instances.length - 1];
+        HazelcastInstance hz = instances[instances.length - 1];
 
         lockClusterState(hz);
 
-        final HazelcastInstance hz2 = instances[instances.length - 2];
+        HazelcastInstance hz2 = instances[instances.length - 2];
 
         exception.expect(TransactionException.class);
         hz2.getCluster().changeClusterState(ClusterState.PASSIVE);
     }
 
     private void lockClusterState(HazelcastInstance hz) {
-        final Node node = getNode(hz);
+        Node node = getNode(hz);
         ClusterServiceImpl clusterService = node.getClusterService();
         int memberListVersion = clusterService.getMemberListVersion();
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
@@ -191,12 +190,12 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_whenInitiatorDies_beforePrepare() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance[] instances = factory.newInstances();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[instances.length - 1];
+        HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
         TransactionOptions options = TransactionOptions.getDefault().setTimeout(60, TimeUnit.SECONDS);
@@ -218,12 +217,12 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldNotFail_whenInitiatorDies_afterPrepare() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance[] instances = factory.newInstances();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[instances.length - 1];
+        HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
         TransactionOptions options = TransactionOptions.getDefault().setDurability(1);
@@ -245,12 +244,12 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_withoutBackup_whenInitiatorDies_beforePrepare() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance[] instances = factory.newInstances();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[instances.length - 1];
+        HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
         TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(60, TimeUnit.SECONDS);
@@ -272,12 +271,12 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_withoutBackup_whenInitiatorDies_afterPrepare() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance[] instances = factory.newInstances();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[instances.length - 1];
+        HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
         TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(60, TimeUnit.SECONDS);
@@ -299,15 +298,15 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldNotFail_whenNonInitiatorMemberDies_duringCommit() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance[] instances = factory.newInstances();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[2];
+        HazelcastInstance hz = instances[2];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        final Address address = getAddress(instances[0]);
+        Address address = getAddress(instances[0]);
 
         TransactionOptions options = TransactionOptions.getDefault().setDurability(0);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
@@ -329,15 +328,15 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void changeClusterState_shouldFail_whenNonInitiatorMemberDies_beforePrepare() throws Exception {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance[] instances = factory.newInstances();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final HazelcastInstance hz = instances[2];
+        HazelcastInstance hz = instances[2];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        final Address address = getAddress(instances[0]);
+        Address address = getAddress(instances[0]);
 
         TransactionOptions options = TransactionOptions.getDefault().setDurability(0);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
@@ -365,7 +364,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
     public void changeClusterState_shouldFail_whenStartupIsNotCompleted() throws Exception {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
-        final AtomicBoolean startupDone = new AtomicBoolean(false);
+        AtomicBoolean startupDone = new AtomicBoolean(false);
 
         HazelcastInstance instance = HazelcastInstanceFactory.newHazelcastInstance(new Config(), randomName(),
                 new MockNodeContext(factory.getRegistry(), new Address("127.0.0.1", 5555)) {
@@ -392,7 +391,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void clusterState_shouldBeTheSame_finally_onAllNodes() {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances();
 
         assertClusterSizeEventually(instances.length, instances);
@@ -415,24 +414,18 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = factory.newInstances(config);
         HazelcastInstance hz1 = instances[0];
         HazelcastInstance hz2 = instances[1];
-        HazelcastInstance hz3 = instances[2];
+
         warmUpPartitions(instances);
         waitAllForSafeState(instances);
 
-        final Address owner = getNode(hz1).getThisAddress();
+        Address owner = getNode(hz1).getThisAddress();
         int partitionId = getPartitionId(hz1);
 
         changeClusterStateEventually(hz2, ClusterState.FROZEN);
         terminateInstance(hz1);
 
-        final InternalPartition partition = getNode(hz2).getPartitionService().getPartition(partitionId);
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(owner, partition.getOwnerOrNull());
-            }
-        }, 3);
+        InternalPartition partition = getNode(hz2).getPartitionService().getPartition(partitionId);
+        assertTrueAllTheTime(() -> assertEquals(owner, partition.getOwnerOrNull()), 3);
     }
 
     @Test
@@ -458,7 +451,6 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = factory.newInstances(config);
         HazelcastInstance hz1 = instances[0];
         HazelcastInstance hz2 = instances[1];
-        HazelcastInstance hz3 = instances[2];
 
         changeClusterStateEventually(hz2, state);
 
@@ -484,11 +476,9 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     private void partitionInvocation_shouldFail_whenPartitionsNotAssigned_whenMigrationNotAllowed(ClusterState state)
             throws InterruptedException {
-
         Config config = new Config();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances(config);
-        HazelcastInstance hz1 = instances[0];
         HazelcastInstance hz2 = instances[1];
         HazelcastInstance hz3 = instances[2];
 
@@ -511,27 +501,23 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
     @Test
     public void test_eitherClusterStateChange_orPartitionInitialization_shouldBeSuccessful()
             throws Exception {
-
         Config config = new Config();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances(config);
         HazelcastInstance hz1 = instances[0];
-        final HazelcastInstance hz2 = instances[1];
-        HazelcastInstance hz3 = instances[2];
+        HazelcastInstance hz2 = instances[1];
 
         assertClusterSizeEventually(instances.length, instances);
 
-        final InternalPartitionService partitionService = getNode(hz1).getPartitionService();
-        final int initialPartitionStateVersion = partitionService.getPartitionStateVersion();
+        InternalPartitionService partitionService = getNode(hz1).getPartitionService();
+        int initialPartitionStateVersion = partitionService.getPartitionStateVersion();
 
-        final ClusterState newState = ClusterState.PASSIVE;
+        ClusterState newState = ClusterState.PASSIVE;
 
-        final Future future = spawn(new Runnable() {
-            public void run() {
-                try {
-                    changeClusterState(hz2, newState, initialPartitionStateVersion);
-                } catch (Exception ignored) {
-                }
+        Future future = spawn(() -> {
+            try {
+                changeClusterState(hz2, newState, initialPartitionStateVersion);
+            } catch (Exception ignored) {
             }
         });
 
@@ -539,14 +525,14 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         future.get(2, TimeUnit.MINUTES);
 
-        final ClusterState currentState = hz2.getCluster().getClusterState();
+        ClusterState currentState = hz2.getCluster().getClusterState();
         if (currentState == newState) {
             // if cluster state changed then partition state version should be equal to initial version
             assertEquals(initialPartitionStateVersion, partitionService.getPartitionStateVersion());
         } else {
             assertEquals(ClusterState.ACTIVE, currentState);
 
-            final InternalPartition partition = partitionService.getPartition(0, false);
+            InternalPartition partition = partitionService.getPartition(0, false);
             if (partition.getOwnerOrNull() == null) {
                 // if partition assignment failed then partition state version should be equal to initial version
                 assertEquals(initialPartitionStateVersion, partitionService.getPartitionStateVersion());
@@ -570,7 +556,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         changeClusterStateEventually(hz2, ClusterState.FROZEN);
 
-        final Address owner = getNode(hz1).getThisAddress();
+        Address owner = getNode(hz1).getThisAddress();
         terminateInstance(hz1);
 
         hz1 = factory.newHazelcastInstance(owner);
@@ -595,7 +581,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
     }
 
     private void nodesCanShutDown_whenClusterState_changesTo(ClusterState state) {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances();
 
         HazelcastInstance hz = instances[instances.length - 1];
@@ -603,7 +589,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         changeClusterStateEventually(hz, state);
 
-        List<HazelcastInstance> instanceList = new ArrayList<HazelcastInstance>(Arrays.asList(instances));
+        List<HazelcastInstance> instanceList = new ArrayList<>(Arrays.asList(instances));
         while (!instanceList.isEmpty()) {
             HazelcastInstance instanceToShutdown = instanceList.remove(0);
             instanceToShutdown.shutdown();
@@ -633,20 +619,14 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         OperationServiceImpl operationService = getNode(hz3).getNodeEngine().getOperationService();
         Operation op = new AddAndGetOperation(key, 1);
-        final Future<Long> future = operationService
-                .invokeOnPartition(LongRegisterService.SERVICE_NAME, op, partitionId);
+        Future<Long> future = operationService.invokeOnPartition(LongRegisterService.SERVICE_NAME, op, partitionId);
 
         assertFalse(future.isDone());
 
         factory.newHazelcastInstance(owner);
         assertClusterSizeEventually(3, hz2);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertTrue(future.isDone());
-            }
-        });
+        assertTrueEventually(() -> assertTrue(future.isDone()));
 
         // should not fail
         future.get();

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -36,7 +36,6 @@ import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -316,7 +315,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         warmUpPartitions(instances);
 
         HazelcastInstance hz = instances[instances.length - 1];
-        Map map = hz.getMap(randomMapName());
+        Map<Object, Object> map = hz.getMap(randomMapName());
         changeClusterStateEventually(hz, ClusterState.PASSIVE);
         map.get(1);
     }
@@ -332,18 +331,18 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     }
 
     private void testNoMigrationWhenNodeLeaves(final ClusterState clusterState) {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance master = factory.newHazelcastInstance();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance master = factory.newHazelcastInstance();
         HazelcastInstance other = factory.newHazelcastInstance();
 
-        final IMap<Object, Object> map = master.getMap(randomMapName());
+        IMap<Object, Object> map = master.getMap(randomMapName());
         for (int i = 0; i < 10000; i++) {
             map.put(i, i);
         }
 
         changeClusterStateEventually(master, clusterState);
 
-        final Address otherAddress = getAddress(other);
+        Address otherAddress = getAddress(other);
 
         other.shutdown();
         assertClusterSizeEventually(1, master);
@@ -356,11 +355,10 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void
-    test_listener_registration_whenClusterState_PASSIVE() {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        final HazelcastInstance master = factory.newHazelcastInstance();
-        final HazelcastInstance other = factory.newHazelcastInstance();
+    public void test_listener_registration_whenClusterState_PASSIVE() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance other = factory.newHazelcastInstance();
 
         changeClusterStateEventually(master, ClusterState.PASSIVE);
         master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
@@ -372,11 +370,11 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
     @Test
     public void test_listener_deregistration_whenClusterState_PASSIVE() {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        final HazelcastInstance master = factory.newHazelcastInstance();
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance other = factory.newHazelcastInstance();
 
-        final UUID registrationId = master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
+        UUID registrationId = master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
         // Expected = 7 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
         // + 2 from map and cache ExpirationManagers * instances
         assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 7);
@@ -393,20 +391,14 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     @Test
     public void test_eventsDispatched_whenClusterState_PASSIVE() {
         System.setProperty(EventServiceImpl.EVENT_SYNC_FREQUENCY_PROP, "1");
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        final HazelcastInstance master = factory.newHazelcastInstance();
-        final HazelcastInstance other = factory.newHazelcastInstance();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance other = factory.newHazelcastInstance();
 
         changeClusterStateEventually(master, ClusterState.PASSIVE);
         master.getMap(randomMapName());
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(1, getNodeEngineImpl(other).getProxyService().getProxyCount());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, getNodeEngineImpl(other).getProxyService().getProxyCount()));
     }
 
     @Test
@@ -439,23 +431,18 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     @Test
     public void backupOperation_shouldBeAllowed_whenClusterState_PASSIVE() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        final HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
         HazelcastInstance hz2 = factory.newHazelcastInstance();
         warmUpPartitions(hz1, hz2);
 
         int partitionId = getPartitionId(hz2);
         changeClusterStateEventually(hz1, ClusterState.PASSIVE);
 
-        InternalCompletableFuture future = getOperationService(hz1).invokeOnPartition(null,
+        InternalCompletableFuture<Object> future = getOperationService(hz1).invokeOnPartition(null,
                 new PrimaryAllowedDuringPassiveStateOperation(), partitionId);
         future.join();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertTrue(hz1.getUserContext().containsKey(BackupOperation.EXECUTION_DONE));
-            }
-        });
+        assertTrueEventually(() -> assertTrue(hz1.getUserContext().containsKey(BackupOperation.EXECUTION_DONE)));
     }
 
     private static void assertNodeState(HazelcastInstance[] instances, NodeState expectedState) {
@@ -466,16 +453,10 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     }
 
     private void assertRegistrationsSizeEventually(final HazelcastInstance instance, final String serviceName, final String topic, final int size) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-
-                final EventService eventService = getNode(instance).getNodeEngine().getEventService();
-                final Collection<EventRegistration> registrations =
-                        eventService.getRegistrations(serviceName, topic);
-                assertEquals(size, registrations.size());
-            }
+        assertTrueEventually(() -> {
+            EventService eventService = getNode(instance).getNodeEngine().getEventService();
+            Collection<EventRegistration> registrations = eventService.getRegistrations(serviceName, topic);
+            assertEquals(size, registrations.size());
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BindMessageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BindMessageTest.java
@@ -83,8 +83,8 @@ public class BindMessageTest {
     }
 
     Map<ProtocolType, Collection<Address>> localAddresses() throws Exception {
-        Map<ProtocolType, Collection<Address>> map = new EnumMap<ProtocolType, Collection<Address>>(ProtocolType.class);
-        Collection<Address> addresses = new ArrayList<Address>();
+        Map<ProtocolType, Collection<Address>> map = new EnumMap<>(ProtocolType.class);
+        Collection<Address> addresses = new ArrayList<>();
         addresses.add(new Address("127.0.0.1", 5701));
         addresses.add(new Address("127.0.0.1", 5702));
         addresses.add(new Address("127.0.0.1", 5703));

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterRollingRestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterRollingRestartTest.java
@@ -63,9 +63,9 @@ public class ClusterRollingRestartTest extends HazelcastTestSupport {
 
     @Test
     public void test_rollingRestart() {
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        final int nodeCount = 3;
-        final HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        int nodeCount = 3;
+        HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
         instances[0] = factory.newHazelcastInstance();
 
         if (partitionAssignmentType == PartitionAssignmentType.DURING_STARTUP) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -16,20 +16,19 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.LockGuard;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.internal.util.Clock;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
 import org.junit.Before;
@@ -140,7 +139,7 @@ public class ClusterStateManagerTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void test_lockClusterState_nullInitiator() throws Exception {
+    public void test_lockClusterState_nullInitiator() {
         clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), null, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
@@ -167,7 +166,7 @@ public class ClusterStateManagerTest {
     @Test(expected = TransactionException.class)
     public void test_lockClusterState_fail() throws Exception {
         Address initiator = newAddress();
-        final ClusterStateChange newState = ClusterStateChange.from(FROZEN);
+        ClusterStateChange newState = ClusterStateChange.from(FROZEN);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
         clusterStateManager.lockClusterState(newState, initiator, ANOTHER_TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
@@ -187,7 +186,7 @@ public class ClusterStateManagerTest {
         clusterStateManager.initialClusterState(FROZEN, CURRENT_CLUSTER_VERSION);
 
         Address initiator = newAddress();
-        final ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
+        ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
         assertLockedBy(initiator);
@@ -199,19 +198,19 @@ public class ClusterStateManagerTest {
         clusterStateManager.initialClusterState(FROZEN, CURRENT_CLUSTER_VERSION);
 
         Address initiator = newAddress();
-        final ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
+        ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
         assertLockedBy(initiator);
     }
 
     @Test(expected = NullPointerException.class)
-    public void test_unlockClusterState_nullTransactionId() throws Exception {
+    public void test_unlockClusterState_nullTransactionId() {
         clusterStateManager.rollbackClusterState(null);
     }
 
     @Test
-    public void test_unlockClusterState_fail_whenNotLocked() throws Exception {
+    public void test_unlockClusterState_fail_whenNotLocked() {
         assertFalse(clusterStateManager.rollbackClusterState(TXN));
     }
 
@@ -240,20 +239,20 @@ public class ClusterStateManagerTest {
 
     @Test
     public void test_lockClusterState_getLockExpiryTime() throws Exception {
-        final Address initiator = newAddress();
+        Address initiator = newAddress();
         clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), MEMBERLIST_VERSION, PARTITION_VERSION);
 
-        final LockGuard stateLock = clusterStateManager.getStateLock();
+        LockGuard stateLock = clusterStateManager.getStateLock();
         assertTrue(Clock.currentTimeMillis() + TimeUnit.HOURS.toMillis(12) < stateLock.getLockExpiryTime());
     }
 
     @Test
     public void test_lockClusterState_extendLease() throws Exception {
-        final Address initiator = newAddress();
+        Address initiator = newAddress();
         clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), MEMBERLIST_VERSION, PARTITION_VERSION);
 
-        final LockGuard stateLock = clusterStateManager.getStateLock();
+        LockGuard stateLock = clusterStateManager.getStateLock();
         assertTrue(Clock.currentTimeMillis() + TimeUnit.HOURS.toMillis(12) < stateLock.getLockExpiryTime());
     }
 
@@ -268,13 +267,10 @@ public class ClusterStateManagerTest {
     @Test
     public void test_lockClusterState_expiry() throws Exception {
         clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1, MEMBERLIST_VERSION, PARTITION_VERSION);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                final LockGuard stateLock = clusterStateManager.getStateLock();
-                assertFalse(stateLock.isLocked());
-                assertEquals(ACTIVE, clusterStateManager.getState());
-            }
+        assertTrueEventually(() -> {
+            LockGuard stateLock = clusterStateManager.getStateLock();
+            assertFalse(stateLock.isLocked());
+            assertEquals(ACTIVE, clusterStateManager.getState());
         });
     }
 
@@ -300,27 +296,27 @@ public class ClusterStateManagerTest {
 
     @Test(expected = TransactionException.class)
     public void test_changeLocalClusterState_fail_whenLockedByElse() throws Exception {
-        final Address initiator = newAddress();
+        Address initiator = newAddress();
         clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(ClusterStateChange.from(FROZEN), initiator, ANOTHER_TXN);
     }
 
     @Test
     public void test_changeLocalClusterState_success() throws Exception {
-        final ClusterStateChange newState = ClusterStateChange.from(FROZEN);
-        final Address initiator = newAddress();
+        ClusterStateChange newState = ClusterStateChange.from(FROZEN);
+        Address initiator = newAddress();
         clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
         assertEquals(newState.getNewState(), clusterStateManager.getState());
-        final LockGuard stateLock = clusterStateManager.getStateLock();
+        LockGuard stateLock = clusterStateManager.getStateLock();
         assertFalse(stateLock.isLocked());
     }
 
     @Test
     public void changeLocalClusterState_shouldChangeNodeStateToShuttingDown_whenStateBecomes_PASSIVE() throws Exception {
-        final ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
-        final Address initiator = newAddress();
+        ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
+        Address initiator = newAddress();
         clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
@@ -330,8 +326,8 @@ public class ClusterStateManagerTest {
 
     @Test
     public void changeLocalClusterState_shouldRemoveMembersDeadWhileFrozen_whenStateBecomes_ACTIVE() throws Exception {
-        final ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
-        final Address initiator = newAddress();
+        ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
+        Address initiator = newAddress();
         clusterStateManager.initialClusterState(FROZEN, CURRENT_CLUSTER_VERSION);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(newState, initiator, TXN);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionInitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionInitTest.java
@@ -24,13 +24,10 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.version.MemberVersion;
-import com.hazelcast.version.Version;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.concurrent.Callable;
 
 import static com.hazelcast.test.Accessors.getNode;
 
@@ -48,13 +45,7 @@ public class ClusterVersionInitTest extends HazelcastTestSupport {
         config.setClusterName(randomName());
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
         setupInstance(config);
-        assertEqualsEventually(new Callable<Version>() {
-            @Override
-            public Version call()
-                    throws Exception {
-                return cluster.getClusterVersion();
-            }
-        }, codebaseVersion.asVersion());
+        assertEqualsEventually(() -> cluster.getClusterVersion(), codebaseVersion.asVersion());
     }
 
     @Test
@@ -64,13 +55,7 @@ public class ClusterVersionInitTest extends HazelcastTestSupport {
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
         setupInstance(config);
-        assertEqualsEventually(new Callable<Version>() {
-            @Override
-            public Version call()
-                    throws Exception {
-                return cluster.getClusterVersion();
-            }
-        }, codebaseVersion.asVersion());
+        assertEqualsEventually(() -> cluster.getClusterVersion(), codebaseVersion.asVersion());
     }
 
     @Test
@@ -80,13 +65,7 @@ public class ClusterVersionInitTest extends HazelcastTestSupport {
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
         setupInstance(config);
-        assertEqualsEventually(new Callable<Version>() {
-            @Override
-            public Version call()
-                    throws Exception {
-                return cluster.getClusterVersion();
-            }
-        }, codebaseVersion.asVersion());
+        assertEqualsEventually(() -> cluster.getClusterVersion(), codebaseVersion.asVersion());
     }
 
     @Test
@@ -96,15 +75,9 @@ public class ClusterVersionInitTest extends HazelcastTestSupport {
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
         setupInstance(config);
         HazelcastInstance joiner = Hazelcast.newHazelcastInstance(config);
-        final ClusterServiceImpl joinerCluster = (ClusterServiceImpl) joiner.getCluster();
+        ClusterServiceImpl joinerCluster = (ClusterServiceImpl) joiner.getCluster();
 
-        assertEqualsEventually(new Callable<Version>() {
-            @Override
-            public Version call()
-                    throws Exception {
-                return joinerCluster.getClusterVersion();
-            }
-        }, codebaseVersion.asVersion());
+        assertEqualsEventually(joinerCluster::getClusterVersion, codebaseVersion.asVersion());
 
         joiner.shutdown();
     }
@@ -117,15 +90,9 @@ public class ClusterVersionInitTest extends HazelcastTestSupport {
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
         setupInstance(config);
         HazelcastInstance joiner = Hazelcast.newHazelcastInstance(config);
-        final ClusterServiceImpl joinerCluster = (ClusterServiceImpl) joiner.getCluster();
+        ClusterServiceImpl joinerCluster = (ClusterServiceImpl) joiner.getCluster();
 
-        assertEqualsEventually(new Callable<Version>() {
-            @Override
-            public Version call()
-                    throws Exception {
-                return joinerCluster.getClusterVersion();
-            }
-        }, codebaseVersion.asVersion());
+        assertEqualsEventually(joinerCluster::getClusterVersion, codebaseVersion.asVersion());
 
         joiner.shutdown();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
@@ -109,7 +109,7 @@ public class DiscoveryJoinerTest {
         String hostAddress = node.getThisAddress().getInetAddress().getHostAddress();
         node.config.getNetworkConfig().getJoin().getTcpIpConfig().setRequiredMember(hostAddress);
 
-        List<DiscoveryNode> nodes = new ArrayList<DiscoveryNode>();
+        List<DiscoveryNode> nodes = new ArrayList<>();
         nodes.add(new SimpleDiscoveryNode(node.getThisAddress(), node.getThisAddress()));
 
         DiscoveryJoiner joiner = new DiscoveryJoiner(node, service, true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -61,23 +60,20 @@ public class EventRegistrationTest extends HazelcastTestSupport {
     }
 
     private HazelcastInstance[] startInstances(int nodeCount) {
-        final List<HazelcastInstance> instancesList = synchronizedList(new ArrayList<HazelcastInstance>());
-        final CountDownLatch latch = new CountDownLatch(nodeCount);
-        final TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(3);
+        List<HazelcastInstance> instancesList = synchronizedList(new ArrayList<>());
+        CountDownLatch latch = new CountDownLatch(nodeCount);
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(3);
 
         for (int i = 0; i < nodeCount; ++i) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        Address address = instanceFactory.nextAddress();
-                        HazelcastInstance instance = instanceFactory.newHazelcastInstance(address, new Config());
-                        instancesList.add(instance);
-                    } catch (Throwable e) {
-                        logger.severe(e);
-                    } finally {
-                        latch.countDown();
-                    }
+            new Thread(() -> {
+                try {
+                    Address address = instanceFactory.nextAddress();
+                    HazelcastInstance instance = instanceFactory.newHazelcastInstance(address, new Config());
+                    instancesList.add(instance);
+                } catch (Throwable e) {
+                    logger.severe(e);
+                } finally {
+                    latch.countDown();
                 }
             }, "Start thread for node " + i).start();
         }
@@ -87,16 +83,12 @@ public class EventRegistrationTest extends HazelcastTestSupport {
         return instancesList.toArray(new HazelcastInstance[0]);
     }
 
-    private static void assertEventRegistrations(final int expected, final HazelcastInstance... instances) {
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                for (HazelcastInstance instance : instances) {
-                    Collection<EventRegistration> regs = getNodeEngineImpl(instance).getEventService().getRegistrations(
-                            ProxyServiceImpl.SERVICE_NAME, ProxyServiceImpl.SERVICE_NAME);
-                    assertEquals(instance + ": " + regs, expected, regs.size());
-                }
+    private static void assertEventRegistrations(int expected, HazelcastInstance... instances) {
+        assertTrueEventually(() -> {
+            for (HazelcastInstance instance : instances) {
+                Collection<EventRegistration> regs = getNodeEngineImpl(instance).getEventService().getRegistrations(
+                        ProxyServiceImpl.SERVICE_NAME, ProxyServiceImpl.SERVICE_NAME);
+                assertEquals(instance + ": " + regs, expected, regs.size());
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
@@ -19,9 +19,6 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -101,19 +98,16 @@ public class MemberListJoinVersionTest extends HazelcastTestSupport {
                 .setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
                 .setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
 
-        final HazelcastInstance member1 = factory.newHazelcastInstance(config);
-        final HazelcastInstance member2 = factory.newHazelcastInstance(config);
-        final HazelcastInstance member3 = factory.newHazelcastInstance(config);
+        HazelcastInstance member1 = factory.newHazelcastInstance(config);
+        HazelcastInstance member2 = factory.newHazelcastInstance(config);
+        HazelcastInstance member3 = factory.newHazelcastInstance(config);
 
         assertClusterSizeEventually(3, member2);
 
-        final CountDownLatch mergeLatch = new CountDownLatch(1);
-        member3.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (event.getState() == MERGED) {
-                    mergeLatch.countDown();
-                }
+        CountDownLatch mergeLatch = new CountDownLatch(1);
+        member3.getLifecycleService().addLifecycleListener(event -> {
+            if (event.getState() == MERGED) {
+                mergeLatch.countDown();
             }
         });
 
@@ -138,12 +132,7 @@ public class MemberListJoinVersionTest extends HazelcastTestSupport {
         assertEquals(afterJoinVersionOnMember1, versionOnLocalMember3);
 
         assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member3));
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
-            }
-        });
+        assertTrueEventually(() -> assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2)));
         assertJoinMemberListVersions(member1, member2, member3);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollectionTest.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.internal.cluster.impl;
 
-import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.MemberSelector;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -48,12 +47,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
-    private static final MemberSelector NO_OP_MEMBER_SELECTOR = new MemberSelector() {
-        @Override
-        public boolean select(Member member) {
-            return true;
-        }
-    };
+    private static final MemberSelector NO_OP_MEMBER_SELECTOR = member -> true;
 
     private MemberImpl thisMember;
 
@@ -84,7 +78,7 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
     }
 
     private Set<MemberImpl> createMembers() {
-        final Set<MemberImpl> members = new LinkedHashSet<MemberImpl>();
+        Set<MemberImpl> members = new LinkedHashSet<MemberImpl>();
         members.add(liteMember);
         members.add(thisMember);
         members.add(dataMember);
@@ -93,14 +87,14 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testSizeWhenAllSelected() {
-        final MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 NO_OP_MEMBER_SELECTOR);
         assertEquals(3, collection.size());
     }
 
     @Test
     public void testContainsWhenAllSelected() {
-        final MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 NO_OP_MEMBER_SELECTOR);
         assertContains(collection, liteMember);
         assertContains(collection, thisMember);
@@ -112,7 +106,7 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
     @Test
     public void testIsEmptyWhenNoMemberIsSelected() {
         members.remove(dataMember);
-        final MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(DATA_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertTrue(collection.isEmpty());
     }
@@ -121,7 +115,7 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
     public void testIsEmptyWhenLiteMembersSelectedAndNoLocalMember() {
         members.remove(liteMember);
         members.remove(dataMember);
-        final MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        MemberSelectingCollection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertTrue(collection.isEmpty());
     }
@@ -130,65 +124,65 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testContainsThisMemberWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertContains(collection, thisMember);
     }
 
     @Test
     public void testDoesNotContainThisMemberWhenDataMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR);
         assertFalse(collection.contains(thisMember));
     }
 
     @Test
     public void testDoesNotContainThisMemberWhenLiteMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertFalse(collection.contains(thisMember));
     }
 
     @Test
     public void testDoesNotContainThisMemberDataMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(DATA_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertFalse(collection.contains(thisMember));
     }
 
     @Test
     public void testContainsMatchingMemberWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertContains(collection, liteMember);
     }
 
     @Test
     public void testContainsMatchingMemberWhenLiteMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertContains(collection, liteMember);
     }
 
     @Test
     public void testDoesNotContainNonMatchingMemberWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertFalse(collection.contains(dataMember));
     }
 
     @Test
     public void testDoesNotContainNonMatchingMemberWhenLiteMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertFalse(collection.contains(dataMember));
     }
 
     @Test
     public void testDoesNotContainOtherMemberWhenDataMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR);
         assertFalse(collection.contains(nonExistingMember));
     }
 
     @Test
     public void testDoesNotContainOtherMemberWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertFalse(collection.contains(nonExistingMember));
     }
 
@@ -196,20 +190,20 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testContainsAllWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertContainsAll(collection, asList(thisMember, liteMember));
     }
 
     @Test
     public void testDoesNotContainAllWhenLiteMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertNotContainsAll(collection, asList(thisMember, liteMember));
     }
 
     @Test
     public void testDoesNotContainNonMatchingMemberTypesWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertNotContainsAll(collection, asList(thisMember, dataMember));
     }
 
@@ -217,27 +211,27 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testSizeWhenThisLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
         assertEquals(2, collection.size());
     }
 
     @Test
     public void testSizeWhenLiteMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertEquals(1, collection.size());
     }
 
     @Test
     public void testSizeWhenDataMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(DATA_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         assertEquals(1, collection.size());
     }
 
     @Test
     public void testSizeWhenDataMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR);
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR);
         assertEquals(1, collection.size());
     }
 
@@ -245,16 +239,16 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testToArrayWhenLiteMembersSelected() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
-        final Object[] array = collection.toArray();
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Object[] array = collection.toArray();
 
         assertArray(collection, array);
     }
 
     @Test
     public void testToArrayWhenLiteMembersSelected2() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
-        final Object[] array = new Object[collection.size()];
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR);
+        Object[] array = new Object[collection.size()];
         collection.toArray(array);
 
         assertArray(collection, array);
@@ -262,18 +256,18 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testToArrayWhenLiteMembersSelectedAndNoLocalMember() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
-        final Object[] array = collection.toArray();
+        Object[] array = collection.toArray();
 
         assertArray(collection, array);
     }
 
     @Test
     public void testToArrayWhenLiteMembersSelectedAndNoLocalMember2() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
-        final Object[] array = new Object[collection.size()];
+        Object[] array = new Object[collection.size()];
         collection.toArray(array);
 
         assertArray(collection, array);
@@ -281,7 +275,7 @@ public class MemberSelectingCollectionTest extends HazelcastTestSupport {
 
     @Test
     public void testToArrayWhenLiteMembersFilteredAndNoLocalMember3() {
-        final Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
+        Collection<MemberImpl> collection = new MemberSelectingCollection<MemberImpl>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR));
         Object[] array = new Object[0];
         array = collection.toArray(array);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
@@ -69,7 +69,7 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
     }
 
     private Set<MemberImpl> createMembers() {
-        final Set<MemberImpl> members = new LinkedHashSet<MemberImpl>();
+        Set<MemberImpl> members = new LinkedHashSet<>();
         members.add(thisMember);
         members.add(matchingMember);
         members.add(nonMatchingMember);
@@ -79,9 +79,9 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
 
     @Test
     public void testSelectingLiteMembersWithThisAddress() {
-        final Set<MemberImpl> members = createMembers();
-        final Iterator<MemberImpl> iterator = new MemberSelectingCollection<MemberImpl>(members, LITE_MEMBER_SELECTOR).iterator();
-        final Set<MemberImpl> filteredMembers = new HashSet<MemberImpl>();
+        Set<MemberImpl> members = createMembers();
+        Iterator<MemberImpl> iterator = new MemberSelectingCollection<>(members, LITE_MEMBER_SELECTOR).iterator();
+        Set<MemberImpl> filteredMembers = new HashSet<>();
 
         while (iterator.hasNext()) {
             filteredMembers.add(iterator.next());
@@ -95,10 +95,10 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
 
     @Test
     public void testSelectingLiteMembersWithoutThisAddress() {
-        final Set<MemberImpl> members = createMembers();
-        final Iterator<MemberImpl> iterator = new MemberSelectingCollection<MemberImpl>(members,
+        Set<MemberImpl> members = createMembers();
+        Iterator<MemberImpl> iterator = new MemberSelectingCollection<>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR)).iterator();
-        final Set<MemberImpl> filteredMembers = new HashSet<MemberImpl>();
+        Set<MemberImpl> filteredMembers = new HashSet<>();
 
         while (iterator.hasNext()) {
             filteredMembers.add(iterator.next());
@@ -111,9 +111,9 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
 
     @Test
     public void testSelectingMembersWithThisAddress() {
-        final Set<MemberImpl> members = createMembers();
-        final Iterator<MemberImpl> iterator = new MemberSelectingCollection<MemberImpl>(members, DATA_MEMBER_SELECTOR).iterator();
-        final Set<MemberImpl> filteredMembers = new HashSet<MemberImpl>();
+        Set<MemberImpl> members = createMembers();
+        Iterator<MemberImpl> iterator = new MemberSelectingCollection<>(members, DATA_MEMBER_SELECTOR).iterator();
+        Set<MemberImpl> filteredMembers = new HashSet<>();
 
         while (iterator.hasNext()) {
             filteredMembers.add(iterator.next());
@@ -125,10 +125,10 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
 
     @Test
     public void testSelectingMembersWithoutThisAddress() {
-        final Set<MemberImpl> members = createMembers();
-        final Iterator<MemberImpl> iterator = new MemberSelectingCollection<MemberImpl>(members,
+        Set<MemberImpl> members = createMembers();
+        Iterator<MemberImpl> iterator = new MemberSelectingCollection<>(members,
                 and(DATA_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR)).iterator();
-        final Set<MemberImpl> filteredMembers = new HashSet<MemberImpl>();
+        Set<MemberImpl> filteredMembers = new HashSet<>();
 
         while (iterator.hasNext()) {
             filteredMembers.add(iterator.next());
@@ -140,8 +140,8 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
 
     @Test
     public void testHasNextCalledTwice() {
-        final Set<MemberImpl> members = createMembers();
-        final Iterator<MemberImpl> iterator = new MemberSelectingCollection<MemberImpl>(members,
+        Set<MemberImpl> members = createMembers();
+        Iterator<MemberImpl> iterator = new MemberSelectingCollection<>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR)).iterator();
 
         while (iterator.hasNext()) {
@@ -152,8 +152,8 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
 
     @Test(expected = NoSuchElementException.class)
     public void testIterationFailsAfterConsumed() {
-        final Set<MemberImpl> members = createMembers();
-        final Iterator<MemberImpl> iterator = new MemberSelectingCollection<MemberImpl>(members,
+        Set<MemberImpl> members = createMembers();
+        Iterator<MemberImpl> iterator = new MemberSelectingCollection<>(members,
                 and(LITE_MEMBER_SELECTOR, NON_LOCAL_MEMBER_SELECTOR)).iterator();
 
         while (iterator.hasNext()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewMetadataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewMetadataTest.java
@@ -36,7 +36,7 @@ public class MembersViewMetadataTest {
     @Test
     public void equalsAndHashCode() throws Exception {
         UUID memberUUID = new UUID(1, 1);
-        final MembersViewMetadata metadata
+        MembersViewMetadata metadata
                 = new MembersViewMetadata(new Address("localhost", 1234), memberUUID, new Address("localhost", 4321), 0);
 
         assertEqualAndHashCode(metadata, metadata);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 public class MembersViewTest {
 
     @Test
-    public void createNew() throws Exception {
+    public void createNew() {
         int version = 7;
         MemberImpl[] members = MemberMapTest.newMembers(5);
         MembersView view = MembersView.createNew(version, Arrays.asList(members));
@@ -52,7 +52,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void cloneAdding() throws Exception {
+    public void cloneAdding() {
         int version = 6;
         MemberImpl[] members = MemberMapTest.newMembers(4);
         List<MemberInfo> additionalMembers
@@ -72,7 +72,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void toMemberMap() throws Exception {
+    public void toMemberMap() {
         int version = 5;
         MemberImpl[] members = MemberMapTest.newMembers(3);
         MembersView view = MembersView.createNew(version, Arrays.asList(members));
@@ -84,7 +84,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void containsAddress() throws Exception {
+    public void containsAddress() {
         MemberImpl[] members = MemberMapTest.newMembers(3);
         MembersView view = MembersView.createNew(1, Arrays.asList(members));
 
@@ -94,7 +94,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void containsMember() throws Exception {
+    public void containsMember() {
         MemberImpl[] members = MemberMapTest.newMembers(3);
         MembersView view = MembersView.createNew(1, Arrays.asList(members));
 
@@ -104,7 +104,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void getAddresses() throws Exception {
+    public void getAddresses() {
         MemberImpl[] members = MemberMapTest.newMembers(3);
         MembersView view = MembersView.createNew(1, Arrays.asList(members));
 
@@ -117,7 +117,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void getMember() throws Exception {
+    public void getMember() {
         MemberImpl[] members = MemberMapTest.newMembers(3);
         MembersView view = MembersView.createNew(1, Arrays.asList(members));
 
@@ -127,7 +127,7 @@ public class MembersViewTest {
     }
 
     @Test
-    public void isLaterThan() throws Exception {
+    public void isLaterThan() {
         MembersView view1 = MembersView.createNew(1, Arrays.asList(MemberMapTest.newMembers(5)));
         MembersView view2 = MembersView.createNew(3, Arrays.asList(MemberMapTest.newMembers(5)));
         MembersView view3 = MembersView.createNew(5, Arrays.asList(MemberMapTest.newMembers(5)));

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -17,12 +17,13 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -38,10 +39,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.instance.impl.TestUtil.terminateInstance;
+import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.EXPLICIT_SUSPICION;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.FETCH_MEMBER_LIST_STATE;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
@@ -56,6 +59,7 @@ import static com.hazelcast.spi.properties.ClusterProperty.MAX_NO_HEARTBEAT_SECO
 import static com.hazelcast.spi.properties.ClusterProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.ClusterProperty.PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT;
 import static com.hazelcast.test.Accessors.getAddress;
 import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
@@ -202,13 +206,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         terminateInstance(master);
 
-        final ClusterServiceImpl clusterService = getNode(masterCandidate).getClusterService();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertTrue(clusterService.getClusterJoinManager().isMastershipClaimInProgress());
-            }
-        });
+        ClusterServiceImpl clusterService = getNode(masterCandidate).getClusterService();
+        assertTrueEventually(() -> assertTrue(clusterService.getClusterJoinManager().isMastershipClaimInProgress()));
 
         sleepSeconds(3);
         terminateInstance(slave1);
@@ -235,13 +234,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         terminateInstance(master);
 
-        final ClusterServiceImpl clusterService = getNode(masterCandidate).getClusterService();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertTrue(clusterService.getClusterJoinManager().isMastershipClaimInProgress());
-            }
-        });
+        ClusterServiceImpl clusterService = getNode(masterCandidate).getClusterService();
+        assertTrueEventually(() -> assertTrue(clusterService.getClusterJoinManager().isMastershipClaimInProgress()));
 
         sleepSeconds(3);
         terminateInstance(masterCandidate);
@@ -314,28 +308,24 @@ public class MembershipFailureTest extends HazelcastTestSupport {
                 .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
         HazelcastInstance master = newHazelcastInstance(config);
         HazelcastInstance slave1 = newHazelcastInstance(config);
-        final HazelcastInstance slave2 = newHazelcastInstance(config);
+        HazelcastInstance slave2 = newHazelcastInstance(config);
 
         assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
 
         dropOperationsBetween(slave2, slave1, F_ID, singletonList(HEARTBEAT));
 
-        final MembershipManager membershipManager = getNode(slave1).getClusterService().getMembershipManager();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertTrue(membershipManager.isMemberSuspected(getAddress(slave2)));
-            }
+        MembershipManager membershipManager = getNode(slave1).getClusterService().getMembershipManager();
+        assertTrueEventually(() -> {
+            Member localMember = slave2.getCluster().getLocalMember();
+            assertTrue(membershipManager.isMemberSuspected(localMember.getAddress(), localMember.getUuid()));
         });
 
         resetPacketFiltersFrom(slave2);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertFalse(membershipManager.isMemberSuspected(getAddress(slave2)));
-            }
+        assertTrueEventually(() -> {
+            Member localMember = slave2.getCluster().getLocalMember();
+            assertFalse(membershipManager.isMemberSuspected(localMember.getAddress(), localMember.getUuid()));
         });
     }
 
@@ -480,14 +470,14 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         Config config = smallInstanceConfig();
         config.setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
                 .setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
-        final HazelcastInstance member1 = newHazelcastInstance(config);
-        final HazelcastInstance member2 = newHazelcastInstance(config);
-        final HazelcastInstance member3 = newHazelcastInstance(config);
+        HazelcastInstance member1 = newHazelcastInstance(config);
+        HazelcastInstance member2 = newHazelcastInstance(config);
+        HazelcastInstance member3 = newHazelcastInstance(config);
 
         assertClusterSize(3, member1, member3);
         assertClusterSizeEventually(3, member2);
 
-        final CountDownLatch mergeLatch = new CountDownLatch(1);
+        CountDownLatch mergeLatch = new CountDownLatch(1);
         member3.getLifecycleService().addLifecycleListener(event -> {
             if (event.getState() == LifecycleState.MERGED) {
                 mergeLatch.countDown();
@@ -509,12 +499,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member3));
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
-            }
-        });
+        assertTrueEventually(() -> assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2)));
     }
 
     @Test
@@ -558,10 +543,10 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         config.setProperty(ClusterProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
 
         HazelcastInstance member1 = newHazelcastInstance(config);
-        final HazelcastInstance member2 = newHazelcastInstance(config);
+        HazelcastInstance member2 = newHazelcastInstance(config);
         HazelcastInstance member3 = newHazelcastInstance(smallInstanceConfig()
                 .setProperty(ClusterProperty.MASTERSHIP_CLAIM_TIMEOUT_SECONDS.getName(), "10"));
-        final HazelcastInstance member4 = newHazelcastInstance(config);
+        HazelcastInstance member4 = newHazelcastInstance(config);
 
         assertClusterSize(4, member1, member4);
         assertClusterSizeEventually(4, member2, member3);
@@ -605,9 +590,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         config.setProperty(ClusterProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
 
         HazelcastInstance member1 = newHazelcastInstance(config);
-        final HazelcastInstance member2 = newHazelcastInstance(config);
-        final HazelcastInstance member3 = newHazelcastInstance(config);
-        final HazelcastInstance member4 = newHazelcastInstance(config);
+        HazelcastInstance member2 = newHazelcastInstance(config);
+        HazelcastInstance member3 = newHazelcastInstance(config);
+        HazelcastInstance member4 = newHazelcastInstance(config);
 
         assertClusterSize(4, member1, member4);
         assertClusterSizeEventually(4, member2, member3);
@@ -658,6 +643,215 @@ public class MembershipFailureTest extends HazelcastTestSupport {
                 assertMemberViewsAreSame(getMemberMap(instances[0]), getMemberMap(instance));
             }
         }
+    }
+
+    @Test
+    public void test_twoSlavesDisconnected() {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, instance2);
+
+        Member member2 = instance2.getCluster().getLocalMember();
+        Member member3 = instance3.getCluster().getLocalMember();
+
+
+        dropOperationsBetween(instance2, instance3, F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(2, instance1);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertTrue("cluster members: " + members, members.contains(member2) ^ members.contains(member3));
+    }
+
+    @Test
+    public void test_twoSlavesDisconnectedFromOneSlave() {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+        HazelcastInstance instance4 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(4, instance2, instance3);
+
+        Member member2 = instance2.getCluster().getLocalMember();
+        Member member3 = instance3.getCluster().getLocalMember();
+        Member member4 = instance4.getCluster().getLocalMember();
+
+
+        dropOperationsBetween(instance2, instance4, F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(instance3, instance4, F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(3, instance1);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertTrue("cluster members: " + members, members.contains(member2));
+        assertTrue("cluster members: " + members, members.contains(member3));
+        assertFalse("cluster members: " + members, members.contains(member4));
+    }
+
+    @Test
+    public void test_oneSlaveDisconnectedFromTwoSlaves() {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+        HazelcastInstance instance4 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(4, instance2, instance3);
+
+        Member member2 = instance2.getCluster().getLocalMember();
+        Member member3 = instance3.getCluster().getLocalMember();
+        Member member4 = instance4.getCluster().getLocalMember();
+
+
+        dropOperationsBetween(instance4, Arrays.asList(instance2, instance3), F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(3, instance1);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertTrue("cluster members: " + members, members.contains(member2));
+        assertTrue("cluster members: " + members, members.contains(member3));
+        assertFalse("cluster members: " + members, members.contains(member4));
+    }
+
+    @Test
+    public void test_threeSlavesDisconnectedFromTwoSlaves() {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+        HazelcastInstance instance4 = newHazelcastInstance(config);
+        HazelcastInstance instance5 = newHazelcastInstance(config);
+        HazelcastInstance instance6 = newHazelcastInstance(config);
+        HazelcastInstance instance7 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(7, instance2, instance3, instance4, instance5, instance6, instance7);
+
+        Member member5 = instance5.getCluster().getLocalMember();
+        Member member6 = instance6.getCluster().getLocalMember();
+
+
+        dropOperationsBetween(instance2, Arrays.asList(instance5, instance6), F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(instance3, Arrays.asList(instance5, instance6), F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(instance4, Arrays.asList(instance5, instance6), F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(5, instance1, instance2, instance3, instance4, instance7);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertFalse("cluster members: " + members, members.contains(member5));
+        assertFalse("cluster members: " + members, members.contains(member6));
+    }
+
+    @Test
+    public void test_twoSlavesDisconnectedFromThreeSlaves() {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+        HazelcastInstance instance4 = newHazelcastInstance(config);
+        HazelcastInstance instance5 = newHazelcastInstance(config);
+        HazelcastInstance instance6 = newHazelcastInstance(config);
+        HazelcastInstance instance7 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(7, instance2, instance3, instance4, instance5, instance6, instance7);
+
+        Member member5 = instance5.getCluster().getLocalMember();
+        Member member6 = instance6.getCluster().getLocalMember();
+
+
+        dropOperationsBetween(instance5, Arrays.asList(instance2, instance3, instance4), F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(instance6, Arrays.asList(instance2, instance3, instance4), F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(5, instance1, instance2, instance3, instance4, instance7);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertFalse("cluster members: " + members, members.contains(member5));
+        assertFalse("cluster members: " + members, members.contains(member6));
+    }
+
+    @Test
+    public void test_multipleDisconnections() {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+        HazelcastInstance instance4 = newHazelcastInstance(config);
+        HazelcastInstance instance5 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(5, instance2, instance3, instance4, instance5);
+
+        Member member3 = instance3.getCluster().getLocalMember();
+
+
+        dropOperationsBetween(instance2, instance3, F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(instance3, Arrays.asList(instance4, instance5), F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(4, instance1, instance2, instance4, instance5);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertFalse("cluster members: " + members, members.contains(member3));
+    }
+
+    @Test
+    public void test_twoSlavesDisconnectedFromOneSlave_when_clusterState_FROZEN() {
+        test_twoSlavesDisconnectedFromOneSlave(ClusterState.FROZEN);
+    }
+
+    @Test
+    public void test_twoSlavesDisconnectedFromOneSlave_when_clusterState_PASSIVE() {
+        test_twoSlavesDisconnectedFromOneSlave(ClusterState.PASSIVE);
+    }
+
+    @Test
+    public void test_twoSlavesDisconnectedFromOneSlave_when_clusterState_NO_MIGRATON() {
+        test_twoSlavesDisconnectedFromOneSlave(ClusterState.NO_MIGRATION);
+    }
+
+    private void test_twoSlavesDisconnectedFromOneSlave(ClusterState clusterState) {
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        HazelcastInstance instance1 = newHazelcastInstance(config);
+        HazelcastInstance instance2 = newHazelcastInstance(config);
+        HazelcastInstance instance3 = newHazelcastInstance(config);
+        HazelcastInstance instance4 = newHazelcastInstance(config);
+
+        assertClusterSizeEventually(4, instance2, instance3, instance4);
+
+        Member member4 = instance4.getCluster().getLocalMember();
+
+        changeClusterStateEventually(instance1, clusterState);
+
+
+        dropOperationsBetween(instance2, instance4, F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(instance3, instance4, F_ID, singletonList(HEARTBEAT));
+
+
+        assertClusterSizeEventually(3, instance1);
+        Set<Member> members = instance1.getCluster().getMembers();
+        assertFalse("cluster members: " + members, members.contains(member4));
     }
 
     private void startInstancesConcurrently(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
@@ -318,14 +319,14 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         MembershipManager membershipManager = getNode(slave1).getClusterService().getMembershipManager();
         assertTrueEventually(() -> {
             Member localMember = slave2.getCluster().getLocalMember();
-            assertTrue(membershipManager.isMemberSuspected(localMember.getAddress(), localMember.getUuid()));
+            assertTrue(membershipManager.isMemberSuspected((MemberImpl) localMember));
         });
 
         resetPacketFiltersFrom(slave2);
 
         assertTrueEventually(() -> {
             Member localMember = slave2.getCluster().getLocalMember();
-            assertFalse(membershipManager.isMemberSuspected(localMember.getAddress(), localMember.getUuid()));
+            assertFalse(membershipManager.isMemberSuspected((MemberImpl) localMember));
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -37,7 +37,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.OverridePropertyRule;
@@ -54,7 +53,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -130,25 +128,17 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
     @Test
     public void parallel_member_join() {
-        final AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(4);
+        AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<>(4);
         for (int i = 0; i < instances.length(); i++) {
-            final int ix = i;
-            spawn(new Runnable() {
-                @Override
-                public void run() {
-                    instances.set(ix, factory.newHazelcastInstance());
-                }
-            });
+            int ix = i;
+            spawn(() -> instances.set(ix, factory.newHazelcastInstance()));
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (int i = 0; i < instances.length(); i++) {
-                    HazelcastInstance instance = instances.get(i);
-                    assertNotNull(instance);
-                    assertClusterSize(instances.length(), instance);
-                }
+        assertTrueEventually(() -> {
+            for (int i = 0; i < instances.length(); i++) {
+                HazelcastInstance instance = instances.get(i);
+                assertNotNull(instance);
+                assertClusterSize(instances.length(), instance);
             }
         });
 
@@ -164,66 +154,50 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void parallel_member_join_whenPostJoinOperationPresent() throws InterruptedException {
+    public void parallel_member_join_whenPostJoinOperationPresent() {
         CountDownLatch latch = new CountDownLatch(1);
 
-        final Config config = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
+        Config config = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
 
-        final AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(6);
+        AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(6);
         for (int i = 0; i < instances.length(); i++) {
-            final int ix = i;
-            spawn(new Runnable() {
-                @Override
-                public void run() {
-                    instances.set(ix, factory.newHazelcastInstance(config));
-                }
-            });
+            int ix = i;
+            spawn(() -> instances.set(ix, factory.newHazelcastInstance(config)));
         }
 
         // just a random latency
         sleepSeconds(3);
         latch.countDown();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (int i = 0; i < instances.length(); i++) {
-                    HazelcastInstance instance = instances.get(i);
-                    assertNotNull(instance);
-                    assertClusterSize(instances.length(), instance);
-                }
+        assertTrueEventually(() -> {
+            for (int i = 0; i < instances.length(); i++) {
+                HazelcastInstance instance = instances.get(i);
+                assertNotNull(instance);
+                assertClusterSize(instances.length(), instance);
             }
         });
     }
 
     @Test
-    public void parallel_member_join_whenPreJoinOperationPresent() throws InterruptedException {
+    public void parallel_member_join_whenPreJoinOperationPresent() {
         CountDownLatch latch = new CountDownLatch(1);
         PreJoinAwareServiceImpl service = new PreJoinAwareServiceImpl(latch);
-        final Config config = getConfigWithService(service, PreJoinAwareServiceImpl.SERVICE_NAME);
+        Config config = getConfigWithService(service, PreJoinAwareServiceImpl.SERVICE_NAME);
 
-        final AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(6);
+        AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<>(6);
         for (int i = 0; i < instances.length(); i++) {
-            final int ix = i;
-            spawn(new Runnable() {
-                @Override
-                public void run() {
-                    instances.set(ix, factory.newHazelcastInstance(config));
-                }
-            });
+            int ix = i;
+            spawn(() -> instances.set(ix, factory.newHazelcastInstance(config)));
         }
 
         sleepSeconds(3);
         latch.countDown();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (int i = 0; i < instances.length(); i++) {
-                    HazelcastInstance instance = instances.get(i);
-                    assertNotNull(instance);
-                    assertClusterSize(instances.length(), instance);
-                }
+        assertTrueEventually(() -> {
+            for (int i = 0; i < instances.length(); i++) {
+                HazelcastInstance instance = instances.get(i);
+                assertNotNull(instance);
+                assertClusterSize(instances.length(), instance);
             }
         });
     }
@@ -287,25 +261,17 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
     @Test
     public void parallel_member_join_and_removal() {
-        final AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(4);
+        AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<>(4);
         for (int i = 0; i < instances.length(); i++) {
-            final int ix = i;
-            spawn(new Runnable() {
-                @Override
-                public void run() {
-                    instances.set(ix, factory.newHazelcastInstance());
-                }
-            });
+            int ix = i;
+            spawn(() -> instances.set(ix, factory.newHazelcastInstance()));
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (int i = 0; i < instances.length(); i++) {
-                    HazelcastInstance instance = instances.get(i);
-                    assertNotNull(instance);
-                    assertClusterSize(instances.length(), instance);
-                }
+        assertTrueEventually(() -> {
+            for (int i = 0; i < instances.length(); i++) {
+                HazelcastInstance instance = instances.get(i);
+                assertNotNull(instance);
+                assertClusterSize(instances.length(), instance);
             }
         });
 
@@ -351,25 +317,17 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
     @Test
     public void parallel_member_join_and_restart() {
-        final AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(3);
+        AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<>(3);
         for (int i = 0; i < instances.length(); i++) {
-            final int ix = i;
-            spawn(new Runnable() {
-                @Override
-                public void run() {
-                    instances.set(ix, factory.newHazelcastInstance());
-                }
-            });
+            int ix = i;
+            spawn(() -> instances.set(ix, factory.newHazelcastInstance()));
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (int i = 0; i < instances.length(); i++) {
-                    HazelcastInstance instance = instances.get(i);
-                    assertNotNull(instance);
-                    assertClusterSize(instances.length(), instance);
-                }
+        assertTrueEventually(() -> {
+            for (int i = 0; i < instances.length(); i++) {
+                HazelcastInstance instance = instances.get(i);
+                assertNotNull(instance);
+                assertClusterSize(instances.length(), instance);
             }
         });
 
@@ -636,9 +594,9 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         Config configMaster = new Config();
         configMaster.setProperty(ClusterProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
-        final HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
 
-        final HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
         HazelcastInstance hz3 = factory.newHazelcastInstance();
         HazelcastInstance hz4 = factory.newHazelcastInstance();
 
@@ -646,7 +604,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         rejectOperationsBetween(hz1, hz2, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
-        final MemberImpl member3 = getNode(hz3).getLocalMember();
+        MemberImpl member3 = getNode(hz3).getLocalMember();
         hz3.getLifecycleService().terminate();
 
         assertClusterSizeEventually(3, hz1, hz4);
@@ -661,55 +619,44 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertMemberViewsAreSame(getMemberMap(hz1), getMemberMap(hz3));
         assertMemberViewsAreSame(getMemberMap(hz1), getMemberMap(hz4));
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertMemberViewsAreSame(getMemberMap(hz1), getMemberMap(hz2));
-            }
-        });
+        assertTrueEventually(() -> assertMemberViewsAreSame(getMemberMap(hz1), getMemberMap(hz2)));
     }
 
     @Test
     public void shouldNotProcessStaleJoinRequest() {
-        final HazelcastInstance hz1 = factory.newHazelcastInstance();
-        final HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
         assertClusterSizeEventually(2, hz1, hz2);
 
-        final JoinRequest staleJoinReq = getNode(hz2).createJoinRequest(true);
+        JoinRequest staleJoinReq = getNode(hz2).createJoinRequest(true);
         hz2.shutdown();
         assertClusterSizeEventually(1, hz1);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() {
-                ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz1);
-                clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
+        assertTrueAllTheTime(() -> {
+            ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz1);
+            clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
 
-                assertClusterSize(1, hz1);
-            }
+            assertClusterSize(1, hz1);
         }, 3);
     }
 
     @Test
     public void shouldNotProcessStaleJoinRequest_whenMasterChanges() {
         HazelcastInstance hz1 = factory.newHazelcastInstance();
-        final HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
         HazelcastInstance hz3 = factory.newHazelcastInstance();
         assertClusterSizeEventually(3, hz1, hz2, hz3);
 
-        final JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(true);
+        JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(true);
         hz3.shutdown();
         hz1.shutdown();
         assertClusterSizeEventually(1, hz2);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() {
-                ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz2);
-                clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
+        assertTrueAllTheTime(() -> {
+            ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz2);
+            clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
 
-                assertClusterSize(1, hz2);
-            }
+            assertClusterSize(1, hz2);
         }, 3);
     }
 
@@ -718,12 +665,12 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         ruleStaleJoinPreventionDuration.setOrClearProperty("5");
 
         Config configMaster = new Config();
-        final HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
-        final HazelcastInstance hz2 = factory.newHazelcastInstance();
-        final HazelcastInstance hz3 = factory.newHazelcastInstance();
+        HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
         assertClusterSizeEventually(3, hz2, hz3);
 
-        final MemberImpl member3 = getNode(hz3).getLocalMember();
+        MemberImpl member3 = getNode(hz3).getLocalMember();
 
         // A new member is restarted with member3's UUID.
         // Then after some time, member3 is terminated.
@@ -731,20 +678,14 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         // but master does not realize its leave in time.
         // When master realizes, member3 is terminated,
         // new member should eventually join the cluster.
-        Future<HazelcastInstance> future = spawn(new Callable<HazelcastInstance>() {
-            @Override
-            public HazelcastInstance call() {
-                NodeContext nodeContext = new StaticMemberNodeContext(factory, member3.getUuid(), factory.nextAddress());
-                return newHazelcastInstance(initOrCreateConfig(new Config()), randomName(), nodeContext);
-            }
+        Future<HazelcastInstance> future = spawn(() -> {
+            NodeContext nodeContext = new StaticMemberNodeContext(factory, member3.getUuid(), factory.nextAddress());
+            return newHazelcastInstance(initOrCreateConfig(new Config()), randomName(), nodeContext);
         });
 
-        spawn(new Runnable() {
-            @Override
-            public void run() {
-                sleepSeconds(5);
-                hz3.getLifecycleService().terminate();
-            }
+        spawn(() -> {
+            sleepSeconds(5);
+            hz3.getLifecycleService().terminate();
         });
 
         HazelcastInstance hz4 = future.get();
@@ -757,37 +698,29 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
     public void noOperationExecuted_beforePreJoinOpIsDone() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         PreJoinAwareServiceImpl service = new PreJoinAwareServiceImpl(latch);
-        final Config config = getConfigWithService(service, PreJoinAwareServiceImpl.SERVICE_NAME);
+        Config config = getConfigWithService(service, PreJoinAwareServiceImpl.SERVICE_NAME);
 
         HazelcastInstance instance1 = factory.newHazelcastInstance(config);
-        final Address instance2Address = factory.nextAddress();
-        final OperationService operationService = getNode(instance1).getNodeEngine().getOperationService();
+        Address instance2Address = factory.nextAddress();
+        OperationService operationService = getNode(instance1).getNodeEngine().getOperationService();
         // send operations from master to joining member. The master has already added the joining member to its member list
         // while the FinalizeJoinOp is being executed on joining member, so it might send operations to the joining member.
-        Future sendOpsFromMaster = spawn(new Runnable() {
-            @Override
-            public void run() {
-                while (true) {
-                    try {
-                        ExecutionTrackerOp op = new ExecutionTrackerOp();
-                        operationService.send(op, instance2Address);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                    if (currentThread().isInterrupted()) {
-                        break;
-                    }
-                    LockSupport.parkNanos(1);
+        Future sendOpsFromMaster = spawn(() -> {
+            while (true) {
+                try {
+                    ExecutionTrackerOp op = new ExecutionTrackerOp();
+                    operationService.send(op, instance2Address);
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
+                if (currentThread().isInterrupted()) {
+                    break;
+                }
+                LockSupport.parkNanos(1);
             }
         });
 
-        Future<HazelcastInstance> future = spawn(new Callable<HazelcastInstance>() {
-            @Override
-            public HazelcastInstance call() {
-                return factory.newHazelcastInstance(instance2Address, config);
-            }
-        });
+        Future<HazelcastInstance> future = spawn(() -> factory.newHazelcastInstance(instance2Address, config));
 
         sleepSeconds(10);
         // on latch countdown, the pre-join op completes
@@ -839,20 +772,15 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(3, hz1, hz2, hz3);
 
-        final Address target = getAddress(hz2);
+        Address target = getAddress(hz2);
         hz2.getLifecycleService().terminate();
 
         assertClusterSizeEventually(2, hz1, hz3);
 
         assertNull(getEndpointManager(hz1).getConnection(target));
 
-        final EndpointManager cm3 = getEndpointManager(hz3);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertNull(cm3.getConnection(target));
-            }
-        });
+        EndpointManager cm3 = getEndpointManager(hz3);
+        assertTrueEventually(() -> assertNull(cm3.getConnection(target)));
     }
 
     @Test
@@ -867,7 +795,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(3, hz1, hz2, hz3);
 
-        final Address target = getAddress(hz3);
+        Address target = getAddress(hz3);
 
         ConnectionRemovedListener connListener1 = new ConnectionRemovedListener(target);
         getEndpointManager(hz1).addConnectionListener(connListener1);
@@ -885,7 +813,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
     }
 
     private Config getConfigWithService(Object service, String serviceName) {
-        final Config config = new Config();
+        Config config = new Config();
         ServiceConfig serviceConfig = new ServiceConfig().setEnabled(true)
                 .setName(serviceName).setImplementation(service);
         ConfigAccessor.getServicesConfig(config).addServiceConfig(serviceConfig);
@@ -897,8 +825,8 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertEquals(expectedMemberMap.size(), actualMemberMap.size());
 
         // order is important
-        List<MemberImpl> expectedMembers = new ArrayList<MemberImpl>(expectedMemberMap.getMembers());
-        List<MemberImpl> actualMembers = new ArrayList<MemberImpl>(actualMemberMap.getMembers());
+        List<MemberImpl> expectedMembers = new ArrayList<>(expectedMemberMap.getMembers());
+        List<MemberImpl> actualMembers = new ArrayList<>(actualMemberMap.getMembers());
 
         assertEquals(expectedMembers, actualMembers);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -67,14 +67,14 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
         terminateInstance(instances[0]);
 
-        final HazelcastInstance hz = factory.newHazelcastInstance(config);
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
 
         assertTrueAllTheTime(new AssertTask() {
-            final Node node = getNode(hz);
-            final InternalPartitionService partitionService = node.getPartitionService();
+            Node node = getNode(hz);
+            InternalPartitionService partitionService = node.getPartitionService();
 
             @Override
-            public void run() throws Exception {
+            public void run() {
                 List<Integer> memberPartitions = partitionService.getMemberPartitions(node.getThisAddress());
                 assertThat(memberPartitions, empty());
                 service.assertNoReplication();
@@ -169,20 +169,17 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         }
     }
 
-    private static void assertAllPartitionsAreAssigned(HazelcastInstance instance, final int replicaCount) {
-        final ClusterServiceImpl clusterService = getNode(instance).getClusterService();
-        final InternalPartitionService partitionService = getNode(instance).getPartitionService();
+    private static void assertAllPartitionsAreAssigned(HazelcastInstance instance, int replicaCount) {
+        ClusterServiceImpl clusterService = getNode(instance).getClusterService();
+        InternalPartitionService partitionService = getNode(instance).getPartitionService();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                InternalPartition[] partitions = partitionService.getInternalPartitions();
-                for (InternalPartition partition : partitions) {
-                    for (int i = 0; i < replicaCount; i++) {
-                        Address owner = partition.getReplicaAddress(i);
-                        assertNotNull(i + "th replica owner is null: " + partition, owner);
-                        assertNotNull("No member for: " + owner, clusterService.getMember(owner));
-                    }
+        assertTrueEventually(() -> {
+            InternalPartition[] partitions = partitionService.getInternalPartitions();
+            for (InternalPartition partition : partitions) {
+                for (int i = 0; i < replicaCount; i++) {
+                    Address owner = partition.getReplicaAddress(i);
+                    assertNotNull(i + "th replica owner is null: " + partition, owner);
+                    assertNotNull("No member for: " + owner, clusterService.getMember(owner));
                 }
             }
         });
@@ -201,12 +198,7 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(2, instances[1], instances[2]);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                service.assertNoReplication();
-            }
-        }, 10);
+        assertTrueAllTheTime(service::assertNoReplication, 10);
     }
 
     @Test
@@ -240,12 +232,7 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
 
         changeClusterStateEventually(instances[1], ClusterState.FROZEN);
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                service.assertNoReplication();
-            }
-        }, 10);
+        assertTrueAllTheTime(service::assertNoReplication, 10);
     }
 
     private Config newConfigWithMigrationAwareService() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.impl.Invocation;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -45,7 +44,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -115,7 +113,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
-        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        factory.newHazelcastInstance(new Config());
 
         exception.expect(IllegalStateException.class);
         hz1.getCluster().promoteLocalLiteMember();
@@ -125,7 +123,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
     public void normalMember_promotion_shouldFail_onNonMaster() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
-        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        factory.newHazelcastInstance(new Config());
         HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
         HazelcastInstance hz3 = factory.newHazelcastInstance(new Config());
 
@@ -247,7 +245,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void promotion_shouldFail_whenMastershipClaimInProgress_duringPromotion() throws Exception {
+    public void promotion_shouldFail_whenMastershipClaimInProgress_duringPromotion() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
@@ -273,17 +271,14 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, hz2);
 
         dropOperationsBetween(hz3, hz1, F_ID, singletonList(PROMOTE_LITE_MEMBER));
-        final Cluster cluster = hz3.getCluster();
-        Future<Exception> future = spawn(new Callable<Exception>() {
-            @Override
-            public Exception call() throws Exception {
-                try {
-                    cluster.promoteLocalLiteMember();
-                } catch (Exception e) {
-                    return e;
-                }
-                return null;
+        Cluster cluster = hz3.getCluster();
+        Future<Exception> future = spawn(() -> {
+            try {
+                cluster.promoteLocalLiteMember();
+            } catch (Exception e) {
+                return e;
             }
+            return null;
         });
         assertPromotionInvocationStarted(hz3);
 
@@ -300,8 +295,8 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
-        final HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
-        final HazelcastInstance hz3 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config().setLiteMember(true));
 
         assertClusterSizeEventually(3, hz2);
 
@@ -309,13 +304,8 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         dropOperationsFrom(hz2, F_ID, asList(MEMBER_INFO_UPDATE, EXPLICIT_SUSPICION));
         dropOperationsFrom(hz1, F_ID, singletonList(HEARTBEAT));
 
-        final Cluster cluster = hz3.getCluster();
-        Future future = spawn(new Runnable() {
-            @Override
-            public void run() {
-                cluster.promoteLocalLiteMember();
-            }
-        });
+        Cluster cluster = hz3.getCluster();
+        Future future = spawn(cluster::promoteLocalLiteMember);
 
         assertPromotionInvocationStarted(hz3);
 
@@ -334,30 +324,21 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
     }
 
     private void assertPromotionInvocationStarted(HazelcastInstance instance) {
-        final OperationServiceImpl operationService =
-                (OperationServiceImpl) getNode(instance).getNodeEngine().getOperationService();
-        final InvocationRegistry invocationRegistry = operationService.getInvocationRegistry();
+        OperationServiceImpl operationService = getNode(instance).getNodeEngine().getOperationService();
+        InvocationRegistry invocationRegistry = operationService.getInvocationRegistry();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (Map.Entry<Long, Invocation> entry : invocationRegistry.entrySet()) {
-                    if (entry.getValue().op instanceof PromoteLiteMemberOp) {
-                        return;
-                    }
+        assertTrueEventually(() -> {
+            for (Map.Entry<Long, Invocation> entry : invocationRegistry.entrySet()) {
+                if (entry.getValue().op instanceof PromoteLiteMemberOp) {
+                    return;
                 }
-                fail("Cannot find PromoteLiteMemberOp invocation!");
             }
+            fail("Cannot find PromoteLiteMemberOp invocation!");
         });
     }
 
-    private static void assertPartitionsAssignedEventually(final HazelcastInstance instance) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertPartitionsAssigned(instance);
-            }
-        });
+    private static void assertPartitionsAssignedEventually(HazelcastInstance instance) {
+        assertTrueEventually(() -> assertPartitionsAssigned(instance));
     }
 
     private static void assertPartitionsAssigned(HazelcastInstance instance) {
@@ -389,13 +370,8 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         }
     }
 
-    private static void assertAllNormalMembersEventually(final Cluster cluster) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertAllNormalMembers(cluster);
-            }
-        });
+    private static void assertAllNormalMembersEventually(Cluster cluster) {
+        assertTrueEventually(() -> assertAllNormalMembers(cluster));
     }
 
     private static Member getMember(HazelcastInstance hz) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/SingleProcessorMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/SingleProcessorMemberTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.spi.properties.ClusterProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
@@ -62,20 +63,15 @@ public class SingleProcessorMemberTest extends HazelcastTestSupport {
         gracefulShutdownTimeoutRule.setOrClearProperty(Integer.toString(Integer.MAX_VALUE));
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        final HazelcastInstance[] instances = factory.newInstances(new Config(), 4);
+        HazelcastInstance[] instances = factory.newInstances(new Config(), 4);
         assertClusterSizeEventually(4, instances);
         if (initializePartitions) {
             warmUpPartitions(instances);
         }
 
-        ArrayList<Future> futures = new ArrayList<Future>();
+        List<Future> futures = new ArrayList<>();
         for (final HazelcastInstance instance : instances) {
-            Future future = spawn(new Runnable() {
-                @Override
-                public void run() {
-                    instance.shutdown();
-                }
-            });
+            Future future = spawn(instance::shutdown);
             futures.add(future);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinderTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.graph;
+
+import com.hazelcast.internal.util.BiTuple;
+import com.hazelcast.internal.util.RandomPicker;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToIntFunction;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class BronKerboschCliqueFinderTest {
+
+    @Test
+    public void test2DisconnectedVerticesIn4vertexGraph() {
+        test2DisconnectedVertices(4);
+    }
+
+    @Test
+    public void test2DisconnectedVerticesIn50vertexGraph() {
+        test2DisconnectedVertices(50);
+    }
+
+    @Test
+    public void test2DisconnectedVerticesIn100vertexGraph() {
+        test2DisconnectedVertices(100);
+    }
+
+    @Test
+    public void test2DisconnectedVerticesIn250vertexGraph() {
+        test2DisconnectedVertices(250);
+    }
+
+    private void test2DisconnectedVertices(int vertexCount) {
+        List<String> vertices = IntStream.range(0, vertexCount).mapToObj(i -> "n" + i).collect(toList());
+        Graph<String> graph = populateFullyConnectedGraph(vertices);
+
+        graph.disconnect("n0", "n1");
+
+
+        Collection<Set<String>> maxCliques = computeMaxCliques(graph);
+
+
+        Set<Set<String>> expectedCliques = new HashSet<>();
+        Set<String> expectedClique1 = new HashSet<>(vertices.subList(2, vertexCount));
+        expectedClique1.add("n0");
+        Set<String> expectedClique2 = new HashSet<>(vertices.subList(2, vertexCount));
+        expectedClique2.add("n1");
+        expectedCliques.add(expectedClique1);
+        expectedCliques.add(expectedClique2);
+
+        assertEquals(expectedCliques, new HashSet<>(maxCliques));
+    }
+
+    private Collection<Set<String>> computeMaxCliques(Graph<String> graph) {
+        return new BronKerboschCliqueFinder<>(graph).computeMaxCliques();
+    }
+
+    @Test
+    public void testSplitInto4VertexLeftCliqueAnd4VertexRightClique() {
+        testFullSplitInto2Cliques(8, 4);
+    }
+
+    @Test
+    public void testSplitInto8VertexLeftCliqueAnd5vertexRightClique() {
+        testFullSplitInto2Cliques(8, 5);
+    }
+
+    @Test
+    public void testSplitInto25VertexLeftCliqueAnd25VertexRightClique() {
+        testFullSplitInto2Cliques(50, 25);
+    }
+
+    @Test
+    public void testSplitInto15VertexLeftCliqueAnd35VertexRightClique() {
+        testFullSplitInto2Cliques(50, 15);
+    }
+
+    @Test
+    public void testSplitInto50VertexLeftCliqueAnd50VertexRightClique() {
+        testFullSplitInto2Cliques(100, 50);
+    }
+
+    @Test
+    public void testSplitInto75VertexLeftCliqueAnd25VertexRightClique() {
+        testFullSplitInto2Cliques(100, 75);
+    }
+
+    @Test
+    public void testSplitInto125VertexLeftCliqueAnd125VertexRightClique() {
+        testFullSplitInto2Cliques(250, 125);
+    }
+
+    @Test
+    public void testSplitInto100VertexLeftCliqueAnd150VertexRightClique() {
+        testFullSplitInto2Cliques(250, 100);
+    }
+
+    private void testFullSplitInto2Cliques(int vertexCount, int leftCliqueSize) {
+        List<String> vertices = IntStream.range(0, vertexCount).mapToObj(i -> "n" + i).collect(toList());
+        Graph<String> graph = populateFullyConnectedGraph(vertices);
+
+        List<String> left = vertices.subList(0, leftCliqueSize);
+        List<String> right = vertices.subList(leftCliqueSize, vertices.size());
+
+        for (String v1 : left) {
+            for (String v2 : right) {
+                graph.disconnect(v1, v2);
+            }
+        }
+
+
+        Collection<Set<String>> maxCliques = computeMaxCliques(graph);
+
+
+        Set<Set<String>> expectedCliques = new HashSet<>();
+        if (left.size() == right.size()) {
+            expectedCliques.add(new HashSet<>(left));
+            expectedCliques.add(new HashSet<>(right));
+        } else if (left.size() < right.size()) {
+            expectedCliques.add(new HashSet<>(right));
+        } else {
+            expectedCliques.add(new HashSet<>(left));
+        }
+
+
+        assertEquals(expectedCliques, new HashSet<>(maxCliques));
+    }
+
+    @Test
+    public void test3VerticesDisconnectFrom2VerticesIn10VertexGraph() {
+        testTwoDisconnectedSubgraphs(10, 3, 2);
+    }
+
+    @Test
+    public void test3VerticesDisconnectFrom3VerticesIn10VertexGraph() {
+        testTwoDisconnectedSubgraphs(10, 3, 3);
+    }
+
+    @Test
+    public void test10VerticesDisconnectFrom10VerticesIn50VertexGraph() {
+        testTwoDisconnectedSubgraphs(50, 10, 10);
+    }
+
+    @Test
+    public void test15VerticesDisconnectFrom10VerticesIn50VertexGraph() {
+        testTwoDisconnectedSubgraphs(50, 15, 10);
+    }
+
+    @Test
+    public void test20VerticesDisconnectFrom20VerticesIn100VertexGraph() {
+        testTwoDisconnectedSubgraphs(100, 20, 20);
+    }
+
+    @Test
+    public void test30VerticesDisconnectFrom20VerticesIn100VertexGraph() {
+        testTwoDisconnectedSubgraphs(100, 30, 20);
+    }
+
+    @Test
+    public void test50VerticesDisconnectFrom50VerticesIn250VertexGraph() {
+        testTwoDisconnectedSubgraphs(250, 50, 50);
+    }
+
+    @Test
+    public void test100VerticesDisconnectFrom50VerticesIn250VertexGraph() {
+        testTwoDisconnectedSubgraphs(250, 100, 50);
+    }
+
+    private void testTwoDisconnectedSubgraphs(int vertexCount, int firstGroupSize, int secondGroupSize) {
+        List<String> vertices = IntStream.range(0, vertexCount).mapToObj(i -> "n" + i).collect(toList());
+        Graph<String> graph = populateFullyConnectedGraph(vertices);
+
+        for (int i = 0; i < firstGroupSize; i++) {
+            for (int j = firstGroupSize; j < firstGroupSize + secondGroupSize; j++) {
+                graph.disconnect("n" + i, "n" + j);
+            }
+        }
+
+        Collection<Set<String>> maxCliques = computeMaxCliques(graph);
+
+
+        Set<Set<String>> expectedCliques = new HashSet<>();
+        if (firstGroupSize == secondGroupSize) {
+            Set<String> expectedClique1 = new HashSet<>(vertices.subList(0, firstGroupSize));
+            Set<String> expectedClique2 = new HashSet<>(vertices.subList(firstGroupSize, firstGroupSize + secondGroupSize));
+            expectedClique1.addAll(vertices.subList(firstGroupSize + secondGroupSize, vertices.size()));
+            expectedClique2.addAll(vertices.subList(firstGroupSize + secondGroupSize, vertices.size()));
+            expectedCliques.add(expectedClique1);
+            expectedCliques.add(expectedClique2);
+        } else if (firstGroupSize < secondGroupSize) {
+            Set<String> expectedClique = new HashSet<>(vertices.subList(firstGroupSize, firstGroupSize + secondGroupSize));
+            expectedClique.addAll(vertices.subList(firstGroupSize + secondGroupSize, vertices.size()));
+            expectedCliques.add(expectedClique);
+        } else {
+            Set<String> expectedClique = new HashSet<>(vertices.subList(0, firstGroupSize));
+            expectedClique.addAll(vertices.subList(firstGroupSize + secondGroupSize, vertices.size()));
+            expectedCliques.add(expectedClique);
+        }
+
+        assertEquals(expectedCliques, new HashSet<>(maxCliques));
+    }
+
+    @Test
+    public void test6DisconnectedSubgraphsInLargerGraph() {
+        List<List<String>> groups = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            int j = i;
+            int vertexCount = i + 10;
+            List<String> vertices = IntStream.range(0, vertexCount).mapToObj(v -> j + "_" + v).collect(toList());
+            groups.add(vertices);
+        }
+
+        Graph<String> graph = populateFullyConnectedGraph(groups.stream().flatMap(Collection::stream).collect(toList()));
+
+        for (BiTuple<Integer, Integer> t : Arrays.asList(BiTuple.of(0, 9), BiTuple.of(1, 8), BiTuple.of(2, 7), BiTuple.of(3, 6),
+                BiTuple.of(4, 5))) {
+            for (String v1 : groups.get(t.element1)) {
+                for (String v2 : groups.get(t.element2)) {
+                    graph.disconnect(v1, v2);
+                }
+            }
+        }
+
+
+        Collection<Set<String>> maxCliques = new BronKerboschCliqueFinder<>(graph, 30, TimeUnit.SECONDS).computeMaxCliques();
+
+
+        assumeFalse(maxCliques.isEmpty());
+
+        Set<String> expectedClique = new HashSet<>();
+        for (int i = groups.size() / 2; i < groups.size(); i++) {
+            expectedClique.addAll(groups.get(i));
+        }
+
+        assertEquals(1, maxCliques.size());
+        assertEquals(expectedClique, maxCliques.iterator().next());
+    }
+
+    @Test
+    public void test6DisconnectedSubgraphsOfWholeGraph() {
+        List<List<String>> groups = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            int j = i;
+            int vertexCount = i + 10;
+            List<String> vertices = IntStream.range(0, vertexCount).mapToObj(v -> j + "_" + v).collect(toList());
+            groups.add(vertices);
+        }
+
+        Graph<String> graph = populateFullyConnectedGraph(groups.stream().flatMap(Collection::stream).collect(toList()));
+
+        List<Integer> groupIndices = new ArrayList<>();
+        while (groupIndices.size() < 6) {
+            int rackIndex = RandomPicker.getInt(groups.size());
+            if (!groupIndices.contains(rackIndex)) {
+                groupIndices.add(rackIndex);
+            }
+        }
+
+        groupIndices.sort(Comparator.comparingInt((ToIntFunction<Integer>) i -> groups.get(i).size()).reversed());
+
+        for (String v1 : groups.get(groupIndices.get(0))) {
+            for (String v2 : groups.get(groupIndices.get(5))) {
+                graph.disconnect(v1, v2);
+            }
+        }
+
+        for (String v1 : groups.get(groupIndices.get(1))) {
+            for (String v2 : groups.get(groupIndices.get(4))) {
+                graph.disconnect(v1, v2);
+            }
+        }
+
+        for (String v1 : groups.get(groupIndices.get(2))) {
+            for (String v2 : groups.get(groupIndices.get(3))) {
+                graph.disconnect(v1, v2);
+            }
+        }
+
+        Collection<Set<String>> maxCliques = new BronKerboschCliqueFinder<>(graph, 30, TimeUnit.SECONDS).computeMaxCliques();
+
+
+        assumeFalse(maxCliques.isEmpty());
+
+        Set<String> expectedClique = new HashSet<>();
+        for (int i = 0; i < groups.size(); i++) {
+            if (i != groupIndices.get(3) && i != groupIndices.get(4) && i != groupIndices.get(5)) {
+                expectedClique.addAll(groups.get(i));
+            }
+        }
+
+        assertEquals(1, maxCliques.size());
+        assertEquals(expectedClique, maxCliques.iterator().next());
+    }
+
+    private Graph<String> populateFullyConnectedGraph(List<String> vertices) {
+        Graph<String> graph = new Graph<>();
+
+        for (String v1 : vertices) {
+            for (String v2 : vertices) {
+                graph.connect(v1, v2);
+            }
+        }
+
+        return graph;
+    }
+
+}


### PR DESCRIPTION
In Hazelcast IMDG 3.9, we improved the algorithms used in the cluster
management layer and resolved several problems. With that work, our member list
management logic procured a good set of consistency and safety guarantees.
In short, the master node manages the cluster member list and publishes member
list updates with version numbers. Other nodes apply these updates
in the correct order by checking version numbers. In addition, each Hazelcast
node tracks the liveness of other nodes. The master node uses this mechanism to
detect failures of other nodes, and other nodes use this mechanism to detect
failure of the master node. This failure detection mechanism also works during
network partitions to help Hazelcast clusters split into multiple subclusters
and remain available.

However, there is a shortcoming in the current design. Even though each node
tracks the liveliness of other nodes, they do not share their failure
detections with each other. Since the master node is the only authority to
update the cluster member list, if there are network problems between slave
nodes, the master node is not aware of these problems and does not update
the cluster member list. This situation can lead to data loss or availability
problems in the cluster.

The solution to this problem is two-fold. First, we make master nodes aware of
network problems that occur between slave nodes. It is sufficient for each
slave node to propagate its failure detections to the master node because we
already have a good set of mechanisms and consistency guarantees built around
the decisions made by the master node. Second, the master node decides on
an optimal cluster member list after it learns the network problems between
other nodes.

In the first part of the solution, we make slave nodes propagate their
suspicions to the master node. We use the heartbeat mechanism for this purpose.
Slave nodes piggyback their suspicions to the heartbeat messages sent to
the master node. The master node collects these suspicions and after some time
it triggers the next step to decide on a new cluster member list.

Using this knowledge, the master node should decide on a new member list such
that all nodes in the new member list are connected to each other, i.e., there
is no connection problem between the nodes in the new member list. This problem
has the same solution with the maximum clique problem in graph theory. A clique
in an undirected graph is a subset of vertices which forms a complete graph,
i.e, each vertex in a clique has an edge to every other vertex. A maximum
clique is the largest clique that satisfies the given definition.

We use an implementation of the Bron–Kerbosch algorithm to find the maximum
clique of a Hazelcast cluster given a set of slave node suspicions. This
algorithm gives us the smallest set of Hazelcast nodes to kick so that
the remaining nodes in the cluster are fully connected to each other again.
So the master node kicks the nodes returned by the Bron-Kerbosch algorithm.

For more fun, please check out the TDD: https://hazelcast.atlassian.net/wiki/spaces/EN/pages/2006220808/Partial+Member+Disconnection+Resolution+Design