### PR TITLE
Additional tests for 3.12.6-adobe

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapPartitionIteratorTest.java
@@ -55,47 +55,47 @@ public abstract class AbstractMapPartitionIteratorTest extends HazelcastTestSupp
 
     @Test
     public void test_HasNext_Returns_False_On_EmptyPartition() throws Exception {
-        ClientMapProxy<Integer, Integer> map = getMapProxy();
+        ClientMapProxy<Integer, Object> map = getMapProxy();
 
-        Iterator<Map.Entry<Integer, Integer>> iterator = map.iterator(10, 1, prefetchValues);
+        Iterator<Map.Entry<Integer, Object>> iterator = map.iterator(10, 1, prefetchValues);
         assertFalse(iterator.hasNext());
     }
 
     @Test
     public void test_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
-        ClientMapProxy<String, String> map = getMapProxy();
+        ClientMapProxy<String, Object> map = getMapProxy();
 
         String key = generateKeyForPartition(server, 1);
-        String value = randomString();
+        Object value = generateValue();
         map.put(key, value);
 
-        Iterator<Map.Entry<String, String>> iterator = map.iterator(10, 1, prefetchValues);
+        Iterator<Map.Entry<String, Object>> iterator = map.iterator(10, 1, prefetchValues);
         assertTrue(iterator.hasNext());
     }
 
     @Test
     public void test_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
-        ClientMapProxy<String, String> map = getMapProxy();
+        ClientMapProxy<String, Object> map = getMapProxy();
 
         String key = generateKeyForPartition(server, 1);
-        String value = randomString();
+        Object value = generateValue();
         map.put(key, value);
 
-        Iterator<Map.Entry<String, String>> iterator = map.iterator(10, 1, prefetchValues);
+        Iterator<Map.Entry<String, Object>> iterator = map.iterator(10, 1, prefetchValues);
         Map.Entry entry = iterator.next();
         assertEquals(value, entry.getValue());
     }
 
     @Test
     public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
-        ClientMapProxy<String, String> map = getMapProxy();
-        String value = randomString();
+        ClientMapProxy<String, Object> map = getMapProxy();
+        Object value = generateValue();
         int count = 1000;
         for (int i = 0; i < count; i++) {
             String key = generateKeyForPartition(server, 42);
             map.put(key, value);
         }
-        Iterator<Map.Entry<String, String>> iterator = map.iterator(10, 42, prefetchValues);
+        Iterator<Map.Entry<String, Object>> iterator = map.iterator(10, 42, prefetchValues);
         for (int i = 0; i < count; i++) {
             Map.Entry entry = iterator.next();
             assertEquals(value, entry.getValue());
@@ -104,6 +104,10 @@ public abstract class AbstractMapPartitionIteratorTest extends HazelcastTestSupp
 
     protected ClientConfig getClientConfig() {
         return new ClientConfig();
+    }
+
+    protected Object generateValue() {
+        return randomString();
     }
 
     private <K, V> ClientMapProxy<K, V> getMapProxy() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapDisableCopyOnReadPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapDisableCopyOnReadPartitionIteratorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.map.impl.query.TestEntityImmutable;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapDisableCopyOnReadPartitionIteratorTest extends AbstractMapPartitionIteratorTest {
+
+    @Before
+    public void setup() {
+        Config config = getConfig();
+        config.addMapConfig(new MapConfig("*").setInMemoryFormat(InMemoryFormat.OBJECT));
+        ClientConfig clientConfig = getClientConfig();
+
+        factory = new TestHazelcastFactory();
+        server = factory.newHazelcastInstance(config);
+        client = factory.newHazelcastClient(clientConfig);
+    }
+
+    @Override
+    protected Object generateValue() {
+        return new TestEntityImmutable(randomString());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
@@ -22,11 +22,18 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.PartitionService;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MapDisableCopyOnReadTest extends HazelcastTestSupport {
 
     private MapProxyImpl<String, TestEntityImmutable> immutableMapProxy;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntityImmutable.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntityImmutable.java
@@ -20,7 +20,7 @@ import com.hazelcast.map.Immutable;
 
 import java.io.Serializable;
 
-class TestEntityImmutable implements Immutable, Serializable {
+public class TestEntityImmutable implements Immutable, Serializable {
     private static final long serialVersionUID = 1L;
     private String test;
 
@@ -30,5 +30,24 @@ class TestEntityImmutable implements Immutable, Serializable {
 
     public String getTest() {
         return test;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TestEntityImmutable)) {
+            return false;
+        }
+
+        TestEntityImmutable that = (TestEntityImmutable) o;
+
+        return getTest() != null ? getTest().equals(that.getTest()) : that.getTest() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getTest() != null ? getTest().hashCode() : 0;
     }
 }


### PR DESCRIPTION
This PR finishes test coverage for the "Disable Copy on Read" feature:
* fixes that `MapDisableCopyOnReadTest` was not executed
* extends test coverage for this block of code https://github.com/hazelcast/hazelcast/pull/16736/files#diff-1c968b94d1fa2b6e2d89065e50fd04f4R72-R78