### PR TITLE
Override "cached" poolName of IExecutorService thread when executing tasks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.lang.Character.isLetter;
 import static java.lang.Character.isLowerCase;
 import static java.lang.Character.toLowerCase;
@@ -387,5 +388,34 @@ public final class StringUtil {
         return (str1 == null || str2 == null)
                 ? false
                 : (str1 == str2 || lowerCaseInternal(str1).equals(lowerCaseInternal(str2)));
+    }
+
+    /**
+     * Return the CSV with its sectionIdx-th section updated to the replacement value, if such section exists
+     *
+     * @param csv input CSV
+     * @param sep the separator character
+     * @param sectionIdx the index of the section to be replaced (start from 0)
+     * @param replacement the replacement string
+     * @return the updated CSV if replacement is possible, otherwise existing input CSV
+     * @throws NullPointerException if input CSV or replacement is null
+     */
+    public static String csvReplaceSection(String csv, char sep, int sectionIdx, String replacement) {
+        checkNotNull(csv, "csv can't be empty");
+        checkNotNull(replacement, "replacement can't be null");
+        if (sectionIdx < 0) {
+            return csv;
+        }
+        final StringBuilder sepRegexBuilder = new StringBuilder();
+        if (".$|()[{^?*+\\".indexOf(sep) > -1) {
+            sepRegexBuilder.append('\\');
+        }
+        sepRegexBuilder.append(sep);
+        final String[] sections = csv.split(sepRegexBuilder.toString(), -1);
+        if (sections.length > sectionIdx) {
+            sections[sectionIdx] = replacement;
+            return String.join(String.valueOf(sep), sections);
+        }
+        return csv;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -155,6 +155,35 @@ public class StringUtilTest extends HazelcastTestSupport {
         }
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testCsvReplaceSection_whenCsvIsNull_ShouldThrowNPE() {
+        StringUtil.csvReplaceSection(null, ',', 0, "foo");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCsvReplaceSection_whenReplacementIsNull_ShouldThrowNPE() {
+        StringUtil.csvReplaceSection("foo", ',', 0, null);
+    }
+
+    @Test
+    public void testCsvReplaceSection() {
+        // Separator is special regex character
+        assertEquals("text", StringUtil.csvReplaceSection("foo,bar,baz", '.', 0, "text"));
+        assertEquals("foo.bar.baz", StringUtil.csvReplaceSection("foo.bar.baz", '.', -1, "text"));
+        assertEquals("foo.bar.baz", StringUtil.csvReplaceSection("foo.bar.baz", '.', 10, "text"));
+        assertEquals("text.bar.baz", StringUtil.csvReplaceSection("foo.bar.baz", '.', 0, "text"));
+        assertEquals("foo.text.baz", StringUtil.csvReplaceSection("foo.bar.baz", '.', 1, "text"));
+        assertEquals("foo.bar.text", StringUtil.csvReplaceSection("foo.bar.baz", '.', 2, "text"));
+
+        // Separator is normal character
+        assertEquals("text", StringUtil.csvReplaceSection("foo.bar.baz", ',', 0, "text"));
+        assertEquals("foo,bar,baz", StringUtil.csvReplaceSection("foo,bar,baz", ',', -1, "text"));
+        assertEquals("foo,bar,baz", StringUtil.csvReplaceSection("foo,bar,baz", ',', 10, "text"));
+        assertEquals("text,bar,baz", StringUtil.csvReplaceSection("foo,bar,baz", ',', 0, "text"));
+        assertEquals("foo,text,baz", StringUtil.csvReplaceSection("foo,bar,baz", ',', 1, "text"));
+        assertEquals("foo,bar,text", StringUtil.csvReplaceSection("foo,bar,baz", ',', 2, "text"));
+    }
+
     private String[] arr(String... strings) {
         return strings;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ThreadUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ThreadUtilTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ThreadUtilTest extends HazelcastTestSupport {
@@ -31,5 +33,33 @@ public class ThreadUtilTest extends HazelcastTestSupport {
     @Test
     public void testConstructor() {
         assertUtilityConstructor(ThreadUtil.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUpdateCurrentThreadPoolName_whenTargetPoolNameIsNull_ShouldThrowException() {
+        ThreadUtil.updateCurrentThreadPoolName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUpdateCurrentThreadPoolName_whenTargetPoolNameIsEmpty_ShouldThrowException() {
+        ThreadUtil.updateCurrentThreadPoolName("");
+    }
+
+    @Test
+    public void testUpdateCurrentThreadPoolName_whenCurrentThreadNameDoesNotMatchPatternWithPoolName_ShouldNotUpdate() {
+        Thread.currentThread().setName("threadName");
+        assertEquals("threadName", ThreadUtil.updateCurrentThreadPoolName("targetPoolName"));
+        assertEquals("threadName", Thread.currentThread().getName());
+
+        Thread.currentThread().setName("hz.hzName.thread-1");
+        assertEquals("hz.hzName.thread-1", ThreadUtil.updateCurrentThreadPoolName("targetPoolName"));
+        assertEquals("hz.hzName.thread-1", Thread.currentThread().getName());
+    }
+
+    @Test
+    public void testUpdateCurrentThreadPoolName_whenCurrentThreadNameMatchesPatternWithPoolName_ShouldUpdate() {
+        Thread.currentThread().setName("hz.hzName.poolName.thread-1");
+        assertEquals("hz.hzName.poolName.thread-1", ThreadUtil.updateCurrentThreadPoolName("targetPoolName"));
+        assertEquals("hz.hzName.targetPoolName.thread-1", Thread.currentThread().getName());
     }
 }


### PR DESCRIPTION
See [Issue #6600](https://github.com/hazelcast/hazelcast/issues/6600)