### PR TITLE
Avoid round-tripping URLs through URI instances

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -25,7 +25,6 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,13 +105,8 @@ public final class ServiceLoader {
             Set<URLDefinition> urlDefinitions = new HashSet<URLDefinition>();
             while (configs.hasMoreElements()) {
                 URL url = configs.nextElement();
-                String externalForm = url.toExternalForm()
-                                         .replace(" ", "%20")
-                                         .replace("^", "%5e");
-                URI uri = new URI(externalForm);
-
                 if (!classLoader.getClass().getName().equals(IGNORED_GLASSFISH_MAGIC_CLASSLOADER)) {
-                    urlDefinitions.add(new URLDefinition(uri, classLoader));
+                    urlDefinitions.add(new URLDefinition(url, classLoader));
                 }
             }
             return urlDefinitions;
@@ -128,7 +122,7 @@ public final class ServiceLoader {
             Set<ServiceDefinition> names = new HashSet<ServiceDefinition>();
             BufferedReader r = null;
             try {
-                URL url = urlDefinition.uri.toURL();
+                URL url = urlDefinition.url;
                 r = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
                 while (true) {
                     String line = r.readLine();
@@ -237,11 +231,11 @@ public final class ServiceLoader {
      */
     private static final class URLDefinition {
 
-        private final URI uri;
+        private final URL url;
         private final ClassLoader classLoader;
 
-        private URLDefinition(URI url, ClassLoader classLoader) {
-            this.uri = url;
+        private URLDefinition(URL url, ClassLoader classLoader) {
+            this.url = url;
             this.classLoader = classLoader;
         }
 
@@ -255,7 +249,7 @@ public final class ServiceLoader {
             }
 
             URLDefinition that = (URLDefinition) o;
-            if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
+            if (url != null ? !url.equals(that.url) : that.url != null) {
                 return false;
             }
             return true;
@@ -263,7 +257,7 @@ public final class ServiceLoader {
 
         @Override
         public int hashCode() {
-            return uri == null ? 0 : uri.hashCode();
+            return url == null ? 0 : url.hashCode();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -227,7 +227,13 @@ public final class ServiceLoader {
 
     /**
      * This class keeps track of available service definition URLs and
-     * the corresponding classloaders.
+     * the corresponding classloaders. It uses the URLs URI for hashing andd
+     * equality comparison, rather than the URL itself. The specifications for
+     * hashing and equality on URL are unusual, and involve blocking DNS
+     * lookups. However, the conversion from URL to URI is lossy, so if there
+     * are multiple URLs that map to the same URI, then they may be considered
+     * equal even if the URLs are not. If these are put in a HashSet, then the
+     * last added element wins.
      */
     private static final class URLDefinition {
 
@@ -249,7 +255,7 @@ public final class ServiceLoader {
             }
 
             URLDefinition that = (URLDefinition) o;
-            if (url != null ? !url.equals(that.url) : that.url != null) {
+            if (url != null ? !url.toURI().equals(that.url.toURI()) : that.url != null) {
                 return false;
             }
             return true;
@@ -257,7 +263,7 @@ public final class ServiceLoader {
 
         @Override
         public int hashCode() {
-            return url == null ? 0 : url.hashCode();
+            return url == null ? 0 : url.toURI().hashCode();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -25,6 +25,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -238,10 +240,12 @@ public final class ServiceLoader {
     private static final class URLDefinition {
 
         private final URL url;
+        private final URI uri;
         private final ClassLoader classLoader;
 
-        private URLDefinition(URL url, ClassLoader classLoader) {
+        private URLDefinition(URL url, ClassLoader classLoader) throws URISyntaxException {
             this.url = url;
+            this.uri = url == null ? null : url.toURI();
             this.classLoader = classLoader;
         }
 
@@ -255,7 +259,7 @@ public final class ServiceLoader {
             }
 
             URLDefinition that = (URLDefinition) o;
-            if (url != null ? !url.toURI().equals(that.url.toURI()) : that.url != null) {
+            if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
                 return false;
             }
             return true;
@@ -263,7 +267,7 @@ public final class ServiceLoader {
 
         @Override
         public int hashCode() {
-            return url == null ? 0 : url.toURI().hashCode();
+            return uri == null ? 0 : uri.hashCode();
         }
     }
 


### PR DESCRIPTION
Instead, keep the original URL object returned from the ClassLoader. This
retains any associated URLStreamHandler with the URL, which allows the
ClassLoader to return in-memory resources.

As an alternative to this change, projects that want to use in-memory
resources with Hazelcast could replace the URLStreamHandlerFactory, adding a
custom scheme for in-memory resources. However, that seems a more invasive
approach, with this change being strictly simpler.

Fixes #16846.