### PR TITLE
Add Serializer unique type id javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Serializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Serializer.java
@@ -25,6 +25,8 @@ package com.hazelcast.nio.serialization;
 public interface Serializer {
 
     /**
+     * Uniquely identifies given serializer.
+     *
      * @return typeId of serializer
      */
     int getTypeId();


### PR DESCRIPTION
Enhanced `Serializer` javadoc, mentioning about type id uniqueness.