### PR TITLE
Create less objects during metrics scan 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -23,8 +23,9 @@ import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -40,7 +41,7 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
     protected final int partitionId;
     protected final Object mutex = new Object();
     protected final AbstractCacheService cacheService;
-    protected final ConcurrentMap<String, ICacheRecordStore> recordStores = new ConcurrentHashMap<String, ICacheRecordStore>();
+    protected final ConcurrentMap<String, ICacheRecordStore> recordStores = new ConcurrentHashMap<>();
     private boolean runningCleanupOperation;
 
     private volatile long lastCleanupTime;
@@ -186,9 +187,16 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
     }
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
-        Collection<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
+        if (recordStores.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
         for (ICacheRecordStore recordStore : recordStores.values()) {
             if (recordStore.getConfig().getTotalBackupCount() >= replicaIndex) {
+                if (namespaces == Collections.EMPTY_LIST) {
+                    namespaces = new LinkedList<>();
+                }
                 namespaces.add(recordStore.getObjectNamespace());
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -20,13 +20,13 @@ import com.hazelcast.cache.impl.event.CacheWanEventPublisher;
 import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
-import com.hazelcast.internal.services.DistributedObjectNamespace;
-import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.partition.MigrationAwareService;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
-import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.internal.services.DistributedObjectNamespace;
+import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.Collection;
 
@@ -95,7 +95,7 @@ public class CacheService extends AbstractCacheService {
 
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event,
-            Collection<ServiceNamespace> namespaces) {
+                                                 Collection<ServiceNamespace> namespaces) {
         assert assertAllKnownNamespaces(namespaces);
 
         CachePartitionSegment segment = segments[event.getPartitionId()];

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClusterViewListenerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClusterViewListenerService.java
@@ -172,23 +172,18 @@ public class ClusterViewListenerService {
      * @return address-&gt;partitions mapping, where address is the client address of the member
      */
     public Map<UUID, List<Integer>> getPartitions(PartitionTableView partitionTableView) {
-
         Map<UUID, List<Integer>> partitionsMap = new HashMap<>();
 
         int partitionCount = partitionTableView.getLength();
+
         for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
             PartitionReplica owner = partitionTableView.getReplica(partitionId, 0);
-            if (owner == null) {
+            if (owner == null || owner.uuid() == null) {
                 partitionsMap.clear();
                 return partitionsMap;
             }
-            UUID ownerUUID = owner.uuid();
-            if (ownerUUID == null) {
-                partitionsMap.clear();
-                return partitionsMap;
-            }
-            List<Integer> indexes = partitionsMap.computeIfAbsent(ownerUUID, k -> new LinkedList<>());
-            indexes.add(partitionId);
+            partitionsMap.computeIfAbsent(owner.uuid(),
+                    k -> new LinkedList<>()).add(partitionId);
         }
         return partitionsMap;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
@@ -17,20 +17,19 @@
 package com.hazelcast.internal.locksupport;
 
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
-import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.scheduler.EntryTaskScheduler;
 import com.hazelcast.internal.util.scheduler.EntryTaskSchedulerFactory;
 import com.hazelcast.internal.util.scheduler.ScheduleType;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -107,13 +106,23 @@ public final class LockStoreContainer {
     }
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
-        Set<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
+        if (lockStores.isEmpty()) {
+            return Collections.EMPTY_LIST;
+        }
+
+        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
         for (LockStoreImpl lockStore : lockStores.values()) {
             if (lockStore.getTotalBackupCount() < replicaIndex) {
                 continue;
             }
+
+            if (namespaces == Collections.EMPTY_LIST) {
+                namespaces = new LinkedList<>();
+            }
+
             namespaces.add(lockStore.getNamespace());
         }
+
         return namespaces;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockSupportServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockSupportServiceImpl.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
 import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.services.ClientAwareService;
 import com.hazelcast.internal.services.ManagedService;
 import com.hazelcast.internal.services.MembershipAwareService;
@@ -32,7 +33,6 @@ import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ConstructorFunction;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -221,11 +221,8 @@ public final class LockSupportServiceImpl implements LockSupportService, Managed
 
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
-        int partitionId = event.getPartitionId();
-        LockStoreContainer container = containers[partitionId];
-        int replicaIndex = event.getReplicaIndex();
-        LockReplicationOperation op = new LockReplicationOperation(container, partitionId, replicaIndex);
-        return op.isEmpty() ? null : op;
+        return prepareReplicationOperation(event,
+                containers[event.getPartitionId()].getAllNamespaces(event.getReplicaIndex()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -17,8 +17,10 @@
 package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
 import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
 import com.hazelcast.internal.partition.PartitionReplica;
+import com.hazelcast.internal.partition.PartitionReplicationEvent;
 import com.hazelcast.internal.partition.operation.PartitionBackupReplicaAntiEntropyOperation;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.logging.ILogger;
@@ -26,14 +28,11 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
-import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
-import com.hazelcast.internal.partition.PartitionReplicationEvent;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 
 import static com.hazelcast.internal.partition.IPartitionService.SERVICE_NAME;
@@ -62,12 +61,14 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
         return partitionId;
     }
 
-    // works only on primary. backups are retained in PartitionBackupReplicaAntiEntropyTask
+    // works only on primary. backups are retained
+    // in PartitionBackupReplicaAntiEntropyTask
     final Collection<ServiceNamespace> retainAndGetNamespaces() {
         PartitionReplicationEvent event = new PartitionReplicationEvent(partitionId, 0);
-        Collection<FragmentedMigrationAwareService> services = nodeEngine.getServices(FragmentedMigrationAwareService.class);
+        Collection<FragmentedMigrationAwareService> services
+                = nodeEngine.getServices(FragmentedMigrationAwareService.class);
 
-        Set<ServiceNamespace> namespaces = new HashSet<>();
+        Collection<ServiceNamespace> namespaces = new LinkedList<>();
         for (FragmentedMigrationAwareService service : services) {
             Collection<ServiceNamespace> serviceNamespaces = service.getAllServiceNamespaces(event);
             if (serviceNamespaces != null) {
@@ -107,10 +108,10 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
 
         if (hasCallback) {
             operationService.createInvocationBuilder(SERVICE_NAME, op, target.address())
-                            .setTryCount(OPERATION_TRY_COUNT)
-                            .setTryPauseMillis(OPERATION_TRY_PAUSE_MILLIS)
-                            .invoke()
-                            .whenCompleteAsync(callback);
+                    .setTryCount(OPERATION_TRY_COUNT)
+                    .setTryPauseMillis(OPERATION_TRY_PAUSE_MILLIS)
+                    .invoke()
+                    .whenCompleteAsync(callback);
         } else {
             operationService.send(op, target.address());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -76,6 +76,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -981,7 +982,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
 
     @Override
     public List<Integer> getMemberPartitions(Address target) {
-        List<Integer> ownedPartitions = new ArrayList<>();
+        List<Integer> ownedPartitions = new LinkedList<>();
         for (int i = 0; i < partitionCount; i++) {
             final Address owner = getPartitionOwner(i);
             if (target.equals(owner)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -76,7 +76,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -982,7 +981,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
 
     @Override
     public List<Integer> getMemberPartitions(Address target) {
-        List<Integer> ownedPartitions = new LinkedList<>();
+        List<Integer> ownedPartitions = new ArrayList<>();
         for (int i = 0; i < partitionCount; i++) {
             final Address owner = getPartitionOwner(i);
             if (target.equals(owner)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -468,7 +468,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         return replicaVersions[partitionId].getNamespaces();
     }
 
-    public void retainNamespaces(int partitionId, Set<ServiceNamespace> namespaces) {
+    public void retainNamespaces(int partitionId, Collection<ServiceNamespace> namespaces) {
         PartitionReplicaVersions versions = replicaVersions[partitionId];
         versions.retainNamespaces(namespaces);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.services.ServiceNamespace;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 // read and updated only by partition threads
 final class PartitionReplicaVersions {
@@ -86,7 +85,7 @@ final class PartitionReplicaVersions {
         return fragmentVersions;
     }
 
-    void retainNamespaces(Set<ServiceNamespace> namespaces) {
+    void retainNamespaces(Collection<ServiceNamespace> namespaces) {
         fragmentVersionsMap.keySet().retainAll(namespaces);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -110,7 +110,8 @@ public class LocalMapStatsProvider {
         Map statsPerMap = new HashMap();
 
         PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
-        for (PartitionContainer partitionContainer : partitionContainers) {
+        for (int i = 0; i < partitionContainers.length; i++) {
+            PartitionContainer partitionContainer = partitionContainers[i];
             Collection<RecordStore> allRecordStores = partitionContainer.getAllRecordStores();
             for (RecordStore recordStore : allRecordStores) {
                 if (!isStatsCalculationEnabledFor(recordStore)) {
@@ -273,7 +274,7 @@ public class LocalMapStatsProvider {
     }
 
     private boolean isReplicaOnThisNode(Address replicaAddress) {
-        return replicaAddress != null && localAddress.equals(replicaAddress);
+        return localAddress.equals(replicaAddress);
     }
 
     private void printWarning(int partitionId, int replica) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -17,6 +17,10 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
+import com.hazelcast.internal.partition.MigrationEndpoint;
+import com.hazelcast.internal.partition.PartitionMigrationEvent;
+import com.hazelcast.internal.partition.PartitionReplicationEvent;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
@@ -33,19 +37,15 @@ import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
-import com.hazelcast.internal.partition.MigrationEndpoint;
-import com.hazelcast.internal.partition.PartitionMigrationEvent;
-import com.hazelcast.internal.partition.PartitionReplicationEvent;
 
 import java.util.Collection;
 import java.util.function.Predicate;
 
+import static com.hazelcast.internal.partition.MigrationEndpoint.DESTINATION;
+import static com.hazelcast.internal.partition.MigrationEndpoint.SOURCE;
 import static com.hazelcast.map.impl.querycache.publisher.AccumulatorSweeper.flushAccumulator;
 import static com.hazelcast.map.impl.querycache.publisher.AccumulatorSweeper.removeAccumulator;
 import static com.hazelcast.map.impl.querycache.publisher.AccumulatorSweeper.sendEndOfSequenceEvents;
-import static com.hazelcast.internal.partition.MigrationEndpoint.DESTINATION;
-import static com.hazelcast.internal.partition.MigrationEndpoint.SOURCE;
 
 /**
  * Defines migration behavior of map service.
@@ -115,14 +115,8 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
 
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
-        int partitionId = event.getPartitionId();
-
-        Operation operation = new MapReplicationOperation(containers[partitionId],
-                partitionId, event.getReplicaIndex());
-        operation.setService(mapServiceContext.getService());
-        operation.setNodeEngine(mapServiceContext.getNodeEngine());
-
-        return operation;
+        return prepareReplicationOperation(event,
+                containers[event.getPartitionId()].getAllNamespaces(event.getReplicaIndex()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -41,18 +41,14 @@ public class MapReplicationOperation extends Operation
     private WriteBehindStateHolder writeBehindStateHolder;
     private MapNearCacheStateHolder mapNearCacheStateHolder;
 
-
     private transient NativeOutOfMemoryError oome;
 
     public MapReplicationOperation() {
     }
 
-    public MapReplicationOperation(PartitionContainer container, int partitionId, int replicaIndex) {
-        this(container, container.getAllNamespaces(replicaIndex), partitionId, replicaIndex);
-    }
+    public MapReplicationOperation(PartitionContainer container,
+                                   Collection<ServiceNamespace> namespaces, int partitionId, int replicaIndex) {
 
-    public MapReplicationOperation(PartitionContainer container, Collection<ServiceNamespace> namespaces,
-                                   int partitionId, int replicaIndex) {
         setPartitionId(partitionId).setReplicaIndex(replicaIndex);
 
         this.mapReplicationStateHolder = new MapReplicationStateHolder();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -16,16 +16,17 @@
 
 package com.hazelcast.multimap.impl;
 
-import com.hazelcast.internal.locksupport.LockSupportService;
 import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.internal.locksupport.LockSupportService;
 import com.hazelcast.internal.services.DistributedObjectNamespace;
-import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
+import com.hazelcast.spi.impl.NodeEngine;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.internal.util.MapUtil.createConcurrentHashMap;
@@ -81,11 +82,19 @@ public class MultiMapPartitionContainer {
     }
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
-        Collection<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
+        if (containerMap.isEmpty()) {
+            return Collections.EMPTY_LIST;
+        }
+
+        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
         for (MultiMapContainer container : containerMap.values()) {
             MultiMapConfig config = container.getConfig();
             if (config.getTotalBackupCount() < replicaIndex) {
                 continue;
+            }
+
+            if (namespaces == Collections.EMPTY_LIST) {
+                namespaces = new LinkedList<>();
             }
             namespaces.add(container.getObjectNamespace());
         }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -19,6 +19,11 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
+import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.partition.PartitionMigrationEvent;
+import com.hazelcast.internal.partition.PartitionReplicationEvent;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.DistributedObjectNamespace;
 import com.hazelcast.internal.services.ManagedService;
@@ -26,11 +31,13 @@ import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.RemoteService;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.services.SplitBrainHandlerService;
-import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.services.SplitBrainProtectionAwareService;
+import com.hazelcast.internal.util.ConstructorFunction;
+import com.hazelcast.internal.util.ContextMutexFactory;
+import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.ringbuffer.impl.operations.MergeOperation;
 import com.hazelcast.ringbuffer.impl.operations.ReplicationOperation;
-import com.hazelcast.internal.services.SplitBrainProtectionAwareService;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
@@ -38,24 +45,17 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.merge.RingbufferMergeData;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.RingbufferMergeTypes;
-import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
-import com.hazelcast.internal.partition.IPartitionService;
-import com.hazelcast.internal.partition.PartitionMigrationEvent;
-import com.hazelcast.internal.partition.PartitionReplicationEvent;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
-import com.hazelcast.internal.util.ConstructorFunction;
-import com.hazelcast.internal.util.ContextMutexFactory;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -92,22 +92,25 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
      * container.
      */
     private final ConcurrentMap<Integer, Map<ObjectNamespace, RingbufferContainer>> containers
-            = new ConcurrentHashMap<Integer, Map<ObjectNamespace, RingbufferContainer>>();
+            = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<String, Object> splitBrainProtectionConfigCache = new ConcurrentHashMap<String, Object>();
+    private final ConcurrentMap<String, Object> splitBrainProtectionConfigCache = new ConcurrentHashMap<>();
     private final ContextMutexFactory splitBrainProtectionConfigCacheMutexFactory = new ContextMutexFactory();
     private final ConstructorFunction<String, Object> splitBrainProtectionConfigConstructor =
             new ConstructorFunction<String, Object>() {
-        @Override
-        public Object createNew(String name) {
-            RingbufferConfig config = nodeEngine.getConfig().findRingbufferConfig(name);
-            String splitBrainProtectionName = config.getSplitBrainProtectionName();
-            // The splitBrainProtectionName will be null if there is no split brain protection defined for this data structure,
-            // but the SplitBrainProtectionService is active, due to another data structure
-            // with a split brain protection configuration
-            return splitBrainProtectionName == null ? NULL_OBJECT : splitBrainProtectionName;
-        }
-    };
+                @Override
+                public Object createNew(String name) {
+                    RingbufferConfig config = nodeEngine.getConfig().findRingbufferConfig(name);
+                    String splitBrainProtectionName = config.getSplitBrainProtectionName();
+                    // The splitBrainProtectionName will be null
+                    // if there is no split brain protection
+                    // defined for this data structure, but the
+                    // SplitBrainProtectionService is active,
+                    // due to another data structure with a
+                    // split brain protection configuration
+                    return splitBrainProtectionName == null ? NULL_OBJECT : splitBrainProtectionName;
+                }
+            };
 
     private NodeEngine nodeEngine;
     private SerializationService serializationService;
@@ -186,7 +189,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
             return ringbuffer;
         }
 
-        ringbuffer = new RingbufferContainer<T, E>(namespace, config, nodeEngine, partitionId);
+        ringbuffer = new RingbufferContainer<>(namespace, config, nodeEngine, partitionId);
         ringbuffer.getStore().instrument(nodeEngine);
         partitionContainers.put(namespace, ringbuffer);
         return ringbuffer;
@@ -212,7 +215,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     private Map<ObjectNamespace, RingbufferContainer> getOrCreateRingbufferContainers(int partitionId) {
         final Map<ObjectNamespace, RingbufferContainer> partitionContainer = containers.get(partitionId);
         if (partitionContainer == null) {
-            containers.putIfAbsent(partitionId, new HashMap<ObjectNamespace, RingbufferContainer>());
+            containers.putIfAbsent(partitionId, new HashMap<>());
         }
         return containers.get(partitionId);
     }
@@ -250,15 +253,16 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event,
                                                  Collection<ServiceNamespace> namespaces) {
-        final int partitionId = event.getPartitionId();
-        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        int partitionId = event.getPartitionId();
+        Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
         if (isNullOrEmpty(partitionContainers)) {
             return null;
         }
-        final Map<ObjectNamespace, RingbufferContainer> migrationData = new HashMap<ObjectNamespace, RingbufferContainer>();
+
+        Map<ObjectNamespace, RingbufferContainer> migrationData = new HashMap<>();
         for (ServiceNamespace namespace : namespaces) {
-            final ObjectNamespace ns = (ObjectNamespace) namespace;
-            final RingbufferContainer container = partitionContainers.get(ns);
+            ObjectNamespace ns = (ObjectNamespace) namespace;
+            RingbufferContainer container = partitionContainers.get(ns);
             if (container != null && container.getConfig().getTotalBackupCount() >= event.getReplicaIndex()) {
                 migrationData.put(ns, container);
             }
@@ -302,15 +306,20 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
 
     @Override
     public Collection<ServiceNamespace> getAllServiceNamespaces(PartitionReplicationEvent event) {
-        final int partitionId = event.getPartitionId();
-        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
-        if (partitionContainers == null || partitionContainers.isEmpty()) {
-            return Collections.emptyList();
+        int partitionId = event.getPartitionId();
+        Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+
+        if (MapUtil.isNullOrEmpty(partitionContainers)) {
+            return Collections.EMPTY_LIST;
         }
-        final Set<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
+
+        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
         for (RingbufferContainer container : partitionContainers.values()) {
             if (container.getConfig().getTotalBackupCount() < event.getReplicaIndex()) {
                 continue;
+            }
+            if (namespaces == Collections.EMPTY_LIST) {
+                namespaces = new LinkedList<>();
             }
             namespaces.add(container.getNamespace());
         }

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -17,9 +17,9 @@
 package com.hazelcast.wan.impl;
 
 import com.hazelcast.config.AbstractWanPublisherConfig;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanCustomPublisherConfig;
-import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.events.AddWanConfigIgnoredEvent;
@@ -70,10 +70,14 @@ public class WanReplicationServiceImpl implements WanReplicationService,
 
     private final Node node;
 
-    /** WAN event counters for all services and only received events */
+    /**
+     * WAN event counters for all services and only received events
+     */
     private final WanEventCounterRegistry receivedWanEventCounters = new WanEventCounterRegistry();
 
-    /** WAN event counters for all services and only sent events */
+    /**
+     * WAN event counters for all services and only sent events
+     */
     private final WanEventCounterRegistry sentWanEventCounters = new WanEventCounterRegistry();
 
     private final ConcurrentMap<String, DelegatingWanScheme> wanReplications = createConcurrentHashMap(1);
@@ -155,7 +159,7 @@ public class WanReplicationServiceImpl implements WanReplicationService,
                 node.getConfigClassLoader(),
                 publisherConfig.getClassName());
         if (publisher == null) {
-            throw new InvalidConfigurationException("Either \'implementation\' or \'className\' "
+            throw new InvalidConfigurationException("Either 'implementation' or 'className' "
                     + "attribute need to be set in the WAN publisher configuration for publisher " + publisherConfig);
         }
         return publisher;
@@ -328,7 +332,7 @@ public class WanReplicationServiceImpl implements WanReplicationService,
             return Collections.emptyList();
         }
 
-        final Set<ServiceNamespace> namespaces = new HashSet<>();
+        Set<ServiceNamespace> namespaces = new HashSet<>();
         for (DelegatingWanScheme publisher : wanReplications.values()) {
             publisher.collectAllServiceNamespaces(event, namespaces);
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
@@ -29,12 +29,13 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.Clock;
-import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -135,6 +136,10 @@ public class CacheSerializationTest extends HazelcastTestSupport {
 
                 int replicaIndex = 1;
                 Collection<ServiceNamespace> namespaces = segment.getAllNamespaces(replicaIndex);
+                if (CollectionUtil.isEmpty(namespaces)) {
+                    continue;
+                }
+
                 CacheReplicationOperation operation = new CacheReplicationOperation();
                 operation.prepare(segment, namespaces, replicaIndex);
                 Data serialized = service.toData(operation);


### PR DESCRIPTION
Encountered this during profiling for a different purpose. This PR tries to decrease temporary object creation.