### PR TITLE
Promote IMap.putAllAsync and IMap.submitToKeys to public API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -1549,9 +1549,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         }
     }
 
-    /**
-     * Async version of {@link #executeOnKeys}.
-     */
+    @Override
     public <R> InternalCompletableFuture<Map<K, R>> submitToKeys(@Nonnull Set<K> keys,
                                                                  @Nonnull EntryProcessor<K, V, R> entryProcessor) {
         checkNotNull(keys, NULL_KEY_IS_NOT_ALLOWED);
@@ -1603,7 +1601,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         putAllInternal(m, null);
     }
 
-    // used by Jet
+    @Override
     public InternalCompletableFuture<Void> putAllAsync(@Nonnull Map<? extends K, ? extends V> m) {
         InternalCompletableFuture<Void> future = new InternalCompletableFuture<>();
         putAllInternal(m, future);

--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -864,6 +864,58 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
                                 long maxIdle, @Nonnull TimeUnit maxIdleUnit);
 
     /**
+     * Asynchronously copies all of the mappings from the specified map to this map.
+     * This version doesn't support batching. Don't mutate the given map until the future completes.
+     * <pre>{@code
+     *     CompletionStage<Void> future = map.putAllAsync(map);
+     *     // do some other stuff, when ready wait for completion
+     *     future.toCompletableFuture.get();
+     * }</pre>
+     * {@code CompletionStage.toCompletableFuture.get()} will block until the actual map.putAll(map) operation completes
+     * You can also register further computation stages to be invoked upon
+     * completion of the {@code CompletionStage} via any of {@link CompletionStage}
+     * methods:
+     * <pre>{@code
+     *      CompletionStage<Void> future = map.putAllAsync(map);
+     *      future.thenRunAsync(() -> System.out.println("All the entries are added"));
+     * }</pre>
+     *  {@inheritDoc}
+     * <p>
+     * No atomicity guarantees are given. It could be that in case of failure
+     * some of the key/value-pairs get written, while others are not.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * For each element not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map, which may come at a significant
+     * performance cost. Exceptions thrown by load fail the operation
+     * and are propagated to the caller. The elements which were added
+     * before the exception was thrown will remain in the map, the rest
+     * will not be added.
+     * <p>
+     * If write-through persistence mode is configured,
+     * {@link MapStore#store(Object, Object)} is invoked for each element
+     * before the element is added in memory, which may come at a
+     * significant performance cost. Exceptions thrown by store fail the
+     * operation and are propagated to the caller. The elements which
+     * were added before the exception was thrown will remain in the map,
+     * the rest will not be added.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     * @param map mappings to be stored in this map
+     * @return CompletionStage on which client code can block waiting for the
+     * operation to complete or register callbacks to be invoked
+     * upon putAll operation completion
+     * @see CompletionStage
+     */
+    CompletionStage<Void> putAllAsync(@Nonnull Map<? extends K, ? extends V> map);
+
+    /**
      * Asynchronously puts the given key and value.
      * The entry lives forever.
      * Similar to the put operation except that set
@@ -2553,6 +2605,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      */
     <R> Map<K, R> executeOnKeys(@Nonnull Set<K> keys,
                                 @Nonnull EntryProcessor<K, V, R> entryProcessor);
+
+    /**
+     * Async version of {@link #executeOnKeys}.
+     * @param keys the keys to execute the entry processor on. Can be empty, in
+     *             that case it's a local no-op
+     * @param entryProcessor the processor to process the keys
+     * @param <R> return type for entry processor
+     * @return CompletionStage on which client code can block waiting for the
+     * operation to complete or register callbacks to be invoked
+     * upon set operation completion
+     * @see CompletionStage
+     */
+    <R> CompletionStage<Map<K, R>> submitToKeys(@Nonnull Set<K> keys,
+                               @Nonnull EntryProcessor<K, V, R> entryProcessor);
 
     /**
      * Applies the user defined {@code EntryProcessor} to the entry mapped by the {@code key}.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -451,11 +451,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         putAllInternal(map, null);
     }
 
-    /**
-     * This version does not support batching. Don't mutate the given map until the
-     * future completes.
-     */
     // used by jet
+    @Override
     public InternalCompletableFuture<Void> putAllAsync(@Nonnull Map<? extends K, ? extends V> map) {
         checkNotNull(map, "Null argument map is not allowed");
         InternalCompletableFuture<Void> future = new InternalCompletableFuture<>();
@@ -730,9 +727,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         }
     }
 
-    /**
-     * Async version of {@link #executeOnKeys}.
-     */
+    @Override
     public <R> InternalCompletableFuture<Map<K, R>> submitToKeys(@Nonnull Set<K> keys,
                                                                  @Nonnull EntryProcessor<K, V, R> entryProcessor) {
         checkNotNull(keys, NULL_KEYS_ARE_NOT_ALLOWED);


### PR DESCRIPTION
Promoted `IMap.putAllAsync()` and `IMap.submitToKeys()` to public API.

Backport of https://github.com/hazelcast/hazelcast/pull/16704