### PR TITLE
Renamed cluster Bind to MemberHandshake

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -64,7 +64,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int MEMBER = 2;
     public static final int HEARTBEAT = 3;
     public static final int CONFIG_CHECK = 4;
-    public static final int BIND_MESSAGE = 5;
+    public static final int MEMBER_HANDSHAKE = 5;
     public static final int MEMBER_INFO_UPDATE = 6;
     public static final int FINALIZE_JOIN = 7;
     public static final int BEFORE_JOIN_CHECK_FAILURE = 8;
@@ -117,7 +117,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         constructors[MEMBER] = arg -> new MemberImpl();
         constructors[HEARTBEAT] = arg -> new HeartbeatOp();
         constructors[CONFIG_CHECK] = arg -> new ConfigCheck();
-        constructors[BIND_MESSAGE] = arg -> new BindMessage();
+        constructors[MEMBER_HANDSHAKE] = arg -> new MemberHandshake();
         constructors[MEMBER_INFO_UPDATE] = arg -> new MembersUpdateOp();
         constructors[FINALIZE_JOIN] = arg -> new FinalizeJoinOp();
         constructors[BEFORE_JOIN_CHECK_FAILURE] = arg -> new BeforeJoinCheckFailureOp();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberHandshake.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberHandshake.java
@@ -35,18 +35,18 @@ import static com.hazelcast.internal.util.UUIDSerializationUtil.readUUID;
 import static com.hazelcast.internal.util.UUIDSerializationUtil.writeUUID;
 
 /**
- * Bind message, conveying information about all kinds of public
+ * MemberHandshake message, conveying information about all kinds of public
  * addresses per protocol type.
  * It is the first message exchanged on a new connection
  * so {@link com.hazelcast.nio.serialization.impl.Versioned Versioned}
  * serialization cannot be used as there may be no cluster version
- * established yet. The {@code BindMessage} itself includes a
+ * established yet. The {@code MemberHandshake} itself includes a
  * schema version so it can be extended in future versions without having
  * to use another packet type.
  *
  * @since 3.12
  */
-public class BindMessage
+public class MemberHandshake
         implements IdentifiedDataSerializable {
 
     private byte schemaVersion;
@@ -55,11 +55,11 @@ public class BindMessage
     private boolean reply;
     private UUID uuid;
 
-    public BindMessage() {
+    public MemberHandshake() {
     }
 
-    public BindMessage(byte schemaVersion, Map<ProtocolType, Collection<Address>> localAddresses,
-                       Address targetAddress, boolean reply, UUID uuid) {
+    public MemberHandshake(byte schemaVersion, Map<ProtocolType, Collection<Address>> localAddresses,
+                           Address targetAddress, boolean reply, UUID uuid) {
         this.schemaVersion = schemaVersion;
         this.localAddresses = new EnumMap<>(localAddresses);
         this.targetAddress = targetAddress;
@@ -94,7 +94,7 @@ public class BindMessage
 
     @Override
     public int getClassId() {
-        return ClusterDataSerializerHook.BIND_MESSAGE;
+        return ClusterDataSerializerHook.MEMBER_HANDSHAKE;
     }
 
     @Override
@@ -136,7 +136,7 @@ public class BindMessage
 
     @Override
     public String toString() {
-        return "BindMessage{" + "schemaVersion=" + schemaVersion + ", localAddresses=" + localAddresses
+        return "MemberHandshake{" + "schemaVersion=" + schemaVersion + ", localAddresses=" + localAddresses
                 + ", targetAddress=" + targetAddress + ", reply=" + reply + ", uuid=" + uuid + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/EndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/EndpointManager.java
@@ -34,7 +34,7 @@ public interface EndpointManager<T extends Connection>
     Collection<T> getConnections();
 
     /**
-     * Returns <b>all</b> connections bind or not that are currently holding resources on this member.
+     * Returns <b>all</b> active connections or not that are currently holding resources on this member.
      * If the connection never successfully finishes with the handshake then it will only be visible
      * through this sub-set.
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -306,7 +306,7 @@ public final class Packet extends HeapData implements OutboundFrame {
          * <p>
          * {@code ordinal = 4}
          */
-        BIND,
+        MEMBER_HANDSHAKE,
         /**
          * Unused packet type. Available for future use.
          * <p>

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnection.java
@@ -60,8 +60,8 @@ public class TcpIpConnection implements Connection {
 
     private final AtomicBoolean alive = new AtomicBoolean(true);
 
-    // indicate whether connection bind exchange is in progress/done (true) or not yet initiated (when false)
-    private final AtomicBoolean binding = new AtomicBoolean();
+    // indicate whether connection handshake is in progress/done (true) or not yet initiated (when false)
+    private final AtomicBoolean handshake = new AtomicBoolean();
 
     private final ILogger logger;
 
@@ -80,7 +80,6 @@ public class TcpIpConnection implements Connection {
     private volatile Throwable closeCause;
 
     private volatile String closeReason;
-
 
     public TcpIpConnection(TcpIpEndpointManager endpointManager,
                            ConnectionLifecycleListener lifecycleListener,
@@ -234,8 +233,8 @@ public class TcpIpConnection implements Connection {
         }
     }
 
-    public boolean setBinding() {
-        return binding.compareAndSet(false, true);
+    public boolean setHandshake() {
+        return handshake.compareAndSet(false, true);
     }
 
     private void logClose() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnector.java
@@ -41,7 +41,7 @@ import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_BIND_AN
 
 /**
  * The TcpIpConnector is responsible to make connections by connecting to a remote serverport. Once completed,
- * it will send the protocol and a bind-message.
+ * it will send the protocol and a MemberHandshake-message.
  */
 class TcpIpConnector {
 
@@ -196,8 +196,7 @@ class TcpIpConnector {
                     ioService.interceptSocket(endpointManager.getEndpointQualifier(), socketChannel.socket(), false);
 
                     connection = endpointManager.newConnection(channel, address);
-                    BindRequest request = new BindRequest(logger, ioService, connection, address, true);
-                    request.send();
+                    new SendMemberHandshakeTask(logger, ioService, connection, address, true).run();
                 } catch (Exception e) {
                     closeConnection(connection, e);
                     closeSocket(socketChannel);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManager.java
@@ -104,7 +104,7 @@ public class TcpIpEndpointManager
     private final ChannelInitializerProvider channelInitializerProvider;
     private final NetworkingService networkingService;
     private final TcpIpConnector connector;
-    private final BindHandler bindHandler;
+    private final MemberHandshakeHandler memberHandshakeHandler;
     private final NetworkStatsImpl networkStats;
 
     @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_CONNECTION_LISTENER_COUNT)
@@ -143,7 +143,7 @@ public class TcpIpEndpointManager
         this.ioService = ioService;
         this.logger = loggingService.getLogger(TcpIpEndpointManager.class);
         this.connector = new TcpIpConnector(this);
-        this.bindHandler = new BindHandler(this, ioService, logger, supportedProtocolTypes);
+        this.memberHandshakeHandler = new MemberHandshakeHandler(this, ioService, logger, supportedProtocolTypes);
         this.networkStats = endpointQualifier == null ? null : new NetworkStatsImpl();
     }
 
@@ -171,7 +171,7 @@ public class TcpIpEndpointManager
 
     @Override
     public synchronized void accept(Packet packet) {
-        bindHandler.process(packet);
+        memberHandshakeHandler.process(packet);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
@@ -72,7 +72,7 @@ public final class PacketDispatcher implements Consumer<Packet> {
                 case EVENT:
                     eventService.accept(packet);
                     break;
-                case BIND:
+                case MEMBER_HANDSHAKE:
                     Connection connection = packet.getConn();
                     EndpointManager endpointManager = connection.getEndpointManager();
                     endpointManager.accept(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberHandshakeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberHandshakeTest.java
@@ -44,9 +44,9 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class BindMessageTest {
+public class MemberHandshakeTest {
 
-    private BindMessage bindMessage;
+    private MemberHandshake bindMessage;
     private SerializationService serializationService;
     private Address targetAddress;
     private UUID uuid;
@@ -60,9 +60,9 @@ public class BindMessageTest {
 
     @Test
     public void testSerialization_withMultipleLocalAddresses() throws Exception {
-        bindMessage = new BindMessage((byte) 1, localAddresses(), targetAddress, true, uuid);
+        bindMessage = new MemberHandshake((byte) 1, localAddresses(), targetAddress, true, uuid);
         Data serialized = serializationService.toData(bindMessage);
-        BindMessage deserialized = serializationService.toObject(serialized);
+        MemberHandshake deserialized = serializationService.toObject(serialized);
         assertEquals(1, deserialized.getSchemaVersion());
         assertEquals(localAddresses(), deserialized.getLocalAddresses());
         assertEquals(targetAddress, deserialized.getTargetAddress());
@@ -72,9 +72,9 @@ public class BindMessageTest {
 
     @Test
     public void testSerialization_whenBindMessageEmpty() {
-        bindMessage = new BindMessage();
+        bindMessage = new MemberHandshake();
         Data serialized = serializationService.toData(bindMessage);
-        BindMessage deserialized = serializationService.toObject(serialized);
+        MemberHandshake deserialized = serializationService.toObject(serialized);
         assertEquals(0, deserialized.getSchemaVersion());
         assertTrue(deserialized.getLocalAddresses().isEmpty());
         assertNull(null, deserialized.getTargetAddress());

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
@@ -57,7 +57,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
-import static com.hazelcast.internal.nio.Packet.Type.BIND;
+import static com.hazelcast.internal.nio.Packet.Type.MEMBER_HANDSHAKE;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUNT;
 
@@ -357,7 +357,7 @@ public class MockIOService implements IOService {
             @Override
             public void accept(Packet packet) {
                 try {
-                    if (packet.getPacketType() == BIND) {
+                    if (packet.getPacketType() == MEMBER_HANDSHAKE) {
                         connection.getEndpointManager().accept(packet);
                     } else {
                         Consumer<Packet> consumer = packetConsumer;


### PR DESCRIPTION
The `bind` name is very confusing because it has nothing to do with socket
level binding. It is about initial message exchange between to members so that
one can join the other cluster.

That is why it has been renamed to `MemberHanshake`. `Handshake` is a common name for
such kind of traffic, e.g. 3 way handshake in TCP. And `Member` because the handshaking is only between (light)members.

There is no wire level change, so we don't need to worry about compatibility.