### PR TITLE
Use Thread#onSpinWait when JDK9+ and fall back to Thread#yield on JDK8

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberOwnedContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberOwnedContainer.java
@@ -75,7 +75,9 @@ public class ScheduledExecutorMemberOwnedContainer
 
     private void acquireMemberPartitionLockIfNeeded() {
         while (!memberPartitionLock.compareAndSet(false, true)) {
-            Thread.yield();
+            if (!ThreadOnSpinWaitJDK8Adapter.onSpinWaitOrNothing()) {
+                Thread.yield();
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ThreadOnSpinWaitJDK8Adapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ThreadOnSpinWaitJDK8Adapter.java
@@ -1,0 +1,33 @@
+package com.hazelcast.scheduledexecutor.impl;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+import static java.lang.invoke.MethodType.methodType;
+
+final class ThreadOnSpinWaitJDK8Adapter {
+    private static final MethodHandle ON_SPIN_WAIT_HANDLE = resolve();
+
+    private ThreadOnSpinWaitJDK8Adapter() {
+    }
+
+    private static MethodHandle resolve() {
+        try {
+            return MethodHandles.lookup().findStatic(Thread.class, "onSpinWait", methodType(void.class));
+        } catch (Exception ignore) {
+        }
+
+        return null;
+    }
+
+    static boolean onSpinWaitOrNothing() {
+        if (ON_SPIN_WAIT_HANDLE != null) {
+            try {
+                ON_SPIN_WAIT_HANDLE.invokeExact();
+                return true;
+            } catch (Throwable ignore) {
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Since IMDG [can be run on JDK9+ runtimes](https://github.com/hazelcast/hazelcast-docker/blob/master/hazelcast-oss/Dockerfile#L33), we could utilize the Thread#onSpinWait as a fine-grained alternative to Thread#yield when busy-spinning.

Depends on: https://github.com/mojohaus/animal-sniffer/issues/67