### PR TITLE
Add JVM name with PID to the client metrics in tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientJmxMetricsTest.java
@@ -62,6 +62,11 @@ public class ClientJmxMetricsTest extends HazelcastTestSupport {
         assertTrueEventually(() -> helper.assertMBeanContains(expectedObjectName));
 
         client.shutdown();
+        // if failing, grep for "test-jvm"
+        // there should be a Metric[com.hazelcast:type=Metrics,instance=$CLIENT_NAME,prefix=test-jvm-$JVM_NAME] metric if the
+        // client was created with TestHazelcastFactory
+        // $JVM_NAME contains the PID, so $CLIENT_NAME + $JVM_NAME together helps identifying the test left the given metric
+        // around
         helper.assertNoMBeans();
     }
 }


### PR DESCRIPTION
`ClientJmxMetricsTest` logs the client and the JVM name including its PID
when it logs dangling JMX beans left around by a client test. The same
client name might appear in multiple tests since the tests can run in
different JVMs that can assign the same client names. This PR is meant
to overcome this problem by introducing a metric with a name including
the JVM name with PID in it for the clients created with
`TestHazelcastFactory`. The name of the client and the JVM should help
with identifying the test leaking metric MBeans.

Note that there are client tests not using `TestHazelcastFactory`. This
trick doesn't help with those.

Related to #16206