### PR TITLE
Add missing probes required for removal of PartitionServiceBeanDTO

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -422,7 +422,9 @@ public final class MetricDescriptorConstants {
     public static final String PARTITIONS_METRIC_PARTITION_SERVICE_MIGRATION_QUEUE_SIZE = "migrationQueueSize";
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_MANAGER_REPLICA_SYNC_SEMAPHORE = "replicaSyncSemaphore";
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_MANAGER_SYNC_REQUEST_COUNTER = "replicaSyncRequestsCounter";
+    public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_PARTITION_COUNT = "partitionCount";
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_LOCAL_PARTITION_COUNT = "localPartitionCount";
+    public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_ACTIVE_PARTITION_COUNT = "activePartitionCount";
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_VERSION = "stateVersion";
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_MEMBER_GROUP_SIZE = "memberGroupsSize";
     // ===[/PARTITIONS]=================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -43,8 +43,10 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_ACTIVE_PARTITION_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_LOCAL_PARTITION_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_MEMBER_GROUP_SIZE;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_PARTITION_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_VERSION;
 
 /**
@@ -56,6 +58,7 @@ public class PartitionStateManager {
     private final ILogger logger;
     private final InternalPartitionServiceImpl partitionService;
 
+    @Probe(name = PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_PARTITION_COUNT)
     private final int partitionCount;
     private final InternalPartitionImpl[] partitions;
 
@@ -101,6 +104,11 @@ public class PartitionStateManager {
             }
         }
         return count;
+    }
+
+    @Probe(name = PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_ACTIVE_PARTITION_COUNT)
+    private int activePartitionCount() {
+        return partitionService.getMemberPartitionsIfAssigned(node.getThisAddress()).size();
     }
 
     private Collection<MemberGroup> createMemberGroups(final Set<Member> excludedMembers) {


### PR DESCRIPTION
* Adds probes necessary to get rid of `PartitionServiceBeanDTO` (which is a part of `TimedMemberState`)

Related with the following MC issue: https://github.com/hazelcast/management-center/issues/3017

A `4.0.z` backport will follow-up once this PR is merged.