### PR TITLE
Restore throws clause

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/PacketDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/PacketDecoder.java
@@ -54,7 +54,7 @@ public class PacketDecoder extends InboundHandlerWithCounters<ByteBuffer, Consum
     }
 
     @Override
-    public HandlerStatus onRead() {
+    public HandlerStatus onRead() throws Exception {
         src.flip();
         try {
             while (src.hasRemaining()) {


### PR DESCRIPTION
Breaks compilation of SymmetricCipherPacketDecoder