### PR TITLE
Add default Serializer.destroy().

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializer.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializer.java
@@ -37,8 +37,4 @@ public class DummySerializer implements StreamSerializer<DummySerializableObject
     public int getTypeId() {
         return 123;
     }
-
-    @Override
-    public void destroy() {
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractCollectionStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractCollectionStreamSerializer.java
@@ -45,9 +45,4 @@ abstract class AbstractCollectionStreamSerializer<CollectionType extends Collect
         }
         return collection;
     }
-
-    @Override
-    public void destroy() {
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractMapStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractMapStreamSerializer.java
@@ -47,9 +47,4 @@ abstract class AbstractMapStreamSerializer<MapType extends Map> implements Strea
         }
         return result;
     }
-
-    @Override
-    public void destroy() {
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayStreamSerializer.java
@@ -45,12 +45,7 @@ public class ArrayStreamSerializer implements StreamSerializer<Object[]> {
     }
 
     @Override
-    public void destroy() {
-    }
-
-    @Override
     public int getTypeId() {
         return SerializationConstants.JAVA_DEFAULT_TYPE_ARRAY;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
@@ -245,10 +245,6 @@ public final class ConstantSerializers {
         public byte[] read(byte[] buffer) throws IOException {
             return buffer;
         }
-
-        @Override
-        public void destroy() {
-        }
     }
 
     public static final class BooleanArraySerializer extends SingletonSerializer<boolean[]> {
@@ -453,13 +449,8 @@ public final class ConstantSerializers {
     }
 
     private abstract static class SingletonSerializer<T> implements StreamSerializer<T> {
-
-        @Override
-        public void destroy() {
-        }
     }
 
     private ConstantSerializers() {
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -316,10 +316,6 @@ public final class JavaDefaultSerializers {
     }
 
     private abstract static class SingletonSerializer<T> implements StreamSerializer<T> {
-
-        @Override
-        public void destroy() {
-        }
     }
 
     private JavaDefaultSerializers() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Serializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Serializer.java
@@ -32,5 +32,6 @@ public interface Serializer {
     /**
      * Called when instance is shutting down. It can be used to clear used resources.
      */
-    void destroy();
+    default void destroy() {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
@@ -152,10 +152,6 @@ public abstract class CardinalityEstimatorAbstractTest extends HazelcastTestSupp
         }
 
         @Override
-        public void destroy() {
-        }
-
-        @Override
         public void write(ObjectDataOutput out, CustomObject object) throws IOException {
             out.writeLong((object.x << Bits.INT_SIZE_IN_BYTES) | object.y);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorTest.java
@@ -167,10 +167,6 @@ public class ClientCardinalityEstimatorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public void destroy() {
-        }
-
-        @Override
         public void write(ObjectDataOutput out, CustomObject object) throws IOException {
             out.writeLong((object.x << Bits.INT_SIZE_IN_BYTES) | object.y);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -405,11 +405,6 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         public int getTypeId() {
             return 0;
         }
-
-        @Override
-        public void destroy() {
-
-        }
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/test/BaseCustomSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/BaseCustomSerializer.java
@@ -43,9 +43,4 @@ public class BaseCustomSerializer implements StreamSerializer<BaseCustom> {
     public int getTypeId() {
         return 3;
     }
-
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/Derived1CustomSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/Derived1CustomSerializer.java
@@ -43,9 +43,4 @@ public class Derived1CustomSerializer implements StreamSerializer<Derived1Custom
     public int getTypeId() {
         return 4;
     }
-
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/Derived2CustomSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/Derived2CustomSerializer.java
@@ -43,9 +43,4 @@ public class Derived2CustomSerializer implements StreamSerializer<Derived2Custom
     public int getTypeId() {
         return 5;
     }
-
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/PersonSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/PersonSerializer.java
@@ -53,9 +53,4 @@ public class PersonSerializer implements StreamSerializer<Person> {
     public int getTypeId() {
         return 999;
     }
-
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -708,9 +708,6 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         public int getTypeId() {
             return 0;
         }
-
-        @Override
-        public void destroy() { }
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -429,10 +429,6 @@ public class AbstractSerializationServiceTest {
         }
 
         @Override
-        public void destroy() {
-        }
-
-        @Override
         public void write(ObjectDataOutput out, StringBuffer stringBuffer) throws IOException {
             if (fail) {
                 throw new RuntimeException();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
@@ -65,10 +65,6 @@ public class SerializationUtilTest {
         public int getTypeId() {
             return 0;
         }
-
-        @Override
-        public void destroy() {
-        }
     }
 
     private class DummyVersionedPortable implements VersionedPortable {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
@@ -55,11 +55,6 @@ public class TestSerializerHook implements SerializerHook {
         }
 
         @Override
-        public void destroy() {
-
-        }
-
-        @Override
         public void write(ObjectDataOutput out, SampleIdentifiedDataSerializable object) throws IOException {
 
         }
@@ -88,11 +83,6 @@ public class TestSerializerHook implements SerializerHook {
         @Override
         public int getTypeId() {
             return 1001;
-        }
-
-        @Override
-        public void destroy() {
-
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
@@ -208,9 +208,6 @@ public class IssuesTest extends HazelcastTestSupport {
                     public int getTypeId() {
                         return 123;
                     }
-
-                    public void destroy() {
-                    }
                 }));
 
         HazelcastInstance hz = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
@@ -202,9 +202,5 @@ public class CustomSerializationTest {
             XMLDecoder decoder = new XMLDecoder(inputStream);
             return (Foo) decoder.readObject();
         }
-
-        @Override
-        public void destroy() {
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -115,9 +115,6 @@ public class SerializationTest extends HazelcastTestSupport {
                     public int getTypeId() {
                         return 123;
                     }
-
-                    public void destroy() {
-                    }
                 }));
 
         SerializationService ss1 = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
@@ -159,9 +156,6 @@ public class SerializationTest extends HazelcastTestSupport {
 
                     public int getTypeId() {
                         return 123;
-                    }
-
-                    public void destroy() {
                     }
                 }));
 
@@ -236,10 +230,6 @@ public class SerializationTest extends HazelcastTestSupport {
                             @Override
                             public int getTypeId() {
                                 return 123;
-                            }
-
-                            @Override
-                            public void destroy() {
                             }
                         }));
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializer.java
@@ -41,8 +41,4 @@ public class CustomByteArraySerializer implements ByteArraySerializer<CustomByte
         ByteBuffer wrap = ByteBuffer.wrap(buffer);
         return new CustomByteArraySerializable(wrap.getInt(), wrap.getFloat());
     }
-
-    @Override
-    public void destroy() {
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializer.java
@@ -39,8 +39,4 @@ public class CustomStreamSerializer implements StreamSerializer<CustomStreamSeri
     public int getTypeId() {
         return ReferenceObjects.CUSTOM_STREAM_SERIALIZABLE_ID;
     }
-
-    @Override
-    public void destroy() {
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -104,10 +104,6 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
         public int getTypeId() {
             return 8778;
         }
-
-        @Override
-        public void destroy() {
-        }
     }
 
     class PutOperationWithNoReplication extends PutOperation {


### PR DESCRIPTION
Added default `Serializer.destroy()` - most of the implementations is empty anyway.

Backport of: #16666 