### PR TITLE
Disable COR on certain IMap operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -71,7 +71,9 @@ public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<
 
         List<Entry<Data, Data>> serializedBatch = new ArrayList<Entry<Data, Data>>(mapEntriesWithCursor.getBatch().size());
         for (Entry<Data, Object> entry : mapEntriesWithCursor.getBatch()) {
-            serializedBatch.add(new SimpleImmutableEntry<Data, Data>(entry.getKey(), serializationService.toData(entry.getValue())));
+            SimpleImmutableEntry<Data, Data> e
+                    = new SimpleImmutableEntry<>(entry.getKey(), serializationService.toData(entry.getValue()));
+            serializedBatch.add(e);
         }
         return serializedBatch;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -69,9 +69,9 @@ public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<
             return (List<Entry<Data, Data>>) (Object) mapEntriesWithCursor.getBatch();
         }
 
-        List<Entry<Data, Data>> serializedBatch = new ArrayList<>(mapEntriesWithCursor.getBatch().size());
+        List<Entry<Data, Data>> serializedBatch = new ArrayList<Entry<Data, Data>>(mapEntriesWithCursor.getBatch().size());
         for (Entry<Data, Object> entry : mapEntriesWithCursor.getBatch()) {
-            serializedBatch.add(new SimpleImmutableEntry<>(entry.getKey(), serializationService.toData(entry.getValue())));
+            serializedBatch.add(new SimpleImmutableEntry<Data, Data>(entry.getKey(), serializationService.toData(entry.getValue())));
         }
         return serializedBatch;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -71,8 +71,8 @@ public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<
 
         List<Entry<Data, Data>> serializedBatch = new ArrayList<Entry<Data, Data>>(mapEntriesWithCursor.getBatch().size());
         for (Entry<Data, Object> entry : mapEntriesWithCursor.getBatch()) {
-            SimpleImmutableEntry<Data, Data> e
-                    = new SimpleImmutableEntry<>(entry.getKey(), serializationService.toData(entry.getValue()));
+            SimpleImmutableEntry<Data, Data> e = new SimpleImmutableEntry<Data, Data>(
+                    entry.getKey(), serializationService.toData(entry.getValue()));
             serializedBatch.add(e);
         }
         return serializedBatch;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -54,7 +54,7 @@ public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<
         }
         MapEntriesWithCursor mapEntriesWithCursor = (MapEntriesWithCursor) response;
         return MapFetchEntriesCodec.encodeResponse(mapEntriesWithCursor.getNextTableIndexToReadFrom(),
-                                                   (List<Map.Entry<Data, Data>>)(Object)mapEntriesWithCursor.getBatch());
+                                                   (List<Map.Entry<Data, Data>>) (Object) mapEntriesWithCursor.getBatch());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<MapFetchEntriesCodec.RequestParameters> {
@@ -53,7 +54,7 @@ public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<
         }
         MapEntriesWithCursor mapEntriesWithCursor = (MapEntriesWithCursor) response;
         return MapFetchEntriesCodec.encodeResponse(mapEntriesWithCursor.getNextTableIndexToReadFrom(),
-                mapEntriesWithCursor.getBatch());
+                                                   (List<Map.Entry<Data, Data>>)(Object)mapEntriesWithCursor.getBatch());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/Immutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/Immutable.java
@@ -1,0 +1,4 @@
+package com.hazelcast.map;
+
+public interface Immutable {
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/Immutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/Immutable.java
@@ -16,8 +16,24 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
- * This is just a marker interface for Adobe Entities so that we can disable Copy on Read for this type
+ * Allows notifying Hazelcast code that the object implementing this interface
+ * is effectively immutable.
+ * This may mean that it either does not have any state (e.g. pure function)
+ * or the state is not mutated at any point.
+ * This interface allows for performance optimisations where applicable such
+ * as avoiding cloning user supplied objects or cloning hazelcast internal
+ * objects supplied to the user.
+ * It is important that the user follows the rules:
+ * <ul>
+ * <li>the object must not have any state which is changed by cloning the object</li>
+ * <li>the existing state must not be changed</li>
+ * </ul>
+ * If an object implements this interface but does not follow these rules,
+ * the results of the execution are undefined.
  */
+@Beta
 public interface Immutable {
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -44,10 +44,10 @@ public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Object>
 
     @Override
     void writeElement(ObjectDataOutput out, Entry<Data, Object> entry) throws IOException {
-        out.writeData((Data)entry.getKey());
+        out.writeData(entry.getKey());
         Object value = entry.getValue();
         if (value instanceof Data) {
-            out.writeData((Data)value);
+            out.writeData((Data) value);
         } else {
             out.writeObject(value);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.iterator;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -45,18 +46,13 @@ public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Object>
     @Override
     void writeElement(ObjectDataOutput out, Entry<Data, Object> entry) throws IOException {
         out.writeData(entry.getKey());
-        Object value = entry.getValue();
-        if (value instanceof Data) {
-            out.writeData((Data) value);
-        } else {
-            out.writeObject(value);
-        }
+        IOUtil.writeObject(out, entry.getValue());
     }
 
     @Override
     Entry<Data, Object> readElement(ObjectDataInput in) throws IOException {
         final Data key = in.readData();
-        final Data value = in.readData();
+        final Object value = IOUtil.readObject(in);
         return new AbstractMap.SimpleEntry<Data, Object>(key, value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -33,26 +33,31 @@ import java.util.Map.Entry;
  *
  * @see com.hazelcast.map.impl.proxy.MapProxyImpl#iterator
  */
-public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Data>> {
+public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Object>> {
 
     public MapEntriesWithCursor() {
     }
 
-    public MapEntriesWithCursor(List<Map.Entry<Data, Data>> entries, int nextTableIndexToReadFrom) {
+    public MapEntriesWithCursor(List<Map.Entry<Data, Object>> entries, int nextTableIndexToReadFrom) {
         super(entries, nextTableIndexToReadFrom);
     }
 
     @Override
-    void writeElement(ObjectDataOutput out, Entry<Data, Data> entry) throws IOException {
-        out.writeData(entry.getKey());
-        out.writeData(entry.getValue());
+    void writeElement(ObjectDataOutput out, Entry<Data, Object> entry) throws IOException {
+        out.writeData((Data)entry.getKey());
+        Object value = entry.getValue();
+        if (value instanceof Data) {
+            out.writeData((Data)value);
+        } else {
+            out.writeObject(value);
+        }
     }
 
     @Override
-    Entry<Data, Data> readElement(ObjectDataInput in) throws IOException {
+    Entry<Data, Object> readElement(ObjectDataInput in) throws IOException {
         final Data key = in.readData();
         final Data value = in.readData();
-        return new AbstractMap.SimpleEntry<Data, Data>(key, value);
+        return new AbstractMap.SimpleEntry<Data, Object>(key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -25,20 +25,20 @@ import com.hazelcast.spi.WaitNotifyKey;
 
 public final class GetOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
 
-    private Data result;
+    private Object result;
 
     public GetOperation() {
     }
 
     public GetOperation(String name, Data dataKey) {
         super(name, dataKey);
-
         this.dataKey = dataKey;
     }
 
     @Override
     public void run() {
-        result = mapServiceContext.toData(recordStore.get(dataKey, false, getCallerAddress()));
+        Object value = this.recordStore.get(this.dataKey, false, getCallerAddress());
+        this.result = (value instanceof com.hazelcast.map.Immutable) ? value : this.mapServiceContext.toData(value);
     }
 
     @Override
@@ -65,7 +65,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
     }
 
     @Override
-    public Data getResponse() {
+    public Object getResponse() {
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -33,13 +33,16 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
 
     public GetOperation(String name, Data dataKey) {
         super(name, dataKey);
+
         this.dataKey = dataKey;
     }
 
     @Override
     public void run() {
-        Object value = this.recordStore.get(this.dataKey, false, getCallerAddress());
-        this.result = (value instanceof Immutable) ? value : mapServiceContext.toData(value);
+        Object currentValue = recordStore.get(dataKey, false, getCallerAddress());
+        result = (currentValue instanceof Immutable)
+                ? currentValue
+                : mapServiceContext.toData(currentValue);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.map.Immutable;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
@@ -38,7 +39,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
     @Override
     public void run() {
         Object value = this.recordStore.get(this.dataKey, false, getCallerAddress());
-        this.result = (value instanceof com.hazelcast.map.Immutable) ? value : this.mapServiceContext.toData(value);
+        this.result = (value instanceof Immutable) ? value : mapServiceContext.toData(value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
@@ -142,11 +142,11 @@ public class PartitionScanRunner {
         while (resultList.size() < fetchSize && lastIndex >= 0) {
             final MapEntriesWithCursor cursor = recordStore.fetchEntries(lastIndex, fetchSize - resultList.size());
             lastIndex = cursor.getNextTableIndexToReadFrom();
-            final Collection<? extends Entry<Data, Data>> entries = cursor.getBatch();
+            final Collection<? extends Entry<Data, Object>> entries = cursor.getBatch();
             if (entries.isEmpty()) {
                 break;
             }
-            for (Entry<Data, Data> entry : entries) {
+            for (Entry<Data, Object> entry : entries) {
                 QueryableEntry queryEntry = new LazyMapEntry(entry.getKey(), entry.getValue(), serializationService, extractors);
                 if (predicate.apply(queryEntry)) {
                     resultList.add(queryEntry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.Immutable;
 import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
@@ -172,12 +173,10 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
         int newTableIndex = records.fetchEntries(tableIndex, size, entries);
         List<Map.Entry<Data, Object>> entriesData = new ArrayList<Map.Entry<Data, Object>>(entries.size());
         for (Map.Entry<Data, R> entry : entries) {
-            R record = (R)(Record)entry.getValue();
+            R record = entry.getValue();
             Object value = record.getValue();
-            Object dataValue = (value instanceof com.hazelcast.map.Immutable) ?
-                    value :
-                    serializationService.toData(value);
-            entriesData.add(new AbstractMap.SimpleEntry((Data)entry.getKey(), dataValue));
+            Object resultValue = (value instanceof Immutable) ? value : serializationService.toData(value);
+            entriesData.add(new AbstractMap.SimpleEntry<Data, Object>(entry.getKey(), resultValue));
         }
         return new MapEntriesWithCursor(entriesData, newTableIndex);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -170,11 +170,14 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
     public MapEntriesWithCursor fetchEntries(int tableIndex, int size, SerializationService serializationService) {
         List<Map.Entry<Data, R>> entries = new ArrayList<Map.Entry<Data, R>>(size);
         int newTableIndex = records.fetchEntries(tableIndex, size, entries);
-        List<Map.Entry<Data, Data>> entriesData = new ArrayList<Map.Entry<Data, Data>>(entries.size());
+        List<Map.Entry<Data, Object>> entriesData = new ArrayList<Map.Entry<Data, Object>>(entries.size());
         for (Map.Entry<Data, R> entry : entries) {
-            R record = entry.getValue();
-            Data dataValue = serializationService.toData(record.getValue());
-            entriesData.add(new AbstractMap.SimpleEntry<Data, Data>(entry.getKey(), dataValue));
+            R record = (R)(Record)entry.getValue();
+            Object value = record.getValue();
+            Object dataValue = (value instanceof com.hazelcast.map.Immutable) ?
+                    value :
+                    serializationService.toData(value);
+            entriesData.add(new AbstractMap.SimpleEntry((Data)entry.getKey(), dataValue));
         }
         return new MapEntriesWithCursor(entriesData, newTableIndex);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.config.Config;
@@ -5,14 +21,11 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.PartitionService;
-import com.hazelcast.map.Immutable;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.Serializable;
 
 public class MapDisableCopyOnReadTest extends HazelcastTestSupport {
 
@@ -26,8 +39,8 @@ public class MapDisableCopyOnReadTest extends HazelcastTestSupport {
         Config config = new Config().addMapConfig(new MapConfig("myMap*").setInMemoryFormat(InMemoryFormat.OBJECT));
         instance = createHazelcastInstance(config);
         partitionService = instance.getPartitionService();
-        immutableMapProxy = (MapProxyImpl)instance.getMap("myMapImmutable");
-        mutableMapProxy = (MapProxyImpl)instance.getMap("myMapMutable");
+        immutableMapProxy = (MapProxyImpl) instance.getMap("myMapImmutable");
+        mutableMapProxy = (MapProxyImpl) instance.getMap("myMapMutable");
     }
 
     @Test
@@ -72,30 +85,15 @@ public class MapDisableCopyOnReadTest extends HazelcastTestSupport {
         Assert.assertFalse(result1 == result2);
     }
 
-}
+    @Test
+    public void testClassCastException() {
+        String key = "testCorKey";
+        TestEntityImmutable tc = new TestEntityImmutable("hello");
+        immutableMapProxy.put(key, tc);
+        int partitionId = partitionService.getPartition(key).getPartitionId();
 
-class TestEntityImmutable implements Immutable, Serializable {
-    private static final long serialVersionUID = 1L;
-    private String test;
-
-    public TestEntityImmutable(String test) {
-        this.test = test;
-    }
-
-    public String getTest() {
-        return test;
-    }
-}
-
-class TestEntity implements Serializable {
-    private static final long serialVersionUID = 1L;
-    private String test;
-
-    public TestEntity(String test) {
-        this.test = test;
-    }
-
-    public String getTest() {
-        return test;
+        TestEntityImmutable result1 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        TestEntityImmutable result2 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        Assert.assertTrue(result1 == result2);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
@@ -1,0 +1,101 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.PartitionService;
+import com.hazelcast.map.Immutable;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+public class MapDisableCopyOnReadTest extends HazelcastTestSupport {
+
+    private MapProxyImpl<String, TestEntityImmutable> immutableMapProxy;
+    private MapProxyImpl<String, TestEntity> mutableMapProxy;
+    private PartitionService partitionService;
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        Config config = new Config().addMapConfig(new MapConfig("myMap*").setInMemoryFormat(InMemoryFormat.OBJECT));
+        instance = createHazelcastInstance(config);
+        partitionService = instance.getPartitionService();
+        immutableMapProxy = (MapProxyImpl)instance.getMap("myMapImmutable");
+        mutableMapProxy = (MapProxyImpl)instance.getMap("myMapMutable");
+    }
+
+    @Test
+    public void testGetImmutable() {
+        TestEntityImmutable tc = new TestEntityImmutable("hello");
+        immutableMapProxy.put("testCor", tc);
+        TestEntityImmutable result1 = immutableMapProxy.get("testCor");
+        TestEntityImmutable result2 = immutableMapProxy.get("testCor");
+        Assert.assertTrue(result1 == result2);
+    }
+
+    @Test
+    public void testGetMutable() {
+        TestEntity tc = new TestEntity("hello");
+        mutableMapProxy.put("testCor", tc);
+        TestEntity result1 = mutableMapProxy.get("testCor");
+        TestEntity result2 = mutableMapProxy.get("testCor");
+        Assert.assertFalse(result1 == result2);
+    }
+
+    @Test
+    public void testMapIteratorImmutable() {
+        String key = "testCorKey";
+        TestEntityImmutable tc = new TestEntityImmutable("hello");
+        immutableMapProxy.put(key, tc);
+        int partitionId = partitionService.getPartition(key).getPartitionId();
+
+        TestEntityImmutable result1 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        TestEntityImmutable result2 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        Assert.assertTrue(result1 == result2);
+    }
+
+    @Test
+    public void testMapIteratorForMutable() {
+        String key = "testCorKey";
+        TestEntity tc = new TestEntity("hello");
+        mutableMapProxy.put(key, tc);
+        int partitionId = partitionService.getPartition(key).getPartitionId();
+
+        TestEntity result1 =  mutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        TestEntity result2 =  mutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        Assert.assertFalse(result1 == result2);
+    }
+
+}
+
+class TestEntityImmutable implements Immutable, Serializable {
+    private static final long serialVersionUID = 1L;
+    private String test;
+
+    public TestEntityImmutable(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
+}
+
+class TestEntity implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private String test;
+
+    public TestEntity(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntity.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntity.java
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map;
+package com.hazelcast.map.impl.query;
 
-/**
- * This is just a marker interface for Adobe Entities so that we can disable Copy on Read for this type
- */
-public interface Immutable {
+import java.io.Serializable;
+
+class TestEntity implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private String test;
+
+    public TestEntity(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntityImmutable.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntityImmutable.java
@@ -14,10 +14,21 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map;
+package com.hazelcast.map.impl.query;
 
-/**
- * This is just a marker interface for Adobe Entities so that we can disable Copy on Read for this type
- */
-public interface Immutable {
+import com.hazelcast.map.Immutable;
+
+import java.io.Serializable;
+
+class TestEntityImmutable implements Immutable, Serializable {
+    private static final long serialVersionUID = 1L;
+    private String test;
+
+    public TestEntityImmutable(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
 }


### PR DESCRIPTION
This PR is introducing a marker interface as a "hint" when reading data that defensive copying can be avoided. Here disable copy on read for selected entities while read from IMap. This only covers the changes needed for a single use case and is not a general purpose fix.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3559