### PR TITLE
Reverts commit 088f3680 (part 2)

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializer.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializer.java
@@ -37,4 +37,8 @@ public class DummySerializer implements StreamSerializer<DummySerializableObject
     public int getTypeId() {
         return 123;
     }
+
+    @Override
+    public void destroy() {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
@@ -152,6 +152,10 @@ public abstract class CardinalityEstimatorAbstractTest extends HazelcastTestSupp
         }
 
         @Override
+        public void destroy() {
+        }
+
+        @Override
         public void write(ObjectDataOutput out, CustomObject object) throws IOException {
             out.writeLong((object.x << Bits.INT_SIZE_IN_BYTES) | object.y);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorTest.java
@@ -167,6 +167,10 @@ public class ClientCardinalityEstimatorTest extends HazelcastTestSupport {
         }
 
         @Override
+        public void destroy() {
+        }
+
+        @Override
         public void write(ObjectDataOutput out, CustomObject object) throws IOException {
             out.writeLong((object.x << Bits.INT_SIZE_IN_BYTES) | object.y);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -405,6 +405,11 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         public int getTypeId() {
             return 0;
         }
+
+        @Override
+        public void destroy() {
+
+        }
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/test/BaseCustomSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/BaseCustomSerializer.java
@@ -43,4 +43,9 @@ public class BaseCustomSerializer implements StreamSerializer<BaseCustom> {
     public int getTypeId() {
         return 3;
     }
+
+    @Override
+    public void destroy() {
+
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/Derived1CustomSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/Derived1CustomSerializer.java
@@ -43,4 +43,9 @@ public class Derived1CustomSerializer implements StreamSerializer<Derived1Custom
     public int getTypeId() {
         return 4;
     }
+
+    @Override
+    public void destroy() {
+
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/Derived2CustomSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/Derived2CustomSerializer.java
@@ -43,4 +43,9 @@ public class Derived2CustomSerializer implements StreamSerializer<Derived2Custom
     public int getTypeId() {
         return 5;
     }
+
+    @Override
+    public void destroy() {
+
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/PersonSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/PersonSerializer.java
@@ -53,4 +53,9 @@ public class PersonSerializer implements StreamSerializer<Person> {
     public int getTypeId() {
         return 999;
     }
+
+    @Override
+    public void destroy() {
+
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -708,6 +708,9 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         public int getTypeId() {
             return 0;
         }
+
+        @Override
+        public void destroy() { }
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -429,6 +429,10 @@ public class AbstractSerializationServiceTest {
         }
 
         @Override
+        public void destroy() {
+        }
+
+        @Override
         public void write(ObjectDataOutput out, StringBuffer stringBuffer) throws IOException {
             if (fail) {
                 throw new RuntimeException();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
@@ -65,6 +65,10 @@ public class SerializationUtilTest {
         public int getTypeId() {
             return 0;
         }
+
+        @Override
+        public void destroy() {
+        }
     }
 
     private class DummyVersionedPortable implements VersionedPortable {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
@@ -55,6 +55,11 @@ public class TestSerializerHook implements SerializerHook {
         }
 
         @Override
+        public void destroy() {
+
+        }
+
+        @Override
         public void write(ObjectDataOutput out, SampleIdentifiedDataSerializable object) throws IOException {
 
         }
@@ -83,6 +88,11 @@ public class TestSerializerHook implements SerializerHook {
         @Override
         public int getTypeId() {
             return 1001;
+        }
+
+        @Override
+        public void destroy() {
+
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
@@ -208,6 +208,9 @@ public class IssuesTest extends HazelcastTestSupport {
                     public int getTypeId() {
                         return 123;
                     }
+
+                    public void destroy() {
+                    }
                 }));
 
         HazelcastInstance hz = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
@@ -202,5 +202,9 @@ public class CustomSerializationTest {
             XMLDecoder decoder = new XMLDecoder(inputStream);
             return (Foo) decoder.readObject();
         }
+
+        @Override
+        public void destroy() {
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -115,6 +115,9 @@ public class SerializationTest extends HazelcastTestSupport {
                     public int getTypeId() {
                         return 123;
                     }
+
+                    public void destroy() {
+                    }
                 }));
 
         SerializationService ss1 = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
@@ -156,6 +159,9 @@ public class SerializationTest extends HazelcastTestSupport {
 
                     public int getTypeId() {
                         return 123;
+                    }
+
+                    public void destroy() {
                     }
                 }));
 
@@ -230,6 +236,10 @@ public class SerializationTest extends HazelcastTestSupport {
                             @Override
                             public int getTypeId() {
                                 return 123;
+                            }
+
+                            @Override
+                            public void destroy() {
                             }
                         }));
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializer.java
@@ -41,4 +41,8 @@ public class CustomByteArraySerializer implements ByteArraySerializer<CustomByte
         ByteBuffer wrap = ByteBuffer.wrap(buffer);
         return new CustomByteArraySerializable(wrap.getInt(), wrap.getFloat());
     }
+
+    @Override
+    public void destroy() {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializer.java
@@ -39,4 +39,8 @@ public class CustomStreamSerializer implements StreamSerializer<CustomStreamSeri
     public int getTypeId() {
         return ReferenceObjects.CUSTOM_STREAM_SERIALIZABLE_ID;
     }
+
+    @Override
+    public void destroy() {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -104,6 +104,10 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
         public int getTypeId() {
             return 8778;
         }
+
+        @Override
+        public void destroy() {
+        }
     }
 
     class PutOperationWithNoReplication extends PutOperation {


### PR DESCRIPTION
Restores `destroy` method implementations in test
`Serializer` classes. Follow up to #16752 which restored
`destroy` only in production classes.

Test classes are also loaded by proxied `HazelcastInstance`s, resulting
in abstract method errors when invoking 4.0 via 4.1 interfaces.
`HazelcastProxyFactoryTest` does not run in the PR builder,
execute locally after building this branch with:

```
mvn -Pnightly-build -Dtest=HazelcastProxyFactoryTest -pl :hazelcast test
```

Fixes #16751 