### PR TITLE
#13938 Remove slash when appended to map key in REST call

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.TextCommandService;
+import com.hazelcast.internal.util.StringUtil;
 
 public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteCommand> {
 
@@ -53,6 +54,7 @@ public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteC
         } else {
             String mapName = uri.substring(URI_MAPS.length(), indexEnd);
             String key = uri.substring(indexEnd + 1);
+            key = StringUtil.stripTrailingSlash(key);
             textCommandService.delete(mapName, key);
             command.send200();
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -377,6 +377,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
     }
 
     private void handleMap(HttpGetCommand command, String uri) {
+        uri = StringUtil.stripTrailingSlash(uri);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         String mapName = uri.substring(URI_MAPS.length(), indexEnd);
         String key = uri.substring(indexEnd + 1);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -254,6 +254,9 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         }
         String mapName = uri.substring(URI_MAPS.length(), indexEnd);
         String key = uri.substring(indexEnd + 1);
+        if (key.charAt(key.length() - 1) == '/') {
+            key = key.substring(0, key.length() - 1);
+        }
         byte[] data = command.getData();
         textCommandService.put(mapName, key, new RestValue(data, command.getContentType()), -1);
         command.send200();

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -248,15 +248,13 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     }
 
     private void handleMap(HttpPostCommand command, String uri) {
+        uri = StringUtil.stripTrailingSlash(uri);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         if (indexEnd == -1) {
             throw new HttpBadRequestException("Missing map name");
         }
         String mapName = uri.substring(URI_MAPS.length(), indexEnd);
         String key = uri.substring(indexEnd + 1);
-        if (key.charAt(key.length() - 1) == '/') {
-            key = key.substring(0, key.length() - 1);
-        }
         byte[] data = command.getData();
         textCommandService.put(mapName, key, new RestValue(data, command.getContentType()), -1);
         command.send200();

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -388,4 +388,17 @@ public final class StringUtil {
                 ? false
                 : (str1 == str2 || lowerCaseInternal(str1).equals(lowerCaseInternal(str2)));
     }
+
+    /**
+     * Strips the trailing slash from the input string, if it is present
+     *
+     * @param str
+     * @return the string with trailing slash removed
+     */
+    public static String stripTrailingSlash(String str) {
+        if (str.charAt(str.length() - 1) == '/') {
+            return str.substring(0, str.length() - 1);
+        }
+        return str;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -396,6 +396,9 @@ public final class StringUtil {
      * @return the string with trailing slash removed
      */
     public static String stripTrailingSlash(String str) {
+        if (isNullOrEmpty(str)) {
+            return str;
+        }
         if (str.charAt(str.length() - 1) == '/') {
             return str.substring(0, str.length() - 1);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -123,6 +123,18 @@ public class RestTest {
     }
 
     @Test
+    public void testMapPutGetByUrlEndingWithSlash() throws Exception {
+        String name = randomMapName();
+
+        String key = "key";
+        String value = "value";
+
+        assertEquals(HTTP_OK, communicator.mapPut(name, key + "/", value));
+        assertEquals(value, communicator.mapGetAndResponse(name, key));
+        assertTrue(instance.getMap(name).containsKey(key));
+    }
+
+    @Test
     public void testMapGetWithJson() throws IOException {
         final String mapName = "mapName";
         final String key = "key";

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -131,6 +131,7 @@ public class RestTest {
 
         assertEquals(HTTP_OK, communicator.mapPut(name, key + "/", value));
         assertEquals(value, communicator.mapGetAndResponse(name, key));
+        assertEquals(value, communicator.mapGetAndResponse(name, key + "/"));
         assertTrue(instance.getMap(name).containsKey(key));
     }
 
@@ -155,6 +156,18 @@ public class RestTest {
 
         assertEquals(HTTP_OK, communicator.mapPut(name, key, value));
         assertEquals(HTTP_OK, communicator.mapDelete(name, key));
+        assertFalse(instance.getMap(name).containsKey(key));
+    }
+
+    @Test
+    public void testMapPutDeleteByUrlEndingWithSlash() throws Exception {
+        String name = randomMapName();
+
+        String key = "key";
+        String value = "value";
+
+        assertEquals(HTTP_OK, communicator.mapPut(name, key, value));
+        assertEquals(HTTP_OK, communicator.mapDelete(name, key + "/"));
         assertFalse(instance.getMap(name).containsKey(key));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -155,6 +155,16 @@ public class StringUtilTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void testStripTrailingSlash() throws Exception {
+        assertEquals(null, StringUtil.stripTrailingSlash(null));
+        assertEquals("", StringUtil.stripTrailingSlash(""));
+        assertEquals("a", StringUtil.stripTrailingSlash("a"));
+        assertEquals("a", StringUtil.stripTrailingSlash("a/"));
+        assertEquals("a/a", StringUtil.stripTrailingSlash("a/a"));
+        assertEquals("a/", StringUtil.stripTrailingSlash("a//"));
+    }
+
     private String[] arr(String... strings) {
         return strings;
     }


### PR DESCRIPTION
This PR removes the ending slash in the uri when it is appended to a key in a REST API call to put a key-value pair to a map.

Fixes: https://github.com/hazelcast/hazelcast/issues/13938