### PR TITLE
Decrease preallocated partition container sizes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -104,7 +104,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     private static final Object NULL_OBJECT = new Object();
 
     private final ConcurrentMap<String, QueueContainer> containerMap = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, LocalQueueStatsImpl> statsMap = MapUtil.createConcurrentHashMap(10);
+    private final ConcurrentMap<String, LocalQueueStatsImpl> statsMap;
     private final ConstructorFunction<String, LocalQueueStatsImpl> localQueueStatsConstructorFunction =
         key -> new LocalQueueStatsImpl();
 
@@ -134,6 +134,8 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         TaskScheduler globalScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
         QueueEvictionProcessor entryProcessor = new QueueEvictionProcessor(nodeEngine);
         this.queueEvictionScheduler = EntryTaskSchedulerFactory.newScheduler(globalScheduler, entryProcessor, POSTPONE);
+        int approxQueueCount = nodeEngine.getConfig().getQueueConfigs().size();
+        this.statsMap = MapUtil.createConcurrentHashMap(approxQueueCount);
     }
 
     public void scheduleEviction(String name, long delay) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -49,6 +49,7 @@ import com.hazelcast.internal.services.TransactionalService;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ContextMutexFactory;
+import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.internal.util.scheduler.EntryTaskScheduler;
 import com.hazelcast.internal.util.scheduler.EntryTaskSchedulerFactory;
 import com.hazelcast.logging.ILogger;
@@ -103,7 +104,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     private static final Object NULL_OBJECT = new Object();
 
     private final ConcurrentMap<String, QueueContainer> containerMap = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, LocalQueueStatsImpl> statsMap = new ConcurrentHashMap<>(1000);
+    private final ConcurrentMap<String, LocalQueueStatsImpl> statsMap = MapUtil.createConcurrentHashMap(10);
     private final ConstructorFunction<String, LocalQueueStatsImpl> localQueueStatsConstructorFunction =
         key -> new LocalQueueStatsImpl();
 

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -75,7 +75,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     private NodeEngine nodeEngine;
     private ExecutionService executionService;
-    private final ConcurrentMap<UUID, Processor> submittedTasks = new ConcurrentHashMap<>(100);
+    private final ConcurrentMap<UUID, Processor> submittedTasks = MapUtil.createConcurrentHashMap(10);
     private final Set<String> shutdownExecutors
             = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final ConcurrentHashMap<String, LocalExecutorStatsImpl> statsMap = new ConcurrentHashMap<>();

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -75,7 +75,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     private NodeEngine nodeEngine;
     private ExecutionService executionService;
-    private final ConcurrentMap<UUID, Processor> submittedTasks = MapUtil.createConcurrentHashMap(10);
+    private final ConcurrentMap<UUID, Processor> submittedTasks = new ConcurrentHashMap<>();
     private final Set<String> shutdownExecutors
             = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final ConcurrentHashMap<String, LocalExecutorStatsImpl> statsMap = new ConcurrentHashMap<>();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -45,7 +45,6 @@ import com.hazelcast.spi.impl.NodeEngine;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
@@ -71,7 +70,7 @@ public class LocalMapStatsProvider {
     private final MapServiceContext mapServiceContext;
     private final MapNearCacheManager mapNearCacheManager;
     private final IPartitionService partitionService;
-    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap = MapUtil.createConcurrentHashMap(10);
+    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap;
     private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction =
             key -> new LocalMapStatsImpl();
 
@@ -83,6 +82,7 @@ public class LocalMapStatsProvider {
         this.clusterService = nodeEngine.getClusterService();
         this.partitionService = nodeEngine.getPartitionService();
         this.localAddress = clusterService.getThisAddress();
+        this.statsMap = MapUtil.createConcurrentHashMap(nodeEngine.getConfig().getMapConfigs().size());
     }
 
     protected MapServiceContext getMapServiceContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -31,6 +31,7 @@ import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
@@ -70,7 +71,7 @@ public class LocalMapStatsProvider {
     private final MapServiceContext mapServiceContext;
     private final MapNearCacheManager mapNearCacheManager;
     private final IPartitionService partitionService;
-    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap = new ConcurrentHashMap<>(1000);
+    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap = MapUtil.createConcurrentHashMap(10);
     private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction =
             key -> new LocalMapStatsImpl();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -49,8 +49,8 @@ public class PartitionContainer {
     private final int partitionId;
     private final MapService mapService;
     private final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
-    private final ConcurrentMap<String, RecordStore> maps = MapUtil.createConcurrentHashMap(10);
-    private final ConcurrentMap<String, Indexes> indexes = MapUtil.createConcurrentHashMap(10);
+    private final ConcurrentMap<String, RecordStore> maps;
+    private final ConcurrentMap<String, Indexes> indexes = new ConcurrentHashMap<>();
     private final ConstructorFunction<String, RecordStore> recordStoreConstructor
             = name -> {
         RecordStore recordStore = createRecordStore(name);
@@ -81,6 +81,8 @@ public class PartitionContainer {
     public PartitionContainer(final MapService mapService, final int partitionId) {
         this.mapService = mapService;
         this.partitionId = partitionId;
+        int approxMapCount = mapService.mapServiceContext.getNodeEngine().getConfig().getMapConfigs().size();
+        this.maps  = MapUtil.createConcurrentHashMap(approxMapCount);
     }
 
     private RecordStore createRecordStore(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ContextMutexFactory;
+import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.map.impl.operation.MapClearExpiredOperation;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.impl.Indexes;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -48,8 +48,8 @@ public class PartitionContainer {
     private final int partitionId;
     private final MapService mapService;
     private final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
-    private final ConcurrentMap<String, RecordStore> maps = new ConcurrentHashMap<>(1000);
-    private final ConcurrentMap<String, Indexes> indexes = new ConcurrentHashMap<>(10);
+    private final ConcurrentMap<String, RecordStore> maps = MapUtil.createConcurrentHashMap(10);
+    private final ConcurrentMap<String, Indexes> indexes = MapUtil.createConcurrentHashMap(10);
     private final ConstructorFunction<String, RecordStore> recordStoreConstructor
             = name -> {
         RecordStore recordStore = createRecordStore(name);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
@@ -34,7 +34,7 @@ import static com.hazelcast.query.impl.AbstractIndex.NULL;
  */
 public class UnorderedIndexStore extends BaseSingleValueIndexStore {
 
-    private final ConcurrentMap<Comparable, Map<Data, QueryableEntry>> recordMap = new ConcurrentHashMap<>(1000);
+    private final ConcurrentMap<Comparable, Map<Data, QueryableEntry>> recordMap = new ConcurrentHashMap<>();
     private final IndexFunctor<Comparable, QueryableEntry> addFunctor;
     private final IndexFunctor<Comparable, Data> removeFunctor;
 


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-enterprise/pull/3536

Code to test effects - adds a single entry in each of 20k partitions, clears the map and then we take a heap dump to see the size:
```java
public static void main(String[] args) throws InterruptedException {
        int partitions = 20_001;
        Config c = new Config()
                .setLicenseKey(licenseKey)
                .setProperty(ClusterProperty.PARTITION_COUNT.getName(), String.valueOf(partitions));

        HazelcastInstance i = Hazelcast.newHazelcastInstance(c);
        IMap<Object, Object> map = i.getMap("map");
        IMap<Object, Object> map2 = i.getMap("map1");

        int parallelism = 4;
        Thread[] threads = new Thread[parallelism];

        for (int j = 0; j < parallelism; j++) {
            int finalJ = j;
            Thread t = new Thread(() -> {
                for (int k = finalJ; k < partitions; k += parallelism) {
                    String key = generateKeyForPartition(i, finalJ);
                    map.put(key, "");
                    map2.put(key, "");
                }
            });
            t.start();
            threads[j] = t;
        }
        for (Thread thread : threads) {
            thread.join();
        }

        System.out.println("DONE " + map.size() + " " + map2.size());
        map.clear();
        map2.clear();
        System.out.println("DONE 2 " + map.size() + " " + map2.size());

    }
```

Heap dump after code runs, with this PR: 312M
Heap dump after code runs, on master: 616M