### PR TITLE
[BACKPORT] Performed cleanup on codecs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageWriter.java
@@ -51,7 +51,7 @@ public class ClientMessageWriter {
     private boolean writeFrame(ByteBuffer dst, ClientMessage.Frame frame, boolean isLastFrame) {
         // the number of bytes that can be written to the bb
         int bytesWritable = dst.remaining();
-        int frameContentLength = frame.content == null ? 0 : frame.content.length;
+        int frameContentLength = frame.content.length;
 
         //if write offset is -1 put the length and flags byte first
         if (writeOffset == -1) {
@@ -72,7 +72,7 @@ public class ClientMessageWriter {
         }
         bytesWritable = dst.remaining();
 
-        if (frame.content == null) {
+        if (frameContentLength == 0) {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ByteArrayCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ByteArrayCodec.java
@@ -27,11 +27,7 @@ public final class ByteArrayCodec {
         clientMessage.add(new ClientMessage.Frame(bytes));
     }
 
-    public static byte[] decode(ClientMessage.Frame frame) {
-        return frame.content;
-    }
-
     public static byte[] decode(ClientMessage.ForwardFrameIterator iterator) {
-        return decode(iterator.next());
+        return iterator.next().content;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/DataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/DataCodec.java
@@ -40,16 +40,12 @@ public final class DataCodec {
         }
     }
 
-    public static Data decode(ClientMessage.Frame frame) {
-        return new HeapData(frame.content);
-    }
-
     public static Data decode(ClientMessage.ForwardFrameIterator iterator) {
-        return decode(iterator.next());
+        return new HeapData(iterator.next().content);
     }
 
     public static Data decodeNullable(ClientMessage.ForwardFrameIterator iterator) {
-        return nextFrameIsNullEndFrame(iterator) ? null : decode(iterator.next());
+        return nextFrameIsNullEndFrame(iterator) ? null : decode(iterator);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListIntegerIntegerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListIntegerIntegerCodec.java
@@ -19,9 +19,9 @@ package com.hazelcast.client.impl.protocol.codec.builtin;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +51,7 @@ public final class EntryListIntegerIntegerCodec {
     public static List<Map.Entry<Integer, Integer>> decode(ClientMessage.ForwardFrameIterator iterator) {
         ClientMessage.Frame frame = iterator.next();
         int itemCount = frame.content.length / ENTRY_SIZE_IN_BYTES;
-        List<Map.Entry<Integer, Integer>> result = new LinkedList<>();
+        List<Map.Entry<Integer, Integer>> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             int key = decodeInteger(frame.content, i * ENTRY_SIZE_IN_BYTES);
             int value = decodeInteger(frame.content, i * ENTRY_SIZE_IN_BYTES + INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListIntegerLongCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListIntegerLongCodec.java
@@ -19,9 +19,9 @@ package com.hazelcast.client.impl.protocol.codec.builtin;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +54,7 @@ public final class EntryListIntegerLongCodec {
     public static List<Map.Entry<Integer, Long>> decode(ClientMessage.ForwardFrameIterator iterator) {
         ClientMessage.Frame frame = iterator.next();
         int itemCount = frame.content.length / ENTRY_SIZE_IN_BYTES;
-        List<Map.Entry<Integer, Long>> result = new LinkedList<>();
+        List<Map.Entry<Integer, Long>> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             int key = decodeInteger(frame.content, i * ENTRY_SIZE_IN_BYTES);
             long value = decodeLong(frame.content, i * ENTRY_SIZE_IN_BYTES + INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListIntegerUUIDCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListIntegerUUIDCodec.java
@@ -19,9 +19,9 @@ package com.hazelcast.client.impl.protocol.codec.builtin;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -55,7 +55,7 @@ public final class EntryListIntegerUUIDCodec {
     public static List<Map.Entry<Integer, UUID>> decode(ClientMessage.ForwardFrameIterator iterator) {
         ClientMessage.Frame frame = iterator.next();
         int itemCount = frame.content.length / ENTRY_SIZE_IN_BYTES;
-        List<Map.Entry<Integer, UUID>> result = new LinkedList<>();
+        List<Map.Entry<Integer, UUID>> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             int key = decodeInteger(frame.content, i * ENTRY_SIZE_IN_BYTES);
             UUID value = decodeUUID(frame.content, i * ENTRY_SIZE_IN_BYTES + INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListUUIDLongCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListUUIDLongCodec.java
@@ -19,9 +19,9 @@ package com.hazelcast.client.impl.protocol.codec.builtin;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -55,7 +55,7 @@ public final class EntryListUUIDLongCodec {
     public static List<Map.Entry<UUID, Long>> decode(ClientMessage.ForwardFrameIterator iterator) {
         ClientMessage.Frame frame = iterator.next();
         int itemCount = frame.content.length / ENTRY_SIZE_IN_BYTES;
-        List<Map.Entry<UUID, Long>> result = new LinkedList<>();
+        List<Map.Entry<UUID, Long>> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             UUID key = decodeUUID(frame.content, i * ENTRY_SIZE_IN_BYTES);
             Long value = decodeLong(frame.content, i * ENTRY_SIZE_IN_BYTES + UUID_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListUUIDUUIDCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/EntryListUUIDUUIDCodec.java
@@ -19,18 +19,15 @@ package com.hazelcast.client.impl.protocol.codec.builtin;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.UUID_SIZE_IN_BYTES;
-import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.decodeLong;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.decodeUUID;
-import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeLong;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeUUID;
 
 public final class EntryListUUIDUUIDCodec {
@@ -55,7 +52,7 @@ public final class EntryListUUIDUUIDCodec {
     public static List<Map.Entry<UUID, UUID>> decode(ClientMessage.ForwardFrameIterator iterator) {
         ClientMessage.Frame frame = iterator.next();
         int itemCount = frame.content.length / ENTRY_SIZE_IN_BYTES;
-        List<Map.Entry<UUID, UUID>> result = new LinkedList<>();
+        List<Map.Entry<UUID, UUID>> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             UUID key = decodeUUID(frame.content, i * ENTRY_SIZE_IN_BYTES);
             UUID value = decodeUUID(frame.content, i * ENTRY_SIZE_IN_BYTES + UUID_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListIntegerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListIntegerCodec.java
@@ -47,7 +47,7 @@ public final class ListIntegerCodec {
     }
 
     public static List<Integer> decode(ClientMessage.Frame frame) {
-        int itemCount = frame.content == null ? 0 : frame.content.length / INT_SIZE_IN_BYTES;
+        int itemCount = frame.content.length / INT_SIZE_IN_BYTES;
         List<Integer> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             result.add(decodeInteger(frame.content, i * INT_SIZE_IN_BYTES));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListLongCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListLongCodec.java
@@ -47,7 +47,7 @@ public final class ListLongCodec {
     }
 
     public static List<Long> decode(ClientMessage.Frame frame) {
-        int itemCount = frame.content == null ? 0 : frame.content.length / LONG_SIZE_IN_BYTES;
+        int itemCount = frame.content.length / LONG_SIZE_IN_BYTES;
         List<Long> result = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; i++) {
             result.add(decodeLong(frame.content, i * LONG_SIZE_IN_BYTES));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/StringCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/StringCodec.java
@@ -32,20 +32,7 @@ public final class StringCodec {
         clientMessage.add(new ClientMessage.Frame(value.getBytes(Bits.UTF_8)));
     }
 
-    public static void encode(ClientMessage clientMessage, TimeUnit timeUnit) {
-        encode(clientMessage, timeUnit.name());
-    }
-
-    public static void encode(ClientMessage clientMessage, ExpiryPolicyType expiryPolicyType) {
-        encode(clientMessage, expiryPolicyType.name());
-    }
-
     public static String decode(ClientMessage.ForwardFrameIterator iterator) {
-        return decode(iterator.next());
+        return new String(iterator.next().content, Bits.UTF_8);
     }
-
-    public static String decode(ClientMessage.Frame frame) {
-        return new String(frame.content, Bits.UTF_8);
-    }
-
 }


### PR DESCRIPTION
* Changed LinkedLists to ArrayList on some builtin codecs in which
the item count is known.
* Removed the meaningless method redirections while decoding some
types
* Removed the code paths that checks whether or not the contents
of frames are null. We use zero-length byte arrays for these cases.
There is no place on the codebase that sets null to the contents
of the frames.

Backport of https://github.com/hazelcast/hazelcast/pull/16724