### PR TITLE
Initial commit to add MultiMap bulk put feature request (#9079)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMultiMapProxy.java
@@ -56,6 +56,7 @@ import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.multimap.LocalMultiMapStats;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.spi.impl.UnmodifiableLazySet;
 
@@ -65,6 +66,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -89,6 +91,20 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
     public ClientMultiMapProxy(String serviceName, String name, ClientContext context) {
         super(serviceName, name, context);
+    }
+
+    @Override
+    public void putAll(@Nonnull Map<?, Collection> m) {
+        //TODO: check for m instance and-or content
+        //TODO: implement
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> putAllAsync(@Nonnull Map<?, Collection> m) {
+        //TODO: check for m instance and-or content
+        InternalCompletableFuture<Void> future = new InternalCompletableFuture<>();
+        //TODO: implement
+        return future;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.LocalMapStats;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -57,6 +58,31 @@ import java.util.concurrent.TimeUnit;
  */
 @SuppressWarnings("checkstyle:methodcount")
 public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
+
+    /**
+     * Stores a Map in the multimap synchronously.
+     * <p>
+     * This method performs a bulk put into a MultiMap
+     * by partitions similar to Map.putAllAsync
+     *
+     * @param m the map to be stored
+     */
+    void putAll(@Nonnull Map<?, Collection> m);
+
+    /**
+     * Stores a Map in the multimap aynchronously.
+     * <p>
+     * This method performs a bulk put into a MultiMap
+     * by partitions similar to Map.putAllAsync.
+     * <p>
+     * <b>Warning:</b> The Map and result of the put cannot be fetched
+     * from the Future.
+     * @param m the map to be stored
+     * @return a void Future
+     */
+    //FIXME:should be narrowly generic, but as it were, MultiMapProxySupport is not genericized. Another alternative is to pass in MultiMapValue
+    InternalCompletableFuture<Void> putAllAsync(@Nonnull Map<? extends Object, Collection> m);
+
     /**
      * Stores a key-value pair in the multimap.
      * <p>

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
@@ -19,6 +19,7 @@ package com.hazelcast.multimap.impl;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.multimap.impl.operations.ClearBackupOperation;
 import com.hazelcast.multimap.impl.operations.ClearOperation;
 import com.hazelcast.multimap.impl.operations.ContainsEntryOperation;
@@ -34,6 +35,7 @@ import com.hazelcast.multimap.impl.operations.MergeOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
 import com.hazelcast.multimap.impl.operations.MultiMapReplicationOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapResponse;
+import com.hazelcast.multimap.impl.operations.PutAllOperation;
 import com.hazelcast.multimap.impl.operations.PutBackupOperation;
 import com.hazelcast.multimap.impl.operations.PutOperation;
 import com.hazelcast.multimap.impl.operations.RemoveAllBackupOperation;
@@ -59,7 +61,6 @@ import com.hazelcast.multimap.impl.txn.TxnRollbackBackupOperation;
 import com.hazelcast.multimap.impl.txn.TxnRollbackOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.internal.util.ConstructorFunction;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MULTIMAP_DS_FACTORY;
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MULTIMAP_DS_FACTORY_ID;
@@ -122,6 +123,8 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
     public static final int MERGE_BACKUP_OPERATION = 50;
     public static final int DELETE = 51;
     public static final int DELETE_BACKUP = 52;
+    public static final int PUT_ALL = 53;
+    public static final int PUT_ALL_PARTITION_AWARE_FACTORY = 54;
 
 
     public int getFactoryId() {
@@ -130,7 +133,7 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
 
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors
-                = new ConstructorFunction[DELETE_BACKUP + 1];
+                = new ConstructorFunction[PUT_ALL_PARTITION_AWARE_FACTORY + 1];
         constructors[CLEAR_BACKUP] = arg -> new ClearBackupOperation();
         constructors[CLEAR] = arg -> new ClearOperation();
         constructors[CONTAINS_ENTRY] = arg -> new ContainsEntryOperation();
@@ -172,6 +175,8 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
         constructors[MERGE_BACKUP_OPERATION] = arg -> new MergeBackupOperation();
         constructors[DELETE] = arg -> new DeleteOperation();
         constructors[DELETE_BACKUP] = arg -> new DeleteBackupOperation();
+        constructors[PUT_ALL] = arg -> new PutAllOperation();
+        constructors[PUT_ALL_PARTITION_AWARE_FACTORY] = arg -> new MultiMapOperationFactory();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
@@ -21,13 +21,14 @@ import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.multimap.LocalMultiMapStats;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.multimap.impl.operations.EntrySetResponse;
 import com.hazelcast.multimap.impl.operations.MultiMapResponse;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.InitializingObject;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 
@@ -90,6 +91,20 @@ public class MultiMapProxyImpl<K, V>
                 }
             }
         }
+    }
+
+    @Override
+    public void putAll(@Nonnull Map<? extends Object, Collection> m) {
+        //TODO: add contains check
+        putAllInternal(m, null);
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> putAllAsync(@Nonnull Map<? extends Object, Collection> m) {
+        //TODO: add contains check
+        InternalCompletableFuture<Void> future = new InternalCompletableFuture<>();
+        putAllInternal(m, future);
+        return future;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -16,52 +16,261 @@
 
 package com.hazelcast.multimap.impl;
 
-import com.hazelcast.internal.locksupport.LockProxySupport;
-import com.hazelcast.internal.locksupport.LockSupportServiceImpl;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.locksupport.LockProxySupport;
+import com.hazelcast.internal.locksupport.LockSupportServiceImpl;
+import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.services.DistributedObjectNamespace;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.ThreadUtil;
+import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.multimap.impl.operations.CountOperation;
 import com.hazelcast.multimap.impl.operations.DeleteOperation;
 import com.hazelcast.multimap.impl.operations.GetAllOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory.OperationFactoryType;
+import com.hazelcast.multimap.impl.operations.MultiMapPutAllOperationFactory;
 import com.hazelcast.multimap.impl.operations.MultiMapResponse;
 import com.hazelcast.multimap.impl.operations.PutOperation;
 import com.hazelcast.multimap.impl.operations.RemoveAllOperation;
 import com.hazelcast.multimap.impl.operations.RemoveOperation;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.AbstractDistributedObject;
-import com.hazelcast.internal.services.DistributedObjectNamespace;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.internal.util.ExceptionUtil;
-import com.hazelcast.internal.util.ThreadUtil;
+import com.hazelcast.spi.impl.operationservice.OperationFactory;
+import com.hazelcast.spi.impl.operationservice.OperationService;
 
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
+import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.MapUtil.toIntSize;
+import static com.hazelcast.multimap.impl.MultiMapProxyImpl.NULL_KEY_IS_NOT_ALLOWED;
+import static com.hazelcast.multimap.impl.MultiMapProxyImpl.NULL_VALUE_IS_NOT_ALLOWED;
+import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
+import static java.lang.Math.ceil;
+import static java.lang.Math.log10;
+import static java.util.Collections.singletonMap;
 
 public abstract class MultiMapProxySupport extends AbstractDistributedObject<MultiMapService> {
 
     protected final MultiMapConfig config;
     protected final String name;
     protected final LockProxySupport lockSupport;
+    protected final SerializationService serializationService;
+    protected final OperationService operationService;
+    protected final IPartitionService partitionService;
+    private final float putAllInitialSizeFactor;
 
     protected MultiMapProxySupport(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
         super(nodeEngine, service);
         this.config = config;
         this.name = name;
 
+        this.partitionService = nodeEngine.getPartitionService();
+        this.serializationService = nodeEngine.getSerializationService();
+        this.operationService = nodeEngine.getOperationService();
+
         lockSupport = new LockProxySupport(new DistributedObjectNamespace(MultiMapService.SERVICE_NAME, name),
                 LockSupportServiceImpl.getMaxLeaseTimeInMillis(nodeEngine.getProperties()));
+
+        //TODO: implement properties and properties.getFloat(MAP_PUT_ALL_INITIAL_SIZE_FACTOR);
+        this.putAllInitialSizeFactor = 1;
     }
 
     @Override
     public String getName() {
         return name;
+    }
+
+    //NB: this method is copied from MapProxySupport#getPutAllInitialSize
+    @SuppressWarnings("checkstyle:magicnumber")
+    private int getPutAllInitialSize(boolean useBatching, int mapSize, int partitionCount) {
+        if (mapSize == 1) {
+            return 1;
+        }
+        //TODO: implement batching
+        /*
+        if (useBatching) {
+            return putAllBatchSize;
+        }*/
+        if (putAllInitialSizeFactor < 1) {
+            // this is an educated guess for the initial size of the entries per partition, depending on the map size
+            return (int) ceil(20f * mapSize / partitionCount / log10(mapSize));
+        }
+        return (int) ceil(putAllInitialSizeFactor * mapSize / partitionCount);
+    }
+
+    //NB: this method is generally copied from MapProxySupport#putAllInternal
+    protected void putAllInternal(Map<? extends Object, Collection> map, @Nullable InternalCompletableFuture<Void> future) {
+
+        //get partition to entries mapping
+        try {
+            int mapSize = map.size();
+            if (mapSize == 0) {
+                if (future != null) {
+                    future.complete(null);
+                }
+                return;
+            }
+
+            //TODO: implement batching
+            //boolean useBatching = future == null && isPutAllUseBatching(mapSize);
+            int partitionCount = partitionService.getPartitionCount();
+            int initialSize = getPutAllInitialSize(false, mapSize, partitionCount);
+
+            //get node to partition mapping
+            Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
+
+            //TODO: implement batching
+            /*
+            MutableLong[] counterPerMember = null;
+            Address[] addresses = null;
+            if (useBatching) {
+                counterPerMember = new MutableLong[partitionCount];
+                addresses = new Address[partitionCount];
+                for (Map.Entry<Address, List<Integer>> addressListEntry : memberPartitionsMap.entrySet()) {
+                    MutableLong counter = new MutableLong();
+                    Address address = addressListEntry.getKey();
+                    for (int partitionId : addressListEntry.getValue()) {
+                        counterPerMember[partitionId] = counter;
+                        addresses[partitionId] = address;
+                    }
+                }
+            }
+            */
+
+            // fill entriesPerPartition
+            MapEntries[] entriesPerPartition = new MapEntries[partitionCount];
+            for (Map.Entry entry : map.entrySet()) {
+                checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
+                checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
+
+                //TODO: add and use PartitioningStrategy?
+                Data keyData = serializationService.toData(entry.getKey());
+                int partitionId = partitionService.getPartitionId(keyData);
+                MapEntries entries = entriesPerPartition[partitionId];
+                if (entries == null) {
+                    entries = new MapEntries(initialSize);
+                    entriesPerPartition[partitionId] = entries;
+                }
+                entries.add(keyData, toData(entry.getValue()));
+
+                //TODO:implement batching
+                /*
+                if (useBatching) {
+                    long currentSize = ++counterPerMember[partitionId].value;
+                    if (currentSize % putAllBatchSize == 0) {
+                        List<Integer> partitions = memberPartitionsMap.get(addresses[partitionId]);
+                        invokePutAllOperation(addresses[partitionId], partitions, entriesPerPartition)
+                                .get();
+                    }
+                }
+                */
+            }
+            // invoke operations for entriesPerPartition
+            AtomicInteger counter = new AtomicInteger(memberPartitionsMap.size());
+            InternalCompletableFuture<Void> resultFuture =
+                    future != null ? future : new InternalCompletableFuture<>();
+            BiConsumer<Void, Throwable> callback = (response, t) -> {
+                if (t != null) {
+                    resultFuture.completeExceptionally(t);
+                }
+
+                if (counter.decrementAndGet() == 0) {
+                    //FIXME: implement finalizePutAll(map);
+                    if (!resultFuture.isDone()) {
+                        resultFuture.complete(null);
+                    }
+                }
+            };
+            for (Map.Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
+                invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition).whenCompleteAsync(callback);
+            }
+            // if executing in sync mode, block for the responses
+            if (future == null) {
+                resultFuture.get();
+            }
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    //NB: this method is generally copied from MapProxySupport#invokePutAllOperation
+    private InternalCompletableFuture<Void> invokePutAllOperation(
+            Address address,
+            List<Integer> memberPartitions,
+            MapEntries[] entriesPerPartition
+    ) {
+        int size = memberPartitions.size();
+        int[] partitions = new int[size];
+        int index = 0;
+        for (Integer partitionId : memberPartitions) {
+            if (entriesPerPartition[partitionId] != null) {
+                partitions[index++] = partitionId;
+            }
+        }
+        if (index == 0) {
+            return newCompletedFuture(null);
+        }
+        // trim partition array to real size
+        if (index < size) {
+            partitions = Arrays.copyOf(partitions, index);
+            size = index;
+        }
+
+        index = 0;
+        MapEntries[] entries = new MapEntries[size];
+        long totalSize = 0;
+        for (int partitionId : partitions) {
+            int batchSize = entriesPerPartition[partitionId].size();
+            //FIXME: implement batching
+            //assert (putAllBatchSize == 0 || batchSize <= putAllBatchSize);
+            entries[index++] = entriesPerPartition[partitionId];
+            totalSize += batchSize;
+            entriesPerPartition[partitionId] = null;
+        }
+        if (totalSize == 0) {
+            return newCompletedFuture(null);
+        }
+
+        OperationFactory factory = new MultiMapPutAllOperationFactory(name, partitions, entries);
+        long startTimeNanos = System.nanoTime();
+        CompletableFuture<Map<Integer, Object>> future =
+                operationService.invokeOnPartitionsAsync(MultiMapService.SERVICE_NAME, factory, singletonMap(address, asIntegerList(partitions)));
+        InternalCompletableFuture<Void> resultFuture = new InternalCompletableFuture<>();
+        long finalTotalSize = totalSize;
+        future.whenCompleteAsync((response, t) -> {
+            //TODO: implement putAllVisitSerializedKeys
+            //putAllVisitSerializedKeys(entries);
+
+            if (t == null) {
+                //TODO: verify stats
+                getService().getLocalMultiMapStatsImpl(name).incrementPutLatencyNanos(finalTotalSize, System.nanoTime() - startTimeNanos);
+                //FIXME: shouldnt we return a reference to the result or the mmap?
+                resultFuture.complete(null);
+            } else {
+                resultFuture.completeExceptionally(t);
+            }
+        }, CALLER_RUNS);
+        return resultFuture;
     }
 
     protected Boolean putInternal(Data dataKey, Data dataValue, int index) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapPutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapPutAllOperationFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap.impl.operations;
+
+import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class MultiMapPutAllOperationFactory extends PartitionAwareOperationFactory {
+    protected String name;
+    protected MapEntries[] mapEntries;
+
+    public MultiMapPutAllOperationFactory(){}
+    public MultiMapPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries){
+        this.name = name;
+        this.partitions = partitions;
+        this.mapEntries = mapEntries;
+        //NB: general structure copied from c.hz.map.impl.operation.PutAllOperationPartitionAwareFactort
+        //May benefit from refactoring or default interfaces
+    }
+
+    @Override
+    public Operation createPartitionOperation(int partitionId) {
+        for (int i = 0; i < partitions.length; i++) {
+            if (partitions[i] == partitionId) {
+                return new PutAllOperation(name, mapEntries[i]);
+            }
+        }
+        throw new IllegalArgumentException("Unknown partitionId " + partitionId + " (" + Arrays.toString(partitions) + ")");
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+        out.writeIntArray(partitions);
+        for (MapEntries entry : mapEntries) {
+            entry.writeData(out);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+        partitions = in.readIntArray();
+        mapEntries = new MapEntries[partitions.length];
+        for (int i = 0; i < partitions.length; i++) {
+            MapEntries entry = new MapEntries();
+            entry.readData(in);
+            mapEntries[i] = entry;
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MultiMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return MultiMapDataSerializerHook.PUT_ALL_PARTITION_AWARE_FACTORY;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutAllOperation.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap.impl.operations;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.memory.NativeOutOfMemoryError;
+import com.hazelcast.multimap.impl.MultiMapContainer;
+import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
+import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class PutAllOperation extends AbstractMultiMapOperation implements MutatingOperation{
+    private transient int currentIndex;
+    private MapEntries mapEntries;
+    private long recordId;
+    public PutAllOperation() {
+        super();
+    }
+
+    public PutAllOperation(String name, MapEntries mapEntries) {
+        super(name);
+        this.mapEntries = mapEntries;
+        //NB: general structure copied from c.hz.map.impl.operation.PutAllOperation
+        //May benefit from refactoring or default interfaces
+    }
+
+    @Override
+    public final void run() {
+        try {
+            runInternal();
+        } catch (NativeOutOfMemoryError e) {
+            //TODO: implement rerun?
+            e.printStackTrace();
+        }
+    }
+
+    protected void runInternal() {
+        //FIXME: potentially bad idiom?
+        int size = mapEntries!=null ? mapEntries.size():0;
+        while (currentIndex < size) {
+            Data dataKey = mapEntries.getKey(currentIndex);
+            Data value = mapEntries.getValue(currentIndex);
+            put(dataKey, value);
+            currentIndex++;
+        }
+        //FIXME: is this the best place to set response?
+        response = true;
+    }
+
+    protected void put(Data dataKey, Data dataValue) {
+        MultiMapContainer container = getOrCreateContainer();
+        Collection c = (Collection)toObject(dataValue);
+        //FIXME:do we even need this null check? Maybe use an Optional?
+        if(c!=null) {
+            Collection<MultiMapRecord> coll = container.getOrCreateMultiMapValue(dataKey).getCollection(false);
+            Iterator it = c.iterator();
+            while(it.hasNext()){
+                Object o = it.next();
+                recordId = container.nextId();
+                MultiMapRecord record = new MultiMapRecord(recordId, o);
+                coll.add(record);
+                //NB: we could make a coll.addAll(c) instead if we changed the getObjectCollection impl
+                getOrCreateContainer().update();
+                //FIXME: there should be a flag to turn this off?
+                publishEvent(EntryEventType.ADDED, dataKey, o, null);
+            }
+        }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(mapEntries);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        mapEntries = in.readObject();
+    }
+    @Override
+    public int getClassId() {
+        return MultiMapDataSerializerHook.PUT_ALL;
+    }
+
+
+}


### PR DESCRIPTION
Hi @mmedenjak 
Apologies for the late update. This is the initial PR for `MultiMap.putAllAsync`. Please take a look.

_Design Issues-Thoughts_
- Generally have followed `Map.putAllAsync` partition bundling bulk operation flow. 
- One ideal signature wouldve been `putAllAsync(Map<? extends K, Collection<? extends V>>)`
But the new `putAllAsync` and `putAll` had to have an `(Map<Object, Collection>)` signature because i) adding generics to `MultiMapSupport` broke the listeners and ii) passing in a generic `Map<?, Collection<?>>` into a non generic `putAllInternal(Map<Object, Collection<Object>>)` doesnt work. 
Other alternatives wouldve been a) preprocessing the generic Map and making a temporary `Map<Data, Data>` to pass into `putAllInternal` or b) defining a `putAllAsync(MultiMapConfig)` interface.
- The new `PutAllOperation` class was not subclassed to `AbstractKeyBasedMultiMapOperation` and be invoked by `MultiMapOperationFactory` due to needing to have `createPartitionOperation`. One other solution couldve been to make `MultiMapOperationFactory` partition aware.
- One other interface couldve been a key specific bulk op `putAll(Key, Collection)`
- Didnt define-implement `getAll` but it might seem it already exists....

_Implementation Issues_
- `ClientMultiMapProxy` `putAllAsync` and `putAll` implementations not done yet.
- Two new statics for `PUT_ALL` are defined in `MultiMapDataSerializerHook` but there seems to already be a preexisting and unused `ADD_ALL` static. Unsure whether `ADD_ALL` is semantically identical to `PUT_ALL`
- Batching not implemented yet (or necessary? am unsure)
- Potentially `BackupOperation` and backup needs to be implemented for `PutAllOperation`
- Didnt tooth comb all the loops yet but have a hunch some are optimizable
