### PR TITLE
Expose dataIterator()/dataSubList() on List proxies 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientListProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientListProxy.java
@@ -54,6 +54,7 @@ import com.hazelcast.spi.impl.UnmodifiableLazyList;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -322,6 +323,22 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     @Override
     public String toString() {
         return "IList{" + "name='" + name + '\'' + '}';
+    }
+
+    // used by jet
+    public Iterator<Data> dataIterator() {
+        ClientMessage request = ListIteratorCodec.encodeRequest(name);
+        ClientMessage response = invokeOnPartition(request);
+        ListIteratorCodec.ResponseParameters resultParameters = ListIteratorCodec.decodeResponse(response);
+        return Collections.unmodifiableList(resultParameters.response).iterator();
+    }
+
+    // used by jet
+    public List<Data> dataSubList(int fromIndex, int toIndex) {
+        ClientMessage request = ListSubCodec.encodeRequest(name, fromIndex, toIndex);
+        ClientMessage response = invokeOnPartition(request);
+        ListSubCodec.ResponseParameters resultParameters = ListSubCodec.decodeResponse(response);
+        return Collections.unmodifiableList(resultParameters.response);
     }
 
     private class ItemEventHandler extends ListAddListenerCodec.AbstractEventHandler

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListProxyImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.list;
 
+import com.hazelcast.collection.IList;
 import com.hazelcast.collection.impl.collection.AbstractCollectionProxyImpl;
 import com.hazelcast.collection.impl.list.operations.ListAddAllOperation;
 import com.hazelcast.collection.impl.list.operations.ListAddOperation;
@@ -25,16 +26,16 @@ import com.hazelcast.collection.impl.list.operations.ListRemoveOperation;
 import com.hazelcast.collection.impl.list.operations.ListSetOperation;
 import com.hazelcast.collection.impl.list.operations.ListSubOperation;
 import com.hazelcast.config.CollectionConfig;
-import com.hazelcast.collection.IList;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -164,4 +165,15 @@ public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E
         return ListService.SERVICE_NAME;
     }
 
+    // used by jet
+    public Iterator<Data> dataIterator() {
+        return dataSubList(-1, -1).listIterator();
+    }
+
+    // used by jet
+    public List<Data> dataSubList(int fromIndex, int toIndex) {
+        ListSubOperation operation = new ListSubOperation(name, fromIndex, toIndex);
+        SerializableList result = invoke(operation);
+        return Collections.unmodifiableList(result.getCollection());
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/BasicListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/BasicListTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.list;
+
+import com.google.common.collect.Iterators;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class BasicListTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private ListProxyImpl<Integer> list;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Before
+    public void setup() {
+        list = (ListProxyImpl) hazelcastFactory.newHazelcastInstance(getConfig())
+                                               .getList(randomName());
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testRawIterator() {
+        list.add(1);
+        list.add(2);
+
+        assertEquals(2, Iterators.size(list.dataIterator()));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRawIterator_throwsException_whenRemove() {
+        list.add(1);
+
+        Iterator<Data> iterator = list.dataIterator();
+
+        iterator.next();
+        iterator.remove();
+    }
+
+    @Test
+    public void testRawSublist() {
+        list.add(1);
+        list.add(2);
+        list.add(3);
+
+        List<Data> listTest = list.dataSubList(1, 2);
+
+        assertEquals(1, listTest.size());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testRawSublist_whenFromIndexIllegal() {
+        list.subList(8, 7);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testRawSublist_whenToIndexIllegal() {
+        list.add(1);
+        list.add(2);
+
+        list.subList(1, 3);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ClientListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ClientListTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.list;
+
+import com.google.common.collect.Iterators;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.proxy.ClientListProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientListTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private ClientListProxy<Integer> list;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Before
+    public void setup() {
+        hazelcastFactory.newHazelcastInstance(getConfig());
+
+        list = (ClientListProxy) hazelcastFactory.newHazelcastClient(new ClientConfig())
+                                                 .getList(randomName());
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testDataIterator() {
+        list.add(1);
+        list.add(2);
+
+        assertEquals(2, Iterators.size(list.dataIterator()));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDataIterator_throwsException_whenRemove() {
+        list.add(1);
+
+        Iterator<Data> iterator = list.dataIterator();
+
+        iterator.next();
+        iterator.remove();
+    }
+
+    @Test
+    public void testDataSublist() {
+        list.add(1);
+        list.add(2);
+        list.add(3);
+
+        List<Data> listTest = list.dataSubList(1, 2);
+
+        assertEquals(1, listTest.size());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testDataSublist_whenFromIndexIllegal() {
+        list.subList(8, 7);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testDataSublist_whenToIndexIllegal() {
+        list.add(1);
+        list.add(2);
+
+        list.subList(1, 3);
+    }
+}


### PR DESCRIPTION
To support contextual serializers Jet requires access to raw `IList` data.

Exposed `dataIterator()`/`dataSubList()` on `List` proxies.

Backport of https://github.com/hazelcast/hazelcast/pull/16782