### PR TITLE
Fix reliable topic and ring buffer client permissions

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -3088,6 +3088,9 @@
                         <xs:element name="user-code-deployment-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
                         <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="ring-buffer-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="reliable-topic-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
                     </xs:choice>
                     <xs:attribute name="on-join-operation" type="permission-on-join-operation" use="optional" default="RECEIVE"/>
                 </xs:complexType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -582,7 +582,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         final Set<PermissionConfig> clientPermissionConfigs = securityConfig.getClientPermissionConfigs();
         assertFalse(securityConfig.getClientBlockUnmappedActions());
         assertTrue(isNotEmpty(clientPermissionConfigs));
-        assertEquals(23, clientPermissionConfigs.size());
+        assertEquals(25, clientPermissionConfigs.size());
         final PermissionConfig pnCounterPermission = new PermissionConfig(PermissionType.PN_COUNTER, "pnCounterPermission", "*")
                 .addAction("create")
                 .setEndpoints(Collections.<String>emptySet());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -719,6 +719,16 @@
                             <hz:action>all</hz:action>
                         </hz:actions>
                     </hz:user-code-deployment-permission>
+                    <hz:ring-buffer-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:ring-buffer-permission>
+                    <hz:reliable-topic-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:reliable-topic-permission>
                 </hz:client-permissions>
                 <hz:client-block-unmapped-actions>false</hz:client-block-unmapped-actions>
             </hz:security>

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -2750,55 +2750,9 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         }
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
-            PermissionConfig.PermissionType type;
-            if ("map-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.MAP;
-            } else if ("queue-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.QUEUE;
-            } else if ("multimap-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.MULTIMAP;
-            } else if ("topic-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.TOPIC;
-            } else if ("list-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.LIST;
-            } else if ("set-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.SET;
-            } else if ("lock-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.LOCK;
-            } else if ("atomic-long-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ATOMIC_LONG;
-            } else if ("atomic-reference-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ATOMIC_REFERENCE;
-            } else if ("countdown-latch-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.COUNTDOWN_LATCH;
-            } else if ("semaphore-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.SEMAPHORE;
-            } else if ("id-generator-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ID_GENERATOR;
-            } else if ("flake-id-generator-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.FLAKE_ID_GENERATOR;
-            } else if ("executor-service-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.EXECUTOR_SERVICE;
-            } else if ("transaction-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.TRANSACTION;
-            } else if ("all-permissions".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ALL;
-            } else if ("durable-executor-service-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.DURABLE_EXECUTOR_SERVICE;
-            } else if ("cardinality-estimator-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.CARDINALITY_ESTIMATOR;
-            } else if ("scheduled-executor-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.SCHEDULED_EXECUTOR;
-            } else if ("pn-counter-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.PN_COUNTER;
-            } else if ("cache-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.CACHE;
-            } else if ("user-code-deployment-permission".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.USER_CODE_DEPLOYMENT;
-            } else if (PermissionConfig.PermissionType.CONFIG.getNodeName().equals(nodeName)) {
-                type = PermissionConfig.PermissionType.CONFIG;
-            } else {
-                continue;
+            PermissionConfig.PermissionType type = PermissionConfig.PermissionType.getType(nodeName);
+            if (type == null) {
+                throw new InvalidConfigurationException("Security permission type is not valid " + nodeName);
             }
             handleSecurityPermission(child, type);
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -58,6 +58,10 @@ public class PermissionConfig {
      */
     public enum PermissionType {
         /**
+         * All
+         */
+        ALL("all-permissions"),
+        /**
          * Map
          */
         MAP("map-permission"),
@@ -138,18 +142,21 @@ public class PermissionConfig {
          */
         USER_CODE_DEPLOYMENT("user-code-deployment-permission"),
         /**
-         * All
-         */
-        ALL("all-permissions"),
-        /**
          * Configuration permission
          */
         CONFIG("config-permission"),
         /**
          * CRDT PN Counter
          */
-        PN_COUNTER("pn-counter-permission");
-
+        PN_COUNTER("pn-counter-permission"),
+        /**
+         * RingBuffer
+         */
+        RING_BUFFER("ring-buffer-permission"),
+        /**
+         * ReliableTopic
+         */
+        RELIABLE_TOPIC("reliable-topic-permission");
         private final String nodeName;
 
         PermissionType(String nodeName) {

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -55,7 +55,6 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
         cfg.addSecurityInterceptorConfig(new SecurityInterceptorConfig(className));
     }
 
-    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:methodlength"})
     protected void handleSecurityPermissions(Node node) {
         String onJoinOp = getAttribute(node, "on-join-operation");
         if (onJoinOp != null) {
@@ -63,57 +62,16 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
                     .valueOf(upperCaseInternal(onJoinOp));
             config.getSecurityConfig().setOnJoinPermissionOperation(onJoinPermissionOperation);
         }
-        for (Node child : childElements(node)) {
+        Iterable<Node> nodes = childElements(node);
+        for (Node child : nodes) {
             String nodeName = cleanNodeName(child);
-            PermissionConfig.PermissionType type;
-            if ("map".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.MAP;
-            } else if ("queue".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.QUEUE;
-            } else if ("multimap".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.MULTIMAP;
-            } else if ("topic".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.TOPIC;
-            } else if ("list".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.LIST;
-            } else if ("set".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.SET;
-            } else if ("lock".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.LOCK;
-            } else if ("atomic-long".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ATOMIC_LONG;
-            } else if ("atomic-reference".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ATOMIC_REFERENCE;
-            } else if ("countdown-latch".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.COUNTDOWN_LATCH;
-            } else if ("semaphore".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.SEMAPHORE;
-            } else if ("id-generator".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ID_GENERATOR;
-            } else if ("flake-id-generator".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.FLAKE_ID_GENERATOR;
-            } else if ("executor-service".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.EXECUTOR_SERVICE;
-            } else if ("transaction".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.TRANSACTION;
-            } else if ("all".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.ALL;
-            } else if ("durable-executor-service".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.DURABLE_EXECUTOR_SERVICE;
-            } else if ("cardinality-estimator".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.CARDINALITY_ESTIMATOR;
-            } else if ("scheduled-executor".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.SCHEDULED_EXECUTOR;
-            } else if ("pn-counter".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.PN_COUNTER;
-            } else if ("cache".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.CACHE;
-            } else if ("user-code-deployment".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.USER_CODE_DEPLOYMENT;
-            } else if ("config".equals(nodeName)) {
-                type = PermissionConfig.PermissionType.CONFIG;
-            } else {
+            if ("on-join-operation".equals(nodeName)) {
                 continue;
+            }
+            nodeName = "all".equals(nodeName) ? nodeName + "-permissions" : nodeName + "-permission";
+            PermissionConfig.PermissionType type = PermissionConfig.PermissionType.getType(nodeName);
+            if (type == null) {
+                throw new InvalidConfigurationException("Security permission type is not valid " + nodeName);
             }
 
             if (PermissionConfig.PermissionType.CONFIG == type

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -43,6 +43,7 @@ import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.topic.impl.TopicService;
+import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 
 import java.security.Permission;
 import java.util.HashMap;
@@ -239,6 +240,12 @@ public final class ActionConstants {
                 return new PNCounterPermission(name, actions);
             }
         });
+        PERMISSION_FACTORY_MAP.put(ReliableTopicService.SERVICE_NAME, new PermissionFactory() {
+            @Override
+            public Permission create(String name, String... actions) {
+                return new ReliableTopicPermission(name, actions);
+            }
+        });
     }
 
     private ActionConstants() {
@@ -251,9 +258,9 @@ public final class ActionConstants {
     /**
      * Creates a permission
      *
-     * @param name
-     * @param serviceName
-     * @param actions
+     * @param name        the permission name
+     * @param serviceName the service name
+     * @param actions     the actions
      * @return the created Permission
      * @throws java.lang.IllegalArgumentException if there is no service found with the given serviceName.
      */

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReliableTopicPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReliableTopicPermission.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security.permission;
+
+public class ReliableTopicPermission extends InstancePermission {
+
+    private static final int PUBLISH = 4;
+    private static final int LISTEN = 8;
+    private static final int ALL = CREATE | DESTROY | LISTEN | PUBLISH;
+
+    public ReliableTopicPermission(String name, String... actions) {
+        super(name, actions);
+    }
+
+    @Override
+    protected int initMask(String[] actions) {
+        int mask = NONE;
+        for (String action : actions) {
+            if (ActionConstants.ACTION_ALL.equals(action)) {
+                return ALL;
+            }
+
+            if (ActionConstants.ACTION_CREATE.equals(action)) {
+                mask |= CREATE;
+            } else if (ActionConstants.ACTION_PUBLISH.equals(action)) {
+                mask |= PUBLISH;
+            } else if (ActionConstants.ACTION_DESTROY.equals(action)) {
+                mask |= DESTROY;
+            } else if (ActionConstants.ACTION_LISTEN.equals(action)) {
+                mask |= LISTEN;
+            }
+        }
+        return mask;
+    }
+}

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2872,6 +2872,8 @@
             <xs:element name="cache-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="user-code-deployment-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="reliable-topic-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="ring-buffer-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
         <xs:attribute name="on-join-operation" type="permission-on-join-operation" use="optional" default="RECEIVE"/>
     </xs:complexType>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -761,6 +761,16 @@
                     <action>all</action>
                 </actions>
             </pn-counter-permission>
+            <ring-buffer-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </ring-buffer-permission>
+            <reliable-topic-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </reliable-topic-permission>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
     </security>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -136,12 +136,10 @@ hazelcast:
     enabled: true
     group-type: CUSTOM
     member-group:
-      -
-        - 10.10.0.*
+      - - 10.10.0.*
         - 10.10.3.*
         - 10.10.5.*
-      -
-        - 10.10.10.10-100
+      - - 10.10.10.10-100
         - 10.10.1.*
         - 10.10.2.*
 
@@ -185,7 +183,7 @@ hazelcast:
         # all put/offer operations will get blocked until the queue size
         # of the JVM goes down below the maximum.
         # Any integer between 0 and Integer.MAX_VALUE. 0 means
-        # Integer.MAX_VALUE. Default is 0.
+      # Integer.MAX_VALUE. Default is 0.
       max-size: 10
 
       backup-count: 2
@@ -193,14 +191,14 @@ hazelcast:
       empty-queue-ttl: 12
 
       item-listeners:
-         - include-value: true
-           class-name: com.hazelcast.examples.ItemListener
+        - include-value: true
+          class-name: com.hazelcast.examples.ItemListener
       queue-store:
-         enabled: true
-         # class-name: DummyClass
-         factory-class-name: DummyFactoryClass
-         properties:
-           foo: bar
+        enabled: true
+        # class-name: DummyClass
+        factory-class-name: DummyFactoryClass
+        properties:
+          foo: bar
 
       quorum-ref: quorumRuleWithThreeMembers
       merge-policy:
@@ -580,11 +578,11 @@ hazelcast:
       - factory-id: 1
         class-name: com.hazelcast.examples.PortableFactory
     global-serializer:
-       override-java-serialization: true
-       class-name: com.hazelcast.examples.GlobalSerializerFactory
+      override-java-serialization: true
+      class-name: com.hazelcast.examples.GlobalSerializerFactory
     serializers:
-       - type-class: com.hazelcast.examples.DummyType
-         class-name: com.hazelcast.examples.SerializerFactory
+      - type-class: com.hazelcast.examples.DummyType
+        class-name: com.hazelcast.examples.SerializerFactory
     check-class-def-errors: false
     java-serialization-filter:
       defaults-disabled: true
@@ -756,6 +754,16 @@ hazelcast:
           actions:
             - all
       executor-service:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      ring-buffer:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      reliable-topic:
         - name: "*"
           principal: "*"
           actions:


### PR DESCRIPTION
Missing ring buffer and reliable topic permission tests are
added.

In this pr, we add a ring buffer config per reliable topic config
into the permissions list as fix.

fixes https://github.com/hazelcast/hazelcast/issues/16703

(cherry picked from commit 454ba85f2249cc419fd41a490f50a606090db180)
(cherry picked from commit 400824771f6725b6222cd4a9a0bbd9f91e74bd42)