### PR TITLE
Kerberos authentication method added.

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -37,11 +37,15 @@ import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.MetricsJmxConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.SSLConfig;
+import com.hazelcast.config.security.JaasAuthenticationConfig;
+import com.hazelcast.config.security.KerberosIdentityConfig;
+import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TokenEncoding;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
@@ -212,8 +216,13 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                             .addConstructorArgValue(TokenEncoding.getTokenEncoding(getAttribute(child, "encoding")))
                             .addConstructorArgValue(getTextContent(child));
                     securityConfigBuilder.addPropertyValue("TokenIdentityConfig", configBuilder.getBeanDefinition());
+                } else if ("kerberos".equals(nodeName)) {
+                    createAndFillBeanBuilder(child, KerberosIdentityConfig.class, "KerberosIdentityConfig",
+                            securityConfigBuilder);
                 } else if ("credentials-ref".equals(nodeName)) {
                     securityConfigBuilder.addPropertyReference("credentials", getTextContent(child));
+                } else if ("realms".equals(nodeName)) {
+                    handleRealms(child, securityConfigBuilder);
                 }
             }
             configBuilder.addPropertyValue("securityConfig", beanDefinition);
@@ -538,6 +547,78 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("metricsConfig", metricsConfigBuilder.getBeanDefinition());
         }
 
+        private void handleRealms(Node node, BeanDefinitionBuilder securityConfigBuilder) {
+            ManagedMap<String, BeanDefinition> realms = new ManagedMap<>();
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("realm".equals(nodeName)) {
+                    realms.put(getAttribute(child, "name"), handleRealm(child, securityConfigBuilder));
+                }
+            }
+            securityConfigBuilder.addPropertyValue("realmConfigs", realms);
+        }
+
+        private AbstractBeanDefinition handleRealm(Node node, BeanDefinitionBuilder securityConfigBuilder) {
+            BeanDefinitionBuilder realmConfigBuilder = createBeanBuilder(RealmConfig.class);
+            AbstractBeanDefinition beanDefinition = realmConfigBuilder.getBeanDefinition();
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("authentication".equals(nodeName)) {
+                    handleAuthentication(child, realmConfigBuilder);
+                }
+            }
+            return beanDefinition;
+        }
+
+
+        private void handleAuthentication(Node node, BeanDefinitionBuilder realmConfigBuilder) {
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("jaas".equals(nodeName)) {
+                    handleLoginModules(child, realmConfigBuilder);
+                }
+            }
+        }
+
+        private void handleLoginModules(Node node, BeanDefinitionBuilder realmConfigBuilder) {
+            BeanDefinitionBuilder jaasConfigBuilder = createBeanBuilder(JaasAuthenticationConfig.class);
+            AbstractBeanDefinition beanDefinition = jaasConfigBuilder.getBeanDefinition();
+            List<BeanDefinition> lms = new ManagedList<>();
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("login-module".equals(nodeName)) {
+                    handleLoginModule(child, lms);
+                }
+            }
+            jaasConfigBuilder.addPropertyValue("loginModuleConfigs", lms);
+            realmConfigBuilder.addPropertyValue("jaasAuthenticationConfig", beanDefinition);
+        }
+
+
+        private void handleLoginModule(Node node, List<BeanDefinition> list) {
+            BeanDefinitionBuilder lmConfigBuilder = createBeanBuilder(LoginModuleConfig.class);
+            AbstractBeanDefinition beanDefinition = lmConfigBuilder.getBeanDefinition();
+            fillAttributeValues(node, lmConfigBuilder, "class-name", "implementation");
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
+            String className = classNameNode != null ? getTextContent(classNameNode) : null;
+            Node implNode = attributes.getNamedItem("implementation");
+            String implementation = implNode != null ? getTextContent(implNode) : null;
+            lmConfigBuilder.addPropertyValue("className", className);
+            if (implementation != null) {
+                lmConfigBuilder.addPropertyReference("implementation", implementation);
+            }
+            isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                    + " attributes is required to create LoginModule!");
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("properties".equals(nodeName)) {
+                    handleProperties(child, lmConfigBuilder);
+                    break;
+                }
+            }
+            list.add(beanDefinition);
+        }
     }
 
 }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -3111,12 +3111,16 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="client-security">
-        <xs:choice>
-            <xs:element name="username-password" type="username-password"/>
-            <xs:element name="credentials-factory" type="credentials-factory"/>
-            <xs:element name="token" type="token"/>
-            <xs:element name="credentials-ref" type="xs:string"/>
-        </xs:choice>
+        <xs:sequence>
+            <xs:choice minOccurs="0">
+                <xs:element name="username-password" type="username-password"/>
+                <xs:element name="credentials-factory" type="credentials-factory"/>
+                <xs:element name="token" type="token"/>
+                <xs:element name="kerberos" type="kerberos-identity"/>
+                <xs:element name="credentials-ref" type="xs:string"/>
+            </xs:choice>
+            <xs:element name="realms" type="realms" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
     </xs:complexType>
     <xs:complexType name="proxy-factories">
         <xs:sequence>
@@ -4952,6 +4956,7 @@
             <xs:element name="jaas" type="login-modules"/>
             <xs:element name="tls" type="tls-authentication"/>
             <xs:element name="ldap" type="ldap-authentication"/>
+            <xs:element name="kerberos" type="kerberos-authentication"/>
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="tls-authentication">
@@ -4978,6 +4983,7 @@
             <xs:element name="user-context" type="xs:string" minOccurs="0"/>
             <xs:element name="user-filter" type="xs:string" minOccurs="0"/>
             <xs:element name="user-search-scope" type="ldap-search-scope" minOccurs="0"/>
+            <xs:element name="skip-authentication" type="xs:boolean" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
     <xs:simpleType name="ldap-role-mapping-mode">
@@ -4994,11 +5000,19 @@
             <xs:enumeration value="subtree"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="kerberos-authentication">
+        <xs:all>
+            <xs:element name="relax-flags-check" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="ldap" type="ldap-authentication" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
     <xs:complexType name="identity">
         <xs:choice>
             <xs:element name="username-password" type="username-password"/>
             <xs:element name="credentials-factory" type="credentials-factory"/>
             <xs:element name="token" type="token"/>
+            <xs:element name="kerberos" type="kerberos-identity"/>
             <xs:element name="credentials-ref" type="xs:string"/>
         </xs:choice>
     </xs:complexType>
@@ -5019,6 +5033,14 @@
                 </xs:attribute>
             </xs:extension>
         </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="kerberos-identity">
+        <xs:all>
+            <xs:element name="realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="service-name-prefix" type="xs:string" minOccurs="0"/>
+            <xs:element name="spn" type="xs:string" minOccurs="0"/>
+        </xs:all>
     </xs:complexType>
     <xs:complexType name="realm-reference">
         <xs:attribute name="realm" type="xs:string" use="required"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -41,12 +41,15 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.config.security.JaasAuthenticationConfig;
+import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
@@ -283,6 +286,20 @@ public class TestClientApplicationContext {
 
         ClientConfig config = client5.getClientConfig();
         assertEquals(1000, config.getConnectionStrategyConfig().getConnectionRetryConfig().getClusterConnectTimeoutMillis());
+    }
+
+    @Test
+    public void testSecurityRealms() {
+        assertNotNull(client5);
+
+        RealmConfig realmConfig = client5.getClientConfig().getSecurityConfig().getRealmConfig("krb5Initiator");
+        assertNotNull(realmConfig);
+        JaasAuthenticationConfig jaasAuthenticationConfig = realmConfig.getJaasAuthenticationConfig();
+        assertNotNull(jaasAuthenticationConfig);
+        assertEquals(1, jaasAuthenticationConfig.getLoginModuleConfigs().size());
+        LoginModuleConfig loginModuleConfig = jaasAuthenticationConfig.getLoginModuleConfigs().get(0);
+        assertEquals("com.sun.security.auth.module.Krb5LoginModule", loginModuleConfig.getClassName());
+        assertEquals("jduke@HAZELCAST.COM", loginModuleConfig.getProperties().getProperty("principal"));
     }
 
     @Test

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -110,6 +110,9 @@ import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.KerberosAuthenticationConfig;
+import com.hazelcast.config.security.KerberosIdentityConfig;
+import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
@@ -176,6 +179,7 @@ import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.spi.properties.ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
+import static java.lang.Boolean.TRUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -595,6 +599,17 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
             permTypes.remove(pc.getType());
         }
         assertTrue("All permission types should be listed in fullConfig. Not found ones: " + permTypes, permTypes.isEmpty());
+
+        RealmConfig kerberosRealm = securityConfig.getRealmConfig("kerberosRealm");
+        assertNotNull(kerberosRealm);
+        KerberosAuthenticationConfig kerbAuthentication = kerberosRealm.getKerberosAuthenticationConfig();
+        assertNotNull(kerbAuthentication);
+        assertEquals(TRUE, kerbAuthentication.getRelaxFlagsCheck());
+        assertEquals("krb5Acceptor", kerbAuthentication.getSecurityRealm());
+        assertNotNull(kerbAuthentication.getLdapAuthenticationConfig());
+        KerberosIdentityConfig kerbIdentity = kerberosRealm.getKerberosIdentityConfig();
+        assertNotNull(kerbIdentity);
+        assertEquals("HAZELCAST.COM", kerbIdentity.getRealm());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -655,6 +655,64 @@
                             <hz:token encoding="base64">aGF6ZWxjYXN0</hz:token>
                         </hz:identity>
                     </hz:realm>
+                    <hz:realm name="kerberosRealm">
+                        <hz:authentication>
+                            <hz:kerberos>
+                                <hz:relax-flags-check>true</hz:relax-flags-check>
+                                <hz:security-realm>krb5Acceptor</hz:security-realm>
+                                <hz:ldap>
+                                    <hz:url>ldap://127.0.0.1/</hz:url>
+                                    <hz:system-user-dn>uid=admin,ou=system</hz:system-user-dn>
+                                    <hz:system-user-password>secret</hz:system-user-password>
+                                    <hz:skip-authentication>true</hz:skip-authentication>
+                                    <hz:user-filter>(krb5PrincipalName={login})</hz:user-filter>
+                                    <hz:role-mapping-attribute>cn</hz:role-mapping-attribute>
+                                </hz:ldap>
+                            </hz:kerberos>
+                        </hz:authentication>
+                        <hz:identity>
+                            <hz:kerberos>
+                                <hz:realm>HAZELCAST.COM</hz:realm>
+                                <hz:security-realm>krb5Initiator</hz:security-realm>
+                                <hz:service-name-prefix>hz/</hz:service-name-prefix>
+                                <hz:spn>hz/127.0.0.1@HAZELCAST.COM</hz:spn>
+                            </hz:kerberos>
+                        </hz:identity>
+                    </hz:realm>
+                    <hz:realm name="krb5Acceptor">
+                        <hz:authentication>
+                            <hz:jaas>
+                                <hz:login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                                    <hz:properties>
+                                        <hz:property name="isInitiator">false</hz:property>
+                                        <hz:property name="useTicketCache">false</hz:property>
+                                        <hz:property name="doNotPrompt">true</hz:property>
+                                        <hz:property name="useKeyTab">true</hz:property>
+                                        <hz:property name="storeKey">true</hz:property>
+                                        <hz:property name="principal">hz/127.0.0.1@HAZELCAST.COM</hz:property>
+                                        <hz:property name="keyTab">/opt/hz-localhost.keytab</hz:property>
+                                    </hz:properties>
+                                </hz:login-module>
+                            </hz:jaas>
+                        </hz:authentication>
+                    </hz:realm>
+                    <hz:realm name="krb5Initiator">
+                        <hz:authentication>
+                            <hz:jaas>
+                                <hz:login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                                    <hz:properties>
+                                        <hz:property name="isInitiator">true</hz:property>
+                                        <hz:property name="useTicketCache">false</hz:property>
+                                        <hz:property name="doNotPrompt">true</hz:property>
+                                        <hz:property name="useKeyTab">true</hz:property>
+                                        <hz:property name="storeKey">true</hz:property>
+                                        <hz:property name="principal">hz/127.0.0.1@HAZELCAST.COM</hz:property>
+                                        <hz:property name="keyTab">/opt/hz-localhost.keytab</hz:property>
+                                    </hz:properties>
+                                </hz:login-module>
+                            </hz:jaas>
+                        </hz:authentication>
+                    </hz:realm>
                 </hz:realms>
                 <hz:member-authentication realm="r1"/>
                 <hz:client-authentication realm="r2"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -200,7 +200,27 @@
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-
+        <hz:security>
+            <hz:realms>
+                <hz:realm name="krb5Initiator">
+                    <hz:authentication>
+                        <hz:jaas>
+                            <hz:login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                                <hz:properties>
+                                    <hz:property name="isInitiator">true</hz:property>
+                                    <hz:property name="useTicketCache">false</hz:property>
+                                    <hz:property name="doNotPrompt">true</hz:property>
+                                    <hz:property name="useKeyTab">true</hz:property>
+                                    <hz:property name="storeKey">true</hz:property>
+                                    <hz:property name="principal">jduke@HAZELCAST.COM</hz:property>
+                                    <hz:property name="keyTab">/opt/jduke.keytab</hz:property>
+                                </hz:properties>
+                            </hz:login-module>
+                        </hz:jaas>
+                    </hz:authentication>
+                </hz:realm>
+            </hz:realms>
+        </hz:security>
     </hz:client>
 
     <hz:client id="client6">

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
@@ -26,6 +26,8 @@ import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.config.security.JaasAuthenticationConfig;
+import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
@@ -290,5 +292,21 @@ public class YamlClientDomConfigProcessor extends ClientDomConfigProcessor {
     protected void handleTokenIdentity(ClientSecurityConfig clientSecurityConfig, Node node) {
         clientSecurityConfig.setTokenIdentityConfig(new TokenIdentityConfig(
                 getTokenEncoding(getAttribute(node, "encoding")), getAttribute(node, "value")));
+    }
+
+    @Override
+    protected void handleRealms(Node node, ClientSecurityConfig clientSecurityConfig) {
+        for (Node child : childElements(node)) {
+            handleRealm(child, clientSecurityConfig);
+        }
+    }
+
+    @Override
+    protected void handleJaasAuthentication(RealmConfig realmConfig, Node node) {
+        JaasAuthenticationConfig jaasAuthenticationConfig = new JaasAuthenticationConfig();
+        for (Node child : childElements(node)) {
+            jaasAuthenticationConfig.addLoginModuleConfig(handleLoginModule(child));
+        }
+        realmConfig.setJaasAuthenticationConfig(jaasAuthenticationConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientCallbackHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientCallbackHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.security.RealmConfigCallback;
+
+/**
+ * {@link CallbackHandler} implementation which can be used on client side to access system internals.
+ */
+public class ClientCallbackHandler implements CallbackHandler {
+
+    private final ClientConfig clientConfig;
+
+    public ClientCallbackHandler(ClientConfig clientConfig) {
+        this.clientConfig = clientConfig;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+        for (Callback cb : callbacks) {
+            handleCallback(cb);
+        }
+    }
+
+    protected void handleCallback(Callback cb) throws UnsupportedCallbackException {
+        if (cb instanceof RealmConfigCallback) {
+            RealmConfigCallback realmCb = (RealmConfigCallback) cb;
+            RealmConfig realmCfg = null;
+            if (clientConfig != null && clientConfig.getSecurityConfig() != null) {
+                realmCfg = clientConfig.getSecurityConfig().getRealmConfig(realmCb.getRealmName());
+            }
+            realmCb.setRealmConfig(realmCfg);
+        } else {
+            throw new UnsupportedCallbackException(cb);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
@@ -49,7 +49,6 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
-import javax.security.auth.callback.UnsupportedCallbackException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -93,9 +92,7 @@ class ClusterDiscoveryServiceBuilder {
             if (credentialsFactory == null) {
                 credentialsFactory = new StaticCredentialsFactory(new UsernamePasswordCredentials(null, null));
             }
-            credentialsFactory.configure(cs -> {
-                throw new UnsupportedCallbackException(cs[0]);
-            });
+            credentialsFactory.configure(new ClientCallbackHandler(config));
             DiscoveryService discoveryService = initDiscoveryService(config);
             AddressProvider provider;
             if (externalAddressProvider != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java
@@ -133,6 +133,10 @@ public class TcpClientConnection implements ClientConnection {
         return remoteAddress;
     }
 
+    public Address getInitAddress() {
+        return (Address) attributeMap.get(Address.class);
+    }
+
     public UUID getRemoteUuid() {
         return remoteUuid;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -771,7 +771,8 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
     }
 
     private void authenticateOnCluster(TcpClientConnection connection) {
-        ClientMessage request = encodeAuthenticationRequest();
+        Address memberAddress = connection.getInitAddress();
+        ClientMessage request = encodeAuthenticationRequest(memberAddress);
         ClientInvocationFuture future = new ClientInvocation(client, request, null, connection).invokeUrgent();
         ClientAuthenticationCodec.ResponseParameters response;
         try {
@@ -859,12 +860,12 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
         }
     }
 
-    private ClientMessage encodeAuthenticationRequest() {
+    private ClientMessage encodeAuthenticationRequest(Address toAddress) {
         InternalSerializationService ss = client.getSerializationService();
         byte serializationVersion = ss.getVersion();
 
         CandidateClusterContext currentContext = clusterDiscoveryService.current();
-        Credentials credentials = currentContext.getCredentialsFactory().newCredentials();
+        Credentials credentials = currentContext.getCredentialsFactory().newCredentials(toAddress);
         String clusterName = currentContext.getClusterName();
         currentCredentials = credentials;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
@@ -98,6 +98,11 @@ public class LoginModuleConfig {
         return this;
     }
 
+    public LoginModuleConfig setProperty(String key, String value) {
+        properties.setProperty(key, value);
+        return this;
+    }
+
     @Override
     public String toString() {
         return "LoginModuleConfig{className='" + className + "', usage=" + usage

--- a/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.security;
+
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+
+import java.util.Objects;
+import java.util.Properties;
+
+public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginConfig<T>> implements AuthenticationConfig {
+
+    private Boolean skipIdentity;
+    private Boolean skipEndpoint;
+    private Boolean skipRole;
+
+    public Boolean getSkipIdentity() {
+        return skipIdentity;
+    }
+
+    public T setSkipIdentity(Boolean skipIdentity) {
+        this.skipIdentity = skipIdentity;
+        return self();
+    }
+
+    public Boolean getSkipEndpoint() {
+        return skipEndpoint;
+    }
+
+    public T setSkipEndpoint(Boolean skipEndpoint) {
+        this.skipEndpoint = skipEndpoint;
+        return self();
+    }
+
+    public Boolean getSkipRole() {
+        return skipRole;
+    }
+
+    public T setSkipRole(Boolean skipRole) {
+        this.skipRole = skipRole;
+        return self();
+    }
+
+    protected Properties initLoginModuleProperties() {
+        Properties props = new Properties();
+        setIfConfigured(props, "skipIdentity", skipIdentity);
+        setIfConfigured(props, "skipEndpoint", skipEndpoint);
+        setIfConfigured(props, "skipRole", skipRole);
+        return props;
+    }
+
+    protected void setIfConfigured(Properties props, String propertyName, String value) {
+        if (!isNullOrEmpty(value)) {
+            props.setProperty(propertyName, value);
+        }
+    }
+
+    protected void setIfConfigured(Properties props, String propertyName, Object value) {
+        if (value != null) {
+            props.setProperty(propertyName, value.toString());
+        }
+    }
+
+    protected void setIfConfigured(Properties props, String propertyName, Enum<?> value) {
+        if (value != null) {
+            props.setProperty(propertyName, value.toString());
+        }
+    }
+
+    protected abstract T self();
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(skipEndpoint, skipIdentity, skipRole);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        AbstractClusterLoginConfig other = (AbstractClusterLoginConfig) obj;
+        return Objects.equals(skipEndpoint, other.skipEndpoint) && Objects.equals(skipIdentity, other.skipIdentity)
+                && Objects.equals(skipRole, other.skipRole);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.security;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+
+public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<KerberosAuthenticationConfig> {
+
+    private Boolean relaxFlagsCheck;
+    private String securityRealm;
+    private LdapAuthenticationConfig ldapAuthenticationConfig;
+
+    public Boolean getRelaxFlagsCheck() {
+        return relaxFlagsCheck;
+    }
+
+    public KerberosAuthenticationConfig setRelaxFlagsCheck(Boolean relaxFlagsCheck) {
+        this.relaxFlagsCheck = relaxFlagsCheck;
+        return this;
+    }
+
+    public String getSecurityRealm() {
+        return securityRealm;
+    }
+
+    public KerberosAuthenticationConfig setSecurityRealm(String securityRealm) {
+        this.securityRealm = securityRealm;
+        return this;
+    }
+
+    public LdapAuthenticationConfig getLdapAuthenticationConfig() {
+        return ldapAuthenticationConfig;
+    }
+
+    public KerberosAuthenticationConfig setLdapAuthenticationConfig(LdapAuthenticationConfig ldapAuthenticationConfig) {
+        this.ldapAuthenticationConfig = ldapAuthenticationConfig;
+        return this;
+    }
+
+    @Override
+    protected Properties initLoginModuleProperties() {
+        Properties props = super.initLoginModuleProperties();
+        setIfConfigured(props, "relaxFlagsCheck", relaxFlagsCheck);
+        setIfConfigured(props, "securityRealm", securityRealm);
+        return props;
+    }
+
+    @Override
+    public LoginModuleConfig[] asLoginModuleConfigs() {
+        LoginModuleConfig loginModuleConfig = new LoginModuleConfig("com.hazelcast.security.loginimpl.GssApiLoginModule",
+                LoginModuleUsage.REQUIRED);
+
+        loginModuleConfig.setProperties(initLoginModuleProperties());
+
+        LoginModuleConfig[] loginModuleConfigs = null;
+        if (ldapAuthenticationConfig != null) {
+            loginModuleConfigs = new LoginModuleConfig[2];
+            loginModuleConfigs[1] = ldapAuthenticationConfig.asLoginModuleConfigs()[0];
+        } else {
+            loginModuleConfigs = new LoginModuleConfig[1];
+        }
+        loginModuleConfigs[0] = loginModuleConfig;
+        return loginModuleConfigs;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(ldapAuthenticationConfig, relaxFlagsCheck, securityRealm);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        KerberosAuthenticationConfig other = (KerberosAuthenticationConfig) obj;
+        return Objects.equals(ldapAuthenticationConfig, other.ldapAuthenticationConfig)
+                && Objects.equals(relaxFlagsCheck, other.relaxFlagsCheck) && Objects.equals(securityRealm, other.securityRealm);
+    }
+
+    @Override
+    public String toString() {
+        return "KerberosAuthenticationConfig [relaxFlagsCheck=" + relaxFlagsCheck + ", securityRealm=" + securityRealm
+                + ", ldapAuthenticationConfig=" + ldapAuthenticationConfig
+                + ", getSkipIdentity()=" + getSkipIdentity() + ", getSkipEndpoint()=" + getSkipEndpoint() + ", getSkipRole()="
+                + getSkipRole() + "]";
+    }
+
+    @Override
+    protected KerberosAuthenticationConfig self() {
+        return this;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.security;
+
+import java.util.Objects;
+
+import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.security.ICredentialsFactory;
+
+public class KerberosIdentityConfig implements IdentityConfig {
+
+    private final CredentialsFactoryConfig factoryConfig = new CredentialsFactoryConfig(
+            "com.hazelcast.security.impl.KerberosCredentialsFactory");
+
+    public String getSpn() {
+        return factoryConfig.getProperties().getProperty("spn");
+    }
+
+    public KerberosIdentityConfig setSpn(String spn) {
+        factoryConfig.getProperties().setProperty("spn", spn);
+        return this;
+    }
+
+    public String getServiceNamePrefix() {
+        return factoryConfig.getProperties().getProperty("serviceNamePrefix");
+    }
+
+    public KerberosIdentityConfig setServiceNamePrefix(String serviceNamePrefix) {
+        factoryConfig.getProperties().setProperty("serviceNamePrefix", serviceNamePrefix);
+        return this;
+    }
+
+    public String getRealm() {
+        return factoryConfig.getProperties().getProperty("realm");
+    }
+
+    public KerberosIdentityConfig setRealm(String realm) {
+        factoryConfig.getProperties().setProperty("realm", realm);
+        return this;
+    }
+
+    public String getSecurityRealm() {
+        return factoryConfig.getProperties().getProperty("securityRealm");
+    }
+
+    public KerberosIdentityConfig setSecurityRealm(String securityRealm) {
+        factoryConfig.getProperties().setProperty("securityRealm", securityRealm);
+        return this;
+    }
+
+    @Override
+    public ICredentialsFactory asCredentialsFactory(ClassLoader cl) {
+        return factoryConfig.asCredentialsFactory(cl);
+    }
+
+    @Override
+    public IdentityConfig copy() {
+        return new KerberosIdentityConfig().setRealm(getRealm()).setSecurityRealm(getSecurityRealm())
+                .setServiceNamePrefix(getServiceNamePrefix()).setSpn(getSpn());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(factoryConfig);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        KerberosIdentityConfig other = (KerberosIdentityConfig) obj;
+        return Objects.equals(factoryConfig, other.factoryConfig);
+    }
+
+    @Override
+    public String toString() {
+        return "KerberosIdentityConfig [spn=" + getSpn() + ", serviceNamePrefix=" + getServiceNamePrefix()
+                + ", realm()=" + getRealm() + ", securityRealm=" + getSecurityRealm() + "]";
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
@@ -30,7 +30,7 @@ import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
  * Typed authentication configuration for {@code BasicLdapLoginModule} and {@code LdapLoginModule}.
  */
 @SuppressWarnings({"checkstyle:methodcount"})
-public class LdapAuthenticationConfig implements AuthenticationConfig {
+public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAuthenticationConfig> {
 
     private String url;
     private String socketFactoryClassName;
@@ -53,6 +53,7 @@ public class LdapAuthenticationConfig implements AuthenticationConfig {
     private String userContext;
     private String userFilter;
     private LdapSearchScope userSearchScope;
+    private Boolean skipAuthentication;
 
     public String getUrl() {
         return url;
@@ -207,15 +208,18 @@ public class LdapAuthenticationConfig implements AuthenticationConfig {
         return this;
     }
 
-    @Override
-    public LoginModuleConfig[] asLoginModuleConfigs() {
-        boolean useSystemUser = !isNullOrEmpty(systemUserDn);
-        LoginModuleConfig loginModuleConfig = new LoginModuleConfig(
-                useSystemUser ? "com.hazelcast.security.loginimpl.LdapLoginModule"
-                        : "com.hazelcast.security.loginimpl.BasicLdapLoginModule",
-                LoginModuleUsage.REQUIRED);
+    public Boolean getSkipAuthentication() {
+        return skipAuthentication;
+    }
 
-        Properties props = loginModuleConfig.getProperties();
+    public LdapAuthenticationConfig setSkipAuthentication(Boolean skipAuthentication) {
+        this.skipAuthentication = skipAuthentication;
+        return this;
+    }
+
+    @Override
+    protected Properties initLoginModuleProperties() {
+        Properties props = super.initLoginModuleProperties();
         setIfConfigured(props, Context.PROVIDER_URL, url);
         setIfConfigured(props, "java.naming.ldap.factory.socket", socketFactoryClassName);
         props.setProperty("parseDN", String.valueOf(parseDn));
@@ -228,7 +232,7 @@ public class LdapAuthenticationConfig implements AuthenticationConfig {
         setIfConfigured(props, "roleSearchScope", roleSearchScope);
         setIfConfigured(props, "userNameAttribute", userNameAttribute);
 
-        if (useSystemUser) {
+        if (!isNullOrEmpty(systemUserDn)) {
             props.setProperty(Context.SECURITY_AUTHENTICATION, "simple");
             props.setProperty(Context.SECURITY_PRINCIPAL, systemUserDn);
             setIfConfigured(props, Context.SECURITY_CREDENTIALS, systemUserPassword);
@@ -236,77 +240,77 @@ public class LdapAuthenticationConfig implements AuthenticationConfig {
             setIfConfigured(props, "userContext", userContext);
             setIfConfigured(props, "userFilter", userFilter);
             setIfConfigured(props, "userSearchScope", userSearchScope);
+            setIfConfigured(props, "skipAuthentication", skipAuthentication);
         }
+        return props;
+    }
+
+    @Override
+    public LoginModuleConfig[] asLoginModuleConfigs() {
+        boolean useSystemUser = !isNullOrEmpty(systemUserDn);
+        LoginModuleConfig loginModuleConfig = new LoginModuleConfig(
+                useSystemUser ? "com.hazelcast.security.loginimpl.LdapLoginModule"
+                        : "com.hazelcast.security.loginimpl.BasicLdapLoginModule",
+                LoginModuleUsage.REQUIRED);
+
+        loginModuleConfig.setProperties(initLoginModuleProperties());
 
         return new LoginModuleConfig[] { loginModuleConfig };
     }
 
     @Override
     public String toString() {
-        return "LdapAuthenticationConfig [url=" + url + ", socketFactoryClassName=" + socketFactoryClassName + ", systemUserDN="
-                + systemUserDn + ", systemUserPassword=***, parseDN=" + parseDn + ", roleContext="
+        return "LdapAuthenticationConfig [url=" + url + ", socketFactoryClassName=" + socketFactoryClassName + ", systemUserDn="
+                + systemUserDn + ", systemUserPassword=" + systemUserPassword + ", parseDn=" + parseDn + ", roleContext="
                 + roleContext + ", roleFilter=" + roleFilter + ", roleMappingAttribute=" + roleMappingAttribute
                 + ", roleMappingMode=" + roleMappingMode + ", roleNameAttribute=" + roleNameAttribute
                 + ", roleRecursionMaxDepth=" + roleRecursionMaxDepth + ", roleSearchScope=" + roleSearchScope
                 + ", userNameAttribute=" + userNameAttribute + ", passwordAttribute=" + passwordAttribute + ", userContext="
-                + userContext + ", userFilter=" + userFilter + ", userSearchScope=" + userSearchScope + "]";
+                + userContext + ", userFilter=" + userFilter + ", userSearchScope=" + userSearchScope + ", skipAuthentication="
+                + skipAuthentication + ", getSkipIdentity()=" + getSkipIdentity() + ", getSkipEndpoint()=" + getSkipEndpoint()
+                + ", getSkipRole()=" + getSkipRole() + "]";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(parseDn, passwordAttribute, roleContext, roleFilter, roleMappingAttribute, roleMappingMode,
-                roleNameAttribute, roleRecursionMaxDepth, roleSearchScope, socketFactoryClassName, systemUserDn,
-                systemUserPassword, url, userContext, userFilter, userNameAttribute, userSearchScope);
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result
+                + Objects.hash(parseDn, passwordAttribute, roleContext, roleFilter, roleMappingAttribute, roleMappingMode,
+                        roleNameAttribute, roleRecursionMaxDepth, roleSearchScope, skipAuthentication, socketFactoryClassName,
+                        systemUserDn, systemUserPassword, url, userContext, userFilter, userNameAttribute, userSearchScope);
+        return result;
     }
 
     @Override
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
         if (getClass() != obj.getClass()) {
             return false;
         }
         LdapAuthenticationConfig other = (LdapAuthenticationConfig) obj;
-        return parseDn == other.parseDn
-                && Objects.equals(passwordAttribute, other.passwordAttribute)
-                && Objects.equals(roleContext, other.roleContext)
-                && Objects.equals(roleFilter, other.roleFilter)
-                && Objects.equals(roleMappingAttribute, other.roleMappingAttribute)
-                && roleMappingMode == other.roleMappingMode
+        return parseDn == other.parseDn && Objects.equals(passwordAttribute, other.passwordAttribute)
+                && Objects.equals(roleContext, other.roleContext) && Objects.equals(roleFilter, other.roleFilter)
+                && Objects.equals(roleMappingAttribute, other.roleMappingAttribute) && roleMappingMode == other.roleMappingMode
                 && Objects.equals(roleNameAttribute, other.roleNameAttribute)
                 && Objects.equals(roleRecursionMaxDepth, other.roleRecursionMaxDepth)
-                && roleSearchScope == other.roleSearchScope
+                && roleSearchScope == other.roleSearchScope && Objects.equals(skipAuthentication, other.skipAuthentication)
                 && Objects.equals(socketFactoryClassName, other.socketFactoryClassName)
                 && Objects.equals(systemUserDn, other.systemUserDn)
-                && Objects.equals(systemUserPassword, other.systemUserPassword)
-                && Objects.equals(url, other.url)
-                && Objects.equals(userContext, other.userContext)
-                && Objects.equals(userFilter, other.userFilter)
-                && Objects.equals(userNameAttribute, other.userNameAttribute)
-                && userSearchScope == other.userSearchScope;
+                && Objects.equals(systemUserPassword, other.systemUserPassword) && Objects.equals(url, other.url)
+                && Objects.equals(userContext, other.userContext) && Objects.equals(userFilter, other.userFilter)
+                && Objects.equals(userNameAttribute, other.userNameAttribute) && userSearchScope == other.userSearchScope;
     }
 
-    private void setIfConfigured(Properties props, String propertyName, String value) {
-        if (!isNullOrEmpty(value)) {
-            props.setProperty(propertyName, value);
-        }
-    }
-
-    private void setIfConfigured(Properties props, String propertyName, Object value) {
-        if (value != null) {
-            props.setProperty(propertyName, value.toString());
-        }
-    }
-
-    private void setIfConfigured(Properties props, String propertyName, Enum<?> value) {
-        if (value != null) {
-            props.setProperty(propertyName, value.toString());
-        }
+    @Override
+    protected LdapAuthenticationConfig self() {
+        return this;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
@@ -261,7 +261,7 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
     @Override
     public String toString() {
         return "LdapAuthenticationConfig [url=" + url + ", socketFactoryClassName=" + socketFactoryClassName + ", systemUserDn="
-                + systemUserDn + ", systemUserPassword=" + systemUserPassword + ", parseDn=" + parseDn + ", roleContext="
+                + systemUserDn + ", systemUserPassword=***, parseDn=" + parseDn + ", roleContext="
                 + roleContext + ", roleFilter=" + roleFilter + ", roleMappingAttribute=" + roleMappingAttribute
                 + ", roleMappingMode=" + roleMappingMode + ", roleNameAttribute=" + roleNameAttribute
                 + ", roleRecursionMaxDepth=" + roleRecursionMaxDepth + ", roleSearchScope=" + roleSearchScope

--- a/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
@@ -65,6 +65,15 @@ public class RealmConfig {
         return this;
     }
 
+    public KerberosAuthenticationConfig getKerberosAuthenticationConfig() {
+        return getIfType(authenticationConfig, KerberosAuthenticationConfig.class);
+    }
+
+    public RealmConfig setKerberosAuthenticationConfig(KerberosAuthenticationConfig authenticationConfig) {
+        this.authenticationConfig = requireNonNull(authenticationConfig, "Authentication config can't be null");
+        return this;
+    }
+
     public UsernamePasswordIdentityConfig getUsernamePasswordIdentityConfig() {
         return getIfType(identityConfig, UsernamePasswordIdentityConfig.class);
     }
@@ -108,6 +117,15 @@ public class RealmConfig {
 
     public RealmConfig setCredentials(Credentials credentials) {
         this.identityConfig = new CredentialsIdentityConfig(credentials);
+        return this;
+    }
+
+    public KerberosIdentityConfig getKerberosIdentityConfig() {
+        return getIfType(identityConfig, KerberosIdentityConfig.class);
+    }
+
+    public RealmConfig setKerberosIdentityConfig(KerberosIdentityConfig identityConfig) {
+        this.identityConfig = identityConfig;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/security/TlsAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/TlsAuthenticationConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config.security;
 
 import java.util.Objects;
+import java.util.Properties;
 
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
@@ -24,7 +25,7 @@ import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 /**
  * Typed authentication configuration for the {@code X509CertificateLoginModule}.
  */
-public class TlsAuthenticationConfig implements AuthenticationConfig {
+public class TlsAuthenticationConfig extends AbstractClusterLoginConfig<TlsAuthenticationConfig> {
 
     private String roleAttribute;
 
@@ -38,25 +39,32 @@ public class TlsAuthenticationConfig implements AuthenticationConfig {
     }
 
     @Override
+    protected Properties initLoginModuleProperties() {
+        Properties props = super.initLoginModuleProperties();
+        setIfConfigured(props, "roleAttribute", roleAttribute);
+        return props;
+    }
+
+    @Override
     public LoginModuleConfig[] asLoginModuleConfigs() {
         LoginModuleConfig loginModuleConfig = new LoginModuleConfig("com.hazelcast.security.loginimpl.X509CertificateLoginModule",
                 LoginModuleUsage.REQUIRED);
-        if (roleAttribute != null) {
-            loginModuleConfig.getProperties().setProperty("roleAttribute", roleAttribute);
-        }
+        loginModuleConfig.setProperties(initLoginModuleProperties());
         return new LoginModuleConfig[] { loginModuleConfig };
     }
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("TlsAuthenticationConfig [roleAttribute=").append(roleAttribute).append("]");
-        return builder.toString();
+        return "TlsAuthenticationConfig [roleAttribute=" + roleAttribute + ", getSkipIdentity()=" + getSkipIdentity()
+                + ", getSkipEndpoint()=" + getSkipEndpoint() + ", getSkipRole()=" + getSkipRole() + "]";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(roleAttribute);
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(roleAttribute);
+        return result;
     }
 
     @Override
@@ -64,7 +72,7 @@ public class TlsAuthenticationConfig implements AuthenticationConfig {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
         if (getClass() != obj.getClass()) {
@@ -72,5 +80,10 @@ public class TlsAuthenticationConfig implements AuthenticationConfig {
         }
         TlsAuthenticationConfig other = (TlsAuthenticationConfig) obj;
         return Objects.equals(roleAttribute, other.roleAttribute);
+    }
+
+    @Override
+    protected TlsAuthenticationConfig self() {
+        return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -761,9 +761,9 @@ public class Node {
                 liteMember, createConfigCheck(), memberAddresses, dataMemberCount, clusterVersion, memberListVersion);
     }
 
-    public JoinRequest createJoinRequest(boolean withCredentials) {
-        final Credentials credentials = (withCredentials && securityContext != null)
-                ? securityContext.getCredentialsFactory().newCredentials() : null;
+    public JoinRequest createJoinRequest(Address remoteAddress) {
+        final Credentials credentials = (remoteAddress != null && securityContext != null)
+                ? securityContext.getCredentialsFactory().newCredentials(remoteAddress) : null;
         final Set<UUID> excludedMemberUuids = nodeExtension.getInternalHotRestartService().getExcludedMemberUuids();
 
         MemberImpl localMember = getLocalMember();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -446,14 +446,13 @@ public class ClusterJoinManager {
      * Send join request to {@code toAddress}.
      *
      * @param toAddress       the currently known master address.
-     * @param withCredentials use cluster credentials
      * @return {@code true} if join request was sent successfully, otherwise {@code false}.
      */
-    public boolean sendJoinRequest(Address toAddress, boolean withCredentials) {
+    public boolean sendJoinRequest(Address toAddress) {
         if (toAddress == null) {
             toAddress = clusterService.getMasterAddress();
         }
-        JoinRequestOp joinRequest = new JoinRequestOp(node.createJoinRequest(withCredentials));
+        JoinRequestOp joinRequest = new JoinRequestOp(node.createJoinRequest(toAddress));
         return nodeEngine.getOperationService().send(joinRequest, toAddress);
     }
 
@@ -530,7 +529,7 @@ public class ClusterJoinManager {
             if (conn != null && conn.isAlive()) {
                 logger.info(format("Ignoring master response %s from %s since this node has an active master %s",
                         masterAddress, callerAddress, currentMaster));
-                sendJoinRequest(currentMaster, true);
+                sendJoinRequest(currentMaster);
             } else {
                 logger.warning(format("Ambiguous master response! Received master response %s from %s. "
                                 + "This node has a master %s, but does not have an active connection to it. "
@@ -546,7 +545,7 @@ public class ClusterJoinManager {
     private void setMasterAndJoin(Address masterAddress) {
         clusterService.setMasterAddress(masterAddress);
         node.getConnectionManager(MEMBER).getOrConnect(masterAddress);
-        if (!sendJoinRequest(masterAddress, true)) {
+        if (!sendJoinRequest(masterAddress)) {
             logger.warning("Could not create connection to possible master " + masterAddress);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -90,7 +90,7 @@ public class MulticastJoiner extends AbstractJoiner {
                 if (logger.isFineEnabled()) {
                     logger.fine("Joining to master " + master);
                 }
-                clusterJoinManager.sendJoinRequest(master, true);
+                clusterJoinManager.sendJoinRequest(master);
             } else {
                 break;
             }
@@ -174,7 +174,7 @@ public class MulticastJoiner extends AbstractJoiner {
             if (logger.isFineEnabled()) {
                 logger.fine("Searching for master node. Max tries: " + maxTryCount.get());
             }
-            JoinRequest joinRequest = node.createJoinRequest(false);
+            JoinRequest joinRequest = node.createJoinRequest(null);
             while (node.isRunning() && currentTryCount.incrementAndGet() <= maxTryCount.get()) {
                 joinRequest.setTryCount(currentTryCount.get());
                 node.multicastService.send(joinRequest);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -122,7 +122,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 if (logger.isFineEnabled()) {
                     logger.fine("Sending joinRequest " + targetAddress);
                 }
-                clusterJoinManager.sendJoinRequest(targetAddress, true);
+                clusterJoinManager.sendJoinRequest(targetAddress);
                 //noinspection BusyWait
                 Thread.sleep(JOIN_RETRY_WAIT_TIME);
             }
@@ -254,7 +254,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 if (logger.isFineEnabled()) {
                     logger.fine("Sending join request to " + masterAddress);
                 }
-                clusterJoinManager.sendJoinRequest(masterAddress, true);
+                clusterJoinManager.sendJoinRequest(masterAddress);
             } else {
                 sendMasterQuestion(addresses);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -150,7 +150,7 @@ public class DynamicSecurityConfig extends SecurityConfig {
 
     @Override
     public RealmConfig getRealmConfig(String realmName) {
-        throw new UnsupportedOperationException("Unsupported operation");
+        return staticSecurityConfig.getRealmConfig(realmName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/MapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapStore.java
@@ -87,8 +87,8 @@ public interface MapStore<K, V> extends MapLoader<K, V> {
      * one-by-one. In this way a MapStore implementation can handle partial
      * deleteAll() cases when some entries were deleted successfully before a
      * failure happens. Entries removed from the keys will be not passed to
-     * subsequent call to delete() method any more. The intended usage is to 
-     * delete items from the provided collection as they are deleted from 
+     * subsequent call to delete() method any more. The intended usage is to
+     * delete items from the provided collection as they are deleted from
      * the store.
      *
      * @param keys the keys of the entries to delete.

--- a/hazelcast/src/main/java/com/hazelcast/security/ICredentialsFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/ICredentialsFactory.java
@@ -20,6 +20,8 @@ import java.util.Properties;
 
 import javax.security.auth.callback.CallbackHandler;
 
+import com.hazelcast.cluster.Address;
+
 /**
  * ICredentialsFactory is used to create {@link Credentials} objects to be used during node authentication before connection is
  * accepted by the master node.
@@ -48,6 +50,16 @@ public interface ICredentialsFactory {
      * @return the new Credentials object
      */
     Credentials newCredentials();
+
+    /**
+     * Creates new {@link Credentials} object for given target {@link Address}.
+     *
+     * @param address Target {@link Address} (may be {@code null})
+     * @return
+     */
+    default Credentials newCredentials(Address address) {
+        return newCredentials();
+    }
 
     /**
      * Destroys {@link ICredentialsFactory}.

--- a/hazelcast/src/main/java/com/hazelcast/security/RealmConfigCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/RealmConfigCallback.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security;
+
+import javax.security.auth.callback.Callback;
+
+import com.hazelcast.config.security.RealmConfig;
+
+/**
+ * This JAAS {@link Callback} is used to retrieve a {@link RealmConfig} from client or member configuration.
+ */
+public class RealmConfigCallback implements Callback {
+
+    private RealmConfig realmConfig;
+    private final String realmName;
+
+    public RealmConfigCallback(String realmName) {
+        this.realmName = realmName;
+    }
+
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public RealmConfig getRealmConfig() {
+        return realmConfig;
+    }
+
+    public void setRealmConfig(RealmConfig realmConfig) {
+        this.realmConfig = realmConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1027,7 +1027,7 @@ public final class ClusterProperty {
      * Client protocol message size limit (in bytes) for unverified connections (i.e. maximal length of authentication message).
      */
     public static final HazelcastProperty CLIENT_PROTOCOL_UNVERIFIED_MESSAGE_BYTES =
-            new HazelcastProperty("hazelcast.client.protocol.max.message.bytes", 1024);
+            new HazelcastProperty("hazelcast.client.protocol.max.message.bytes", 4096);
 
     public static final HazelcastProperty AUDIT_LOG_ENABLED = new HazelcastProperty("hazelcast.auditlog.enabled", false);
 

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -418,22 +418,53 @@
         </xs:simpleContent>
     </xs:complexType>
     <xs:complexType name="security">
+        <xs:sequence>
+            <xs:choice minOccurs="0">
+                <xs:element name="username-password" type="username-password"/>
+                <xs:element name="credentials-factory" type="security-object"/>
+                <xs:element name="token" type="token"/>
+                <xs:element name="kerberos" type="kerberos-identity"/>
+            </xs:choice>
+            <xs:element name="realms" type="realms" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="realms">
+        <xs:sequence>
+            <xs:element name="realm" type="realm" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="realm">
+        <xs:all>
+            <xs:element name="authentication" type="authentication" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="authentication">
         <xs:choice>
-            <xs:element name="username-password" type="username-password"/>
-            <xs:element name="credentials-factory" type="security-object"/>
-            <xs:element name="token" type="token"/>
+            <xs:element name="jaas" type="login-modules"/>
         </xs:choice>
     </xs:complexType>
-    <xs:complexType name="credentials">
-        <xs:annotation>
-            <xs:documentation>Credentials className
-            </xs:documentation>
-        </xs:annotation>
-        <xs:simpleContent>
-            <xs:extension base="non-space-string"/>
-        </xs:simpleContent>
+    <xs:complexType name="login-modules">
+        <xs:sequence>
+            <xs:element name="login-module" type="login-module" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
     </xs:complexType>
-
+    <xs:complexType name="login-module">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" type="non-space-string" use="required"/>
+        <xs:attribute name="usage" use="optional" default="REQUIRED">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string">
+                    <xs:enumeration value="REQUIRED"/>
+                    <xs:enumeration value="OPTIONAL"/>
+                    <xs:enumeration value="REQUISITE"/>
+                    <xs:enumeration value="SUFFICIENT"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
     <xs:complexType name="security-object">
         <xs:sequence>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
@@ -844,6 +875,14 @@
                 </xs:attribute>
             </xs:extension>
         </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="kerberos-identity">
+        <xs:all>
+            <xs:element name="realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="service-name-prefix" type="xs:string" minOccurs="0"/>
+            <xs:element name="spn" type="xs:string" minOccurs="0"/>
+        </xs:all>
     </xs:complexType>
 
     <xs:complexType name="metrics">

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -377,6 +377,9 @@
         * <token>
             Defines a static TokenCredentials instance as the client's identity. It can have attribute "encoding".
             Content of the element is token value in given encoding (or in plain text).
+        * <kerberos>
+            Uses Kerberos service ticket (wrapped as GSS-API init token) as the identity.
+            It may reference a security realm  in the <realms> section. The realm is used for the Kerberos authentication.
     -->
     <security>
         <credentials-factory class-name="com.hazelcast.examples.MyCredentialsFactory">
@@ -387,7 +390,32 @@
         <!--
         <username-password username="client1" password="s3crEt"/>
         <token encoding="base64">SGF6ZWxjYXN0</token>
+        <kerberos>
+            <realm>HAZELCAST.COM</realm>
+            <security-realm>krb5Initiator</security-realm>
+            <service-name-prefix>hz/</service-name-prefix>
+            <spn>hz/127.0.0.1@HAZELCAST.COM</spn>
+        </kerberos>
          -->
+        <realms>
+            <realm name="krb5Initiator">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                            <properties>
+                                <property name="isInitiator">true</property>
+                                <property name="useTicketCache">false</property>
+                                <property name="doNotPrompt">true</property>
+                                <property name="useKeyTab">true</property>
+                                <property name="storeKey">true</property>
+                                <property name="principal">jduke@HAZELCAST.COM</property>
+                                <property name="keyTab">/opt/jduke.keytab</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
     </security>
 
     <!--

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -342,12 +342,30 @@ hazelcast-client:
   # * "token"
   #     Defines a static TokenCredentials instance as the client's identity. It can have attribute "encoding".
   #     Content of the attribute "value" is token value in given encoding (or in plain text).
-  #
+  # * "kerberos"
+  #     Uses Kerberos service ticket (wrapped as GSS-API init token) as the identity.
+  #     It may reference a security realm  in the <realms> section. The realm is used for the Kerberos authentication.
+
   security:
     credentials-factory:
       class-name: com.hazelcast.examples.MyCredentialsFactory
       properties:
         property: value
+    realms:
+      - name: krb5Initiator
+        authentication:
+          jaas:
+            - class-name: com.sun.security.auth.module.Krb5LoginModule
+              usage: REQUIRED
+              properties:
+                isInitiator: true
+                useTicketCache: false
+                doNotPrompt: true
+                useKeyTab: true
+                storeKey: true
+                principal: jduke@HAZELCAST.COM
+                keyTab: /opt/jduke.keytab
+
   #
   # ===== HAZELCAST LISTENER CONFIGURATIONS =====
   #

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -4832,33 +4832,50 @@
             <xs:element name="jaas" type="login-modules"/>
             <xs:element name="tls" type="tls-authentication"/>
             <xs:element name="ldap" type="ldap-authentication"/>
+            <xs:element name="kerberos" type="kerberos-authentication"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="basic-authentication">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="skip-identity" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="skip-endpoint" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="skip-role" type="xs:boolean" minOccurs="0"/>
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="tls-authentication">
-        <xs:attribute name="roleAttribute" type="xs:string" use="optional" default="cn" />
+        <xs:complexContent>
+            <xs:extension base="basic-authentication">
+                <xs:attribute name="roleAttribute" type="xs:string" use="optional" default="cn" />
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="ldap-authentication">
-        <xs:all>
-            <xs:element name="url" type="xs:string"/>
-            <xs:element name="socket-factory-class-name" type="xs:string" minOccurs="0"/>
-
-            <xs:element name="parse-dn" type="xs:boolean" minOccurs="0"/>
-            <xs:element name="role-context" type="xs:string" minOccurs="0"/>
-            <xs:element name="role-filter" type="xs:string" minOccurs="0"/>
-            <xs:element name="role-mapping-attribute" type="xs:string" minOccurs="0"/>
-            <xs:element name="role-mapping-mode" type="ldap-role-mapping-mode" minOccurs="0"/>
-            <xs:element name="role-name-attribute" type="xs:string" minOccurs="0"/>
-            <xs:element name="role-recursion-max-depth" type="xs:int" minOccurs="0"/>
-            <xs:element name="role-search-scope" type="ldap-search-scope" minOccurs="0"/>
-            <xs:element name="user-name-attribute" type="xs:string" minOccurs="0"/>
-
-            <xs:element name="system-user-dn" type="xs:string" minOccurs="0"/>
-            <xs:element name="system-user-password" type="xs:string" minOccurs="0"/>
-            <xs:element name="password-attribute" type="xs:string" minOccurs="0"/>
-            <xs:element name="user-context" type="xs:string" minOccurs="0"/>
-            <xs:element name="user-filter" type="xs:string" minOccurs="0"/>
-            <xs:element name="user-search-scope" type="ldap-search-scope" minOccurs="0"/>
-        </xs:all>
+        <xs:complexContent>
+            <xs:extension base="basic-authentication">
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element name="url" type="xs:string"/>
+                    <xs:element name="socket-factory-class-name" type="xs:string" minOccurs="0"/>
+        
+                    <xs:element name="parse-dn" type="xs:boolean" minOccurs="0"/>
+                    <xs:element name="role-context" type="xs:string" minOccurs="0"/>
+                    <xs:element name="role-filter" type="xs:string" minOccurs="0"/>
+                    <xs:element name="role-mapping-attribute" type="xs:string" minOccurs="0"/>
+                    <xs:element name="role-mapping-mode" type="ldap-role-mapping-mode" minOccurs="0"/>
+                    <xs:element name="role-name-attribute" type="xs:string" minOccurs="0"/>
+                    <xs:element name="role-recursion-max-depth" type="xs:int" minOccurs="0"/>
+                    <xs:element name="role-search-scope" type="ldap-search-scope" minOccurs="0"/>
+                    <xs:element name="user-name-attribute" type="xs:string" minOccurs="0"/>
+        
+                    <xs:element name="system-user-dn" type="xs:string" minOccurs="0"/>
+                    <xs:element name="system-user-password" type="xs:string" minOccurs="0"/>
+                    <xs:element name="password-attribute" type="xs:string" minOccurs="0"/>
+                    <xs:element name="user-context" type="xs:string" minOccurs="0"/>
+                    <xs:element name="user-filter" type="xs:string" minOccurs="0"/>
+                    <xs:element name="user-search-scope" type="ldap-search-scope" minOccurs="0"/>
+                    <xs:element name="skip-authentication" type="xs:boolean" minOccurs="0"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
     <xs:simpleType name="ldap-role-mapping-mode">
         <xs:restriction base="non-space-string">
@@ -4874,12 +4891,32 @@
             <xs:enumeration value="subtree"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="kerberos-authentication">
+        <xs:complexContent>
+            <xs:extension base="basic-authentication">
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element name="relax-flags-check" type="xs:boolean" minOccurs="0"/>
+                    <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
+                    <xs:element name="ldap" type="ldap-authentication" minOccurs="0"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
     <xs:complexType name="identity">
         <xs:choice>
             <xs:element name="username-password" type="username-password"/>
             <xs:element name="credentials-factory" type="security-object"/>
             <xs:element name="token" type="token"/>
+            <xs:element name="kerberos" type="kerberos-identity"/>
         </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="kerberos-identity">
+        <xs:all>
+            <xs:element name="realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
+            <xs:element name="service-name-prefix" type="xs:string" minOccurs="0"/>
+            <xs:element name="spn" type="xs:string" minOccurs="0"/>
+        </xs:all>
     </xs:complexType>
     <xs:complexType name="username-password">
         <xs:attribute name="username" type="xs:string" use="required" />

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2153,6 +2153,8 @@
                     in Hazelcast network configuration)
                 * <ldap>
                     LDAP based authentication
+                * <kerberos>
+                    Kerberos based authentication
                 Identity configuration types:
                 * <credentials-factory>:
                     Specifies the name and properties of your class that you developed by implementing Hazelcast's Credentials
@@ -2168,6 +2170,8 @@
                 * <token>
                     Defines a static TokenCredentials instance as the client's identity. It can have attribute "encoding".
                     Content of the element is token value in given encoding (or in plain text).
+                * <kerberos>
+                    Uses Kerberos ticket (wrapped as GSS-API init token) as the identity.
             -->
             <realm name="mr">
                 <authentication>
@@ -2240,6 +2244,65 @@
                 <identity>
                     <token encoding="base64">SGF6ZWxjYXN0</token>
                 </identity>
+            </realm>
+            <realm name="kerberosRealm">
+                <authentication>
+                    <kerberos>
+                        <skip-role>true</skip-role>
+                        <relax-flags-check>true</relax-flags-check>
+                        <security-realm>krb5Acceptor</security-realm>
+                        <ldap>
+                            <url>ldap://127.0.0.1/</url>
+                            <system-user-dn>uid=admin,ou=system</system-user-dn>
+                            <system-user-password>secret</system-user-password>
+                            <skip-authentication>true</skip-authentication>
+                            <user-filter>(krb5PrincipalName={login})</user-filter>
+                            <role-mapping-attribute>cn</role-mapping-attribute>
+                        </ldap>
+                    </kerberos>
+                </authentication>
+                <identity>
+                    <kerberos>
+                        <realm>HAZELCAST.COM</realm>
+                        <security-realm>krb5Initiator</security-realm>
+                        <service-name-prefix>hz/</service-name-prefix>
+                        <spn>hz/127.0.0.1@HAZELCAST.COM</spn>
+                    </kerberos>
+                </identity>
+            </realm>
+            <realm name="krb5Acceptor">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                            <properties>
+                                <property name="isInitiator">false</property>
+                                <property name="useTicketCache">false</property>
+                                <property name="doNotPrompt">true</property>
+                                <property name="useKeyTab">true</property>
+                                <property name="storeKey">true</property>
+                                <property name="principal">hz/127.0.0.1@HAZELCAST.COM</property>
+                                <property name="keyTab">/opt/hz-localhost.keytab</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
+            <realm name="krb5Initiator">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                            <properties>
+                                <property name="isInitiator">true</property>
+                                <property name="useTicketCache">false</property>
+                                <property name="doNotPrompt">true</property>
+                                <property name="useKeyTab">true</property>
+                                <property name="storeKey">true</property>
+                                <property name="principal">hz/127.0.0.1@HAZELCAST.COM</property>
+                                <property name="keyTab">/opt/hz-localhost.keytab</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
             </realm>
         </realms>
         <member-authentication realm="mr"/>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2207,6 +2207,51 @@ hazelcast:
           token:
              encoding: base64
              value: SGF6ZWxjYXN0
+      - name: kerberosRealm
+        authentication:
+          kerberos:
+            skip-role: true
+            relax-flags-check: true
+            security-realm: krb5Acceptor
+            ldap:
+              url: ldap://127.0.0.1/
+              system-user-dn: uid=admin,ou=system
+              system-user-password: secret
+              skip-authentication: true
+              user-filter: "(krb5PrincipalName={login})"
+              role-mapping-attribute: cn
+        identity:
+          kerberos:
+            realm: HAZELCAST.COM
+            security-realm: krb5Initiator
+            service-name-prefix: hz/
+            spn: hz/127.0.0.1@HAZELCAST.COM
+      - name: krb5Acceptor
+        authentication:
+          jaas:
+            - class-name: com.sun.security.auth.module.Krb5LoginModule
+              usage: REQUIRED
+              properties:
+                isInitiator: false
+                useTicketCache: false
+                doNotPrompt: true
+                useKeyTab: true
+                storeKey: true
+                principal: hz/127.0.0.1@HAZELCAST.COM
+                keyTab: /opt/hz-localhost.keytab
+      - name: krb5Initiator
+        authentication:
+          jaas:
+            - class-name: com.sun.security.auth.module.Krb5LoginModule
+              usage: REQUIRED
+              properties:
+                isInitiator: true
+                useTicketCache: false
+                doNotPrompt: true
+                useKeyTab: true
+                storeKey: true
+                principal: hz/127.0.0.1@HAZELCAST.COM
+                keyTab: /opt/hz-localhost.keytab
     member-authentication:
       realm: mr
     client-authentication:

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -31,6 +31,8 @@ import com.hazelcast.config.IndexType;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.QueryCacheConfig;
@@ -39,6 +41,8 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.XMLConfigBuilderTest;
+import com.hazelcast.config.security.JaasAuthenticationConfig;
+import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.topic.TopicOverloadPolicy;
@@ -403,6 +407,17 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
         assertEquals("com.hazelcast.examples.MyCredentialsFactory", credentialsFactoryConfig.getClassName());
         Properties properties = credentialsFactoryConfig.getProperties();
         assertEquals("value", properties.getProperty("property"));
+        RealmConfig realmConfig = securityConfig.getRealmConfig("krb5Initiator");
+        assertNotNull(realmConfig);
+        JaasAuthenticationConfig jaasConf = realmConfig.getJaasAuthenticationConfig();
+        assertNotNull(jaasConf);
+        List<LoginModuleConfig> loginModuleConfigs = jaasConf.getLoginModuleConfigs();
+        assertNotNull(loginModuleConfigs);
+        assertEquals(1, loginModuleConfigs.size());
+        LoginModuleConfig loginModuleConfig = loginModuleConfigs.get(0);
+        assertEquals("com.sun.security.auth.module.Krb5LoginModule", loginModuleConfig.getClassName());
+        assertEquals(LoginModuleUsage.REQUIRED, loginModuleConfig.getUsage());
+        assertEquals("jduke@HAZELCAST.COM", loginModuleConfig.getProperties().get("principal"));
     }
 
     @Test(expected = HazelcastException.class)
@@ -455,6 +470,9 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
 
     @Test
     public abstract void testTokenIdentityConfig();
+
+    @Test
+    public abstract void testKerberosIdentityConfig();
 
     @Test
     public abstract void testMetricsConfig();

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType;
 import com.hazelcast.config.NearCacheConfig;
@@ -40,6 +41,10 @@ import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+import com.hazelcast.config.security.JaasAuthenticationConfig;
+import com.hazelcast.config.security.KerberosIdentityConfig;
+import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TokenEncoding;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
@@ -313,6 +318,24 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         clientConfig.getSecurityConfig().setTokenIdentityConfig(identityConfig);
         ClientConfig actual = newConfigViaGenerator();
         assertEquals(identityConfig, actual.getSecurityConfig().getTokenIdentityConfig());
+    }
+
+    @Test
+    public void kerberosIdentity() {
+        KerberosIdentityConfig identityConfig = new KerberosIdentityConfig()
+                .setRealm("realm")
+                .setSecurityRealm("security-realm")
+                .setServiceNamePrefix("prefix")
+                .setSpn("spn");
+        RealmConfig realmConfig = new RealmConfig().setJaasAuthenticationConfig(new JaasAuthenticationConfig()
+                .addLoginModuleConfig(new LoginModuleConfig("test.Krb5LoginModule", LoginModuleUsage.REQUIRED)
+                        .setProperty("principal", "jduke")));
+
+        ClientSecurityConfig securityConfig = clientConfig.getSecurityConfig()
+            .setKerberosIdentityConfig(identityConfig)
+            .addRealmConfig("kerberos", realmConfig);
+        ClientConfig actual = newConfigViaGenerator();
+        assertEquals(securityConfig, actual.getSecurityConfig());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.XMLConfigBuilderTest;
+import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.cluster.Versions;
@@ -376,6 +377,28 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         assertNotNull(tokenIdentityConfig);
         assertArrayEquals("Hazelcast".getBytes(StandardCharsets.US_ASCII), tokenIdentityConfig.getToken());
         assertEquals("SGF6ZWxjYXN0", tokenIdentityConfig.getTokenEncoded());
+    }
+
+    @Override
+    @Test
+    public void testKerberosIdentityConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<security>"
+                + "    <kerberos>\n"
+                + "        <realm>HAZELCAST.COM</realm>"
+                + "        <security-realm>krb5Initiator</security-realm>"
+                + "        <service-name-prefix>hz/</service-name-prefix>"
+                + "        <spn>hz/127.0.0.1@HAZELCAST.COM</spn>"
+                + "    </kerberos>"
+                + "</security>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig config = buildConfig(xml);
+        KerberosIdentityConfig identityConfig = config.getSecurityConfig().getKerberosIdentityConfig();
+        assertNotNull(identityConfig);
+        assertEquals("HAZELCAST.COM", identityConfig.getRealm());
+        assertEquals("krb5Initiator", identityConfig.getSecurityRealm());
+        assertEquals("hz/", identityConfig.getServiceNamePrefix());
+        assertEquals("hz/127.0.0.1@HAZELCAST.COM", identityConfig.getSpn());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.YamlConfigBuilderTest;
+import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.util.RootCauseMatcher;
@@ -381,6 +382,27 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         assertNotNull(tokenIdentityConfig);
         assertArrayEquals("Hazelcast".getBytes(StandardCharsets.US_ASCII), tokenIdentityConfig.getToken());
         assertEquals("SGF6ZWxjYXN0", tokenIdentityConfig.getTokenEncoded());
+    }
+
+    @Override
+    @Test
+    public void testKerberosIdentityConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  security:\n"
+                + "    kerberos:\n"
+                + "      realm: HAZELCAST.COM\n"
+                + "      security-realm: krb5Initiator\n"
+                + "      service-name-prefix: hz/\n"
+                + "      spn: hz/127.0.0.1@HAZELCAST.COM\n";
+
+        ClientConfig config = buildConfig(yaml);
+        KerberosIdentityConfig identityConfig = config.getSecurityConfig().getKerberosIdentityConfig();
+        assertNotNull(identityConfig);
+        assertEquals("HAZELCAST.COM", identityConfig.getRealm());
+        assertEquals("krb5Initiator", identityConfig.getSecurityRealm());
+        assertEquals("hz/", identityConfig.getServiceNamePrefix());
+        assertEquals("hz/127.0.0.1@HAZELCAST.COM", identityConfig.getSpn());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -247,6 +247,11 @@ class TestClientRegistry {
             return true;
         }
 
+        @Override
+        public Address getInitAddress() {
+            return remoteAddress;
+        }
+
         private ClientMessage readFromPacket(ClientMessage packet) {
             //Since frames are read, there should be no need to re-read to client message
             //return ClientMessage.createForDecode(packet.buffer(), 0);

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -24,6 +24,8 @@ import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
+import com.hazelcast.config.security.KerberosAuthenticationConfig;
+import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TlsAuthenticationConfig;
@@ -1555,8 +1557,10 @@ public class ConfigCompatibilityChecker {
                     && isCompatible(c1.getJaasAuthenticationConfig(), c2.getJaasAuthenticationConfig())
                     && isCompatible(c1.getTlsAuthenticationConfig(), c2.getTlsAuthenticationConfig())
                     && isCompatible(c1.getLdapAuthenticationConfig(), c2.getLdapAuthenticationConfig())
+                    && isCompatible(c1.getKerberosAuthenticationConfig(), c2.getKerberosAuthenticationConfig())
                     && isCompatible(c1.getUsernamePasswordIdentityConfig(), c2.getUsernamePasswordIdentityConfig())
                     && isCompatible(c1.getTokenIdentityConfig(), c2.getTokenIdentityConfig())
+                    && isCompatible(c1.getKerberosIdentityConfig(), c2.getKerberosIdentityConfig())
                     ;
         }
 
@@ -1574,6 +1578,14 @@ public class ConfigCompatibilityChecker {
         }
 
         private static boolean isCompatible(LdapAuthenticationConfig c1, LdapAuthenticationConfig c2) {
+            return c1 == c2 || (c1 != null && c2 != null && c1.equals(c2));
+        }
+
+        private static boolean isCompatible(KerberosAuthenticationConfig c1, KerberosAuthenticationConfig c2) {
+            return c1 == c2 || (c1 != null && c2 != null && c1.equals(c2));
+        }
+
+        private static boolean isCompatible(KerberosIdentityConfig c1, KerberosIdentityConfig c2) {
             return c1 == c2 || (c1 != null && c2 != null && c1.equals(c2));
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -628,7 +628,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz2 = factory.newHazelcastInstance();
         assertClusterSizeEventually(2, hz1, hz2);
 
-        JoinRequest staleJoinReq = getNode(hz2).createJoinRequest(true);
+        JoinRequest staleJoinReq = getNode(hz2).createJoinRequest(getNode(hz1).address);
         hz2.shutdown();
         assertClusterSizeEventually(1, hz1);
 
@@ -647,7 +647,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz3 = factory.newHazelcastInstance();
         assertClusterSizeEventually(3, hz1, hz2, hz3);
 
-        JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(true);
+        JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(getNode(hz2).address);
         hz3.shutdown();
         hz1.shutdown();
         assertClusterSizeEventually(1, hz2);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -67,7 +67,7 @@ class MockJoiner extends AbstractJoiner {
                 }
 
                 logger.fine("Sending join request to " + joinAddress);
-                if (!clusterJoinManager.sendJoinRequest(joinAddress, true)) {
+                if (!clusterJoinManager.sendJoinRequest(joinAddress)) {
                     logger.fine("Could not send join request to " + joinAddress);
                     clusterService.setMasterAddressToJoin(null);
                 }

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -163,6 +163,25 @@
                 <property name="property">value</property>
             </properties>
         </credentials-factory>
+        <realms>
+            <realm name="krb5Initiator">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                            <properties>
+                                <property name="isInitiator">true</property>
+                                <property name="useTicketCache">false</property>
+                                <property name="doNotPrompt">true</property>
+                                <property name="useKeyTab">true</property>
+                                <property name="storeKey">true</property>
+                                <property name="principal">jduke@HAZELCAST.COM</property>
+                                <property name="keyTab">/opt/jduke.keytab</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
     </security>
 
     <listeners>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -140,11 +140,24 @@ hazelcast-client:
             key-boolean: true
 
   security:
-    credentials: com.hazelcast.security.UsernamePasswordCredentials
     credentials-factory:
       class-name: com.hazelcast.examples.MyCredentialsFactory
       properties:
         property: value
+    realms:
+      - name: krb5Initiator
+        authentication:
+          jaas:
+            - class-name: com.sun.security.auth.module.Krb5LoginModule
+              usage: REQUIRED
+              properties:
+                isInitiator: true
+                useTicketCache: false
+                doNotPrompt: true
+                useKeyTab: true
+                storeKey: true
+                principal: jduke@HAZELCAST.COM
+                keyTab: /opt/jduke.keytab
 
   listeners:
     - com.hazelcast.examples.MembershipListener

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -640,6 +640,103 @@
                     </jaas>
                 </authentication>
             </realm>
+            <realm name="ldapRealm">
+                <authentication>
+                    <ldap>
+                        <url>ldap://ldap.my-company.example</url>
+                        <socket-factory-class-name>socketFactoryClassName</socket-factory-class-name>
+                        <parse-dn>true</parse-dn>
+                        <role-context>roleContext</role-context>
+                        <role-filter>roleFilter</role-filter>
+                        <role-mapping-attribute>roleMappingAttribute</role-mapping-attribute>
+                        <role-mapping-mode>reverse</role-mapping-mode>
+                        <role-name-attribute>roleNameAttribute</role-name-attribute>
+                        <role-recursion-max-depth>25</role-recursion-max-depth>
+                        <role-search-scope>object</role-search-scope>
+                        <user-name-attribute>userNameAttribute</user-name-attribute>
+                        <system-user-dn>systemUserDn</system-user-dn>
+                        <system-user-password>systemUserPassword</system-user-password>
+                        <password-attribute>passwordAttribute</password-attribute>
+                        <user-context>userContext</user-context>
+                        <user-filter>userFilter</user-filter>
+                        <user-search-scope>one-level</user-search-scope>
+                    </ldap>
+                </authentication>
+            </realm>
+            <realm name="tlsRealm">
+                <authentication>
+                    <tls roleAttribute="cn"/>
+                </authentication>
+            </realm>
+            <realm name="usernamePasswordIdentityRealm">
+                <identity>
+                    <username-password username="user" password="Hazelcast" />
+                </identity>
+            </realm>
+            <realm name="tokenIdentityRealm">
+                <identity>
+                    <token encoding="base64">SGF6ZWxjYXN0</token>
+                </identity>
+            </realm>
+            <realm name="kerberosRealm">
+                <authentication>
+                    <kerberos>
+                        <skip-role>true</skip-role>
+                        <relax-flags-check>true</relax-flags-check>
+                        <security-realm>krb5Acceptor</security-realm>
+                        <ldap>
+                            <url>ldap://127.0.0.1/</url>
+                            <system-user-dn>uid=admin,ou=system</system-user-dn>
+                            <system-user-password>secret</system-user-password>
+                            <skip-authentication>true</skip-authentication>
+                            <user-filter>(krb5PrincipalName={login})</user-filter>
+                            <role-mapping-attribute>cn</role-mapping-attribute>
+                        </ldap>
+                    </kerberos>
+                </authentication>
+                <identity>
+                    <kerberos>
+                        <realm>HAZELCAST.COM</realm>
+                        <security-realm>krb5Initiator</security-realm>
+                        <service-name-prefix>hz/</service-name-prefix>
+                        <spn>hz/127.0.0.1@HAZELCAST.COM</spn>
+                    </kerberos>
+                </identity>
+            </realm>
+            <realm name="krb5Acceptor">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                            <properties>
+                                <property name="isInitiator">false</property>
+                                <property name="useTicketCache">false</property>
+                                <property name="doNotPrompt">true</property>
+                                <property name="useKeyTab">true</property>
+                                <property name="storeKey">true</property>
+                                <property name="principal">hz/127.0.0.1@HAZELCAST.COM</property>
+                                <property name="keyTab">/opt/hz-localhost.keytab</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
+            <realm name="krb5Initiator">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
+                            <properties>
+                                <property name="isInitiator">true</property>
+                                <property name="useTicketCache">false</property>
+                                <property name="doNotPrompt">true</property>
+                                <property name="useKeyTab">true</property>
+                                <property name="storeKey">true</property>
+                                <property name="principal">hz/127.0.0.1@HAZELCAST.COM</property>
+                                <property name="keyTab">/opt/hz-localhost.keytab</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
         </realms>
         <member-authentication realm="mr"/>
         <client-authentication realm="cr"/>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -614,6 +614,85 @@ hazelcast:
               usage: REQUIRED
               properties:
                 property: value
+      - name: ldapRealm
+        authentication:
+          ldap:
+             url: ldap://ldap.my-company.example
+             socket-factory-class-name: socketFactoryClassName
+             parse-dn: true
+             role-context: roleContext
+             role-filter: roleFilter
+             role-mapping-attribute: roleMappingAttribute
+             role-mapping-mode: reverse
+             role-name-attribute: roleNameAttribute
+             role-recursion-max-depth: 25
+             role-search-scope: object
+             user-name-attribute: userNameAttribute
+             system-user-dn: systemUserDn
+             system-user-password: systemUserPassword
+             password-attribute: passwordAttribute
+             user-context: userContext
+             user-filter: userFilter
+             user-search-scope: one-level
+      - name: tlsRealm
+        authentication:
+          tls:
+             roleAttribute: cn
+      - name: usernamePasswordIdentityRealm
+        identity:
+          username-password:
+             username: user
+             password: Hazelcast
+      - name: tokenIdentityRealm
+        identity:
+          token:
+             encoding: base64
+             value: SGF6ZWxjYXN0
+      - name: kerberosRealm
+        authentication:
+          kerberos:
+            skip-role: true
+            relax-flags-check: true
+            security-realm: krb5Acceptor
+            ldap:
+              url: ldap://127.0.0.1/
+              system-user-dn: uid=admin,ou=system
+              system-user-password: secret
+              skip-authentication: true
+              user-filter: "(krb5PrincipalName={login})"
+              role-mapping-attribute: cn
+        identity:
+          kerberos:
+            realm: HAZELCAST.COM
+            security-realm: krb5Initiator
+            service-name-prefix: hz/
+            spn: hz/127.0.0.1@HAZELCAST.COM
+      - name: krb5Acceptor
+        authentication:
+          jaas:
+            - class-name: com.sun.security.auth.module.Krb5LoginModule
+              usage: REQUIRED
+              properties:
+                isInitiator: false
+                useTicketCache: false
+                doNotPrompt: true
+                useKeyTab: true
+                storeKey: true
+                principal: hz/127.0.0.1@HAZELCAST.COM
+                keyTab: /opt/hz-localhost.keytab
+      - name: krb5Initiator
+        authentication:
+          jaas:
+            - class-name: com.sun.security.auth.module.Krb5LoginModule
+              usage: REQUIRED
+              properties:
+                isInitiator: true
+                useTicketCache: false
+                doNotPrompt: true
+                useKeyTab: true
+                storeKey: true
+                principal: hz/127.0.0.1@HAZELCAST.COM
+                keyTab: /opt/hz-localhost.keytab
     member-authentication:
       realm: mr
     client-authentication:


### PR DESCRIPTION
OS part of Kerberos authentication.
EE PR: hazelcast/hazelcast-enterprise#3574

This PR introduces Kerberos ticket authentication support into Hazelcast. This OS part only helps with the configuration. The main Kerberos related logic is part of the Hazelcast Enterprise.

Main configuration changes:
* added 'kerberos' identity (clients & members)
* added 'kerberos' authentication (members)
* added limited security `realm` configuration to client-side - allows specifying named JAAS authentication

Implementation:
* added new credentials factory, which is able to retrieve a Kerberos service ticket: `com.hazelcast.security.impl.KerberosCredentialsFactory`
* added new login module, which accepts/verifies the Kerberos service tickets: `com.hazelcast.security.loginimpl.GssApiLoginModule`

### Kerberos Identity

The Kerberos identity configures a credentials factory to provide Kerberos service tickets.

Default Service principal names for Hazelcast members are in the form `hz/address@REALM` (e.g. `hz/192.168.1.1@ACME.COM`). The `security-ream` configuration allows delegating Kerberos authentication to another realm configured within the Hazelcast configuration.

```xml
<realm name="kerberosRealm">
    <identity>
        <kerberos>
            <realm>ACME.COM</realm>
            <security-realm>krb5Initiator</security-realm>
        </kerberos>
    </identity>
</realm>
<realm name="krb5Initiator">
    <authentication>
        <jaas>
            <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
                <properties>
                    <property name="useTicketCache">true</property>
                    <property name="doNotPrompt">true</property>
                </properties>
            </login-module>
        </jaas>
    </authentication>
</realm>
```

#### Properties of Kerberos identity

The `KerberosCredentialsFactory` has the following properties, which can be specified in the configuration:

| Property name | Default value | Description |
|---|---|---|
|spn| |Allows configuring static service principal name (SPN). It's meant for use-cases where all members share a single Kerberos identity.|
|serviceNamePrefix| `"hz/"` | Defines prefix of the Service Principal Name. By default the member's principal name (for which this credentials factory asks the service ticket) is in form `"[servicePrefix][memberIpAddress]@[REALM]"` (e.g. `"hz/192.168.1.1@ACME.COM"`).|
| realm| | Kerberos realm name (e.g. `"ACME.COM"`)
| securityRealm | | Security realm name in Hazelcast configuration used for Kerberos authentication. The authentication configuration in the referenced security realm will be used to fill the Subject with Kerberos credentials (e.g. TGT). |

### Kerberos Authentication

The corresponding authenticating part on the server-side is able to accept the Kerberos tickets and verify them. Again the Kerberos authentication is delegated to another realm with Kerberos login module configured.

```xml
<realm name="kerberosRealm">
    <authentication>
        <kerberos>
            <security-realm>krb5Acceptor</security-realm>
        </kerberos>
    </authentication>
</realm>
<realm name="krb5Acceptor">
    <authentication>
        <jaas>
            <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
                <properties>
                    <property name="isInitiator">false</property>
                    <property name="useTicketCache">false</property>
                    <property name="doNotPrompt">true</property>
                    <property name="useKeyTab">true</property>
                    <property name="storeKey">true</property>
                    <property name="principal">hz/192.168.1.1@ACME.COM</property>
                    <property name="keyTab">/opt/member1.keytab</property>
                </properties>
            </login-module>
        </jaas>
    </authentication>
</realm>
```

This configuration only loads Kerberos secrets from the keytab file and it doesn't authenticate against the Kerberos KDC.

#### Properties of Kerberos authentication

The `GssApiLoginModule` derives from the abstract `ClusterLoginModule` so it supports its options (`skipIdentity`, `skipEndpoint` and `skipRole`). It introduces also its own options:

| Property name | Default value | Description |
|---|---|---|
|relaxFlagsCheck| `false` | Allows disabling some of the checks on the incoming token (e.g. passes authentication even if the mutual authentication is required by the token).|
| securityRealm | | Security realm name in Hazelcast configuration used for Kerberos authentication. The authentication configuration in the referenced security realm will be used to fill the Subject with Kerberos credentials (e.g. Keytab). |

#### LDAP integration
The Kerberos authentication allows loading role mapping information from an LDAP server (usually the one backing the Kerberos KDC server too).

```xml
<realm name="kerberosRealm">
    <authentication>
        <kerberos>
            <skip-role>true</skip-role>
            <security-realm>krb5Acceptor</security-realm>
            <ldap>
                <url>ldap://127.0.0.1/</url>
                <system-user-dn>uid=admin,ou=system</system-user-dn>
                <system-user-password>secret</system-user-password>
                <skip-authentication>true</skip-authentication>
                <user-filter>(krb5PrincipalName={login})</user-filter>
                <role-mapping-attribute>cn</role-mapping-attribute>
            </ldap>
        </kerberos>
    </authentication>
</realm>
```

#### New Property in LdapLoginModule

LDAP login modules in Hazelcast were used to verify the credentials till now. Integrating it with Kerberos we don't want to verify (again) the credentials, but rather load roles for the Kerberos identity.
Therefore a new option is introduced, which allows proceeding without credentials verification:


| Property name | Default value | Description |
|---|---|---|
| skipAuthentication | `false` | Allows disabling password verification and only takes care about filling `HazelcastPrincipal` instances into the Subject.|


### Security realms on client-side

Security realms configuration was introduced on the client-side too. It allows specifying JAAS login modules which can be referenced from Kerberos identity configuration.

```xml
<security>
    <kerberos>
        <realm>ACME.COM</realm>
        <security-realm>krb5Initiator</security-realm>
    </kerberos>
    <realms>
        <realm name="krb5Initiator">
            <authentication>
                <jaas>
                    <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
                        <properties>
                            <property name="isInitiator">true</property>
                            <property name="useTicketCache">false</property>
                            <property name="doNotPrompt">true</property>
                            <property name="useKeyTab">true</property>
                            <property name="storeKey">true</property>
                            <property name="principal">jduke@HAZELCAST.COM</property>
                            <property name="keyTab">/opt/jduke.keytab</property>
                        </properties>
                    </login-module>
                </jaas>
            </authentication>
        </realm>
    </realms>
</security>
```

### Hazelcast security realms and JGSS

It's also possible to use a direct JGSS approach, where we don't specify 2 extra security realms in Hazelcast configuration. Users in such case provide a path to the JAAS login configuration file as the `-Djava.security.auth.login.config` argument. The login configurations have to be named according to JGSS implementation naming:

```
com.sun.security.jgss.initiate {
  com.sun.security.auth.module.Krb5LoginModule required
  useTicketCache=true
  doNotPrompt=true
  debug=true
  ;
};
 
com.sun.security.jgss.accept {
  com.sun.security.auth.module.Krb5LoginModule required
  storeKey=true
  doNotPrompt=true
  debug=true
  useKeyTab=true
  keyTab="c:/hazelcast/member1.keytab"
  principal="hazelcast/member1.acme.com@ACME.COM"
  isInitiator=false
  ;
};
```

### Limitations
* This Kerberos authentication is only able to validate connections on the server-side. It doesn't support mutual authentication.
* The GSS-API is not used for protecting (wrapping) messages after authentication (e.g. encryption, integrity checks). It's only used for accepting tokens.
* The token itself is not protected against Man-in-the-Middle attacks. If an attacker is able to eavesdrop the token and use it before the original sender, then the attacker succeeds with the authentication but the original sender won't.
  * There is replay protection in Java which caches already used tokens.
  * Java Kerberos implementation accepts the token for 5min  (by default) from its creation.
* Time has to be synchronized on the machines where the Kerberos is used.

If you are running Hazelcast in an untrusted network with a MITM attack risk, then enable encryption on Hazelcast protocols to prevent stealing the token.