### PR TITLE
Expose BufferObjectDataInput creation based on byte[] and offset

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InputOutputFactory.java
@@ -27,6 +27,8 @@ public interface InputOutputFactory {
 
     BufferObjectDataInput createInput(byte[] buffer, InternalSerializationService service);
 
+    BufferObjectDataInput createInput(byte[] buffer, int offset, InternalSerializationService service);
+
     BufferObjectDataOutput createOutput(int size, InternalSerializationService service);
 
     ByteOrder getByteOrder();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -80,6 +80,8 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     BufferObjectDataInput createObjectDataInput(byte[] data);
 
+    BufferObjectDataInput createObjectDataInput(byte[] data, int offset);
+
     BufferObjectDataInput createObjectDataInput(Data data);
 
     BufferObjectDataOutput createObjectDataOutput(int size);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -306,6 +306,11 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     @Override
+    public final BufferObjectDataInput createObjectDataInput(byte[] data, int offset) {
+        return inputOutputFactory.createInput(data, offset, this);
+    }
+
+    @Override
     public final BufferObjectDataInput createObjectDataInput(Data data) {
         return inputOutputFactory.createInput(data, this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
@@ -43,6 +43,11 @@ final class ByteArrayInputOutputFactory implements InputOutputFactory {
     }
 
     @Override
+    public BufferObjectDataInput createInput(byte[] buffer, int offset, InternalSerializationService service) {
+        return new ByteArrayObjectDataInput(buffer, offset, service, byteOrder);
+    }
+
+    @Override
     public BufferObjectDataOutput createOutput(int size, InternalSerializationService service) {
         return new ByteArrayObjectDataOutput(size, service, byteOrder);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeInputOutputFactory.java
@@ -37,6 +37,11 @@ final class UnsafeInputOutputFactory implements InputOutputFactory {
     }
 
     @Override
+    public BufferObjectDataInput createInput(byte[] buffer, int offset, InternalSerializationService service) {
+        return new UnsafeObjectDataInput(buffer, offset, service);
+    }
+
+    @Override
     public BufferObjectDataOutput createOutput(int size, InternalSerializationService service) {
         return new UnsafeObjectDataOutput(size, service);
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -144,6 +144,11 @@ public class SamplingSerializationService implements InternalSerializationServic
     }
 
     @Override
+    public BufferObjectDataInput createObjectDataInput(byte[] data, int offset) {
+        return delegate.createObjectDataInput(data, offset);
+    }
+
+    @Override
     public BufferObjectDataInput createObjectDataInput(Data data) {
         return delegate.createObjectDataInput(data);
     }


### PR DESCRIPTION
To avoid byte array copying, at times it's useful to be able to create BufferObjectDataInput based on byte[] and offset into provided array.

Backport of: https://github.com/hazelcast/hazelcast/pull/16701