### PR TITLE
Remove assert and log instead

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -453,6 +453,9 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         // permit count can exceed allowed parallelization count.
         replicaSyncSemaphore.drainPermits();
         replicaSyncSemaphore.release(maxParallelReplications);
+        if (logger.isFinestEnabled()) {
+            logger.finest(String.format("Reset replica sync permits to %d", maxParallelReplications));
+        }
     }
 
     void scheduleReplicaVersionSync(ExecutionService executionService) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -419,8 +419,8 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
 
         if (logger.isWarningEnabled() && acquiredPermits < permitsToRelease) {
             logger.warning(format("Found more replica sync permits than configured max number!"
-                            + " (acquired: %d, available: %d, max: %d)",
-                    acquiredPermits, availablePermits, maxParallelReplications));
+                            + " (permitsToRelease: %d, acquired: %d, available: %d, max: %d)",
+                    permitsToRelease, acquiredPermits, availablePermits, maxParallelReplications));
         }
 
         int permits = Math.min(acquiredPermits, permitsToRelease);

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/DistributedObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/DistributedObjectNamespace.java
@@ -80,7 +80,6 @@ public final class DistributedObjectNamespace implements ObjectNamespace, Identi
         return SpiDataSerializerHook.DISTRIBUTED_OBJECT_NS;
     }
 
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -103,5 +102,13 @@ public final class DistributedObjectNamespace implements ObjectNamespace, Identi
         int result = service.hashCode();
         result = 31 * result + objectName.hashCode();
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DistributedObjectNamespace{"
+                + "service='" + service + '\''
+                + ", objectName='" + objectName + '\''
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/MapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapStore.java
@@ -87,8 +87,8 @@ public interface MapStore<K, V> extends MapLoader<K, V> {
      * one-by-one. In this way a MapStore implementation can handle partial
      * deleteAll() cases when some entries were deleted successfully before a
      * failure happens. Entries removed from the keys will be not passed to
-     * subsequent call to delete() method any more. The intended usage is to 
-     * delete items from the provided collection as they are deleted from 
+     * subsequent call to delete() method any more. The intended usage is to
+     * delete items from the provided collection as they are deleted from
      * the store.
      *
      * @param keys the keys of the entries to delete.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
@@ -24,9 +24,11 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,19 +52,22 @@ import static org.junit.Assert.assertEquals;
 @Category(NightlyTest.class)
 public class MapSplitBrainStressTest extends SplitBrainTestSupport {
 
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace.xml");
+
     static final int ITERATION_COUNT = 50;
     static final int MAP_COUNT = 100;
     static final int ENTRY_COUNT = 100;
     static final int FIRST_BRAIN_SIZE = 3;
     static final int SECOND_BRAIN_SIZE = 2;
-    static final Class MERGE_POLICY = PassThroughMergePolicy.class;
+    static final Class<PassThroughMergePolicy> MERGE_POLICY = PassThroughMergePolicy.class;
 
     static final int TEST_TIMEOUT_IN_MILLIS = 15 * 60 * 1000;
     static final String MAP_NAME_PREFIX = MapSplitBrainStressTest.class.getSimpleName() + "-";
     static final ILogger LOGGER = Logger.getLogger(MapSplitBrainStressTest.class);
 
-    final Map<HazelcastInstance, UUID> listenerRegistry = new ConcurrentHashMap<HazelcastInstance, UUID>();
-    final Map<Integer, String> mapNames = new ConcurrentHashMap<Integer, String>();
+    final Map<HazelcastInstance, UUID> listenerRegistry = new ConcurrentHashMap<>();
+    final Map<Integer, String> mapNames = new ConcurrentHashMap<>();
 
     MergeLifecycleListener mergeLifecycleListener;
     int iteration = 1;

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
@@ -53,7 +53,8 @@ import static org.junit.Assert.assertEquals;
 public class MapSplitBrainStressTest extends SplitBrainTestSupport {
 
     @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace.xml");
+    public static ChangeLoggingRule changeLoggingRule
+            = new ChangeLoggingRule("log4j2-trace-map-split-brain-stress.xml");
 
     static final int ITERATION_COUNT = 50;
     static final int MAP_COUNT = 100;

--- a/hazelcast/src/test/resources/log4j2-trace-map-split-brain-stress.xml
+++ b/hazelcast/src/test/resources/log4j2-trace-map-split-brain-stress.xml
@@ -18,13 +18,15 @@
 <Configuration status="ERROR">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+            <PatternLayout
+                    pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="com.hazelcast.internal.partition.impl.PartitionReplicaManager" level="trace"/>
+        <Logger name="com.hazelcast.internal.partition.impl.PartitionReplicaManager"
+                level="trace"/>
     </Loggers>
 </Configuration>

--- a/hazelcast/src/test/resources/log4j2-trace.xml
+++ b/hazelcast/src/test/resources/log4j2-trace.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.internal.partition.impl.PartitionReplicaManager" level="trace"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/16837

It is a known issue that permit count can exceed allowed max parallelization count. Given that the issue happens rarely, when it happens, there is no real reason to make replica sync process fail.

In this PR, not to introduce a complex fix, we are improving the situation and trying to keep released permit count eventually under max allowed and logging any anomalies as a warning.