### PR TITLE
Allow AbstractSerializationService.serializerFor() to be overridden

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -18,7 +18,9 @@ package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.partition.PartitioningStrategy;
+import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.nio.BufferObjectDataOutput;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InputOutputFactory;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPool;
@@ -27,15 +29,13 @@ import com.hazelcast.internal.serialization.impl.bufferpool.BufferPoolThreadLoca
 import com.hazelcast.internal.usercodedeployment.impl.ClassLocator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.BufferObjectDataInput;
-import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.partition.PartitioningStrategy;
 
 import java.io.Externalizable;
 import java.io.Serializable;
@@ -98,6 +98,17 @@ public abstract class AbstractSerializationService implements InternalSerializat
         this.bufferPoolThreadLocal = new BufferPoolThreadLocal(this, builder.bufferPoolFactory,
                 builder.notActiveExceptionSupplier);
         this.nullSerializerAdapter = createSerializerAdapter(new ConstantSerializers.NullSerializer(), this);
+    }
+
+    protected AbstractSerializationService(AbstractSerializationService prototype) {
+        this.version = prototype.version;
+        this.inputOutputFactory = prototype.inputOutputFactory;
+        this.classLoader = prototype.classLoader;
+        this.managedContext = prototype.managedContext;
+        this.globalPartitioningStrategy = prototype.globalPartitioningStrategy;
+        this.outputBufferSize = prototype.outputBufferSize;
+        this.bufferPoolThreadLocal = prototype.bufferPoolThreadLocal;
+        this.nullSerializerAdapter = prototype.nullSerializerAdapter;
     }
 
     //region Serialization Service
@@ -435,7 +446,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         return serializer;
     }
 
-    protected final SerializerAdapter serializerFor(final int typeId) {
+    public SerializerAdapter serializerFor(final int typeId) {
         if (typeId <= 0) {
             final int index = indexForDefaultType(typeId);
             if (index < CONSTANT_SERIALIZERS_LENGTH) {
@@ -445,7 +456,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         return idMap.get(typeId);
     }
 
-    protected final SerializerAdapter serializerFor(Object object) {
+    public SerializerAdapter serializerFor(Object object) {
         /*
             Searches for a serializer for the provided object
             Serializers will be  searched in this order;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
@@ -25,11 +25,11 @@ import com.hazelcast.nio.serialization.TypedByteArrayDeserializer;
 
 import java.io.IOException;
 
-class ByteArraySerializerAdapter implements SerializerAdapter {
+public class ByteArraySerializerAdapter implements SerializerAdapter {
 
     protected final ByteArraySerializer serializer;
 
-    ByteArraySerializerAdapter(ByteArraySerializer serializer) {
+    public ByteArraySerializerAdapter(ByteArraySerializer serializer) {
         this.serializer = serializer;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
@@ -25,11 +25,11 @@ import com.hazelcast.nio.serialization.TypedByteArrayDeserializer;
 
 import java.io.IOException;
 
-public class ByteArraySerializerAdapter implements SerializerAdapter {
+class ByteArraySerializerAdapter implements SerializerAdapter {
 
     protected final ByteArraySerializer serializer;
 
-    public ByteArraySerializerAdapter(ByteArraySerializer serializer) {
+    ByteArraySerializerAdapter(ByteArraySerializer serializer) {
         this.serializer = serializer;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -115,7 +115,8 @@ public final class SerializationUtil {
         throw new HazelcastSerializationException("Failed to serialize '" + clazz + '\'', e);
     }
 
-    static SerializerAdapter createSerializerAdapter(Serializer serializer, InternalSerializationService serializationService) {
+    public static SerializerAdapter createSerializerAdapter(Serializer serializer,
+                                                            InternalSerializationService serializationService) {
         final SerializerAdapter s;
         if (serializer instanceof StreamSerializer) {
             s = new StreamSerializerAdapter(serializationService, (StreamSerializer) serializer);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializerAdapter.java
@@ -16,14 +16,13 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Serializer;
 
 import java.io.IOException;
 
-interface SerializerAdapter {
+public interface SerializerAdapter {
 
     void write(ObjectDataOutput out, Object object) throws IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
@@ -26,12 +26,12 @@ import com.hazelcast.nio.serialization.TypedStreamDeserializer;
 
 import java.io.IOException;
 
-public class StreamSerializerAdapter implements SerializerAdapter {
+class StreamSerializerAdapter implements SerializerAdapter {
 
     protected final InternalSerializationService service;
     protected final StreamSerializer serializer;
 
-    public StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
+    StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
         this.service = service;
         this.serializer = serializer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -27,12 +26,12 @@ import com.hazelcast.nio.serialization.TypedStreamDeserializer;
 
 import java.io.IOException;
 
-class StreamSerializerAdapter implements SerializerAdapter {
+public class StreamSerializerAdapter implements SerializerAdapter {
 
     protected final InternalSerializationService service;
     protected final StreamSerializer serializer;
 
-    StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
+    public StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
         this.service = service;
         this.serializer = serializer;
     }


### PR DESCRIPTION
Changed the visibility and allowed overriding of `AbstractSerializationService.serializerFor()` to be able to implement a `SerializationService` with dynamic serializer lookup.

Backport of: #16722