### PR TITLE
Do attribute canonicalization in QueryContext.getIndex

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -31,10 +31,11 @@ public interface Index {
 
     /**
      * @return the canonical name of this index: for single-attribute
-     * non-composite indexes, it's the attribute name itself stripping an
-     * unnecessary "this." qualifier, if any; for composite indexes, it's a
-     * comma-separated list of index components with a single space character
-     * going after every comma, any unnecessary "this." qualifiers are stripped.
+     * non-composite indexes, it's an attribute name itself stripping an
+     * unnecessary "this." qualifier and replacing "#" qualifier with ".",
+     * if any; for composite indexes, it's a comma-separated list of
+     * canonicalized index component attribute names with a single space
+     * character going after every comma.
      * @see PredicateUtils#canonicalizeAttribute
      * @see PredicateUtils#constructCanonicalCompositeIndexName
      */

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.query.impl.predicates.PredicateUtils;
+
+import static com.hazelcast.query.impl.predicates.PredicateUtils.canonicalizeAttribute;
+
 /**
  * Provides the context for queries execution.
  */
@@ -84,14 +88,17 @@ public class QueryContext {
      * for the given attribute.
      */
     public Index getIndex(String attribute) {
-        return matchIndex(attribute, IndexMatchHint.NONE);
+        return matchIndex(canonicalizeAttribute(attribute), IndexMatchHint.NONE);
     }
 
     /**
      * Matches an index for the given pattern and match hint.
      *
      * @param pattern   the pattern to match an index for. May be either an
-     *                  attribute name or an exact index name.
+     *                  attribute name or an exact index name. It's a caller's
+     *                  responsibility to canonicalize the passed pattern as
+     *                  specified by {@link PredicateUtils#canonicalizeAttribute}
+     *                  and {@link Index#getName}.
      * @param matchHint the match hint.
      * @return the matched index or {@code null} if nothing matched.
      * @see QueryContext.IndexMatchHint

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
@@ -57,6 +57,7 @@ public class AttributeCanonicalizationTest {
         assertEquals("foo.bar", canonicalizeAttribute("foo.bar"));
         assertEquals("__key", canonicalizeAttribute("__key"));
         assertEquals("__key.foo", canonicalizeAttribute("__key.foo"));
+        assertEquals("__key.foo", canonicalizeAttribute("__key#foo"));
     }
 
     @Test
@@ -69,6 +70,7 @@ public class AttributeCanonicalizationTest {
         assertEquals("foo.bar", new TestPredicate("foo.bar").attributeName);
         assertEquals("__key", new TestPredicate("__key").attributeName);
         assertEquals("__key.foo", new TestPredicate("__key.foo").attributeName);
+        assertEquals("__key.foo", new TestPredicate("__key#foo").attributeName);
     }
 
     @Test
@@ -83,6 +85,7 @@ public class AttributeCanonicalizationTest {
         checkIndex(indexes, "foo.bar", "foo.bar");
         checkIndex(indexes, "__key", "__key");
         checkIndex(indexes, "__key.foo", "__key.foo");
+        checkIndex(indexes, "__key.foo", "__key#foo");
     }
 
     @Test
@@ -97,6 +100,7 @@ public class AttributeCanonicalizationTest {
         checkIndex(indexes, "foo, bar.baz", "this.foo, this.bar.baz");
         checkIndex(indexes, "foo.bar, baz", "foo.bar, baz");
         checkIndex(indexes, "foo, bar, __key.baz", "foo, this.bar, __key.baz");
+        checkIndex(indexes, "foo, bar, __key.baz", "foo, this.bar, __key#baz");
     }
 
     private static void checkIndex(Indexes indexes, String expected, String name) {


### PR DESCRIPTION
Makes `__key.attr` and `__key#attr` equal for `QueryContext.getIndex`.

Related to:
https://github.com/hazelcast/hazelcast/pull/15836
https://github.com/hazelcast/hazelcast/pull/15817