### PR TITLE
SQL thread pools (#16805)

### DIFF
--- a/docs/design/sql/02-operator-interface.md
+++ b/docs/design/sql/02-operator-interface.md
@@ -7,7 +7,7 @@ introduced in Goetz Graefe seminal paper [[1]].
 In this document, we describe the design of the Hazelcast Mustang operator interface, which is based
 on the Volcano Model.
 
-## Relational Operators
+## 1 Relational Operators
 An SQL query is first parsed into a **parse tree**, which is used for syntactic and semantic checking.
 
 The parse tree is then converted into **relational operator tree**, or simply **relational tree**,
@@ -55,7 +55,7 @@ HAVING SUM(b) > 50
 -------- Scan [table]
 ```
 
-## Volcano Model
+## 2 Volcano Model
 
 Volcano Model defines the common data exchange interface between operators in the relational tree. This allows
 for extensibility, as new operators could be implemented with minimal changes to the engine.
@@ -71,7 +71,7 @@ interface Operator {
 }
 ```
 
-## Volcano Model in Hazelcast Mustang
+## 3 Volcano Model in Hazelcast Mustang
 
 The original Volcano Model has two drawbacks:
 1. Operators exchange one row at a time, which leads to performance overhead
@@ -81,7 +81,7 @@ operators often wait for remote data or free space in the send buffer.
 To achieve high performance, we introduce several changes to the original Volcano Model: batching and
 non-blocking execution.
 
-### Row and RowBatch
+### 3.1 Row and RowBatch
 We define the `RowBatch` interface which is a collection of rows (tuples).
 
 *Snippet 5: RowBatch interface*
@@ -111,7 +111,7 @@ interface Row extends RowBatch {
 }
 ```
 
-### Operator
+### 3.2 Operator
 The operator is defined by `Exec` interface:
 1. Operators exchange `RowBatch` instead of `Row`
 1. The blocking `next()` method is replaced with the non-blocking `advance()` method, which returns the iteration
@@ -150,7 +150,7 @@ If the engine has received `WAIT`, then query execution is halted, and the contr
 execution queue. The query execution is resumed upon an external signal (e.g. when the batch arrives from the remote node,
 or free space in the send buffer appears).
 
-## Implementation Guidelines
+## 4 Implementation Guidelines
 Operator implementations must adhere to the following rules:
 1. `Row` instances should be immutable to facilitate their transfer between batches
 1. The row batch returned by the `Exec.currentBatch()` call is valid before the next call to the `Exec.advance()` interface.

--- a/docs/design/sql/04-mulitthreaded-execution.md
+++ b/docs/design/sql/04-mulitthreaded-execution.md
@@ -1,0 +1,215 @@
+# SQL Multithreaded Execution
+
+## Overview
+
+The Hazelcast Mustang engine executes queries in parallel. This document describes the design of the multithreaded execution
+environment of the engine.
+
+The document doesn't discuss operator-level parallelism, which is a different topic.
+
+The rest of this document is organized as follows. In section 1 we discuss the existing threading infrastructure of Hazelcast
+IMDG and Hazelcast Jet. In section 2 we analyze why the existing infrastructure is inappropriate for query execution and then
+describe the design of the Hazelcast Mustang execution environment. In section 3 we discuss possible alternative approaches
+that were rejected.
+
+## 1 Existing Infrastructure
+
+Hazelcast IMDG uses staged event-driven architecture (SEDA) for message processing. During execution, a message passes through
+several thread pools (stages), each optimized for a specific type of workload. We now describe stages that exist in Hazelcast.
+
+### 1.1 IO Pool
+
+Hazelcast uses a dedicated thread pool for message send and receive, which will be referred to as **IO Pool** in this paper.
+Each thread from the IO pool maintains a subset of connections to remote members. Consider that we have a sender member (S)
+and a receiver member (R). The typical execution flow is organized as follows:
+1. The message is added to the queue of a single IO thread, and the thread is notified
+1. The sender IO thread wakes up and sends the message over the network
+1. A receiver IO thread is notified by the operating system on receive
+1. The receiver IO thread wakes up, determines the next execution stage, adds the message to the stage's queue and notifies the
+stage
+1. The next execution stage processes the message
+
+*Snippet 1: Message execution flow*
+```
+Stage(S)                 IO(S)        IO(R)                Stage(R)
+   |----enqueue/notify->--|            |                      |
+   |                      |----send->--|                      |
+   |                      |            |----enqueue/notify->--|
+```
+
+We now discuss the organization of different execution stages.
+
+### 1.2 Partition Pool
+
+A message may have a logical **partition**, which is a positive integer number. Messages with defined partition are routed to
+a special thread pool, which we refer to as **partition pool**. The pool has several threads. Every thread has a dedicated task
+queue. Partition of the message is used to determine the exact thread which will process the message:
+`threadIndex = partition % threadCount`.
+
+The partition pool has the following advantages:
+1. Only one thread processes messages with the given partition so that processing logic may use less synchronization
+1. Dedicated thread queues reduce contention on enqueue/deque operations
+
+The partition pool has the following disadvantage:
+1. There is no balancing between threads: a single long-running task may delay other tasks from the same partition
+indefinitely; likewise, an imbalance between partitions may cause resource underutilization
+
+The partition pool is thus most suitable for small tasks that operate on independent physical resources, and that are
+distributed equally between logical partitions. An example is `IMap` operations, which update separate physical partitions,
+such as `GET` and `PUT`.
+
+Since the partition is a logical notion, it is possible to multiplex tasks from different components to a single partition pool.
+For example, CP Subsystem schedules tasks, all with the same partition, to the partition pool to ensure total processing order.
+
+### 1.3 Generic Pool
+
+If a message doesn't have a logical partition, it is submitted to the **generic pool**. This is a conventional thread pool with
+a shared blocking queue. It has inherent balancing capabilities. But at the same time, this pool may demonstrate less than
+optimal throughput when a lot of small tasks are submitted due to contention on the queue.
+
+### 1.4 Hazelcast Jet Pool
+
+Hazelcast Jet uses its own cooperative pool to execute Jet jobs. Every thread has its own queue of jobs that are executed
+cooperatively. There is no balancing: once the job is submitted to a specific thread, it is always executed in that thread.
+
+IO pool doesn't notify the Jet pool about new data batch ("push"). Instead, the message is just enqueued, and the Jet thread
+checks the queue periodically ("poll").
+
+## 2 Design
+
+We now define the requirements to Hazelcast Mustang threading model, analyze them concerning existing infrastructure, and
+define the design.
+
+### 2.1 Requirements
+
+The requirements are thread safety, load balancing, and ordered message processing.
+
+First, the infrastructure must guarantee that operator execution is thread-safe. That is, the stateful operator should not be
+executed by multiple threads simultaneously. This simplifies operator implementations and makes them more performant.
+Hazelcast Jet follows this principle, as only one thread may execute a particular job. However, Hazelcast Jet pool doesn't
+satisfy the load balancing requirement discussed below.
+
+Second, the execution environment must support load balancing. Query execution may take a long time to complete. If several query
+fragments have been assigned to a single execution thread, it should be possible to reassign them to available free thread
+dynamically. Hence neither partition pool nor Hazelcast Jet pool designs are applicable to Hazelcast Mustang because they lack
+balancing capabilities.
+
+Third, it should be possible to execute some tasks in order. That is, if task `A` is received before task `B`, then it
+should be executed before `B`. It is always possible to implement an ordering guarantee with the help of additional
+synchronization primitives, but it increases complexity and typically reduces performance. So we prefer to have a threading
+infrastructure with ordering guarantees, such as in the partition pool. Examples of tasks requiring ordered processing:
+1. Query cancel should be executed after query start to minimize resource leaks
+1. The N-th batch from the stream should be processed before the (N+1)-th batch, as described in [[1]] (p. 1.3)
+
+### 2.1 General Design
+
+We define the taxonomy of tasks related to query execution.
+
+First, the engine must execute query fragments, i.e., advance Volcano-style operators, as explained in [[2]] (p. 3). Fragment
+execution is initiated in response to query start or data messages. Fragment execution may take significant time to complete.
+
+Second, the engine must process query operations described in [[1]] (p. 3), such as query start, query cancel, batch arrival,
+and flow control. These operations take short time to complete. Moreover, query start operation may trigger the parallel
+execution of several fragments.
+
+Given the different nature of query operations and fragment execution, we split them into independent stages, called
+**operation pool** and **fragment pool**. The former executes query operation, and the latter executes fragments. This design
+provides a clear separation of concerns and allows us to optimize stages for their tasks as described below, which improves
+performance. On the other hand, this design introduces an additional thread notification, as shown on the snippets below, which
+may negatively affect performance. Nevertheless, we think that the advantages of this approach outweigh the disadvantages.
+
+*Snippet 2: Query start flow (receiver only)*
+```
+IO                Operation pool         Fragment pool
+ |----enqueue/notify-->-|                      |
+ |                      |----enqueue/notify-->-|
+```
+
+### 2.2 Operation Pool
+
+Every network message received by the IO pool is first submitted to the operation pool.
+
+The pool is organized as a fixed pool of threads with dedicated per-thread queues. Dedicated queues reduce contention and
+increase the throughput, which is important given that processing of a single message takes little time.
+
+Every message may define an optional logical partition. If the partition is not defined, a random thread is picked for message
+processing. If the partition is defined, the index of executing thread is defined as `threadIndex = partition % threadCount`.
+Two messages with the same partition are guaranteed to be processed by the same thread, thus providing ordering guarantees.
+
+Some messages may trigger query fragment execution, as described below. In this case, a fragment execution task is created and
+submitted for execution to the fragment pool.
+1. `execute` - triggers the execution of one or more fragments
+1. `batch` and `flow_control` - trigger execution of one fragment defined by query ID and edge ID, as described in [[1]]
+
+### 2.3 Fragment Pool
+
+The fragment pool is responsible for the execution of individual query fragments. Fragment execution is always initiated by
+a task from the operation pool.
+
+Unlike operations, fragment execution may take arbitrary time depending on the query structure. It is, therefore, important to
+guarantee high throughput for short fragments, while still providing load balancing for long fragments. The ideal candidate
+is a thread pool with dedicated per-thread queues and work-stealing. For this reason, we choose JDK's `ForkJoinPool` as a
+backbone of the fragment pool. We create a separate instance of the `ForkJoinPool` rather than using `ForkJoinPool.commonPool()`
+to avoid interference with user workloads.
+
+We may decide to introduce multiple fragment pools for better resource management in the future. This will help limit the
+maximum number of CPU cores dedicated to a particular workload. An example of this approach is **Resource Pools** in MemSQL [[3]].
+
+## 3 Alternative Approaches
+
+Several other approaches were considered but then rejected. This section explains these approaches and the rejection
+reasons.
+
+### 3.1 Use Single Pool
+
+It is possible to use a single pool for both operation and fragment processing and remove the additional notifications for
+fragment execution. The problem is that an operation task is short and requires fast response, while fragment execution is
+potentially a long-running task. Consider two examples that demonstrate when this approach doesn't work well.
+
+**Example 1**:
+
+Consider that long-running fragments occupied all threads in the pool. Then a `cancel` message arrives, but it cannot be
+processed because all threads are busy. To fix it, we would have to introduce a separate priority queue, which should be
+checked periodically by fragment tasks. This may lead to wasted CPU cycles and frequent interrupts to fragment tasks.
+
+**Example 2**
+
+Consider a fragment which occupied the thread `A`. Then a `batch` message arrives, which should resume execution of another
+fragment. Given that the processing of `batch` message should is ordered, it has logical partition defined. It may happen that
+the thread chosen for `batch` operation processing will also be the thread `A`, that is currently busy. So we either delay
+the resume of the fragment associated with the batch, reducing the throughput, or we introduce a priority queue and interrupt
+the running fragment, wasting CPU cycles.
+
+### 3.2 Use IO Pool
+
+Another approach is to use the IO pool to process short operations, such as `batch` processing, to eliminate an additional
+notification. Hazelcast Jet uses this approach for batch processing, but with two important traits:
+1. The "poll" approach without thread notifications is used. This is inappropriate for SQL where low latency is required
+1. The batch destination is encoded inside the network `Packet` at known positions, and therefore no expensive deserialization
+is needed. We expect SQL protocol to change frequently during first releases, so it is not desirable to have an additional
+contract on message structure at the moment
+
+### 3.3 Use Partition Pool
+
+The partition pool cannot be used for fragment execution, because it may significantly delay other operations, such as `IMap`
+'GET' and 'PUT'. However, it is possible to use the partition pool instead of the operation pool. The partition pool and query
+operation pool have a very similar design. By merging them, we may decrease the total number of threads and possibly reduce the
+number of context switches. But with this design, query operations will interfere with other workloads, that are potentially
+long-running (e.g., `EntryProcessor`) or skewed (e.g., bad data distribution), causing unpredictable side effects.
+
+We may revisit this decision at any time in the future because it doesn't affect the network protocol.
+
+### 3.4 Use Generic Pool
+
+It is possible to execute query fragments in the generic pool. But if we do so, we would have to restrict the execution of
+queries from any tasks that may potentially be executed in the generic pool.
+
+For example, it will be impossible to execute SQL from `IScheduledExecutorService`. Otherwise, thread starvation is possible as
+described below:
+1. User starts many tasks from the `IScheduledExecutorService`, and they occupy all generic threads
+1. Every task starts execution of the query
+1. But query execution cannot complete because it needs free generic threads, resulting in a distributed deadlock
+
+[1]: 03-network-protocol.md "SQL Network Protocol"
+[2]: 02-operator-interface.md "SQL Operator Interface"
+[3]: https://docs.memsql.com/v6.8/guides/cluster-management/operations/setting-resource-limits/ "MemSQL: Setting Resource Limits"

--- a/docs/design/sql/04-mulitthreaded-execution.md
+++ b/docs/design/sql/04-mulitthreaded-execution.md
@@ -55,8 +55,8 @@ The partition pool has the following disadvantage:
 indefinitely; likewise, an imbalance between partitions may cause resource underutilization
 
 The partition pool is thus most suitable for small tasks that operate on independent physical resources, and that are
-distributed equally between logical partitions. An example is `IMap` operations, which update separate physical partitions,
-such as `GET` and `PUT`.
+distributed equally between logical partitions. An example is `IMap` operations, which operate on separate physical
+partitions, such as `GET` and `PUT`.
 
 Since the partition is a logical notion, it is possible to multiplex tasks from different components to a single partition pool.
 For example, CP Subsystem schedules tasks, all with the same partition, to the partition pool to ensure total processing order.
@@ -90,9 +90,9 @@ Hazelcast Jet follows this principle, as only one thread may execute a particula
 satisfy the load balancing requirement discussed below.
 
 Second, the execution environment must support load balancing. Query execution may take a long time to complete. If several query
-fragments have been assigned to a single execution thread, it should be possible to reassign them to available free thread
-dynamically. Hence neither partition pool nor Hazelcast Jet pool designs are applicable to Hazelcast Mustang because they lack
-balancing capabilities.
+fragments have been assigned to a single execution thread, it should be possible to reassign them to idle threads dynamically.
+Hence neither partition pool nor Hazelcast Jet pool designs are applicable to Hazelcast Mustang because they lack balancing
+capabilities.
 
 Third, it should be possible to execute some tasks in order. That is, if task `A` is received before task `B`, then it
 should be executed before `B`. It is always possible to implement an ordering guarantee with the help of additional

--- a/docs/design/sql/04-mulitthreaded-execution.md
+++ b/docs/design/sql/04-mulitthreaded-execution.md
@@ -175,7 +175,7 @@ checked periodically by fragment tasks. This may lead to wasted CPU cycles and f
 **Example 2**
 
 Consider a fragment which occupied the thread `A`. Then a `batch` message arrives, which should resume execution of another
-fragment. Given that the processing of `batch` message should is ordered, it has logical partition defined. It may happen that
+fragment. Given that the processing of `batch` message should be ordered, it has logical partition defined. It may happen that
 the thread chosen for `batch` operation processing will also be the thread `A`, that is currently busy. So we either delay
 the resume of the fragment associated with the batch, reducing the throughput, or we introduce a priority queue and interrupt
 the running fragment, wasting CPU cycles.

--- a/docs/design/sql/04-mulitthreaded-execution.md
+++ b/docs/design/sql/04-mulitthreaded-execution.md
@@ -113,7 +113,7 @@ and flow control. These operations take short time to complete. Moreover, query 
 execution of several fragments.
 
 Given the different nature of query operations and fragment execution, we split them into independent stages, called
-**operation pool** and **fragment pool**. The former executes query operation, and the latter executes fragments. This design
+**operation pool** and **fragment pool**. The former executes query operations, and the latter executes fragments. This design
 provides a clear separation of concerns and allows us to optimize stages for their tasks as described below, which improves
 performance. On the other hand, this design introduces an additional thread notification, as shown on the snippets below, which
 may negatively affect performance. Nevertheless, we think that the advantages of this approach outweigh the disadvantages.

--- a/docs/design/sql/04-mulitthreaded-execution.md
+++ b/docs/design/sql/04-mulitthreaded-execution.md
@@ -115,14 +115,14 @@ execution of several fragments.
 Given the different nature of query operations and fragment execution, we split them into independent stages, called
 **operation pool** and **fragment pool**. The former executes query operations, and the latter executes fragments. This design
 provides a clear separation of concerns and allows us to optimize stages for their tasks as described below, which improves
-performance. On the other hand, this design introduces an additional thread notification, as shown on the snippets below, which
+performance. On the other hand, this design introduces an additional thread notification, as shown in the snippet below, which
 may negatively affect performance. Nevertheless, we think that the advantages of this approach outweigh the disadvantages.
 
 *Snippet 2: Query start flow (receiver only)*
 ```
-IO                Operation pool         Fragment pool
- |----enqueue/notify-->-|                      |
- |                      |----enqueue/notify-->-|
+IO               Operation pool         Fragment pool
+|----enqueue/notify-->-|                      |
+|                      |----enqueue/notify-->-|
 ```
 
 ### 2.2 Operation Pool

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl;
+
+/**
+ * Common SQL engine utility methods used by both "core" and "sql" modules.
+ */
+public final class QueryUtils {
+
+    public static final String WORKER_TYPE_OPERATION = "operation-worker";
+    public static final String WORKER_TYPE_FRAGMENT = "fragment-worker";
+
+    private QueryUtils() {
+        // No-op.
+    }
+
+    public static String workerName(String instanceName, String workerType, long index) {
+        return instanceName + "-" + workerType + "-worker-" + index;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/fragment/QueryFragmentContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/fragment/QueryFragmentContext.java
@@ -16,24 +16,43 @@
 
 package com.hazelcast.sql.impl.fragment;
 
+import com.hazelcast.sql.impl.state.QueryStateCallback;
+import com.hazelcast.sql.impl.worker.QueryFragmentScheduleCallback;
+
 import java.util.List;
 
 /**
  * Context of a running query fragment.
  */
-public class QueryFragmentContext {
+public final class QueryFragmentContext {
 
     private final List<Object> arguments;
+    private final QueryFragmentScheduleCallback scheduleCallback;
+    private final QueryStateCallback stateCallback;
 
-    public QueryFragmentContext(List<Object> arguments) {
+    public QueryFragmentContext(
+        List<Object> arguments,
+        QueryFragmentScheduleCallback scheduleCallback,
+        QueryStateCallback stateCallback
+    ) {
         assert arguments != null;
 
         this.arguments = arguments;
+        this.scheduleCallback = scheduleCallback;
+        this.stateCallback = stateCallback;
     }
 
     public Object getArgument(int index) {
         assert index >= 0 && index < arguments.size();
 
         return arguments.get(index);
+    }
+
+    public void schedule() {
+        scheduleCallback.schedule();
+    }
+
+    public void checkCancelled() {
+        stateCallback.checkCancelled();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/InboundBatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/InboundBatch.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 /**
  * Mailbox batch received from the remote member.
  */
-public class InboundBatch {
+public final class InboundBatch {
 
     private final RowBatch batch;
     private final boolean last;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/InboundBatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/InboundBatch.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.mailbox;
+
+import com.hazelcast.sql.impl.row.RowBatch;
+
+import java.util.UUID;
+
+/**
+ * Mailbox batch received from the remote member.
+ */
+public class InboundBatch {
+
+    private final RowBatch batch;
+    private final boolean last;
+    private final UUID senderId;
+
+    public InboundBatch(RowBatch batch, boolean last, UUID senderId) {
+        this.batch = batch;
+        this.last = last;
+        this.senderId = senderId;
+    }
+
+    public RowBatch getBatch() {
+        return batch;
+    }
+
+    public boolean isLast() {
+        return last;
+    }
+
+    public UUID getSenderId() {
+        return senderId;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/InboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/InboundHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.mailbox;
+
+/**
+ * Core interface for inbound message processing.
+ */
+public interface InboundHandler {
+    /**
+     * Handle batch from the remote outbound handler.
+     *
+     * @param batch Data batch.
+     * @param remainingMemory Amount of available memory as seen by the remote outbound handler.
+     */
+    void onBatch(InboundBatch batch, long remainingMemory);
+
+    /**
+     * Send flow control message to the remote outbound handler.
+     */
+    void sendFlowControl();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/OutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/OutboundHandler.java
@@ -23,7 +23,7 @@ public interface OutboundHandler {
     /**
      * Handle flow control response from the remote inbound handler.
      *
-     * @param remainingMemory Amount of memory which available on the remote end.
+     * @param remainingMemory Amount of memory which is available on the remote end.
      */
     void onFlowControl(long remainingMemory);
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/OutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/mailbox/OutboundHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.mailbox;
+
+/**
+ * Core interface for outbound message processing.
+ */
+public interface OutboundHandler {
+    /**
+     * Handle flow control response from the remote inbound handler.
+     *
+     * @param remainingMemory Amount of memory which available on the remote end.
+     */
+    void onFlowControl(long remainingMemory);
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryAbstractIdAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryAbstractIdAwareOperation.java
@@ -60,7 +60,11 @@ public abstract class QueryAbstractIdAwareOperation extends QueryOperation {
         queryId = new QueryId();
         queryId.readData(in);
 
-        readInternal1(in);
+        try {
+            readInternal1(in);
+        } catch (Exception e) {
+            throw new QueryOperationDeserializationException(queryId, getCallerId(), getClass().getSimpleName(), e);
+        }
     }
 
     protected abstract void writeInternal1(ObjectDataOutput out) throws IOException;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationDeserializationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationDeserializationException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.operation;
+
+import com.hazelcast.sql.impl.QueryId;
+
+import java.util.UUID;
+
+/**
+ * An error which occurred during deserialization of a query operation.
+ */
+public class QueryOperationDeserializationException extends RuntimeException {
+
+    private final QueryId queryId;
+    private final UUID callerId;
+    private final String operationClassName;
+
+    public QueryOperationDeserializationException(QueryId queryId, UUID callerId, String operationClassName, Throwable cause) {
+        super(cause);
+
+        this.queryId = queryId;
+        this.callerId = callerId;
+        this.operationClassName = operationClassName;
+    }
+
+    public QueryId getQueryId() {
+        return queryId;
+    }
+
+    public UUID getCallerId() {
+        return callerId;
+    }
+
+    public String getOperationClassName() {
+        return operationClassName;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandler.java
@@ -27,7 +27,7 @@ public interface QueryOperationHandler {
      *
      * @param memberId ID of the member.
      * @param operation Operation to be executed.
-     * @return {@code True} if operation is triggered, {@code false} if target member is not available.
+     * @return {@code true} if operation is triggered, {@code false} if target member is not available.
      */
     boolean submit(UUID memberId, QueryOperation operation);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.operation;
+
+import java.util.UUID;
+
+/**
+ * Query operation executor.
+ */
+public interface QueryOperationHandler {
+    /**
+     * Submit operation for execution on a member.
+     *
+     * @param memberId ID of the member.
+     * @param operation Operation to be executed.
+     * @return {@code True} if operation is triggered, {@code false} if target member is not available.
+     */
+    boolean submit(UUID memberId, QueryOperation operation);
+
+    /**
+     * Execute the operation synchronously.
+     *
+     * @param operation Operation.
+     */
+    void execute(QueryOperation operation);
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateCallback.java
@@ -34,7 +34,7 @@ public interface QueryStateCallback {
 
     /**
      * Check whether the query is cancelled. If the query is not cancelled, the method returns with no side effects.
-     * Otherwise and exception is thrown.
+     * Otherwise an exception is thrown.
      */
     void checkCancelled();
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.state;
+
+/**
+ * Callback to perform various actions on the query state.
+ */
+public interface QueryStateCallback {
+    /**
+     * Notify the query that fragment execution has finished.
+     */
+    void onFragmentFinished();
+
+    /**
+     * Cancel the query with error.
+     *
+     * @param e Error.
+     */
+    void cancel(Exception e);
+
+    /**
+     * Check whether the query is cancelled. If the query is not cancelled, the method returns with no side effects.
+     * Otherwise and exception is thrown.
+     */
+    void checkCancelled();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutable.java
@@ -167,25 +167,17 @@ public class QueryFragmentExecutable implements QueryFragmentScheduleCallback {
 
             // Notify state about the exception to trigger cancel operation.
             stateCallback.cancel(e);
+        } finally {
+            unscheduleOrReschedule();
         }
-
-        // Unschedule the fragment with double-check for new batches.
-        unschedule();
     }
 
     @Override
     public boolean schedule() {
-        // If the fragment is already scheduled, we do not need to do anything else, because executor will re-check queue state
-        // before exiting.
-        if (scheduled.get()) {
-            return false;
-        }
-
-        // Otherwise we schedule the fragment into the worker pool.
-        boolean res = scheduled.compareAndSet(false, true);
+        boolean res = !scheduled.get() && scheduled.compareAndSet(false, true);
 
         if (res) {
-            fragmentPool.submit(this);
+            submit();
         }
 
         return res;
@@ -194,14 +186,29 @@ public class QueryFragmentExecutable implements QueryFragmentScheduleCallback {
     /**
      * Unschedule the fragment.
      */
-    private void unschedule() {
-        // Unset the scheduled flag.
-        scheduled.lazySet(false);
+    private void unscheduleOrReschedule() {
+        boolean completed0 = completed;
 
-        // If new tasks arrived concurrently, reschedule the fragment again.
-        if (!operations.isEmpty() && !completed) {
+        // Check for new operations. If there are some, re-submit the fragment for execution immediately.
+        if (!completed0 && !operations.isEmpty()) {
+            // New operations arrived. Submit the fragment for execution again.
+            submit();
+        }
+
+        // Otherwise, reset the "scheduled" flag to let other threads re-submit the fragment when needed.
+        // Normal volatile write (seq-cst) is required here. Release semantics alone is not enough, because it will allow
+        // the further check for pending operations to be reordered before the write.
+        scheduled.set(false);
+
+        // Double-check for new operations to prevent the race condition when another thread added the batch after we checked
+        // for pending operations, but before we reset the "scheduled" flag.
+        if (!completed0 && !operations.isEmpty()) {
             schedule();
         }
+    }
+
+    private void submit() {
+        fragmentPool.submit(this);
     }
 
     private void setupExecutor() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutable.java
@@ -193,6 +193,8 @@ public class QueryFragmentExecutable implements QueryFragmentScheduleCallback {
         if (!completed0 && !operations.isEmpty()) {
             // New operations arrived. Submit the fragment for execution again.
             submit();
+
+            return;
         }
 
         // Otherwise, reset the "scheduled" flag to let other threads re-submit the fragment when needed.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutable.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.sql.impl.exec.Exec;
+import com.hazelcast.sql.impl.exec.IterationResult;
+import com.hazelcast.sql.impl.fragment.QueryFragmentContext;
+import com.hazelcast.sql.impl.mailbox.InboundHandler;
+import com.hazelcast.sql.impl.mailbox.InboundBatch;
+import com.hazelcast.sql.impl.mailbox.OutboundHandler;
+import com.hazelcast.sql.impl.operation.QueryBatchExchangeOperation;
+import com.hazelcast.sql.impl.operation.QueryAbstractExchangeOperation;
+import com.hazelcast.sql.impl.operation.QueryFlowControlExchangeOperation;
+import com.hazelcast.sql.impl.operation.QueryOperation;
+import com.hazelcast.sql.impl.state.QueryStateCallback;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Query fragment executable that advances the top-level operator, consumes data operations, and manages scheduling.
+ */
+public class QueryFragmentExecutable implements QueryFragmentScheduleCallback {
+
+    private final QueryStateCallback stateCallback;
+    private final List<Object> arguments;
+    private final Exec exec;
+    private final Map<Integer, InboundHandler> inboxes;
+    private final Map<Integer, Map<UUID, OutboundHandler>> outboxes;
+    private final QueryFragmentWorkerPool fragmentPool;
+
+    /** Operations to be processed. */
+    private final ConcurrentLinkedDeque<QueryAbstractExchangeOperation> operations = new ConcurrentLinkedDeque<>();
+
+    /** Batch count which we used instead of batches.size() (which is O(N)) to prevent starvation. */
+    private final AtomicInteger operationCount = new AtomicInteger();
+
+    /** Schedule flag. */
+    private final AtomicBoolean scheduled = new AtomicBoolean();
+
+    /** Whether the fragment is initialized. */
+    private volatile boolean initialized;
+
+    /** Whether the fragment has completed. */
+    private volatile boolean completed;
+
+    public QueryFragmentExecutable(
+        QueryStateCallback stateCallback,
+        List<Object> arguments,
+        Exec exec,
+        Map<Integer, InboundHandler> inboxes,
+        Map<Integer, Map<UUID, OutboundHandler>> outboxes,
+        QueryFragmentWorkerPool fragmentPool
+    ) {
+        this.stateCallback = stateCallback;
+        this.arguments = arguments;
+        this.exec = exec;
+        this.inboxes = inboxes;
+        this.outboxes = outboxes;
+        this.fragmentPool = fragmentPool;
+    }
+
+    public Collection<Integer> getInboxEdgeIds() {
+        return inboxes.keySet();
+    }
+
+    public Collection<Integer> getOutboxEdgeIds() {
+        return outboxes.keySet();
+    }
+
+    /**
+     * Add operation to be processed.
+     */
+    public void addOperation(QueryAbstractExchangeOperation operation) {
+        operationCount.incrementAndGet();
+        operations.addLast(operation);
+    }
+
+    public void run() {
+        try {
+            if (completed) {
+                return;
+            }
+
+            // Setup the executor if needed.
+            setupExecutor();
+
+            // Feed all batches to relevant inboxes first. Set the upper boundary on the number of batches to avoid
+            // starvation when batches arrive quicker than we are able to process them.
+            int maxOperationCount = operationCount.get();
+            int processedBatchCount = 0;
+
+            QueryOperation operation;
+
+            while ((operation = operations.pollFirst()) != null) {
+                if (operation instanceof QueryBatchExchangeOperation) {
+                    QueryBatchExchangeOperation operation0 = (QueryBatchExchangeOperation) operation;
+
+                    InboundHandler inbox = inboxes.get(operation0.getEdgeId());
+                    assert inbox != null;
+
+                    InboundBatch batch = new InboundBatch(
+                        operation0.getBatch(),
+                        operation0.isLast(),
+                        operation0.getCallerId()
+                    );
+
+                    inbox.onBatch(batch, operation0.getRemainingMemory());
+                } else {
+                    assert operation instanceof QueryFlowControlExchangeOperation;
+
+                    QueryFlowControlExchangeOperation operation0 = (QueryFlowControlExchangeOperation) operation;
+
+                    Map<UUID, OutboundHandler> edgeOutboxes = outboxes.get(operation0.getEdgeId());
+                    assert edgeOutboxes != null;
+
+                    OutboundHandler outbox = edgeOutboxes.get(operation.getCallerId());
+                    assert outbox != null;
+
+                    outbox.onFlowControl(operation0.getRemainingMemory());
+                }
+
+                if (++processedBatchCount >= maxOperationCount) {
+                    break;
+                }
+            }
+
+            operationCount.addAndGet(-1 * processedBatchCount);
+
+            IterationResult res = exec.advance();
+
+            // Send flow control messages if needed.
+            if (res != IterationResult.FETCHED_DONE) {
+                for (InboundHandler inbox : inboxes.values()) {
+                    inbox.sendFlowControl();
+                }
+            }
+
+            // If executor finished, notify the state.
+            if (res == IterationResult.FETCHED_DONE) {
+                completed = true;
+
+                stateCallback.onFragmentFinished();
+            }
+        } catch (Exception e) {
+            // Prevent subsequent invocations.
+            completed = true;
+
+            // Notify state about the exception to trigger cancel operation.
+            stateCallback.cancel(e);
+        }
+
+        // Unschedule the fragment with double-check for new batches.
+        unschedule();
+    }
+
+    @Override
+    public boolean schedule() {
+        // If the fragment is already scheduled, we do not need to do anything else, because executor will re-check queue state
+        // before exiting.
+        if (scheduled.get()) {
+            return false;
+        }
+
+        // Otherwise we schedule the fragment into the worker pool.
+        boolean res = scheduled.compareAndSet(false, true);
+
+        if (res) {
+            fragmentPool.submit(this);
+        }
+
+        return res;
+    }
+
+    /**
+     * Unschedule the fragment.
+     */
+    private void unschedule() {
+        // Unset the scheduled flag.
+        scheduled.lazySet(false);
+
+        // If new tasks arrived concurrently, reschedule the fragment again.
+        if (!operations.isEmpty() && !completed) {
+            schedule();
+        }
+    }
+
+    private void setupExecutor() {
+        if (initialized) {
+            return;
+        }
+
+        try {
+            exec.setup(new QueryFragmentContext(arguments, this, stateCallback));
+        } finally {
+            initialized = true;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentScheduleCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentScheduleCallback.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+public interface QueryFragmentScheduleCallback {
+    /**
+     * Schedule the fragment for execution.
+     *
+     * @return {@code True} if the fragment was scheduled, {@code false} if already scheduled.
+     */
+    boolean schedule();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentScheduleCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentScheduleCallback.java
@@ -20,7 +20,7 @@ public interface QueryFragmentScheduleCallback {
     /**
      * Schedule the fragment for execution.
      *
-     * @return {@code True} if the fragment was scheduled, {@code false} if already scheduled.
+     * @return {@code true} if the fragment was scheduled, {@code false} if already scheduled.
      */
     boolean schedule();
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentWorkerPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentWorkerPool.java
@@ -53,7 +53,7 @@ public class QueryFragmentWorkerPool {
      * @param task Fragment.
      */
     public void submit(QueryFragmentExecutable task) {
-        pool.submit(task::run);
+        pool.execute(task::run);
     }
 
     private static final class WorkerThread extends ForkJoinWorkerThread {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentWorkerPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentWorkerPool.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.sql.impl.QueryUtils;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.sql.impl.QueryUtils.WORKER_TYPE_FRAGMENT;
+
+/**
+ * Thread pool that executes query fragments.
+ */
+public class QueryFragmentWorkerPool {
+
+    private final ForkJoinPool pool;
+
+    public QueryFragmentWorkerPool(String instanceName, int threadCount) {
+        pool = new ForkJoinPool(threadCount, new WorkerThreadFactory(instanceName), null, false);
+    }
+
+    /**
+     * Stop the pool.
+     */
+    public void stop() {
+        pool.shutdownNow();
+    }
+
+    /**
+     * Schedule query fragment in the pool.
+     *
+     * @param task Fragment.
+     */
+    public void submit(QueryFragmentExecutable task) {
+        pool.submit(task::run);
+    }
+
+    private static final class WorkerThread extends ForkJoinWorkerThread {
+        private WorkerThread(ForkJoinPool pool) {
+            super(pool);
+        }
+    }
+
+    private static final class WorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+        private final String instanceName;
+        private final AtomicLong indexGenerator = new AtomicLong();
+
+        private WorkerThreadFactory(String instanceName) {
+            this.instanceName = instanceName;
+        }
+
+        @Override
+        public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+            String name = QueryUtils.workerName(instanceName, WORKER_TYPE_FRAGMENT, indexGenerator.incrementAndGet());
+
+            WorkerThread thread = new WorkerThread(pool);
+
+            thread.setName(name);
+
+            return thread;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationExecutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationExecutable.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.sql.impl.operation.QueryOperation;
 
 /**
- * Operation descriptor.
+ * Query operation to be executed. Could be either local (i.e. requested on the local member), or remote.
  */
 public final class QueryOperationExecutable {
     private final QueryOperation localOperation;
@@ -37,6 +37,10 @@ public final class QueryOperationExecutable {
 
     public static QueryOperationExecutable remote(Packet packet) {
         return new QueryOperationExecutable(null, packet);
+    }
+
+    public boolean isLocal() {
+        return localOperation != null;
     }
 
     public QueryOperation getLocalOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationExecutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationExecutable.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.sql.impl.operation.QueryOperation;
+
+/**
+ * Operation descriptor.
+ */
+public final class QueryOperationExecutable {
+    private final QueryOperation localOperation;
+    private final Packet remoteOperation;
+
+    private QueryOperationExecutable(QueryOperation localOperation, Packet remoteOperation) {
+        this.localOperation = localOperation;
+        this.remoteOperation = remoteOperation;
+    }
+
+    public static QueryOperationExecutable local(QueryOperation localOperation) {
+        return new QueryOperationExecutable(localOperation, null);
+    }
+
+    public static QueryOperationExecutable remote(Packet packet) {
+        return new QueryOperationExecutable(null, packet);
+    }
+
+    public QueryOperation getLocalOperation() {
+        return localOperation;
+    }
+
+    public Packet getRemoteOperation() {
+        return remoteOperation;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationWorker.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationWorker.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.concurrent.MPSCQueue;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.sql.HazelcastSqlException;
+import com.hazelcast.sql.impl.QueryId;
+import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.operation.QueryCancelOperation;
+import com.hazelcast.sql.impl.operation.QueryOperation;
+import com.hazelcast.sql.impl.operation.QueryOperationDeserializationException;
+import com.hazelcast.sql.impl.operation.QueryOperationHandler;
+
+import java.util.UUID;
+
+import static com.hazelcast.sql.impl.QueryUtils.WORKER_TYPE_OPERATION;
+
+/**
+ * Worker responsible for operation processing.
+ */
+public class QueryOperationWorker implements Runnable {
+
+    private static final Object POISON = new Object();
+
+    private final QueryOperationHandler operationHandler;
+    private final SerializationService ss;
+    private final Thread thread;
+    private final MPSCQueue<Object> queue;
+    private final ILogger logger;
+
+    private UUID localMemberId;
+
+    public QueryOperationWorker(
+        QueryOperationHandler operationHandler,
+        SerializationService ss,
+        String instanceName,
+        int index,
+        ILogger logger
+    ) {
+        this.operationHandler = operationHandler;
+        this.ss = ss;
+        this.logger = logger;
+
+        thread = new Thread(this,  QueryUtils.workerName(instanceName, WORKER_TYPE_OPERATION, index));
+        queue = new MPSCQueue<>(thread, null);
+
+        thread.start();
+    }
+
+    public void init(UUID localMemberId) {
+        this.localMemberId = localMemberId;
+    }
+
+    public void submit(QueryOperationExecutable task) {
+        queue.add(task);
+    }
+
+    public void stop() {
+        queue.clear();
+        queue.add(POISON);
+
+        thread.interrupt();
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (true) {
+                Object task = queue.take();
+
+                if (task == POISON) {
+                    break;
+                } else {
+                    assert task instanceof QueryOperationExecutable;
+
+                    execute((QueryOperationExecutable) task);
+                }
+            }
+        } catch (InterruptedException e) {
+            // No-op.
+        }
+    }
+
+    private void execute(QueryOperationExecutable task) {
+        QueryOperation operation = task.getLocalOperation();
+
+        if (operation == null) {
+            operation = deserialize(task.getRemoteOperation());
+        }
+
+        operationHandler.execute(operation);
+    }
+
+    /**
+     * Deserializes the packet into operation. If an exception happens, the query is cancelled.
+     *
+     * @param packet Packet packet.
+     * @return Query operation.
+     */
+    private QueryOperation deserialize(Packet packet) {
+        try {
+            return ss.toObject(packet);
+        } catch (Exception e) {
+            if (e.getCause() instanceof QueryOperationDeserializationException) {
+                QueryOperationDeserializationException error = (QueryOperationDeserializationException) e.getCause();
+
+                // We assume that only ID aware operations may hold user data. Other operations contain only HZ classes and
+                // we should never see deserialization errors for them.
+                sendDeserializationError(error);
+            } else {
+                // It is not easy to decide how to handle an arbitrary exception. We do not have caller coordinates, so
+                // we do not know how to notify it. We also cannot panic (i.e. kill local member), because it would be a
+                // security threat. So the only sensible solution is to log the error.
+                logger.warning("Failed to deserialize query operation received from " + packet.getConn().getEndPoint()
+                    + " (will be ignored)", e);
+            }
+        }
+
+        return null;
+    }
+
+    private void sendDeserializationError(QueryOperationDeserializationException e) {
+        QueryId queryId = e.getQueryId();
+        UUID callerId = e.getCallerId();
+
+        HazelcastSqlException error = HazelcastSqlException.error("Failed to deserialize " + e.getOperationClassName()
+            + " received from " + callerId + ": " + e.getMessage(), e);
+
+        QueryCancelOperation cancelOperation =
+            new QueryCancelOperation(queryId, error.getCode(), error.getMessage(), localMemberId);
+
+        try {
+            operationHandler.submit(queryId.getMemberId(), cancelOperation);
+        } catch (Exception ignore) {
+            // This should never happen, since we do not transmit user objects.
+        }
+    }
+
+    /**
+     * For testing only.
+     */
+    boolean isThreadTerminated() {
+        return thread.getState() == Thread.State.TERMINATED;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationWorker.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationWorker.java
@@ -109,11 +109,19 @@ public class QueryOperationWorker implements Runnable {
     }
 
     private void execute(QueryOperationExecutable task) {
-        QueryOperation operation = task.getLocalOperation();
+        QueryOperation operation;
 
-        if (operation == null) {
+        if (task.isLocal()) {
+            operation = task.getLocalOperation();
+        } else {
             operation = deserialize(task.getRemoteOperation());
+
+            if (operation == null) {
+                return;
+            }
         }
+
+        assert operation != null;
 
         operationHandler.execute(operation);
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationWorkerPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryOperationWorkerPool.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.sql.impl.operation.QueryOperationHandler;
+import com.hazelcast.sql.impl.operation.QueryOperation;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Thread pool that executes query operations.
+ */
+public class QueryOperationWorkerPool {
+
+    private final int threadCount;
+    private final QueryOperationWorker[] workers;
+
+    public QueryOperationWorkerPool(
+        String instanceName,
+        int threadCount,
+        QueryOperationHandler operationHandler,
+        SerializationService serializationService,
+        ILogger logger
+    ) {
+        this.threadCount = threadCount;
+
+        workers = new QueryOperationWorker[threadCount];
+
+        for (int i = 0; i < threadCount; i++) {
+            QueryOperationWorker worker =
+                new QueryOperationWorker(operationHandler, serializationService, instanceName, i, logger);
+
+            workers[i] = worker;
+        }
+    }
+
+    public void init(UUID localMemberId) {
+        for (QueryOperationWorker worker : workers) {
+            worker.init(localMemberId);
+        }
+    }
+
+    public void submit(int partition, QueryOperationExecutable task) {
+        int index = getWorkerIndex(partition);
+
+        QueryOperationWorker worker = getWorker(index);
+
+        worker.submit(task);
+    }
+
+    public void stop() {
+        for (QueryOperationWorker worker : workers) {
+            worker.stop();
+        }
+    }
+
+    QueryOperationWorker getWorker(int index) {
+        return workers[index];
+    }
+
+    private int getWorkerIndex(int partition) {
+        int index;
+
+        if (partition == QueryOperation.PARTITION_ANY) {
+            index = ThreadLocalRandom.current().nextInt(threadCount);
+        } else {
+            index = partition % threadCount;
+        }
+
+        assert index >= 0 && index < threadCount;
+
+        return index;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractExecTest.java
@@ -43,7 +43,7 @@ public class AbstractExecTest {
         assertEquals(1, exec.getId());
 
         // Setup.
-        QueryFragmentContext context = new QueryFragmentContext(Collections.emptyList());
+        QueryFragmentContext context = new QueryFragmentContext(Collections.emptyList(), null, null);
 
         exec.setup(context);
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractUpstreamAwareExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractUpstreamAwareExecTest.java
@@ -37,7 +37,7 @@ public class AbstractUpstreamAwareExecTest {
         ChildExec childExec = new ChildExec();
         ParentExec parentExec = new ParentExec(childExec);
 
-        QueryFragmentContext context = new QueryFragmentContext(Collections.emptyList());
+        QueryFragmentContext context = new QueryFragmentContext(Collections.emptyList(), null, null);
 
         parentExec.setup(context);
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/UpstreamStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/UpstreamStateTest.java
@@ -56,7 +56,7 @@ public class UpstreamStateTest {
         UpstreamState state = new UpstreamState(exec);
 
         // Test setup.
-        QueryFragmentContext context = new QueryFragmentContext(Collections.emptyList());
+        QueryFragmentContext context = new QueryFragmentContext(Collections.emptyList(), null, null);
 
         state.setup(context);
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/fragment/QueryFragmentContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/fragment/QueryFragmentContextTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql.impl.fragment;
 
+import com.hazelcast.sql.impl.state.QueryStateCallback;
+import com.hazelcast.sql.impl.worker.QueryFragmentScheduleCallback;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -26,7 +28,9 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -38,9 +42,58 @@ public class QueryFragmentContextTest {
         args.add(new Object());
         args.add(new Object());
 
-        QueryFragmentContext context = new QueryFragmentContext(args);
+        TestFragmentScheduleCallback fragmentScheduleCallback = new TestFragmentScheduleCallback();
+        TestStateCallback stateCallback = new TestStateCallback();
+
+        QueryFragmentContext context = new QueryFragmentContext(args, fragmentScheduleCallback, stateCallback);
 
         assertSame(args.get(0), context.getArgument(0));
         assertSame(args.get(1), context.getArgument(1));
+
+        context.schedule();
+        assertTrue(fragmentScheduleCallback.isInvoked());
+
+        context.checkCancelled();
+        assertEquals(1, stateCallback.getCheckCancelledInvocationCount());
+    }
+
+    private static class TestFragmentScheduleCallback implements QueryFragmentScheduleCallback {
+
+        private boolean invoked;
+
+        @Override
+        public boolean schedule() {
+            invoked = true;
+
+            return true;
+        }
+
+        private boolean isInvoked() {
+            return invoked;
+        }
+    }
+
+    private static class TestStateCallback implements QueryStateCallback {
+
+        private int checkCancelledInvocationCount;
+
+        @Override
+        public void onFragmentFinished() {
+            // No-op.
+        }
+
+        @Override
+        public void cancel(Exception e) {
+            // No-op.
+        }
+
+        @Override
+        public void checkCancelled() {
+            checkCancelledInvocationCount++;
+        }
+
+        public int getCheckCancelledInvocationCount() {
+            return checkCancelledInvocationCount;
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/mailbox/InboundBatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/mailbox/InboundBatchTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.mailbox;
+
+import com.hazelcast.sql.impl.row.ListRowBatch;
+import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class InboundBatchTest {
+    @Test
+    public void testInboundBatch() {
+        RowBatch rowBatch = new ListRowBatch();
+        boolean last = true;
+        UUID senderId = UUID.randomUUID();
+
+        InboundBatch batch = new InboundBatch(rowBatch, last, senderId);
+
+        assertSame(rowBatch, batch.getBatch());
+        assertEquals(last, batch.isLast());
+        assertEquals(senderId, batch.getSenderId());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
@@ -208,7 +208,7 @@ public class QueryFragmentExecutableTest extends HazelcastTestSupport {
      */
     @Test
     public void testMessages() throws Exception {
-        int repeatCount = 10;
+        int repeatCount = 100;
 
         for (int i = 0; i < repeatCount; i++) {
             // Prepare data structures for messages.

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.sql.impl.QueryId;
+import com.hazelcast.sql.impl.exec.AbstractExec;
+import com.hazelcast.sql.impl.exec.IterationResult;
+import com.hazelcast.sql.impl.fragment.QueryFragmentContext;
+import com.hazelcast.sql.impl.mailbox.InboundBatch;
+import com.hazelcast.sql.impl.mailbox.InboundHandler;
+import com.hazelcast.sql.impl.mailbox.OutboundHandler;
+import com.hazelcast.sql.impl.operation.QueryAbstractExchangeOperation;
+import com.hazelcast.sql.impl.operation.QueryBatchExchangeOperation;
+import com.hazelcast.sql.impl.operation.QueryFlowControlExchangeOperation;
+import com.hazelcast.sql.impl.row.EmptyRowBatch;
+import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.sql.impl.state.QueryStateCallback;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class QueryFragmentExecutableTest extends HazelcastTestSupport {
+
+    private QueryFragmentWorkerPool pool;
+
+    @After
+    public void after() {
+        if (pool != null) {
+            pool.stop();
+
+            pool = null;
+        }
+    }
+
+    @Test
+    public void testSetupIsCalledOnlyOnce() {
+        pool = createPool();
+
+        TestStateCallback stateCallback = new TestStateCallback();
+        TestExec exec = new TestExec().setPayload(new ResultExecPayload(IterationResult.FETCHED));
+
+        QueryFragmentExecutable fragmentExecutable = new QueryFragmentExecutable(
+            stateCallback,
+            Collections.emptyList(),
+            exec,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            pool
+        );
+
+        fragmentExecutable.run();
+        assertEquals(1, exec.getSetupInvocationCount());
+
+        fragmentExecutable.run();
+        assertEquals(1, exec.getSetupInvocationCount());
+    }
+
+    @Test
+    public void testAdvanceIsCalledUntilCompletion() {
+        pool = createPool();
+
+        TestStateCallback stateCallback = new TestStateCallback();
+        TestExec exec = new TestExec();
+
+        QueryFragmentExecutable fragmentExecutable = new QueryFragmentExecutable(
+            stateCallback,
+            Collections.emptyList(),
+            exec,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            pool
+        );
+
+        exec.setPayload(new ResultExecPayload(IterationResult.WAIT));
+        fragmentExecutable.run();
+        fragmentExecutable.run();
+        assertEquals(2, exec.getAdvanceInvocationCount());
+
+        exec.setPayload(new ResultExecPayload(IterationResult.FETCHED));
+        fragmentExecutable.run();
+        fragmentExecutable.run();
+        assertEquals(4, exec.getAdvanceInvocationCount());
+        assertEquals(0, stateCallback.getFragmentFinishedInvocationCount());
+
+        exec.setPayload(new ResultExecPayload(IterationResult.FETCHED_DONE));
+        fragmentExecutable.run();
+        fragmentExecutable.run();
+        assertEquals(5, exec.getAdvanceInvocationCount());
+        assertEquals(1, stateCallback.getFragmentFinishedInvocationCount());
+    }
+
+    @Test
+    public void testExceptionDuringExecution() {
+        pool = createPool();
+
+        TestStateCallback stateCallback = new TestStateCallback();
+        TestExec exec = new TestExec();
+
+        QueryFragmentExecutable fragmentExecutable = new QueryFragmentExecutable(
+            stateCallback,
+            Collections.emptyList(),
+            exec,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            pool
+        );
+
+        // Throw an exception.
+        exec.setPayload(new ExceptionExecPayload());
+        fragmentExecutable.run();
+        assertEquals(1, exec.getAdvanceInvocationCount());
+        assertSame(ExceptionExecPayload.ERROR, stateCallback.getCancelException());
+
+        // Make sure that no advance is possible after that.
+        fragmentExecutable.run();
+        assertEquals(1, exec.getAdvanceInvocationCount());
+        assertEquals(0, stateCallback.getFragmentFinishedInvocationCount());
+    }
+
+    @Test
+    public void testSchedule() throws Exception {
+        pool = createPool();
+
+        TestStateCallback stateCallback = new TestStateCallback();
+        TestExec exec = new TestExec();
+
+        AtomicBoolean flowControlNotified = new AtomicBoolean();
+
+        InboundHandler inboundHandler = new InboundHandler() {
+            @Override
+            public void onBatch(InboundBatch batch, long remainingMemory) {
+                // No-op.
+            }
+
+            @Override
+            public void sendFlowControl() {
+                flowControlNotified.set(true);
+            }
+        };
+
+        QueryFragmentExecutable fragmentExecutable = new QueryFragmentExecutable(
+            stateCallback,
+            Collections.emptyList(),
+            exec,
+            Collections.singletonMap(1, inboundHandler),
+            Collections.emptyMap(),
+            pool
+        );
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch stopLatch = new CountDownLatch(1);
+
+        exec.setPayload(() -> {
+            startLatch.countDown();
+            stopLatch.await();
+
+            return IterationResult.FETCHED;
+        });
+
+        assertTrue(fragmentExecutable.schedule());
+        startLatch.await();
+
+        assertFalse(fragmentExecutable.schedule());
+        stopLatch.countDown();
+
+        assertTrueEventually(() -> assertTrue(flowControlNotified.get()));
+    }
+
+    /**
+     * Concurrent test which submit messages from different threads and see if all of them are processed.
+     */
+    @Test
+    public void testMessages() throws Exception {
+        int repeatCount = 10;
+
+        for (int i = 0; i < repeatCount; i++) {
+            // Prepare data structures for messages.
+            ConcurrentLinkedQueue<Long> inboundQueue = new ConcurrentLinkedQueue<>();
+            ConcurrentLinkedQueue<Long> outboundQueue = new ConcurrentLinkedQueue<>();
+
+            Set<Long> inboundSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
+            Set<Long> outboundSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+            InboundHandler inboundHandler = new InboundHandler() {
+                @Override
+                public void onBatch(InboundBatch batch, long remainingMemory) {
+                    inboundQueue.add(remainingMemory);
+                }
+
+                @Override
+                public void sendFlowControl() {
+                    // No-op.
+                }
+            };
+
+            OutboundHandler outboundHandler = outboundQueue::add;
+
+            // Prepare executable.
+            QueryId queryId = QueryId.create(UUID.randomUUID());
+            UUID callerId = UUID.randomUUID();
+            int edgeId = 1;
+
+            pool = createPool();
+
+            TestStateCallback stateCallback = new TestStateCallback();
+
+            TestExec exec = new TestExec().setPayload(() -> {
+                while (!inboundQueue.isEmpty()) {
+                    inboundSet.add(inboundQueue.poll());
+                }
+
+                while (!outboundQueue.isEmpty()) {
+                    outboundSet.add(outboundQueue.poll());
+                }
+
+                return IterationResult.FETCHED;
+            });
+
+            QueryFragmentExecutable fragmentExecutable = new QueryFragmentExecutable(
+                stateCallback,
+                Collections.emptyList(),
+                exec,
+                Collections.singletonMap(edgeId, inboundHandler),
+                Collections.singletonMap(edgeId, Collections.singletonMap(callerId, outboundHandler)),
+                pool
+            );
+
+            assertEquals(1, fragmentExecutable.getInboxEdgeIds().size());
+            assertEquals(1, fragmentExecutable.getOutboxEdgeIds().size());
+            assertEquals(edgeId, (int) fragmentExecutable.getInboxEdgeIds().iterator().next());
+            assertEquals(edgeId, (int) fragmentExecutable.getOutboxEdgeIds().iterator().next());
+
+            // Start threads and wait for completion.
+            int operationCount = 10_000;
+            int threadCount = 8;
+
+            AtomicInteger doneOperationCount = new AtomicInteger();
+            CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+            Runnable run = () -> {
+                try {
+                    while (true) {
+                        int counter = doneOperationCount.getAndIncrement();
+
+                        if (counter >= operationCount) {
+                            break;
+                        }
+
+                        QueryAbstractExchangeOperation operation;
+
+                        if (ThreadLocalRandom.current().nextBoolean()) {
+                            operation = new QueryBatchExchangeOperation(queryId, edgeId, EmptyRowBatch.INSTANCE, false, counter);
+                        } else {
+                            operation = new QueryFlowControlExchangeOperation(queryId, edgeId, counter);
+                        }
+
+                        operation.setCallerId(callerId);
+
+                        fragmentExecutable.addOperation(operation);
+                        fragmentExecutable.schedule();
+                    }
+                } finally {
+                    doneLatch.countDown();
+                }
+            };
+
+            for (int j = 0; j < threadCount; j++) {
+                new Thread(run).start();
+            }
+
+            doneLatch.await();
+
+            // Make sure that all batches were drained.
+            assertTrueEventually(() -> assertTrue(inboundQueue.isEmpty()));
+            assertTrueEventually(() -> assertTrue(outboundQueue.isEmpty()));
+
+            // Make sure that the executor observed all batches.
+            assertTrueEventually(() -> assertEquals(operationCount, inboundSet.size() + outboundSet.size()));
+        }
+    }
+
+    /**
+     * Test that ensures propagation of cancel.
+     */
+    @Test
+    public void testShutdown() throws Exception {
+        pool = createPool();
+
+        TestStateCallback stateCallback = new TestStateCallback();
+        TestExec exec = new TestExec();
+
+        QueryFragmentExecutable fragmentExecutable = new QueryFragmentExecutable(
+            stateCallback,
+            Collections.emptyList(),
+            exec,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            pool
+        );
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch blockLatch = new CountDownLatch(1);
+        AtomicBoolean interruptCaught = new AtomicBoolean();
+
+        exec.setPayload(() -> {
+            startLatch.countDown();
+
+            try {
+                blockLatch.await();
+            } catch (InterruptedException e) {
+                interruptCaught.set(true);
+
+                Thread.currentThread().interrupt();
+
+                throw e;
+            }
+
+            return IterationResult.FETCHED;
+        });
+
+        // Await exec is reached.
+        assertTrue(fragmentExecutable.schedule());
+        startLatch.await();
+
+        // Shutdown.
+        pool.stop();
+
+        assertTrueEventually(() -> assertTrue(interruptCaught.get()));
+    }
+
+    private QueryFragmentWorkerPool createPool() {
+        return new QueryFragmentWorkerPool("instance", 4);
+    }
+
+    private interface ExecPayload {
+        IterationResult run() throws Exception;
+    }
+
+    private static class ResultExecPayload implements ExecPayload {
+
+        private final IterationResult result;
+
+        private ResultExecPayload(IterationResult result) {
+            this.result = result;
+        }
+
+        @Override
+        public IterationResult run() throws Exception {
+            return result;
+        }
+    }
+
+    private static class ExceptionExecPayload implements ExecPayload {
+
+        private static final Exception ERROR = new RuntimeException("Failed");
+
+        @Override
+        public IterationResult run() throws Exception {
+            throw ERROR;
+        }
+    }
+
+    @SuppressWarnings("NonAtomicOperationOnVolatileField")
+    private static class TestExec extends AbstractExec {
+
+        private volatile ExecPayload payload;
+        private volatile int setupInvocationCount;
+        private volatile int advanceInvocationCount;
+
+        private TestExec() {
+            super(1);
+        }
+
+        @Override
+        protected IterationResult advance0() {
+            advanceInvocationCount++;
+
+            try {
+                return payload.run();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        protected RowBatch currentBatch0() {
+            return null;
+        }
+
+        @Override
+        protected void setup0(QueryFragmentContext ctx) {
+            setupInvocationCount++;
+        }
+
+        private int getSetupInvocationCount() {
+            return setupInvocationCount;
+        }
+
+        public int getAdvanceInvocationCount() {
+            return advanceInvocationCount;
+        }
+
+        public TestExec setPayload(ExecPayload payload) {
+            this.payload = payload;
+
+            return this;
+        }
+    }
+
+    @SuppressWarnings("NonAtomicOperationOnVolatileField")
+    private static class TestStateCallback implements QueryStateCallback {
+
+        private volatile Exception cancelException;
+        private volatile int fragmentFinishedInvocationCount;
+
+        @Override
+        public void onFragmentFinished() {
+            fragmentFinishedInvocationCount++;
+        }
+
+        @Override
+        public void cancel(Exception e) {
+            cancelException = e;
+        }
+
+        @Override
+        public void checkCancelled() {
+            // No-op.
+        }
+
+        public Exception getCancelException() {
+            return cancelException;
+        }
+
+        public int getFragmentFinishedInvocationCount() {
+            return fragmentFinishedInvocationCount;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
@@ -208,7 +208,7 @@ public class QueryFragmentExecutableTest extends HazelcastTestSupport {
      */
     @Test
     public void testMessages() throws Exception {
-        int repeatCount = 100;
+        int repeatCount = 50;
 
         for (int i = 0; i < repeatCount; i++) {
             // Prepare data structures for messages.

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryFragmentExecutableTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.worker;
 
+import com.hazelcast.logging.NoLogFactory;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.exec.AbstractExec;
 import com.hazelcast.sql.impl.exec.IterationResult;
@@ -365,7 +366,7 @@ public class QueryFragmentExecutableTest extends HazelcastTestSupport {
     }
 
     private QueryFragmentWorkerPool createPool() {
-        return new QueryFragmentWorkerPool("instance", 4);
+        return new QueryFragmentWorkerPool("instance", 4, new NoLogFactory().getLogger("logger"));
     }
 
     private interface ExecPayload {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryOperationExecutableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryOperationExecutableTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.sql.impl.operation.QueryExecuteOperation;
+import com.hazelcast.sql.impl.operation.QueryOperation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class QueryOperationExecutableTest {
+    @Test
+    public void testLocalExecutable() {
+        QueryOperation operation = new QueryExecuteOperation();
+
+        QueryOperationExecutable localExecutable = QueryOperationExecutable.local(operation);
+
+        assertSame(operation, localExecutable.getLocalOperation());
+        assertNull(localExecutable.getRemoteOperation());
+    }
+
+    @Test
+    public void testRemoteExecutable() {
+        Packet packet = new Packet();
+
+        QueryOperationExecutable remoteExecutable = QueryOperationExecutable.remote(packet);
+
+        assertNull(remoteExecutable.getLocalOperation());
+        assertSame(packet, remoteExecutable.getRemoteOperation());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryOperationWorkerPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryOperationWorkerPoolTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.worker;
+
+import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.logging.NoLogFactory;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryId;
+import com.hazelcast.sql.impl.operation.QueryBatchExchangeOperation;
+import com.hazelcast.sql.impl.operation.QueryCancelOperation;
+import com.hazelcast.sql.impl.operation.QueryExecuteOperation;
+import com.hazelcast.sql.impl.operation.QueryOperation;
+import com.hazelcast.sql.impl.operation.QueryOperationHandler;
+import com.hazelcast.sql.impl.row.HeapRow;
+import com.hazelcast.sql.impl.row.ListRowBatch;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class QueryOperationWorkerPoolTest extends HazelcastTestSupport {
+
+    private static final int THREAD_COUNT = 4;
+
+    private QueryOperationWorkerPool pool;
+
+    @After
+    public void after() {
+        if (pool != null) {
+            pool.stop();
+
+            pool = null;
+        }
+    }
+
+    @Test
+    public void testSubmitLocal() {
+        TestQueryOperationHandler operationHandler = new TestQueryOperationHandler();
+
+        pool = createPool(operationHandler);
+
+        // Test specific partition.
+        QueryOperation operation = new QueryExecuteOperation();
+
+        int repeatCount = 10;
+
+        for (int i = 0; i < repeatCount; i++) {
+            pool.submit(500, QueryOperationExecutable.local(operation));
+        }
+
+        assertTrueEventually(() -> {
+            List<ExecuteInfo> infos = operationHandler.tryPollExecuteInfos(repeatCount);
+
+            assertNotNull(infos);
+
+            Set<String> threadNames = new HashSet<>();
+
+            for (int i = 1; i < infos.size(); i++) {
+                assertSame(operation, infos.get(i).getOperation());
+
+                threadNames.add(infos.get(i).getThreadName());
+            }
+
+            assertEquals(1, threadNames.size());
+        });
+
+        // Test random partitions.
+        for (int i = 0; i < repeatCount; i++) {
+            pool.submit(QueryOperation.PARTITION_ANY, QueryOperationExecutable.local(operation));
+        }
+
+        assertTrueEventually(() -> {
+            List<ExecuteInfo> infos = operationHandler.tryPollExecuteInfos(repeatCount);
+
+            assertNotNull(infos);
+
+            Set<String> threadNames = new HashSet<>();
+
+            for (ExecuteInfo info : infos) {
+                assertSame(operation, info.getOperation());
+
+                threadNames.add(info.getThreadName());
+            }
+
+            assertTrue(threadNames.size() > 0);
+        });
+    }
+
+    @Test
+    public void testSubmitRemote() {
+        TestQueryOperationHandler operationHandler = new TestQueryOperationHandler();
+
+        pool = createPool(operationHandler);
+
+        QueryCancelOperation cancelOperation =
+            new QueryCancelOperation(QueryId.create(UUID.randomUUID()), -1, "err", UUID.randomUUID());
+
+        cancelOperation.setCallerId(UUID.randomUUID());
+
+        Packet packet = toPacket(cancelOperation);
+
+        pool.submit(cancelOperation.getPartition(), QueryOperationExecutable.remote(packet));
+
+        assertTrueEventually(() -> {
+            List<ExecuteInfo> infos = operationHandler.tryPollExecuteInfos(1);
+
+            assertNotNull(infos);
+
+            QueryCancelOperation operation = (QueryCancelOperation) infos.get(0).getOperation();
+
+            assertEquals(cancelOperation.getCallerId(), operation.getCallerId());
+            assertEquals(cancelOperation.getQueryId(), operation.getQueryId());
+            assertEquals(cancelOperation.getErrorCode(), operation.getErrorCode());
+            assertEquals(cancelOperation.getErrorMessage(), operation.getErrorMessage());
+            assertEquals(cancelOperation.getOriginatingMemberId(), operation.getOriginatingMemberId());
+        });
+    }
+
+    @Test
+    public void testSubmitRemoteWithDeserializationError() {
+        TestQueryOperationHandler operationHandler = new TestQueryOperationHandler();
+
+        pool = createPool(operationHandler);
+
+        UUID localMemberId = UUID.randomUUID();
+        UUID remoteMemberId = UUID.randomUUID();
+
+        pool.init(localMemberId);
+
+        QueryBatchExchangeOperation badOperation = new QueryBatchExchangeOperation(
+            QueryId.create(remoteMemberId),
+            1,
+            new ListRowBatch(Collections.singletonList(new HeapRow(new Object[]{new BadValue()}))),
+            false,
+            100
+        );
+
+        pool.submit(badOperation.getPartition(), QueryOperationExecutable.remote(toPacket(badOperation)));
+
+        assertTrueEventually(() -> {
+            SubmitInfo info = operationHandler.tryPollSubmitInfo();
+
+            assertNotNull(info);
+
+            assertEquals(remoteMemberId, info.getMemberId());
+
+            QueryCancelOperation cancelOperation = (QueryCancelOperation) info.getOperation();
+
+            assertEquals(SqlErrorCode.GENERIC, cancelOperation.getErrorCode());
+            assertTrue(cancelOperation.getErrorMessage().startsWith("Failed to deserialize"));
+            assertEquals(localMemberId, cancelOperation.getOriginatingMemberId());
+        });
+    }
+
+    @Test
+    public void testShutdown() {
+        pool = createPool(new TestQueryOperationHandler());
+
+        pool.stop();
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            QueryOperationWorker worker = pool.getWorker(i);
+
+            assertTrueEventually(() -> assertTrue(worker.isThreadTerminated()));
+        }
+    }
+
+    private QueryOperationWorkerPool createPool(TestQueryOperationHandler operationHandler) {
+        return new QueryOperationWorkerPool(
+            "instance",
+            THREAD_COUNT,
+            operationHandler,
+            new DefaultSerializationServiceBuilder().build(),
+            new NoLogFactory().getLogger("logger")
+        );
+    }
+
+    private static Packet toPacket(QueryOperation operation) {
+        return new Packet(new DefaultSerializationServiceBuilder().build().toBytes(operation), operation.getPartition());
+    }
+
+    private static class TestQueryOperationHandler implements QueryOperationHandler {
+
+        private final LinkedBlockingQueue<SubmitInfo> submitInfos = new LinkedBlockingQueue<>();
+        private final LinkedBlockingQueue<ExecuteInfo> executeInfos = new LinkedBlockingQueue<>();
+
+        @Override
+        public boolean submit(UUID memberId, QueryOperation operation) {
+            submitInfos.add(new SubmitInfo(memberId, operation));
+
+            return true;
+        }
+
+        @Override
+        public void execute(QueryOperation operation) {
+            executeInfos.add(new ExecuteInfo(operation, Thread.currentThread().getName()));
+        }
+
+        public SubmitInfo tryPollSubmitInfo() {
+            return submitInfos.poll();
+        }
+
+        public List<ExecuteInfo> tryPollExecuteInfos(int count) {
+            if (executeInfos.size() >= count) {
+                List<ExecuteInfo> res = new ArrayList<>();
+
+                for (int i = 0; i < count; i++) {
+                    res.add(executeInfos.poll());
+                }
+
+                return res;
+            } else {
+                return null;
+            }
+        }
+    }
+
+    private static class SubmitInfo {
+        private final UUID memberId;
+        private final QueryOperation operation;
+
+        private SubmitInfo(UUID memberId, QueryOperation operation) {
+            this.memberId = memberId;
+            this.operation = operation;
+        }
+
+        private UUID getMemberId() {
+            return memberId;
+        }
+
+        private QueryOperation getOperation() {
+            return operation;
+        }
+    }
+
+    private static class ExecuteInfo {
+        private final QueryOperation operation;
+        private final String threadName;
+
+        private ExecuteInfo(QueryOperation operation, String threadName) {
+            this.operation = operation;
+            this.threadName = threadName;
+        }
+
+        private QueryOperation getOperation() {
+            return operation;
+        }
+
+        private String getThreadName() {
+            return threadName;
+        }
+    }
+
+    private static class BadValue implements DataSerializable {
+        private BadValue() {
+            // No-op.
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(1);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            throw new IOException("Error!");
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces two thread pools that are used for SQL execution. The design document [1] explains why the engine is organized in that way.

@pveentjer, @tkountis, your inputs are especially welcomed since you focus on performance.

Closes #16805 

[1] https://github.com/devozerov/hazelcast/blob/issues/16805/docs/design/sql/04-mulitthreaded-execution.md