### PR TITLE
Remove dependency to InternalSerializationService from StreamSerializerAdapter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -97,7 +97,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         this.outputBufferSize = builder.initialOutputBufferSize;
         this.bufferPoolThreadLocal = new BufferPoolThreadLocal(this, builder.bufferPoolFactory,
                 builder.notActiveExceptionSupplier);
-        this.nullSerializerAdapter = createSerializerAdapter(new ConstantSerializers.NullSerializer(), this);
+        this.nullSerializerAdapter = createSerializerAdapter(new ConstantSerializers.NullSerializer());
     }
 
     protected AbstractSerializationService(AbstractSerializationService prototype) {
@@ -378,7 +378,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             throw new IllegalArgumentException(
                     "Type ID must be positive. Current: " + serializer.getTypeId() + ", Serializer: " + serializer);
         }
-        safeRegister(type, createSerializerAdapter(serializer, this));
+        safeRegister(type, createSerializerAdapter(serializer));
     }
 
     public final void registerGlobal(final Serializer serializer) {
@@ -386,7 +386,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     public final void registerGlobal(final Serializer serializer, boolean overrideJavaSerialization) {
-        SerializerAdapter adapter = createSerializerAdapter(serializer, this);
+        SerializerAdapter adapter = createSerializerAdapter(serializer);
         if (!global.compareAndSet(null, adapter)) {
             throw new IllegalStateException("Global serializer is already registered");
         }
@@ -414,7 +414,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     protected final boolean safeRegister(final Class type, final Serializer serializer) {
-        return safeRegister(type, createSerializerAdapter(serializer, this));
+        return safeRegister(type, createSerializerAdapter(serializer));
     }
 
     protected final boolean safeRegister(final Class type, final SerializerAdapter serializer) {
@@ -435,7 +435,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     protected final void registerConstant(Class type, Serializer serializer) {
-        registerConstant(type, createSerializerAdapter(serializer, this));
+        registerConstant(type, createSerializerAdapter(serializer));
     }
 
     protected final void registerConstant(Class type, SerializerAdapter serializer) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -117,14 +117,14 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         }
 
         dataSerializerAdapter = createSerializerAdapter(
-                new DataSerializableSerializer(builder.dataSerializableFactories, builder.getClassLoader()), this);
+                new DataSerializableSerializer(builder.dataSerializableFactories, builder.getClassLoader()));
         portableSerializer = new PortableSerializer(portableContext, loader.getFactories());
-        portableSerializerAdapter = createSerializerAdapter(portableSerializer, this);
+        portableSerializerAdapter = createSerializerAdapter(portableSerializer);
 
         javaSerializerAdapter = createSerializerAdapter(
-                new JavaSerializer(builder.enableSharedObject, builder.enableCompression, builder.classNameFilter), this);
+                new JavaSerializer(builder.enableSharedObject, builder.enableCompression, builder.classNameFilter));
         javaExternalizableAdapter = createSerializerAdapter(
-                new JavaDefaultSerializers.ExternalizableSerializer(builder.enableCompression, builder.classNameFilter), this);
+                new JavaDefaultSerializers.ExternalizableSerializer(builder.enableCompression, builder.classNameFilter));
         registerConstantSerializers();
         registerJavaTypeSerializers();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -115,11 +115,10 @@ public final class SerializationUtil {
         throw new HazelcastSerializationException("Failed to serialize '" + clazz + '\'', e);
     }
 
-    public static SerializerAdapter createSerializerAdapter(Serializer serializer,
-                                                            InternalSerializationService serializationService) {
+    public static SerializerAdapter createSerializerAdapter(Serializer serializer) {
         final SerializerAdapter s;
         if (serializer instanceof StreamSerializer) {
-            s = new StreamSerializerAdapter(serializationService, (StreamSerializer) serializer);
+            s = new StreamSerializerAdapter((StreamSerializer) serializer);
         } else if (serializer instanceof ByteArraySerializer) {
             s = new ByteArraySerializerAdapter((ByteArraySerializer) serializer);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -28,11 +27,9 @@ import java.io.IOException;
 
 class StreamSerializerAdapter implements SerializerAdapter {
 
-    protected final InternalSerializationService service;
     protected final StreamSerializer serializer;
 
-    StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
-        this.service = service;
+    StreamSerializerAdapter(StreamSerializer serializer) {
         this.serializer = serializer;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
@@ -51,7 +51,7 @@ public class SerializationUtilTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testCreateSerializerAdapter_invalidSerializer() {
-        SerializationUtil.createSerializerAdapter(new InvalidSerializer(), null);
+        SerializationUtil.createSerializerAdapter(new InvalidSerializer());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapterTest.java
@@ -48,7 +48,7 @@ public class StreamSerializerAdapterTest {
     public void setUp() {
         mockSerializationService = mock(InternalSerializationService.class);
         serializer = new ConstantSerializers.IntegerArraySerializer();
-        adapter = new StreamSerializerAdapter(mockSerializationService, serializer);
+        adapter = new StreamSerializerAdapter(serializer);
     }
 
     @After
@@ -72,9 +72,9 @@ public class StreamSerializerAdapterTest {
     }
 
     @Test
-    public void testAdaptorEqualAndHashCode() throws Exception {
-        StreamSerializerAdapter theOther = new StreamSerializerAdapter(mockSerializationService, serializer);
-        StreamSerializerAdapter theEmptyOne = new StreamSerializerAdapter(mockSerializationService, null);
+    public void testAdaptorEqualAndHashCode() {
+        StreamSerializerAdapter theOther = new StreamSerializerAdapter(serializer);
+        StreamSerializerAdapter theEmptyOne = new StreamSerializerAdapter(null);
 
         assertEquals(adapter, adapter);
         assertEquals(adapter, theOther);
@@ -88,7 +88,7 @@ public class StreamSerializerAdapterTest {
     }
 
     @Test
-    public void testString() throws Exception {
+    public void testString() {
         assertNotNull(adapter.toString());
     }
 }


### PR DESCRIPTION
Removed dependency to `InternalSerializationService` from `StreamSerializerAdapter` - it was unused.

Backport of https://github.com/hazelcast/hazelcast/pull/16740