### PR TITLE
Replace WanReplicationConsumer/Publisher references with WanConsumer/Publisher

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2610,7 +2610,7 @@
         <xs:attributeGroup ref="class-or-bean-name">
             <xs:annotation>
                 <xs:documentation>
-                    Fully qualified class name of WAN Replication implementation WanReplicationPublisher.
+                    Fully qualified class name of WAN Replication implementation WanPublisher.
                 </xs:documentation>
             </xs:annotation>
         </xs:attributeGroup>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2631,7 +2631,7 @@
         <xs:attributeGroup ref="class-or-bean-name">
             <xs:annotation>
                 <xs:documentation>
-                    Defines a custom WAN consumer (WanReplicationConsumer).
+                    Defines a custom WAN consumer (WanConsumer).
                     If you don't define a class name or implementation, the default processing
                     logic for incoming WAN events will be used.
                 </xs:documentation>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -2630,7 +2630,7 @@
         <xs:attributeGroup ref="class-or-bean-name">
             <xs:annotation>
                 <xs:documentation>
-                    Defines a custom WAN consumer (WanReplicationConsumer).
+                    Defines a custom WAN consumer (WanConsumer).
                     If you don't define a class name or implementation, the default processing
                     logic for incoming WAN events will be used.
                 </xs:documentation>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -2609,7 +2609,7 @@
         <xs:attributeGroup ref="class-or-bean-name">
             <xs:annotation>
                 <xs:documentation>
-                    Fully qualified class name of WAN Replication implementation WanReplicationPublisher.
+                    Fully qualified class name of WAN Replication implementation WanPublisher.
                 </xs:documentation>
             </xs:annotation>
         </xs:attributeGroup>

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -2342,7 +2342,7 @@
             <xs:element name="class-name" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        Fully qualified class name of WAN Replication implementation WanReplicationPublisher.
+                        Fully qualified class name of WAN Replication implementation WanPublisher.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -2384,7 +2384,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Sets the fully qualified class name of the class implementing
-                        a custom WAN consumer (WanReplicationConsumer).
+                        a custom WAN consumer (WanConsumer).
                         If you don't define a class name, the default processing logic for
                         incoming WAN events will be used.
                     </xs:documentation>

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -2342,7 +2342,7 @@
             <xs:element name="class-name" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        Fully qualified class name of WAN Replication implementation WanReplicationPublisher.
+                        Fully qualified class name of WAN Replication implementation WanPublisher.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -2384,7 +2384,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Sets the fully qualified class name of the class implementing
-                        a custom WAN consumer (WanReplicationConsumer).
+                        a custom WAN consumer (WanConsumer).
                         If you don't define a class name, the default processing logic for
                         incoming WAN events will be used.
                     </xs:documentation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -312,7 +312,7 @@
                     </discovery-strategy>
                 </discovery-strategies>
         * <custom-publisher>:
-            Custom implementation of a WAN publisher implementing WanReplicationPublisher.
+            Custom implementation of a WAN publisher implementing WanPublisher.
             * "<class-name>":
                 Mandatory config value defining the fully qualified class name of the
                 WAN publisher implementation.

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -330,7 +330,7 @@
             It has the following sub-elements:
             - <class-name>:
                 Sets the fully qualified class name of the class implementing
-                a custom WAN consumer (WanReplicationConsumer).
+                a custom WAN consumer (WanConsumer).
                 If you don't define a class name, the default processing logic for
                 incoming WAN events will be used.
             - <properties>:

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -318,7 +318,7 @@ hazelcast:
   #     It has the following sub-elements:
   #     - "class-name":
   #         Sets the fully qualified class name of the class implementing
-  #         a custom WAN consumer (WanReplicationConsumer).
+  #         a custom WAN consumer (WanConsumer).
   #         If you don't define a class name, the default processing logic for
   #         incoming WAN events will be used.
   #     - "properties":

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -300,7 +300,7 @@ hazelcast:
   #                  connection-timeout-seconds: 10
   #                  hz-port: 5702
   # * "custom-publisher":
-  #     Custom implementation of a WAN publisher implementing WanReplicationPublisher.
+  #     Custom implementation of a WAN publisher implementing WanPublisher.
   #     * "class-name":
   #     Mandatory config value defining the fully qualified class name of the
   #     WAN publisher implementation.


### PR DESCRIPTION
`WanReplicationConsumer` was superseded with `WanConsumer` and `WanReplicationPublisher` was superseded with `WanPublisher` in 4.0 but various places still refer to the old naming convention.