### PR TITLE
add codec versioning support

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
@@ -18,6 +18,7 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.connection.AddressProvider;
+import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.HazelcastInstance;
 
 public class HazelcastClientUtil {
@@ -28,5 +29,19 @@ public class HazelcastClientUtil {
 
     public static String getInstanceName(ClientConfig config) {
         return HazelcastClient.getInstanceName(config, null);
+    }
+
+    public static ClientMessage.Frame fastForwardToEndFrame(ClientMessage.ForwardFrameIterator iterator) {
+        int numberOfExpectedEndFrames = 1;
+        ClientMessage.Frame frame = null;
+        while (numberOfExpectedEndFrames != 0) {
+            frame = iterator.next();
+            if (frame.isEndFrame()) {
+                numberOfExpectedEndFrames--;
+            } else if (frame.isBeginFrame()) {
+                numberOfExpectedEndFrames++;
+            }
+        }
+        return frame;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_2_0.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,12 +37,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -123,7 +127,7 @@ public class ClientCompatibilityNullTest_2_0 {
         ClientAddClusterViewListenerCodec.ResponseParameters parameters = ClientAddClusterViewListenerCodec.decodeResponse(fromFile);
     }
 
-    private class ClientAddClusterViewListenerCodecHandler extends ClientAddClusterViewListenerCodec.AbstractEventHandler {
+    private static class ClientAddClusterViewListenerCodecHandler extends ClientAddClusterViewListenerCodec.AbstractEventHandler {
         @Override
         public void handleMembersViewEvent(int version, java.util.Collection<com.hazelcast.internal.cluster.MemberInfo> memberInfos) {
             assertTrue(isEqual(anInt, version));
@@ -198,7 +202,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
+    private static class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
         @Override
         public void handlePartitionLostEvent(int partitionId, int lostBackupCount, java.util.UUID source) {
             assertTrue(isEqual(anInt, partitionId));
@@ -263,7 +267,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
+    private static class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
         @Override
         public void handleDistributedObjectEvent(java.lang.String name, java.lang.String serviceName, java.lang.String eventType, java.util.UUID source) {
             assertTrue(isEqual(aString, name));
@@ -373,7 +377,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ClientLocalBackupListenerCodecHandler extends ClientLocalBackupListenerCodec.AbstractEventHandler {
+    private static class ClientLocalBackupListenerCodecHandler extends ClientLocalBackupListenerCodec.AbstractEventHandler {
         @Override
         public void handleBackupEvent(long sourceInvocationCorrelationId) {
             assertTrue(isEqual(aLong, sourceInvocationCorrelationId));
@@ -749,7 +753,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -786,7 +790,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -823,7 +827,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -860,7 +864,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -913,7 +917,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
+    private static class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
         @Override
         public void handleMapPartitionLostEvent(int partitionId, java.util.UUID uuid) {
             assertTrue(isEqual(anInt, partitionId));
@@ -1504,7 +1508,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
+    private static class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
         @Override
         public void handleIMapInvalidationEvent(com.hazelcast.internal.serialization.Data key, java.util.UUID sourceUuid, java.util.UUID partitionUuid, long sequence) {
             assertTrue(isEqual(null, key));
@@ -1877,7 +1881,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
+    private static class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -1914,7 +1918,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
+    private static class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -2329,7 +2333,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
+    private static class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleItemEvent(com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType) {
             assertTrue(isEqual(null, item));
@@ -2425,7 +2429,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
+    private static class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
         @Override
         public void handleTopicEvent(com.hazelcast.internal.serialization.Data item, long publishTime, java.util.UUID uuid) {
             assertTrue(isEqual(aData, item));
@@ -2633,7 +2637,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
+    private static class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleItemEvent(com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType) {
             assertTrue(isEqual(null, item));
@@ -3016,7 +3020,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
+    private static class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleItemEvent(com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType) {
             assertTrue(isEqual(null, item));
@@ -3768,7 +3772,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -3805,7 +3809,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -3842,7 +3846,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -3879,7 +3883,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -3980,7 +3984,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(null, key));
@@ -4575,7 +4579,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
+    private static class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleCacheEvent(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
             assertTrue(isEqual(anInt, type));
@@ -4970,7 +4974,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
+    private static class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
         @Override
         public void handleCachePartitionLostEvent(int partitionId, java.util.UUID uuid) {
             assertTrue(isEqual(anInt, partitionId));
@@ -5050,7 +5054,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
+    private static class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
         @Override
         public void handleCacheInvalidationEvent(java.lang.String name, com.hazelcast.internal.serialization.Data key, java.util.UUID sourceUuid, java.util.UUID partitionUuid, long sequence) {
             assertTrue(isEqual(aString, name));
@@ -5371,7 +5375,7 @@ public class ClientCompatibilityNullTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
+    private static class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleQueryCacheSingleEvent(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
             assertTrue(isEqual(aQueryCacheEventData, data));
@@ -6925,13 +6929,18 @@ public class ClientCompatibilityNullTest_2_0 {
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
             boolean isFinal = binaryFrameIterator.peekNext() == null;
+            boolean isEndFrame = binaryFrame.isEndFrame();
             if (!isInitialFramesCompared) {
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, encodedFrame.content);
+                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
+                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
+                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+                }
             }
         }
         assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,12 +37,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -123,7 +127,7 @@ public class ClientCompatibilityTest_2_0 {
         ClientAddClusterViewListenerCodec.ResponseParameters parameters = ClientAddClusterViewListenerCodec.decodeResponse(fromFile);
     }
 
-    private class ClientAddClusterViewListenerCodecHandler extends ClientAddClusterViewListenerCodec.AbstractEventHandler {
+    private static class ClientAddClusterViewListenerCodecHandler extends ClientAddClusterViewListenerCodec.AbstractEventHandler {
         @Override
         public void handleMembersViewEvent(int version, java.util.Collection<com.hazelcast.internal.cluster.MemberInfo> memberInfos) {
             assertTrue(isEqual(anInt, version));
@@ -198,7 +202,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
+    private static class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
         @Override
         public void handlePartitionLostEvent(int partitionId, int lostBackupCount, java.util.UUID source) {
             assertTrue(isEqual(anInt, partitionId));
@@ -263,7 +267,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
+    private static class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
         @Override
         public void handleDistributedObjectEvent(java.lang.String name, java.lang.String serviceName, java.lang.String eventType, java.util.UUID source) {
             assertTrue(isEqual(aString, name));
@@ -373,7 +377,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ClientLocalBackupListenerCodecHandler extends ClientLocalBackupListenerCodec.AbstractEventHandler {
+    private static class ClientLocalBackupListenerCodecHandler extends ClientLocalBackupListenerCodec.AbstractEventHandler {
         @Override
         public void handleBackupEvent(long sourceInvocationCorrelationId) {
             assertTrue(isEqual(aLong, sourceInvocationCorrelationId));
@@ -749,7 +753,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -786,7 +790,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -823,7 +827,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -860,7 +864,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
+    private static class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -913,7 +917,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
+    private static class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
         @Override
         public void handleMapPartitionLostEvent(int partitionId, java.util.UUID uuid) {
             assertTrue(isEqual(anInt, partitionId));
@@ -1504,7 +1508,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
+    private static class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
         @Override
         public void handleIMapInvalidationEvent(com.hazelcast.internal.serialization.Data key, java.util.UUID sourceUuid, java.util.UUID partitionUuid, long sequence) {
             assertTrue(isEqual(aData, key));
@@ -1877,7 +1881,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
+    private static class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -1914,7 +1918,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
+    private static class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -2329,7 +2333,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
+    private static class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleItemEvent(com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType) {
             assertTrue(isEqual(aData, item));
@@ -2425,7 +2429,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
+    private static class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
         @Override
         public void handleTopicEvent(com.hazelcast.internal.serialization.Data item, long publishTime, java.util.UUID uuid) {
             assertTrue(isEqual(aData, item));
@@ -2633,7 +2637,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
+    private static class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleItemEvent(com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType) {
             assertTrue(isEqual(aData, item));
@@ -3016,7 +3020,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
+    private static class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleItemEvent(com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType) {
             assertTrue(isEqual(aData, item));
@@ -3768,7 +3772,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -3805,7 +3809,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -3842,7 +3846,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -3879,7 +3883,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -3980,7 +3984,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
+    private static class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleEntryEvent(com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries) {
             assertTrue(isEqual(aData, key));
@@ -4575,7 +4579,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
+    private static class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
         @Override
         public void handleCacheEvent(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
             assertTrue(isEqual(anInt, type));
@@ -4970,7 +4974,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
+    private static class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
         @Override
         public void handleCachePartitionLostEvent(int partitionId, java.util.UUID uuid) {
             assertTrue(isEqual(anInt, partitionId));
@@ -5050,7 +5054,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
+    private static class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
         @Override
         public void handleCacheInvalidationEvent(java.lang.String name, com.hazelcast.internal.serialization.Data key, java.util.UUID sourceUuid, java.util.UUID partitionUuid, long sequence) {
             assertTrue(isEqual(aString, name));
@@ -5371,7 +5375,7 @@ public class ClientCompatibilityTest_2_0 {
         assertTrue(isEqual(aUUID, parameters.response));
     }
 
-    private class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
+    private static class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
         @Override
         public void handleQueryCacheSingleEvent(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
             assertTrue(isEqual(aQueryCacheEventData, data));
@@ -6925,13 +6929,18 @@ public class ClientCompatibilityTest_2_0 {
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
             boolean isFinal = binaryFrameIterator.peekNext() == null;
+            boolean isEndFrame = binaryFrame.isEndFrame();
             if (!isInitialFramesCompared) {
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, encodedFrame.content);
+                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
+                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
+                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+                }
             }
         }
         assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_2_0.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.client.protocol.compatibility;
 
+import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
@@ -6921,37 +6920,24 @@ public class ClientCompatibilityTest_2_0 {
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
         ClientMessage.ForwardFrameIterator encodedFrameIterator = encodedMessage.frameIterator();
+        assertTrue("Client message that is read from the binary file does not have any frames", binaryFrameIterator.hasNext());
 
-        boolean isInitialFramesCompared = false;
         while (binaryFrameIterator.hasNext()) {
             binaryFrame = binaryFrameIterator.next();
             encodedFrame = encodedFrameIterator.next();
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
-            boolean isFinal = binaryFrameIterator.peekNext() == null;
-            boolean isEndFrame = binaryFrame.isEndFrame();
-            if (!isInitialFramesCompared) {
-                compareInitialFrame(binaryFrame, encodedFrame, isFinal);
-                isInitialFramesCompared = true;
-            } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-                int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
-                assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
-                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+            if (binaryFrame.isEndFrame() && !encodedFrame.isEndFrame()) {
+                if (encodedFrame.isBeginFrame()) {
+                    HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
+                encodedFrame = HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
             }
-        }
-        assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);
-    }
 
-    private void compareInitialFrame(ClientMessage.Frame binaryFrame, ClientMessage.Frame encodedFrame, boolean isFinal) {
-        assertTrue("Encoded client message have shorter initial frame",
-                binaryFrame.content.length <= encodedFrame.content.length);
-        assertArrayEquals("Initial frames have different contents",
-                binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-        int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-        assertEquals("Initial frames have different flags", binaryFrame.flags, flags);
+            boolean isFinal = binaryFrameIterator.peekNext() == null;
+            int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+            assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
+            assertEquals("Frames have different flags", binaryFrame.flags, flags);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/MemberCompatibilityNullTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/MemberCompatibilityNullTest_2_0.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.client.protocol.compatibility;
 
+import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
@@ -7425,37 +7424,24 @@ public class MemberCompatibilityNullTest_2_0 {
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
         ClientMessage.ForwardFrameIterator encodedFrameIterator = encodedMessage.frameIterator();
+        assertTrue("Client message that is read from the binary file does not have any frames", binaryFrameIterator.hasNext());
 
-        boolean isInitialFramesCompared = false;
         while (binaryFrameIterator.hasNext()) {
             binaryFrame = binaryFrameIterator.next();
             encodedFrame = encodedFrameIterator.next();
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
-            boolean isFinal = binaryFrameIterator.peekNext() == null;
-            boolean isEndFrame = binaryFrame.isEndFrame();
-            if (!isInitialFramesCompared) {
-                compareInitialFrame(binaryFrame, encodedFrame, isFinal);
-                isInitialFramesCompared = true;
-            } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-                int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
-                assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
-                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+            if (binaryFrame.isEndFrame() && !encodedFrame.isEndFrame()) {
+                if (encodedFrame.isBeginFrame()) {
+                    HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
+                encodedFrame = HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
             }
-        }
-        assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);
-    }
 
-    private void compareInitialFrame(ClientMessage.Frame binaryFrame, ClientMessage.Frame encodedFrame, boolean isFinal) {
-        assertTrue("Encoded client message have shorter initial frame",
-                binaryFrame.content.length <= encodedFrame.content.length);
-        assertArrayEquals("Initial frames have different contents",
-                binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-        int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-        assertEquals("Initial frames have different flags", binaryFrame.flags, flags);
+            boolean isFinal = binaryFrameIterator.peekNext() == null;
+            int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+            assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
+            assertEquals("Frames have different flags", binaryFrame.flags, flags);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/MemberCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/MemberCompatibilityTest_2_0.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,12 +37,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -7417,7 +7420,7 @@ public class MemberCompatibilityTest_2_0 {
         compareClientMessages(fromFile, encoded);
     }
 
-     private void compareClientMessages(ClientMessage binaryMessage, ClientMessage encodedMessage) {
+    private void compareClientMessages(ClientMessage binaryMessage, ClientMessage encodedMessage) {
         ClientMessage.Frame binaryFrame, encodedFrame;
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
@@ -7430,13 +7433,18 @@ public class MemberCompatibilityTest_2_0 {
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
             boolean isFinal = binaryFrameIterator.peekNext() == null;
+            boolean isEndFrame = binaryFrame.isEndFrame();
             if (!isInitialFramesCompared) {
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, encodedFrame.content);
+                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
+                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
+                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+                }
             }
         }
         assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/MemberCompatibilityTest_2_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/MemberCompatibilityTest_2_0.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.client.protocol.compatibility;
 
+import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
@@ -7425,37 +7424,24 @@ public class MemberCompatibilityTest_2_0 {
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
         ClientMessage.ForwardFrameIterator encodedFrameIterator = encodedMessage.frameIterator();
+        assertTrue("Client message that is read from the binary file does not have any frames", binaryFrameIterator.hasNext());
 
-        boolean isInitialFramesCompared = false;
         while (binaryFrameIterator.hasNext()) {
             binaryFrame = binaryFrameIterator.next();
             encodedFrame = encodedFrameIterator.next();
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
-            boolean isFinal = binaryFrameIterator.peekNext() == null;
-            boolean isEndFrame = binaryFrame.isEndFrame();
-            if (!isInitialFramesCompared) {
-                compareInitialFrame(binaryFrame, encodedFrame, isFinal);
-                isInitialFramesCompared = true;
-            } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-                int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
-                assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
-                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+            if (binaryFrame.isEndFrame() && !encodedFrame.isEndFrame()) {
+                if (encodedFrame.isBeginFrame()) {
+                    HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
+                encodedFrame = HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
             }
-        }
-        assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);
-    }
 
-    private void compareInitialFrame(ClientMessage.Frame binaryFrame, ClientMessage.Frame encodedFrame, boolean isFinal) {
-        assertTrue("Encoded client message have shorter initial frame",
-                binaryFrame.content.length <= encodedFrame.content.length);
-        assertArrayEquals("Initial frames have different contents",
-                binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-        int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-        assertEquals("Initial frames have different flags", binaryFrame.flags, flags);
+            boolean isFinal = binaryFrameIterator.peekNext() == null;
+            int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+            assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
+            assertEquals("Frames have different flags", binaryFrame.flags, flags);
+        }
     }
 }


### PR DESCRIPTION
This PR reflects the necessary changes to Hazelcast side for the work done on the protocol side to add the ability to add new parameters, methods, services, events, custom types to codecs.

Apart from the minor minor changes, following logic is added to the client message comparison:
- If a new fix sized parameter is added to a custom type, initial frames of the messages read from the old binary files (e.g. 2.0 binary file) and the encoded messages (e.g. message encoded by the 2.1 codec) will differ such that the encoded initial frame will contain extra parameters. Old clients/members does not try to decode them so we should not try to compare them. Therefore, we only compare the part of the encodedFrame which is sliced with the size of the binaryFrame.

- If a new var sized parameter is added to a custom type, encoded message (message encoded by the 2.1 codec) will have extra frames compared to the messages read from the old binary files (e.g. 2.0 binary file). When we reach the `END_FRAME` of the binary message, we will not be at the `END_FRAME` of the encoded message. Therefore, we skip the additional frames to reach the end frame. Also, as an edge case, if a custom type is added to another custom type as an extension, we should also skip to its `END_FRAME`. The `fastForwardToEndFrame` call inside the if check is for this case.

Although it is not in this PR, following things will happen when protocol is expanded:
- A new set of binary and test files (e.g. 2.0.1.protocol.compatibility.binary, ClientCompatibilityTest_2_0_1.java ... ) will be automatically generated.
- For the newly added parameters, there will be an extra boolean called `isXXExists` on the `ResponseParameters`, `RequestParameters`, `handleYYEvent` method, constructor/factory of the custom type depending on where the parameter is added. When `isXXExist` is true, one may assume that the `XX` field/parameter is encoded by the other end of the communication and it is successfully decoded. If it is false, it means that the message comes from an endpoint that is older than the version that the `XX` is added and `XX` field/parameter will have the default value (0, false or null). 
- If a new parameter is added to a [custom type](https://github.com/hazelcast/hazelcast-client-protocol/blob/master/protocol-definitions/custom/Custom.yaml), an extra step is necessary for the compatibility tests. Lets say a new String parameter (xx) is added to the `Address` and the protocol is updated. The new string will be added to the [reference object](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java#L638). However, there will be 2.0 compatibility tests that call `        assertTrue(isEqual(anAddress, parameters.address));` Now, the equality check is not that straightforward. For 2.0 binaries `parameters.address` will contain host and port, but for the 2.1 binaries `parameters.address` will contain host, port and xx. Therefore one needs to add an `isEqual(Address, Address)` method to the reference objects (or update the equals method of the Address) that will return true when host and port fields matches and the `isXXExists` is false. If `isXXExists` is true, `isEqual` method should also compare the xx fields. 

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/309