### PR TITLE
Fix class definitions registration with same class id

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -237,11 +237,12 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         for (ClassDefinition cd : classDefinitions) {
             int factoryId = cd.getFactoryId();
             Map<Integer, ClassDefinition> classDefMap = factoryMap.computeIfAbsent(factoryId, k -> new HashMap<>());
-            if (classDefMap.containsKey(cd.getClassId())) {
+            int classId = cd.getClassId();
+            if (classDefMap.containsKey(classId)) {
                 throw new HazelcastSerializationException("Duplicate registration found for factory-id : "
-                        + factoryId + ", class-id " + cd.getClassId());
+                        + factoryId + ", class-id " + classId);
             }
-            classDefMap.put(factoryId, cd);
+            classDefMap.put(classId, cd);
         }
         for (ClassDefinition classDefinition : classDefinitions) {
             registerClassDefinition(classDefinition, factoryMap, checkClassDefErrors);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.DataType;
 import com.hazelcast.internal.serialization.PortableContext;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.BooleanSerializer;
@@ -26,7 +27,6 @@ import com.hazelcast.internal.serialization.impl.ConstantSerializers.StringArray
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassNameFilter;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.FieldDefinition;
@@ -84,10 +84,10 @@ import static com.hazelcast.internal.serialization.impl.ConstantSerializers.Long
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.LongSerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.ShortArraySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.ShortSerializer;
+import static com.hazelcast.internal.serialization.impl.ConstantSerializers.SimpleEntrySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.StringSerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.TheByteArraySerializer;
 import static com.hazelcast.internal.serialization.impl.ConstantSerializers.UuidSerializer;
-import static com.hazelcast.internal.serialization.impl.ConstantSerializers.SimpleEntrySerializer;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.EE_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.IDS_FLAG;
 import static com.hazelcast.internal.serialization.impl.DataSerializableSerializer.isFlagSet;
@@ -233,33 +233,43 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     }
 
     public void registerClassDefinitions(Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {
-        final Map<Integer, ClassDefinition> classDefMap = createHashMap(classDefinitions.size());
+        Map<Integer, Map<Integer, ClassDefinition>> factoryMap = createHashMap(classDefinitions.size());
         for (ClassDefinition cd : classDefinitions) {
+            int factoryId = cd.getFactoryId();
+            Map<Integer, ClassDefinition> classDefMap = factoryMap.computeIfAbsent(factoryId, k -> new HashMap<>());
             if (classDefMap.containsKey(cd.getClassId())) {
-                throw new HazelcastSerializationException("Duplicate registration found for class-id[" + cd.getClassId() + "]!");
+                throw new HazelcastSerializationException("Duplicate registration found for factory-id : "
+                        + factoryId + ", class-id " + cd.getClassId());
             }
-            classDefMap.put(cd.getClassId(), cd);
+            classDefMap.put(factoryId, cd);
         }
         for (ClassDefinition classDefinition : classDefinitions) {
-            registerClassDefinition(classDefinition, classDefMap, checkClassDefErrors);
+            registerClassDefinition(classDefinition, factoryMap, checkClassDefErrors);
         }
     }
 
-    protected void registerClassDefinition(ClassDefinition cd, Map<Integer, ClassDefinition> classDefMap,
-                                           boolean checkClassDefErrors) {
-        final Set<String> fieldNames = cd.getFieldNames();
+    private void registerClassDefinition(ClassDefinition cd, Map<Integer, Map<Integer, ClassDefinition>> factoryMap,
+                                         boolean checkClassDefErrors) {
+        Set<String> fieldNames = cd.getFieldNames();
         for (String fieldName : fieldNames) {
             FieldDefinition fd = cd.getField(fieldName);
             if (fd.getType() == FieldType.PORTABLE || fd.getType() == FieldType.PORTABLE_ARRAY) {
+                int factoryId = fd.getFactoryId();
                 int classId = fd.getClassId();
-                ClassDefinition nestedCd = classDefMap.get(classId);
-                if (nestedCd != null) {
-                    registerClassDefinition(nestedCd, classDefMap, checkClassDefErrors);
-                    portableContext.registerClassDefinition(nestedCd);
-                } else if (checkClassDefErrors) {
-                    throw new HazelcastSerializationException(
-                            "Could not find registered ClassDefinition for class-id: " + classId);
+                Map<Integer, ClassDefinition> classDefinitionMap = factoryMap.get(factoryId);
+                if (classDefinitionMap != null) {
+                    ClassDefinition nestedCd = classDefinitionMap.get(classId);
+                    if (nestedCd != null) {
+                        registerClassDefinition(nestedCd, factoryMap, checkClassDefErrors);
+                        portableContext.registerClassDefinition(nestedCd);
+                        continue;
+                    }
                 }
+                if (checkClassDefErrors) {
+                    throw new HazelcastSerializationException("Could not find registered ClassDefinition for factory-id : "
+                            + factoryId + ", class-id " + classId);
+                }
+
             }
         }
         portableContext.registerClassDefinition(cd);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ExplicitClassDefinitionRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ExplicitClassDefinitionRegistrationTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ExplicitClassDefinitionRegistrationTest {
+
+    public static class MyPortable1 implements Portable {
+
+        public static final int ID = 1;
+
+        private String stringField;
+
+        public MyPortable1(String stringField) {
+            this.stringField = stringField;
+        }
+
+        public MyPortable1() {
+
+        }
+
+        @Override
+        public int getFactoryId() {
+            return MyPortableFactory1.ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return ID;
+        }
+
+        @Override
+        public void writePortable(final PortableWriter writer) throws IOException {
+            writer.writeUTF("stringField", stringField);
+        }
+
+        @Override
+        public void readPortable(final PortableReader reader) throws IOException {
+            stringField = reader.readUTF("stringField");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            MyPortable1 that = (MyPortable1) o;
+
+            return stringField != null ? stringField.equals(that.stringField) : that.stringField == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return stringField != null ? stringField.hashCode() : 0;
+        }
+    }
+
+    public static class MyPortable2 implements Portable {
+
+        public static final int ID = 1;
+
+        private int intField;
+
+        public MyPortable2(int intField) {
+            this.intField = intField;
+        }
+
+        public MyPortable2() {
+
+        }
+
+        @Override
+        public int getFactoryId() {
+            return MyPortableFactory2.ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return ID;
+        }
+
+        @Override
+        public void writePortable(final PortableWriter writer) throws IOException {
+            writer.writeInt("intField", intField);
+        }
+
+        @Override
+        public void readPortable(final PortableReader reader) throws IOException {
+            intField = reader.readInt("intField");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            MyPortable2 that = (MyPortable2) o;
+
+            return intField == that.intField;
+        }
+
+        @Override
+        public int hashCode() {
+            return intField;
+        }
+    }
+
+    public static class MyPortableFactory1 implements PortableFactory {
+
+        public static final int ID = 1;
+
+        @Override
+        public Portable create(final int classId) {
+            if (classId == MyPortable1.ID) {
+                return new MyPortable1();
+            }
+            return null;
+        }
+
+    }
+
+    public static class MyPortableFactory2 implements PortableFactory {
+
+        public static final int ID = 2;
+
+        @Override
+        public Portable create(final int classId) {
+            if (classId == MyPortable2.ID) {
+                return new MyPortable2();
+            }
+            return null;
+        }
+
+    }
+
+
+    @Test
+    public void test_classesWithSameClassIdInDifferentFactories() {
+        SerializationService ss = new DefaultSerializationServiceBuilder()
+                .addPortableFactory(MyPortableFactory1.ID, new MyPortableFactory1())
+                .addPortableFactory(MyPortableFactory2.ID, new MyPortableFactory2())
+                .addClassDefinition(new ClassDefinitionBuilder(MyPortableFactory1.ID, MyPortable1.ID)
+                        .addUTFField("stringField")
+                        .build())
+                .addClassDefinition(new ClassDefinitionBuilder(MyPortableFactory2.ID, MyPortable2.ID)
+                        .addIntField("intField")
+                        .build())
+                .build();
+
+
+        MyPortable1 object = new MyPortable1("test");
+        Data data = ss.toData(object);
+        assertEquals(object, ss.toObject(data));
+
+        MyPortable2 object2 = new MyPortable2(1);
+        Data data2 = ss.toData(object2);
+        assertEquals(object2, ss.toObject(data2));
+
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void test_classesWithSameClassId_andSameFactoryId() {
+        new DefaultSerializationServiceBuilder()
+                .addClassDefinition(new ClassDefinitionBuilder(1, 1)
+                        .addIntField("stringField")
+                        .build())
+                .addClassDefinition(new ClassDefinitionBuilder(1, 1)
+                        .addIntField("intField")
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
When class definition is registered explicitly from serialization config
, if user gives same class id in different factories, we could not
handle it correctly. This pr makes sure it works from now on.

fixes https://github.com/hazelcast/hazelcast/issues/16820

(cherry picked from commit 29b1fb3ad3f29e78757d472ab827bb0b222b39ad)
(cherry picked from commit 781ca35b62d3fbca74cfaa9d9f5551d55e83f5f6)