### PR TITLE
Partially reverts commit 088f3680

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractCollectionStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractCollectionStreamSerializer.java
@@ -45,4 +45,9 @@ abstract class AbstractCollectionStreamSerializer<CollectionType extends Collect
         }
         return collection;
     }
+
+    @Override
+    public void destroy() {
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractMapStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractMapStreamSerializer.java
@@ -47,4 +47,9 @@ abstract class AbstractMapStreamSerializer<MapType extends Map> implements Strea
         }
         return result;
     }
+
+    @Override
+    public void destroy() {
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayStreamSerializer.java
@@ -45,6 +45,10 @@ public class ArrayStreamSerializer implements StreamSerializer<Object[]> {
     }
 
     @Override
+    public void destroy() {
+    }
+
+    @Override
     public int getTypeId() {
         return SerializationConstants.JAVA_DEFAULT_TYPE_ARRAY;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
@@ -245,6 +245,10 @@ public final class ConstantSerializers {
         public byte[] read(byte[] buffer) throws IOException {
             return buffer;
         }
+
+        @Override
+        public void destroy() {
+        }
     }
 
     public static final class BooleanArraySerializer extends SingletonSerializer<boolean[]> {
@@ -449,6 +453,10 @@ public final class ConstantSerializers {
     }
 
     private abstract static class SingletonSerializer<T> implements StreamSerializer<T> {
+
+        @Override
+        public void destroy() {
+        }
     }
 
     private ConstantSerializers() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -316,6 +316,10 @@ public final class JavaDefaultSerializers {
     }
 
     private abstract static class SingletonSerializer<T> implements StreamSerializer<T> {
+
+        @Override
+        public void destroy() {
+        }
     }
 
     private JavaDefaultSerializers() {


### PR DESCRIPTION
Reasoning: removing the `destroy()` method implementation
from `Serializer`s breaks shutdown of proxied Hazelcast
instances (required for compatibility tests). With this PR
we keep the default `destroy` method in 4.1 codebase's
`Serializer` interface. Empty implementations can be
safely removed during 4.2 development cycle.

Fixes #16751 