### PR TITLE
Allow longer metric words, fail-fast if exceeded

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.core.HazelcastException;
+
+public class LongWordException extends HazelcastException {
+    public LongWordException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-public class LongWordException extends Exception {
+import com.hazelcast.core.HazelcastException;
+
+public class LongWordException extends HazelcastException {
     public LongWordException(String message) {
         super(message);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-import com.hazelcast.core.HazelcastException;
-
-public class LongWordException extends HazelcastException {
+public class LongWordException extends Exception {
     public LongWordException(String message) {
         super(message);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -238,7 +238,7 @@ public class MetricsCompressor {
         return target.copy(from);
     }
 
-    private int getDictionaryId(String word) throws LongWordException {
+    private int getDictionaryId(String word) {
         if (word == null) {
             return NULL_DICTIONARY_ID;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -138,27 +138,31 @@ public class MetricsCompressor {
 
     public void addLong(MetricDescriptor descriptor, long value) {
         try {
+            tmpBaos.reset();
             writeDescriptor(descriptor);
             tmpDos.writeByte(ValueType.LONG.ordinal());
             tmpDos.writeLong(value);
             metricDos.write(tmpBaos.internalBuffer(), 0, tmpBaos.size());
-            tmpBaos.reset();
         } catch (IOException e) {
             // should never be thrown
             throw new RuntimeException(e);
+        } catch (LongWordException ignored) {
+            // ignore
         }
     }
 
     public void addDouble(MetricDescriptor descriptor, double value) {
         try {
+            tmpBaos.reset();
             writeDescriptor(descriptor);
             tmpDos.writeByte(ValueType.DOUBLE.ordinal());
             tmpDos.writeDouble(value);
             metricDos.write(tmpBaos.internalBuffer(), 0, tmpBaos.size());
-            tmpBaos.reset();
         } catch (IOException e) {
             // should never be thrown
             throw new RuntimeException(e);
+        } catch (LongWordException ignored) {
+            // ignore
         }
     }
 
@@ -259,6 +263,7 @@ public class MetricsCompressor {
         dictionaryDos.writeInt(words.size());
         String lastWord = "";
         for (MetricsDictionary.Word word : words) {
+            tmpBaos.reset();
             String wordText = word.word();
             if (wordText.length() > UNSIGNED_BYTE_MAX_VALUE) {
                 // this should have been checked earlier, this is a safety check
@@ -281,7 +286,6 @@ public class MetricsCompressor {
             }
             lastWord = wordText;
             dictionaryDos.write(tmpBaos.internalBuffer(), 0, tmpBaos.size());
-            tmpBaos.reset();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -136,7 +136,7 @@ public class MetricsCompressor {
         tmpDos = new DataOutputStream(tmpBaos);
     }
 
-    public void addLong(MetricDescriptor descriptor, long value) {
+    public void addLong(MetricDescriptor descriptor, long value) throws LongWordException {
         try {
             tmpBaos.reset();
             writeDescriptor(descriptor);
@@ -146,12 +146,10 @@ public class MetricsCompressor {
         } catch (IOException e) {
             // should never be thrown
             throw new RuntimeException(e);
-        } catch (LongWordException ignored) {
-            // ignore
         }
     }
 
-    public void addDouble(MetricDescriptor descriptor, double value) {
+    public void addDouble(MetricDescriptor descriptor, double value) throws LongWordException {
         try {
             tmpBaos.reset();
             writeDescriptor(descriptor);
@@ -161,13 +159,11 @@ public class MetricsCompressor {
         } catch (IOException e) {
             // should never be thrown
             throw new RuntimeException(e);
-        } catch (LongWordException ignored) {
-            // ignore
         }
     }
 
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
-    private void writeDescriptor(MetricDescriptor descriptor) throws IOException {
+    private void writeDescriptor(MetricDescriptor descriptor) throws IOException, LongWordException {
         int mask = calculateDescriptorMask(descriptor);
         tmpDos.writeByte(mask);
 
@@ -242,7 +238,7 @@ public class MetricsCompressor {
         return target.copy(from);
     }
 
-    private int getDictionaryId(String word) {
+    private int getDictionaryId(String word) throws LongWordException {
         if (word == null) {
             return NULL_DICTIONARY_ID;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -272,13 +272,16 @@ public class MetricsCompressor {
             }
 
             int diffLen = wordText.length() - commonLen;
-            dictionaryDos.writeInt(word.dictionaryId());
-            dictionaryDos.writeByte(commonLen);
-            dictionaryDos.writeByte(diffLen);
+            // we write to tmpDos to avoid the allocation of byte[1] in DeflaterOutputStream.write(int)
+            tmpDos.writeInt(word.dictionaryId());
+            tmpDos.writeByte(commonLen);
+            tmpDos.writeByte(diffLen);
             for (int i = commonLen; i < wordText.length(); i++) {
-                dictionaryDos.writeChar(wordText.charAt(i));
+                tmpDos.writeChar(wordText.charAt(i));
             }
             lastWord = wordText;
+            dictionaryDos.write(tmpBaos.internalBuffer(), 0, tmpBaos.size());
+            tmpBaos.reset();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -269,7 +269,7 @@ public class MetricsCompressor {
                 // this should have been checked earlier, this is a safety check
                 throw new RuntimeException("Dictionary element too long: " + wordText);
             }
-            int maxCommonLen = Math.min(lastWord.length(), wordText.length()) & UNSIGNED_BYTE_MAX_VALUE;
+            int maxCommonLen = Math.min(lastWord.length(), wordText.length());
             int commonLen = 0;
             while (commonLen < maxCommonLen
                     && wordText.charAt(commonLen) == lastWord.charAt(commonLen)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsDictionary.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsDictionary.java
@@ -16,9 +16,6 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-import com.hazelcast.internal.util.QuickMath;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.TreeMap;
@@ -26,19 +23,18 @@ import java.util.TreeMap;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Metrics dictionary storing word -> id and id -> word mappings. Used by
- * {@link MetricsCompressor}'s dictionary based algorithm.
+ * Metrics dictionary storing word -> id mapping. Used by {@link
+ * MetricsCompressor}'s dictionary-based algorithm.
  */
 class MetricsDictionary {
-    private static final int INITIAL_CAPACITY = 512;
+    /**
+     * Word length is limited by {@link MetricsCompressor#writeDictionary()},
+     * if there's no shared prefix, the remainder length is stored as an
+     * unsigned byte.
+     */
+    static final int MAX_WORD_LENGTH = MetricsCompressor.UNSIGNED_BYTE_MAX_VALUE;
 
-    private String[] dictionary;
-    private int size;
     private TreeMap<String, Word> orderedDictionary = new TreeMap<>(Comparator.naturalOrder());
-
-    MetricsDictionary() {
-        this.dictionary = new String[INITIAL_CAPACITY];
-    }
 
     /**
      * Returns the dictionary id for the given word. If the word is not yet
@@ -50,39 +46,14 @@ class MetricsDictionary {
      */
     int getDictionaryId(String word) {
         requireNonNull(word);
-
-        Word wordObj = orderedDictionary.get(word);
-        if (wordObj != null) {
-            return wordObj.id;
+        if (word.length() > MAX_WORD_LENGTH) {
+            throw new RuntimeException("Maximum dictionary element length is " + MAX_WORD_LENGTH + ": " + word);
         }
 
-        int nextIdx = size;
-        orderedDictionary.put(word, new Word(word, nextIdx));
-        ensureCapacity(nextIdx);
-        dictionary[nextIdx] = word;
-        size++;
-
-        return nextIdx;
-    }
-
-    /**
-     * Returns the word mapped to the given dictionary id.
-     *
-     * @param dictionaryId The given dictionary id
-     * @return the word or {@code null} if the dictionary id is outside
-     * of the mapped range, including negative ids
-     */
-    @Nullable
-    String get(int dictionaryId) {
-        if (dictionaryId < 0 || dictionaryId > size) {
-            return null;
-        }
-
-        return dictionary[dictionaryId];
-    }
-
-    int size() {
-        return size;
+        int nextWordId = orderedDictionary.size();
+        return orderedDictionary
+                .computeIfAbsent(word, key -> new Word(word, nextWordId))
+                .id;
     }
 
     /**
@@ -92,17 +63,6 @@ class MetricsDictionary {
      */
     public Collection<Word> words() {
         return orderedDictionary.values();
-    }
-
-    private void ensureCapacity(int newIndex) {
-        if (newIndex < dictionary.length - 1) {
-            return;
-        }
-
-        int newCapacity = QuickMath.nextPowerOfTwo(dictionary.length + 1);
-        String[] newDictionary = new String[newCapacity];
-        System.arraycopy(dictionary, 0, newDictionary, 0, dictionary.length);
-        dictionary = newDictionary;
     }
 
     static final class Word {
@@ -124,10 +84,7 @@ class MetricsDictionary {
 
         @Override
         public String toString() {
-            return "Word{"
-                    + "word='" + word + '\''
-                    + ", id=" + id
-                    + '}';
+            return "Word{word='" + word + '\'' + ", id=" + id + '}';
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsDictionary.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsDictionary.java
@@ -44,10 +44,11 @@ class MetricsDictionary {
      * @param word The word to look for
      * @return the id assigned to the given word
      */
-    int getDictionaryId(String word) {
+    int getDictionaryId(String word) throws LongWordException {
         requireNonNull(word);
         if (word.length() > MAX_WORD_LENGTH) {
-            throw new LongWordException("Maximum dictionary element length is " + MAX_WORD_LENGTH + ": " + word);
+            throw new LongWordException("Too long value in the metric descriptor found, maximum is "
+                    + MAX_WORD_LENGTH + ": " + word);
         }
 
         int nextWordId = orderedDictionary.size();

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsDictionary.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsDictionary.java
@@ -47,7 +47,7 @@ class MetricsDictionary {
     int getDictionaryId(String word) {
         requireNonNull(word);
         if (word.length() > MAX_WORD_LENGTH) {
-            throw new RuntimeException("Maximum dictionary element length is " + MAX_WORD_LENGTH + ": " + word);
+            throw new LongWordException("Maximum dictionary element length is " + MAX_WORD_LENGTH + ": " + word);
         }
 
         int nextWordId = orderedDictionary.size();

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompressorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompressorTest.java
@@ -57,7 +57,7 @@ public class MetricsCompressorTest {
     private final MetricsCompressor compressor = new MetricsCompressor();
 
     @Test
-    public void testSingleLongMetric() {
+    public void testSingleLongMetric() throws Exception {
         MetricDescriptor originalMetric = supplier.get()
                                                   .withPrefix("prefix")
                                                   .withMetric("metricName")
@@ -76,7 +76,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testSingleDoubleMetric() {
+    public void testSingleDoubleMetric() throws Exception {
         MetricDescriptor originalMetric = supplier.get()
                                                   .withPrefix("prefix")
                                                   .withMetric("metricName")
@@ -95,7 +95,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testSingleMetricWithoutPrefix() {
+    public void testSingleMetricWithoutPrefix() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -116,7 +116,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testSingleMetricWithoutUnit() {
+    public void testSingleMetricWithoutUnit() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -137,7 +137,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_withDelta() {
+    public void testTwoMetrics_withDelta() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -163,7 +163,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_fullDifferent() {
+    public void testTwoMetrics_fullDifferent() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -193,7 +193,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_secondWithoutTags() {
+    public void testTwoMetrics_secondWithoutTags() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -220,7 +220,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_sameExcludedTargets() {
+    public void testTwoMetrics_sameExcludedTargets() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -245,7 +245,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_differentExcludedTargets() {
+    public void testTwoMetrics_differentExcludedTargets() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -270,7 +270,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testModifyingExtractedDoesntImpactExtraction() {
+    public void testModifyingExtractedDoesntImpactExtraction() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -317,7 +317,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testLongTagValue() {
+    public void testLongTagValue() throws Exception {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -352,38 +352,42 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__tagName() {
+    public void when_tooLongWord_then_metricIgnored__tagName() throws Exception {
         when_tooLongWord_then_metricIgnored(supplier.get().withTag(LONG_NAME, "a"));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__tagValue() {
+    public void when_tooLongWord_then_metricIgnored__tagValue() throws Exception {
         when_tooLongWord_then_metricIgnored(supplier.get().withTag("n", LONG_NAME));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__metricName() {
+    public void when_tooLongWord_then_metricIgnored__metricName() throws Exception {
         when_tooLongWord_then_metricIgnored(supplier.get().withMetric(LONG_NAME));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__prefix() {
+    public void when_tooLongWord_then_metricIgnored__prefix() throws Exception {
         when_tooLongWord_then_metricIgnored(supplier.get().withPrefix(LONG_NAME));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__discriminatorTag() {
+    public void when_tooLongWord_then_metricIgnored__discriminatorTag() throws Exception {
         when_tooLongWord_then_metricIgnored(supplier.get().withDiscriminator(LONG_NAME, "a"));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__discriminatorValue() {
+    public void when_tooLongWord_then_metricIgnored__discriminatorValue() throws Exception {
         when_tooLongWord_then_metricIgnored(supplier.get().withDiscriminator("n", LONG_NAME));
     }
 
-    private void when_tooLongWord_then_metricIgnored(MetricDescriptor badDescriptor) {
+    private void when_tooLongWord_then_metricIgnored(MetricDescriptor badDescriptor) throws Exception {
         MetricsCompressor compressor = new MetricsCompressor();
-        compressor.addLong(badDescriptor, 42);
+        try {
+            compressor.addLong(badDescriptor, 42);
+            fail("should have failed");
+        } catch (LongWordException ignored) {
+        }
         assertEquals(0, compressor.count());
         // add a good descriptor after a bad one to check that the tmp streams are reset properly
         MetricDescriptor goodDescriptor = supplier.get();

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompressorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompressorTest.java
@@ -57,7 +57,7 @@ public class MetricsCompressorTest {
     private final MetricsCompressor compressor = new MetricsCompressor();
 
     @Test
-    public void testSingleLongMetric() throws Exception {
+    public void testSingleLongMetric() {
         MetricDescriptor originalMetric = supplier.get()
                                                   .withPrefix("prefix")
                                                   .withMetric("metricName")
@@ -76,7 +76,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testSingleDoubleMetric() throws Exception {
+    public void testSingleDoubleMetric() {
         MetricDescriptor originalMetric = supplier.get()
                                                   .withPrefix("prefix")
                                                   .withMetric("metricName")
@@ -95,7 +95,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testSingleMetricWithoutPrefix() throws Exception {
+    public void testSingleMetricWithoutPrefix() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -116,7 +116,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testSingleMetricWithoutUnit() throws Exception {
+    public void testSingleMetricWithoutUnit() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -137,7 +137,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_withDelta() throws Exception {
+    public void testTwoMetrics_withDelta() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -163,7 +163,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_fullDifferent() throws Exception {
+    public void testTwoMetrics_fullDifferent() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -193,7 +193,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_secondWithoutTags() throws Exception {
+    public void testTwoMetrics_secondWithoutTags() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -220,7 +220,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_sameExcludedTargets() throws Exception {
+    public void testTwoMetrics_sameExcludedTargets() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -245,7 +245,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testTwoMetrics_differentExcludedTargets() throws Exception {
+    public void testTwoMetrics_differentExcludedTargets() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -270,7 +270,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testModifyingExtractedDoesntImpactExtraction() throws Exception {
+    public void testModifyingExtractedDoesntImpactExtraction() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -317,7 +317,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testLongTagValue() throws Exception {
+    public void testLongTagValue() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -352,36 +352,36 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__tagName() throws Exception {
+    public void when_tooLongWord_then_metricIgnored__tagName() {
         when_tooLongWord_then_metricIgnored(supplier.get().withTag(LONG_NAME, "a"));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__tagValue() throws Exception {
+    public void when_tooLongWord_then_metricIgnored__tagValue() {
         when_tooLongWord_then_metricIgnored(supplier.get().withTag("n", LONG_NAME));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__metricName() throws Exception {
+    public void when_tooLongWord_then_metricIgnored__metricName() {
         when_tooLongWord_then_metricIgnored(supplier.get().withMetric(LONG_NAME));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__prefix() throws Exception {
+    public void when_tooLongWord_then_metricIgnored__prefix() {
         when_tooLongWord_then_metricIgnored(supplier.get().withPrefix(LONG_NAME));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__discriminatorTag() throws Exception {
+    public void when_tooLongWord_then_metricIgnored__discriminatorTag() {
         when_tooLongWord_then_metricIgnored(supplier.get().withDiscriminator(LONG_NAME, "a"));
     }
 
     @Test
-    public void when_tooLongWord_then_metricIgnored__discriminatorValue() throws Exception {
+    public void when_tooLongWord_then_metricIgnored__discriminatorValue() {
         when_tooLongWord_then_metricIgnored(supplier.get().withDiscriminator("n", LONG_NAME));
     }
 
-    private void when_tooLongWord_then_metricIgnored(MetricDescriptor badDescriptor) throws Exception {
+    private void when_tooLongWord_then_metricIgnored(MetricDescriptor badDescriptor) {
         MetricsCompressor compressor = new MetricsCompressor();
         try {
             compressor.addLong(badDescriptor, 42);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompressorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompressorTest.java
@@ -318,7 +318,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void testLongValue() {
+    public void testLongTagValue() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 
@@ -353,7 +353,7 @@ public class MetricsCompressorTest {
     }
 
     @Test
-    public void when_tooLongValue_then_fails() {
+    public void when_tooLongTagValue_then_fails() {
         DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
         MetricsCompressor compressor = new MetricsCompressor();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
@@ -16,51 +16,52 @@
 
 package com.hazelcast.internal.metrics.impl;
 
+import com.hazelcast.internal.metrics.impl.MetricsDictionary.Word;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.util.Iterator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MetricsDictionaryTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private MetricsDictionary dictionary = new MetricsDictionary();
+
     @Test
     public void testGrowing() {
-        MetricsDictionary dictionary = new MetricsDictionary();
         for (int i = 0; i < 256; i++) {
             String word = Integer.toString(i);
             int dictionaryId = dictionary.getDictionaryId(word);
             assertEquals(i, dictionaryId);
-            assertEquals(word, dictionary.get(i));
-
-            String foundWord = dictionary.get(dictionaryId);
-            assertEquals(word, foundWord);
-
-            assertNull(dictionary.get(i + 1));
-            assertEquals(i + 1, dictionary.size());
         }
     }
 
     @Test
-    public void testGetWithNegativeIdReturnsNull() {
-        MetricsDictionary dictionary = new MetricsDictionary();
-        assertNull(dictionary.get(-1));
-    }
+    public void testWordsOrdered() {
+        assertEquals(0, dictionary.getDictionaryId("b"));
+        assertEquals(1, dictionary.getDictionaryId("a"));
 
-    @Test
-    public void testGetWithNonExistentIdReturnsNull() {
-        MetricsDictionary dictionary = new MetricsDictionary();
-        assertNull(dictionary.get(Integer.MAX_VALUE));
+        Iterator<Word> iterator = dictionary.words().iterator();
+        assertEquals("a", iterator.next().word());
+        assertEquals("b", iterator.next().word());
     }
 
     @Test
     public void testGetDictionaryIdReturnsSameIdForSameWord() {
-        MetricsDictionary dictionary = new MetricsDictionary();
         int word1Id = dictionary.getDictionaryId("word1");
         dictionary.getDictionaryId("word2");
         dictionary.getDictionaryId("word3");
@@ -69,4 +70,12 @@ public class MetricsDictionaryTest {
         assertEquals(word1Id, dictionary.getDictionaryId("word1"));
     }
 
+    @Test
+    public void when_tooLongValue_then_fails() {
+        String longWord = Stream.generate(() -> "a")
+                                .limit(MetricsDictionary.MAX_WORD_LENGTH + 1)
+                                .collect(Collectors.joining());
+        exception.expect(RuntimeException.class);
+        dictionary.getDictionaryId(longWord);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
@@ -42,7 +42,7 @@ public class MetricsDictionaryTest {
     private MetricsDictionary dictionary = new MetricsDictionary();
 
     @Test
-    public void testGrowing() {
+    public void testGrowing() throws Exception {
         for (int i = 0; i < 256; i++) {
             String word = Integer.toString(i);
             int dictionaryId = dictionary.getDictionaryId(word);
@@ -51,7 +51,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void testWordsOrdered() {
+    public void testWordsOrdered() throws Exception {
         assertEquals(0, dictionary.getDictionaryId("b"));
         assertEquals(1, dictionary.getDictionaryId("a"));
 
@@ -61,7 +61,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void testGetDictionaryIdReturnsSameIdForSameWord() {
+    public void testGetDictionaryIdReturnsSameIdForSameWord() throws Exception {
         int word1Id = dictionary.getDictionaryId("word1");
         dictionary.getDictionaryId("word2");
         dictionary.getDictionaryId("word3");
@@ -71,7 +71,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void when_tooLongWord_then_fails() {
+    public void when_tooLongWord_then_fails() throws Exception {
         String longWord = Stream.generate(() -> "a")
                                 .limit(MetricsDictionary.MAX_WORD_LENGTH + 1)
                                 .collect(Collectors.joining());

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
@@ -42,7 +42,7 @@ public class MetricsDictionaryTest {
     private MetricsDictionary dictionary = new MetricsDictionary();
 
     @Test
-    public void testGrowing() throws Exception {
+    public void testGrowing() {
         for (int i = 0; i < 256; i++) {
             String word = Integer.toString(i);
             int dictionaryId = dictionary.getDictionaryId(word);
@@ -51,7 +51,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void testWordsOrdered() throws Exception {
+    public void testWordsOrdered() {
         assertEquals(0, dictionary.getDictionaryId("b"));
         assertEquals(1, dictionary.getDictionaryId("a"));
 
@@ -61,7 +61,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void testGetDictionaryIdReturnsSameIdForSameWord() throws Exception {
+    public void testGetDictionaryIdReturnsSameIdForSameWord() {
         int word1Id = dictionary.getDictionaryId("word1");
         dictionary.getDictionaryId("word2");
         dictionary.getDictionaryId("word3");
@@ -71,7 +71,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void when_tooLongWord_then_fails() throws Exception {
+    public void when_tooLongWord_then_fails() {
         String longWord = Stream.generate(() -> "a")
                                 .limit(MetricsDictionary.MAX_WORD_LENGTH + 1)
                                 .collect(Collectors.joining());

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
@@ -71,7 +71,7 @@ public class MetricsDictionaryTest {
     }
 
     @Test
-    public void when_tooLongValue_then_fails() {
+    public void when_tooLongWord_then_fails() {
         String longWord = Stream.generate(() -> "a")
                                 .limit(MetricsDictionary.MAX_WORD_LENGTH + 1)
                                 .collect(Collectors.joining());

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsDictionaryTest.java
@@ -75,7 +75,7 @@ public class MetricsDictionaryTest {
         String longWord = Stream.generate(() -> "a")
                                 .limit(MetricsDictionary.MAX_WORD_LENGTH + 1)
                                 .collect(Collectors.joining());
-        exception.expect(RuntimeException.class);
+        exception.expect(LongWordException.class);
         dictionary.getDictionaryId(longWord);
     }
 }


### PR DESCRIPTION
When metric dictionary word was longer than 127 characters, incorrect
compressed stream was produced. This PR pushes the limit to 255
characters and fails fast if exceeded.

Also removes unnused `Strign[] dictionary` from `MetricsDictionary`.

Related to hazelcast/hazelcast-jet#2155