### PR TITLE
fix: measure ReplicatedMap operations latency in nanoseconds and report in milliseconds

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -59,7 +59,7 @@ public class ReplicatedMapGetMessageTask
         ReplicatedMapService replicatedMapService = getService(ReplicatedMapService.SERVICE_NAME);
         if (replicatedMapService.getReplicatedMapConfig(parameters.name).isStatisticsEnabled()) {
             LocalReplicatedMapStatsImpl stats = replicatedMapService.getLocalReplicatedMapStatsImpl(parameters.name);
-            stats.incrementGets(System.nanoTime() - startTimeNanos);
+            stats.incrementGetsNanos(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.security.permission.ReplicatedMapPermission;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
+import java.util.concurrent.TimeUnit;
 
 public class ReplicatedMapGetMessageTask
         extends AbstractPartitionMessageTask<ReplicatedMapGetCodec.RequestParameters> {
@@ -59,7 +60,7 @@ public class ReplicatedMapGetMessageTask
         ReplicatedMapService replicatedMapService = getService(ReplicatedMapService.SERVICE_NAME);
         if (replicatedMapService.getReplicatedMapConfig(parameters.name).isStatisticsEnabled()) {
             LocalReplicatedMapStatsImpl stats = replicatedMapService.getLocalReplicatedMapStatsImpl(parameters.name);
-            stats.incrementGets(System.nanoTime() - startTimeNanos);
+            stats.incrementGets(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -29,7 +29,6 @@ import com.hazelcast.security.permission.ReplicatedMapPermission;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
-import java.util.concurrent.TimeUnit;
 
 public class ReplicatedMapGetMessageTask
         extends AbstractPartitionMessageTask<ReplicatedMapGetCodec.RequestParameters> {
@@ -60,7 +59,7 @@ public class ReplicatedMapGetMessageTask
         ReplicatedMapService replicatedMapService = getService(ReplicatedMapService.SERVICE_NAME);
         if (replicatedMapService.getReplicatedMapConfig(parameters.name).isStatisticsEnabled()) {
             LocalReplicatedMapStatsImpl stats = replicatedMapService.getLocalReplicatedMapStatsImpl(parameters.name);
-            stats.incrementGets(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
+            stats.incrementGets(System.nanoTime() - startTimeNanos);
         }
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
@@ -68,9 +68,8 @@ import static com.hazelcast.internal.util.ConcurrencyUtil.setMax;
 import static com.hazelcast.internal.util.JsonUtil.getInt;
 import static com.hazelcast.internal.util.JsonUtil.getLong;
 import static com.hazelcast.internal.util.JsonUtil.getObject;
-import static com.hazelcast.internal.util.TimeUtil.timeInMsOrOneIfResultIsZero;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static com.hazelcast.internal.util.TimeUtil.convertMillisToNanos;
+import static com.hazelcast.internal.util.TimeUtil.convertNanosToMillis;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 /**
@@ -635,13 +634,5 @@ public class LocalMapStatsImpl implements LocalMapStats, JsonSerializable {
                 + ", indexedQueryCount=" + indexedQueryCount
                 + ", indexStats=" + indexStats
                 + '}';
-    }
-
-    private static long convertNanosToMillis(long nanos) {
-        return timeInMsOrOneIfResultIsZero(nanos, NANOSECONDS);
-    }
-
-    private static long convertMillisToNanos(long millis) {
-        return MILLISECONDS.toNanos(millis);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -281,19 +281,19 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
     @Probe(name = REPLICATED_MAP_MAX_GET_LATENCY, unit = MS)
     @Override
     public long getMaxPutLatency() {
-        return maxPutLatencyNanos;
+        return convertNanosToMillis(maxPutLatencyNanos);
     }
 
     @Probe(name = REPLICATED_MAP_MAX_PUT_LATENCY, unit = MS)
     @Override
     public long getMaxGetLatency() {
-        return maxGetLatencyNanos;
+        return convertNanosToMillis(maxGetLatencyNanos);
     }
 
     @Probe(name = REPLICATED_MAP_MAX_REMOVE_LATENCY, unit = MS)
     @Override
     public long getMaxRemoveLatency() {
-        return maxRemoveLatencyNanos;
+        return convertNanosToMillis(maxRemoveLatencyNanos);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -48,9 +48,8 @@ import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static com.hazelcast.internal.util.ConcurrencyUtil.setMax;
 import static com.hazelcast.internal.util.JsonUtil.getLong;
-import static com.hazelcast.internal.util.TimeUtil.timeInMsOrOneIfResultIsZero;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static com.hazelcast.internal.util.TimeUtil.convertMillisToNanos;
+import static com.hazelcast.internal.util.TimeUtil.convertNanosToMillis;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 /**
@@ -83,11 +82,11 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
     private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_REMOVE_LATENCIES =
             newUpdater(LocalReplicatedMapStatsImpl.class, "totalRemoveLatenciesNanos");
     private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_GET_LATENCY =
-            newUpdater(LocalReplicatedMapStatsImpl.class, "maxGetLatency");
+            newUpdater(LocalReplicatedMapStatsImpl.class, "maxGetLatencyNanos");
     private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_PUT_LATENCY =
-            newUpdater(LocalReplicatedMapStatsImpl.class, "maxPutLatency");
+            newUpdater(LocalReplicatedMapStatsImpl.class, "maxPutLatencyNanos");
     private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_REMOVE_LATENCY =
-            newUpdater(LocalReplicatedMapStatsImpl.class, "maxRemoveLatency");
+            newUpdater(LocalReplicatedMapStatsImpl.class, "maxRemoveLatencyNanos");
     private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> OWNED_ENTRY_MEMORY_COST =
             newUpdater(LocalReplicatedMapStatsImpl.class, "ownedEntryMemoryCost");
 
@@ -112,13 +111,9 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
     private volatile long totalGetLatenciesNanos;
     private volatile long totalPutLatenciesNanos;
     private volatile long totalRemoveLatenciesNanos;
-
-    @Probe(name = REPLICATED_MAP_MAX_GET_LATENCY, unit = MS)
-    private volatile long maxGetLatency;
-    @Probe(name = REPLICATED_MAP_MAX_PUT_LATENCY, unit = MS)
-    private volatile long maxPutLatency;
-    @Probe(name = REPLICATED_MAP_MAX_REMOVE_LATENCY, unit = MS)
-    private volatile long maxRemoveLatency;
+    private volatile long maxGetLatencyNanos;
+    private volatile long maxPutLatencyNanos;
+    private volatile long maxRemoveLatencyNanos;
 
     @Probe(name = REPLICATED_MAP_CREATION_TIME, unit = MS)
     private volatile long creationTime;
@@ -237,10 +232,10 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         return putCount;
     }
 
-    public void incrementPuts(long latency) {
+    public void incrementPutsNanos(long latencyNanos) {
         PUT_COUNT.incrementAndGet(this);
-        TOTAL_PUT_LATENCIES.addAndGet(this, latency);
-        setMax(this, MAX_PUT_LATENCY, latency);
+        TOTAL_PUT_LATENCIES.addAndGet(this, latencyNanos);
+        setMax(this, MAX_PUT_LATENCY, latencyNanos);
     }
 
     @Override
@@ -248,10 +243,10 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         return getCount;
     }
 
-    public void incrementGets(long latency) {
+    public void incrementGetsNanos(long latencyNanos) {
         GET_COUNT.incrementAndGet(this);
-        TOTAL_GET_LATENCIES.addAndGet(this, latency);
-        setMax(this, MAX_GET_LATENCY, latency);
+        TOTAL_GET_LATENCIES.addAndGet(this, latencyNanos);
+        setMax(this, MAX_GET_LATENCY, latencyNanos);
     }
 
     @Override
@@ -259,10 +254,10 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         return removeCount;
     }
 
-    public void incrementRemoves(long latency) {
+    public void incrementRemovesNanos(long latencyNanos) {
         REMOVE_COUNT.incrementAndGet(this);
-        TOTAL_REMOVE_LATENCIES.addAndGet(this, latency);
-        setMax(this, MAX_REMOVE_LATENCY, latency);
+        TOTAL_REMOVE_LATENCIES.addAndGet(this, latencyNanos);
+        setMax(this, MAX_REMOVE_LATENCY, latencyNanos);
     }
 
     @Probe(name = REPLICATED_MAP_METRIC_TOTAL_PUT_LATENCIES, unit = MS)
@@ -283,19 +278,22 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         return convertNanosToMillis(totalRemoveLatenciesNanos);
     }
 
+    @Probe(name = REPLICATED_MAP_MAX_GET_LATENCY, unit = MS)
     @Override
     public long getMaxPutLatency() {
-        return maxPutLatency;
+        return maxPutLatencyNanos;
     }
 
+    @Probe(name = REPLICATED_MAP_MAX_PUT_LATENCY, unit = MS)
     @Override
     public long getMaxGetLatency() {
-        return maxGetLatency;
+        return maxGetLatencyNanos;
     }
 
+    @Probe(name = REPLICATED_MAP_MAX_REMOVE_LATENCY, unit = MS)
     @Override
     public long getMaxRemoveLatency() {
-        return maxRemoveLatency;
+        return maxRemoveLatencyNanos;
     }
 
     @Override
@@ -386,9 +384,9 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         root.add("totalGetLatencies", convertNanosToMillis(totalGetLatenciesNanos));
         root.add("totalPutLatencies", convertNanosToMillis(totalPutLatenciesNanos));
         root.add("totalRemoveLatencies", convertNanosToMillis(totalRemoveLatenciesNanos));
-        root.add("maxGetLatency", maxGetLatency);
-        root.add("maxPutLatency", maxPutLatency);
-        root.add("maxRemoveLatency", maxRemoveLatency);
+        root.add("maxGetLatency", convertNanosToMillis(maxGetLatencyNanos));
+        root.add("maxPutLatency", convertNanosToMillis(maxPutLatencyNanos));
+        root.add("maxRemoveLatency", convertNanosToMillis(maxRemoveLatencyNanos));
         return root;
     }
 
@@ -408,17 +406,9 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         totalGetLatenciesNanos = convertMillisToNanos(getLong(json, "totalGetLatencies", -1L));
         totalPutLatenciesNanos = convertMillisToNanos(getLong(json, "totalPutLatencies", -1L));
         totalRemoveLatenciesNanos = convertMillisToNanos(getLong(json, "totalRemoveLatencies", -1L));
-        maxGetLatency = getLong(json, "maxGetLatency", -1L);
-        maxPutLatency = getLong(json, "maxPutLatency", -1L);
-        maxRemoveLatency = getLong(json, "maxRemoveLatency", -1L);
-    }
-
-    private static long convertNanosToMillis(long nanos) {
-        return timeInMsOrOneIfResultIsZero(nanos, NANOSECONDS);
-    }
-
-    private static long convertMillisToNanos(long millis) {
-        return MILLISECONDS.toNanos(millis);
+        maxGetLatencyNanos = convertMillisToNanos(getLong(json, "maxGetLatency", -1L));
+        maxPutLatencyNanos = convertMillisToNanos(getLong(json, "maxPutLatency", -1L));
+        maxRemoveLatencyNanos = convertMillisToNanos(getLong(json, "maxRemoveLatency", -1L));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/TimeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/TimeUtil.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -33,6 +34,27 @@ public final class TimeUtil {
     private static final int HOURS_PER_DAY = 24;
 
     private TimeUtil() {
+    }
+
+    /**
+     * Convert nanoseconds to milliseconds
+     * If conversion result is 0 and {@code nanos} was &gt; 0, then 1 is returned.
+     *
+     * @param nanos     The number of nanoseconds
+     * @return The millisecond representation of the input
+     */
+    public static long convertNanosToMillis(long nanos) {
+        return timeInMsOrOneIfResultIsZero(nanos, NANOSECONDS);
+    }
+
+    /**
+     * Convert milliseconds to nanoseconds
+     *
+     * @param millis     The number of milliseconds
+     * @return The nanoseconds representation of the input
+     */
+    public static long convertMillisToNanos(long millis) {
+        return MILLISECONDS.toNanos(millis);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -86,7 +86,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             storage.remove(marshalledKey, current);
         }
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementRemoves(System.nanoTime() - time);
+            getStats().incrementRemovesNanos(System.nanoTime() - time);
         }
         cancelTtlEntry(marshalledKey);
         return oldValue;
@@ -112,7 +112,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         ReplicatedMapEventPublishingService eventPublishingService = replicatedMapService.getEventPublishingService();
         eventPublishingService.fireEntryListenerEvent(dataKey, dataOldValue, null, EVICTED, name, nodeEngine.getThisAddress());
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementRemoves(System.nanoTime() - time);
+            getStats().incrementRemovesNanos(System.nanoTime() - time);
         }
     }
 
@@ -130,7 +130,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
 
         Object value = replicatedRecord == null ? null : unmarshall(replicatedRecord.getValue());
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementGets(System.nanoTime() - time);
+            getStats().incrementGetsNanos(System.nanoTime() - time);
         }
         return value;
     }
@@ -192,7 +192,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             cancelTtlEntry(marshalledKey);
         }
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementPuts(System.nanoTime() - time);
+            getStats().incrementPutsNanos(System.nanoTime() - time);
         }
         return oldValue;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -75,7 +75,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     @SuppressWarnings("unchecked")
     private Object remove(InternalReplicatedMapStorage<K, V> storage, Object key) {
         isNotNull(key, "key");
-        long time = Clock.currentTimeMillis();
+        long time = System.nanoTime();
         V oldValue;
         K marshalledKey = (K) marshall(key);
         ReplicatedRecord current = storage.get(marshalledKey);
@@ -86,7 +86,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             storage.remove(marshalledKey, current);
         }
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementRemoves(Clock.currentTimeMillis() - time);
+            getStats().incrementRemoves(System.nanoTime() - time);
         }
         cancelTtlEntry(marshalledKey);
         return oldValue;
@@ -96,7 +96,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     @SuppressWarnings("unchecked")
     public void evict(Object key) {
         isNotNull(key, "key");
-        long time = Clock.currentTimeMillis();
+        long time = System.nanoTime();
         V oldValue;
         K marshalledKey = (K) marshall(key);
         InternalReplicatedMapStorage<K, V> storage = getStorage();
@@ -112,14 +112,14 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         ReplicatedMapEventPublishingService eventPublishingService = replicatedMapService.getEventPublishingService();
         eventPublishingService.fireEntryListenerEvent(dataKey, dataOldValue, null, EVICTED, name, nodeEngine.getThisAddress());
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementRemoves(Clock.currentTimeMillis() - time);
+            getStats().incrementRemoves(System.nanoTime() - time);
         }
     }
 
     @Override
     public Object get(Object key) {
         isNotNull(key, "key");
-        long time = Clock.currentTimeMillis();
+        long time = System.nanoTime();
         ReplicatedRecord replicatedRecord = getStorage().get(marshall(key));
 
         // Force return null on ttl expiration (but before cleanup thread run)
@@ -130,7 +130,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
 
         Object value = replicatedRecord == null ? null : unmarshall(replicatedRecord.getValue());
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementGets(Clock.currentTimeMillis() - time);
+            getStats().incrementGets(System.nanoTime() - time);
         }
         return value;
     }
@@ -167,7 +167,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         if (ttl < 0) {
             throw new IllegalArgumentException("ttl must be a positive integer");
         }
-        long time = Clock.currentTimeMillis();
+        long time = System.nanoTime();
         V oldValue = null;
         K marshalledKey = (K) marshall(key);
         V marshalledValue = (V) marshall(value);
@@ -192,7 +192,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             cancelTtlEntry(marshalledKey);
         }
         if (replicatedMapConfig.isStatisticsEnabled()) {
-            getStats().incrementPuts(Clock.currentTimeMillis() - time);
+            getStats().incrementPuts(System.nanoTime() - time);
         }
         return oldValue;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImplTest.java
@@ -50,12 +50,12 @@ public class LocalReplicatedMapStatsImplTest {
         localReplicatedMapStats.setLockedEntryCount(1231);
         localReplicatedMapStats.setDirtyEntryCount(4252);
 
-        localReplicatedMapStats.incrementPuts(5631);
-        localReplicatedMapStats.incrementPuts(1);
-        localReplicatedMapStats.incrementGets(1233);
-        localReplicatedMapStats.incrementGets(5);
-        localReplicatedMapStats.incrementGets(9);
-        localReplicatedMapStats.incrementRemoves(1238);
+        localReplicatedMapStats.incrementPutsNanos(5631);
+        localReplicatedMapStats.incrementPutsNanos(1);
+        localReplicatedMapStats.incrementGetsNanos(1233);
+        localReplicatedMapStats.incrementGetsNanos(5);
+        localReplicatedMapStats.incrementGetsNanos(9);
+        localReplicatedMapStats.incrementRemovesNanos(1238);
         localReplicatedMapStats.incrementOtherOperations();
         localReplicatedMapStats.incrementOtherOperations();
         localReplicatedMapStats.incrementOtherOperations();

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImplTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.util.TimeUtil.convertMillisToNanos;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -50,12 +51,12 @@ public class LocalReplicatedMapStatsImplTest {
         localReplicatedMapStats.setLockedEntryCount(1231);
         localReplicatedMapStats.setDirtyEntryCount(4252);
 
-        localReplicatedMapStats.incrementPutsNanos(5631);
-        localReplicatedMapStats.incrementPutsNanos(1);
-        localReplicatedMapStats.incrementGetsNanos(1233);
-        localReplicatedMapStats.incrementGetsNanos(5);
-        localReplicatedMapStats.incrementGetsNanos(9);
-        localReplicatedMapStats.incrementRemovesNanos(1238);
+        localReplicatedMapStats.incrementPutsNanos(convertMillisToNanos(5631));
+        localReplicatedMapStats.incrementPutsNanos(convertMillisToNanos(1));
+        localReplicatedMapStats.incrementGetsNanos(convertMillisToNanos(1233));
+        localReplicatedMapStats.incrementGetsNanos(convertMillisToNanos(5));
+        localReplicatedMapStats.incrementGetsNanos(convertMillisToNanos(9));
+        localReplicatedMapStats.incrementRemovesNanos(convertMillisToNanos(1238));
         localReplicatedMapStats.incrementOtherOperations();
         localReplicatedMapStats.incrementOtherOperations();
         localReplicatedMapStats.incrementOtherOperations();

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/MemberStateImplTest.java
@@ -76,7 +76,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         HazelcastInstance hazelcastInstance = createHazelcastInstance();
 
         LocalReplicatedMapStatsImpl replicatedMapStats = new LocalReplicatedMapStatsImpl();
-        replicatedMapStats.incrementPuts(30);
+        replicatedMapStats.incrementPutsNanos(30);
         CacheStatisticsImpl cacheStatistics = new CacheStatisticsImpl(Clock.currentTimeMillis());
         cacheStatistics.increaseCacheHits(5);
         UUID clientUuid = UUID.randomUUID();


### PR DESCRIPTION
> `LocalReplicatedMapStatsImpl` states that `maxGetLatency` is measured in `MS` but in `ReplicatedMapGetMessageTask` we call `incrementGets` with nanoseconds diff.

As suggested in https://github.com/hazelcast/hazelcast/pull/16795#discussion_r397300346 the PR changes logic how IMDG compute `max*Latency` metrics.

After merging the PR `max*Latency` values are collected in nanoseconds and reported in milliseconds