### PR TITLE
TcpIpAcceptor owns intercept logic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.nio;
 
 import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.MemcacheProtocolConfig;
 import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.SSLConfig;
@@ -29,13 +30,10 @@ import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.tcp.TcpIpConnection;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
-import java.io.IOException;
-import java.net.Socket;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -93,10 +91,6 @@ public interface IOService {
     boolean isSocketBind();
 
     boolean isSocketBindAny();
-
-    void interceptSocket(EndpointQualifier endpointQualifier, Socket socket, boolean onAccept) throws IOException;
-
-    boolean isSocketInterceptorEnabled(EndpointQualifier endpointQualifier);
 
     int getSocketConnectTimeoutSeconds(EndpointQualifier endpointQualifier);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpNetworkingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpNetworkingService.java
@@ -71,6 +71,7 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
 
     private final Networking networking;
     private final MetricsRegistry metricsRegistry;
+    private final Config config;
     // accessed only in synchronized methods
     private ScheduledFuture refreshStatsFuture;
     private final RefreshNetworkStatsTask refreshStatsTask;
@@ -105,6 +106,7 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
                                   HazelcastProperties properties) {
 
         this.ioService = ioService;
+        this.config = config;
         this.networking = networking;
         this.metricsRegistry = metricsRegistry;
         this.refreshStatsTask = new RefreshNetworkStatsTask(endpointManagers);
@@ -286,7 +288,7 @@ public final class TcpIpNetworkingService implements NetworkingService<TcpIpConn
             shutdownAcceptor();
         }
 
-        acceptorRef.set(new TcpIpAcceptor(registry, this, ioService).start());
+        acceptorRef.set(new TcpIpAcceptor(registry, this, ioService, config).start());
     }
 
     private void shutdownAcceptor() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/MockIOService.java
@@ -17,26 +17,26 @@
 package com.hazelcast.internal.nio.tcp;
 
 import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.MemcacheProtocolConfig;
 import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.auditlog.AuditlogService;
 import com.hazelcast.internal.auditlog.impl.NoOpAuditlogService;
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
+import com.hazelcast.internal.nio.IOService;
+import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.impl.LoggingServiceImpl;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
-import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
@@ -46,7 +46,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.net.Socket;
 import java.nio.channels.ServerSocketChannel;
 import java.util.Collection;
 import java.util.Collections;
@@ -179,15 +178,6 @@ public class MockIOService implements IOService {
     @Override
     public boolean isSocketBindAny() {
         return true;
-    }
-
-    @Override
-    public void interceptSocket(EndpointQualifier endpointQualifier, Socket socket, boolean onAccept) {
-    }
-
-    @Override
-    public boolean isSocketInterceptorEnabled(EndpointQualifier endpointQualifier) {
-        return false;
     }
 
     @Override


### PR DESCRIPTION
So the logic was moved into the IOService and this makes the logic hard
to comprehend. The whole logic has now been moved into the TcpIpAcceptor
so that the logic is easier to understand because it is smeared out
over less places.