### PR TITLE
Bind properties cleanup in TcpIpAcceptor.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOService.java
@@ -90,10 +90,6 @@ public interface IOService {
 
     void shouldConnectTo(Address address);
 
-    boolean isSocketBind();
-
-    boolean isSocketBindAny();
-
     void interceptSocket(EndpointQualifier endpointQualifier, Socket socket, boolean onAccept) throws IOException;
 
     boolean isSocketInterceptorEnabled(EndpointQualifier endpointQualifier);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/NodeIOService.java
@@ -233,16 +233,6 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public boolean isSocketBind() {
-        return node.getProperties().getBoolean(ClusterProperty.SOCKET_CLIENT_BIND);
-    }
-
-    @Override
-    public boolean isSocketBindAny() {
-        return node.getProperties().getBoolean(ClusterProperty.SOCKET_CLIENT_BIND_ANY);
-    }
-
-    @Override
     public void interceptSocket(EndpointQualifier endpointQualifier, Socket socket, boolean onAccept) throws IOException {
         socket.getChannel().configureBlocking(true);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
@@ -172,16 +172,6 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public boolean isSocketBind() {
-        return true;
-    }
-
-    @Override
-    public boolean isSocketBindAny() {
-        return true;
-    }
-
-    @Override
     public void interceptSocket(EndpointQualifier endpointQualifier, Socket socket, boolean onAccept) {
     }
 


### PR DESCRIPTION
Instead of asking the IO service for these properties, we just ask
IOService for the 'properties' object and find the properties directly.

This makes code more tranparent since you can see which properties are
actually involved and it reduces bloat on the IOService.