### PR TITLE
Don't retry member based invocations if TargetNotMember

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -348,7 +348,7 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
 
         if (uuid != null && t instanceof TargetNotMemberException) {
             //when invocation send to a specific member
-            //if target is not longer a member, we should not retry
+            //if target is no longer a member, we should not retry
             //note that this exception could come from the server
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 import com.hazelcast.spi.impl.operationservice.impl.BaseInvocation;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
@@ -37,7 +38,6 @@ import java.util.UUID;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.function.BiFunction;
 
 import static com.hazelcast.internal.util.Clock.currentTimeMillis;
 import static com.hazelcast.internal.util.StringUtil.timeToString;
@@ -74,7 +74,6 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
     private volatile long invocationTimeoutMillis;
     private boolean urgent;
     private boolean allowRetryOnRandom = true;
-    private BiFunction<ClientInvocation, Object, Boolean> invocationMethod;
 
     protected ClientInvocation(HazelcastClientInstanceImpl client,
                                ClientMessage clientMessage,
@@ -344,6 +343,13 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
 
     private boolean shouldRetry(Throwable t) {
         if (isBindToSingleConnection() && (t instanceof IOException || t instanceof TargetDisconnectedException)) {
+            return false;
+        }
+
+        if (uuid != null && t instanceof TargetNotMemberException) {
+            //when invocation send to a specific member
+            //if target is not longer a member, we should not retry
+            //note that this exception could come from the server
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.pncounter;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.ConsistencyLostException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.crdt.pncounter.PNCounter;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientPNCounterTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test(expected = ConsistencyLostException.class)
+    public void testClusterRestart() {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        PNCounter pnCounter = client.getPNCounter("test");
+
+        pnCounter.incrementAndGet();
+
+        instance.shutdown();
+        hazelcastFactory.newHazelcastInstance();
+
+        pnCounter.incrementAndGet();
+    }
+
+}


### PR DESCRIPTION
regression caused by changes in #16603

We were not retrying an invocation if it is send to a specific member
and exception is TargetNotMemberException .
We have removed this check since we are not throwing
TargetNotMemberException on the client side anymore. In this failure
exception comes from the server. It seems this check is still needed.
This pr puts it back.

fixes https://github.com/hazelcast/hazelcast/issues/16836