### PR TITLE
Fix class definitions registration with same class id

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -195,11 +195,12 @@ public class SerializationServiceV1 extends AbstractSerializationService {
                 classDefMap = new HashMap<Integer, ClassDefinition>();
                 factoryMap.put(factoryId, classDefMap);
             }
-            if (classDefMap.containsKey(cd.getClassId())) {
+            int classId = cd.getClassId();
+            if (classDefMap.containsKey(classId)) {
                 throw new HazelcastSerializationException("Duplicate registration found for factory-id : "
-                        + factoryId + ", class-id " + cd.getClassId());
+                        + factoryId + ", class-id " + classId);
             }
-            classDefMap.put(factoryId, cd);
+            classDefMap.put(classId, cd);
         }
         for (ClassDefinition classDefinition : classDefinitions) {
             registerClassDefinition(classDefinition, factoryMap, checkClassDefErrors);
@@ -207,7 +208,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     }
 
     private void registerClassDefinition(ClassDefinition cd, Map<Integer, Map<Integer, ClassDefinition>> factoryMap,
-                                           boolean checkClassDefErrors) {
+                                         boolean checkClassDefErrors) {
         Set<String> fieldNames = cd.getFieldNames();
         for (String fieldName : fieldNames) {
             FieldDefinition fd = cd.getField(fieldName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.internal.serialization.PortableContext;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.BooleanSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.ByteSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.StringArraySerializer;
-import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.ClassNameFilter;
 import com.hazelcast.nio.ObjectDataInput;
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
@@ -73,8 +74,8 @@ import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.B
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.ClassSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.DateSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.EnumSerializer;
-import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JavaSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.HazelcastJsonValueSerializer;
+import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JavaSerializer;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createSerializerAdapter;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
@@ -185,33 +186,48 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     }
 
     public void registerClassDefinitions(Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {
-        final Map<Integer, ClassDefinition> classDefMap = createHashMap(classDefinitions.size());
+        Map<Integer, Map<Integer, ClassDefinition>> factoryMap = createHashMap(classDefinitions.size());
         for (ClassDefinition cd : classDefinitions) {
-            if (classDefMap.containsKey(cd.getClassId())) {
-                throw new HazelcastSerializationException("Duplicate registration found for class-id[" + cd.getClassId() + "]!");
+
+            int factoryId = cd.getFactoryId();
+            Map<Integer, ClassDefinition> classDefMap = factoryMap.get(factoryId);
+            if (classDefMap == null) {
+                classDefMap = new HashMap<Integer, ClassDefinition>();
+                factoryMap.put(factoryId, classDefMap);
             }
-            classDefMap.put(cd.getClassId(), cd);
+            if (classDefMap.containsKey(cd.getClassId())) {
+                throw new HazelcastSerializationException("Duplicate registration found for factory-id : "
+                        + factoryId + ", class-id " + cd.getClassId());
+            }
+            classDefMap.put(factoryId, cd);
         }
         for (ClassDefinition classDefinition : classDefinitions) {
-            registerClassDefinition(classDefinition, classDefMap, checkClassDefErrors);
+            registerClassDefinition(classDefinition, factoryMap, checkClassDefErrors);
         }
     }
 
-    protected void registerClassDefinition(ClassDefinition cd, Map<Integer, ClassDefinition> classDefMap,
+    private void registerClassDefinition(ClassDefinition cd, Map<Integer, Map<Integer, ClassDefinition>> factoryMap,
                                            boolean checkClassDefErrors) {
-        final Set<String> fieldNames = cd.getFieldNames();
+        Set<String> fieldNames = cd.getFieldNames();
         for (String fieldName : fieldNames) {
             FieldDefinition fd = cd.getField(fieldName);
             if (fd.getType() == FieldType.PORTABLE || fd.getType() == FieldType.PORTABLE_ARRAY) {
+                int factoryId = fd.getFactoryId();
                 int classId = fd.getClassId();
-                ClassDefinition nestedCd = classDefMap.get(classId);
-                if (nestedCd != null) {
-                    registerClassDefinition(nestedCd, classDefMap, checkClassDefErrors);
-                    portableContext.registerClassDefinition(nestedCd);
-                } else if (checkClassDefErrors) {
-                    throw new HazelcastSerializationException(
-                            "Could not find registered ClassDefinition for class-id: " + classId);
+                Map<Integer, ClassDefinition> classDefinitionMap = factoryMap.get(factoryId);
+                if (classDefinitionMap != null) {
+                    ClassDefinition nestedCd = classDefinitionMap.get(classId);
+                    if (nestedCd != null) {
+                        registerClassDefinition(nestedCd, factoryMap, checkClassDefErrors);
+                        portableContext.registerClassDefinition(nestedCd);
+                        continue;
+                    }
                 }
+                if (checkClassDefErrors) {
+                    throw new HazelcastSerializationException("Could not find registered ClassDefinition for factory-id : "
+                            + factoryId + ", class-id " + classId);
+                }
+
             }
         }
         portableContext.registerClassDefinition(cd);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ExplicitClassDefinitionRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ExplicitClassDefinitionRegistrationTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static groovy.util.GroovyTestCase.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ExplicitClassDefinitionRegistrationTest {
+
+    public static class MyPortable1 implements Portable {
+
+        public static final int ID = 1;
+
+        private String stringField;
+
+        public MyPortable1(String stringField) {
+            this.stringField = stringField;
+        }
+
+        public MyPortable1() {
+
+        }
+
+        @Override
+        public int getFactoryId() {
+            return MyPortableFactory1.ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return ID;
+        }
+
+        @Override
+        public void writePortable(final PortableWriter writer) throws IOException {
+            writer.writeUTF("stringField", stringField);
+        }
+
+        @Override
+        public void readPortable(final PortableReader reader) throws IOException {
+            stringField = reader.readUTF("stringField");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            MyPortable1 that = (MyPortable1) o;
+
+            return stringField != null ? stringField.equals(that.stringField) : that.stringField == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return stringField != null ? stringField.hashCode() : 0;
+        }
+    }
+
+    public static class MyPortable2 implements Portable {
+
+        public static final int ID = 1;
+
+        private int intField;
+
+        public MyPortable2(int intField) {
+            this.intField = intField;
+        }
+
+        public MyPortable2() {
+
+        }
+
+        @Override
+        public int getFactoryId() {
+            return MyPortableFactory2.ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return ID;
+        }
+
+        @Override
+        public void writePortable(final PortableWriter writer) throws IOException {
+            writer.writeInt("intField", intField);
+        }
+
+        @Override
+        public void readPortable(final PortableReader reader) throws IOException {
+            intField = reader.readInt("intField");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            MyPortable2 that = (MyPortable2) o;
+
+            return intField == that.intField;
+        }
+
+        @Override
+        public int hashCode() {
+            return intField;
+        }
+    }
+
+    public static class MyPortableFactory1 implements PortableFactory {
+
+        public static final int ID = 1;
+
+        @Override
+        public Portable create(final int classId) {
+            if (classId == MyPortable1.ID) {
+                return new MyPortable1();
+            }
+            return null;
+        }
+
+    }
+
+    public static class MyPortableFactory2 implements PortableFactory {
+
+        public static final int ID = 2;
+
+        @Override
+        public Portable create(final int classId) {
+            if (classId == MyPortable2.ID) {
+                return new MyPortable2();
+            }
+            return null;
+        }
+
+    }
+
+
+    @Test
+    public void test_classesWithSameClassIdInDifferentFactories() {
+        SerializationService ss = new DefaultSerializationServiceBuilder()
+                .addPortableFactory(MyPortableFactory1.ID, new MyPortableFactory1())
+                .addPortableFactory(MyPortableFactory2.ID, new MyPortableFactory2())
+                .addClassDefinition(new ClassDefinitionBuilder(MyPortableFactory1.ID, MyPortable1.ID)
+                        .addUTFField("stringField")
+                        .build())
+                .addClassDefinition(new ClassDefinitionBuilder(MyPortableFactory2.ID, MyPortable2.ID)
+                        .addIntField("intField")
+                        .build())
+                .build();
+
+
+        MyPortable1 object = new MyPortable1("test");
+        Data data = ss.toData(object);
+        assertEquals(object, ss.toObject(data));
+
+        MyPortable2 object2 = new MyPortable2(1);
+        Data data2 = ss.toData(object2);
+        assertEquals(object2, ss.toObject(data2));
+
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void test_classesWithSameClassId_andSameFactoryId() {
+        new DefaultSerializationServiceBuilder()
+                .addClassDefinition(new ClassDefinitionBuilder(1, 1)
+                        .addIntField("stringField")
+                        .build())
+                .addClassDefinition(new ClassDefinitionBuilder(1, 1)
+                        .addIntField("intField")
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
When class definition is registered explicitly from serialization config
, if user gives same class id in different factories, we could not
handle it correctly. This pr makes sure it works from now on.

fixes https://github.com/hazelcast/hazelcast/issues/16820