### PR TITLE
Create separate buffer pool for each SerializationService 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -64,8 +64,10 @@ public class AbstractSerializationServiceTest {
     }
 
     protected AbstractSerializationService newAbstractSerializationService() {
-        DefaultSerializationServiceBuilder defaultSerializationServiceBuilder = new DefaultSerializationServiceBuilder();
-        return defaultSerializationServiceBuilder.setVersion(InternalSerializationService.VERSION_1).build();
+        return new DefaultSerializationServiceBuilder()
+                .setVersion(InternalSerializationService.VERSION_1)
+                .setNotActiveExceptionSupplier(HazelcastInstanceNotActiveException::new)
+                .build();
     }
 
     @Test


### PR DESCRIPTION
Creating separate buffer pool for each `SerializationService` so buffers retain reference to proper service.

Backport of https://github.com/hazelcast/hazelcast/pull/16791