### PR TITLE
dependency version upgrades for hazelcast 4.0

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-hibernate5</artifactId>
-            <version>1.4.0-SNAPSHOT</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-wm</artifactId>
-            <version>3.8.3</version>
+            <version>4.0</version>
         </dependency>
 
         <dependency>

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -36,8 +36,8 @@
         <org.springframework.version>4.3.23.RELEASE</org.springframework.version>
         <jsr250.api.version>1.0</jsr250.api.version>
         <maven-artifact.version>3.6.0</maven-artifact.version>
-        <hazelcast.latest.version>3.8</hazelcast.latest.version>
-        <hazelcast-hibernate5.version>1.4.0-SNAPSHOT</hazelcast-hibernate5.version>
+        <hazelcast.latest.version>4.0</hazelcast.latest.version>
+        <hazelcast-hibernate5.version>2.0.0</hazelcast-hibernate5.version>
     </properties>
 
     <build>


### PR DESCRIPTION
upgrades hazelcast 4.0 compatible versions for:
-  hibernate5
-  hazelcast-wm
-  hazelcast-spring

