### PR TITLE
Remove assert and log instead 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -419,8 +419,8 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
 
         if (logger.isWarningEnabled() && acquiredPermits < permitsToRelease) {
             logger.warning(format("Found more replica sync permits than configured max number!"
-                            + " (acquired: %d, available: %d, max: %d)",
-                    acquiredPermits, availablePermits, maxParallelReplications));
+                            + " (permitsToRelease: %d, acquired: %d, available: %d, max: %d)",
+                    permitsToRelease, acquiredPermits, availablePermits, maxParallelReplications));
         }
 
         int permits = Math.min(acquiredPermits, permitsToRelease);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -409,24 +409,32 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
     /**
      * Releases the previously acquired permits.
      *
-     * @param permits number of permits
+     * @param permitsToRelease number of permits
      */
-    public void releaseReplicaSyncPermits(int permits) {
-        assert permits > 0 : "Invalid permits: " + permits;
+    public void releaseReplicaSyncPermits(int permitsToRelease) {
+        assert permitsToRelease > 0 : "Invalid permits: " + permitsToRelease;
+
+        int availablePermits = availableReplicaSyncPermits();
+        int acquiredPermits = maxParallelReplications - availablePermits;
+
+        if (logger.isWarningEnabled() && acquiredPermits < permitsToRelease) {
+            logger.warning(format("Found more replica sync permits than configured max number!"
+                            + " (acquired: %d, available: %d, max: %d)",
+                    acquiredPermits, availablePermits, maxParallelReplications));
+        }
+
+        int permits = Math.min(acquiredPermits, permitsToRelease);
+        if (permits <= 0) {
+            return;
+        }
 
         replicaSyncSemaphore.release(permits);
 
         if (logger.isFinestEnabled()) {
-            int availableReplicaSyncPermits = availableReplicaSyncPermits();
-
-            logger.finest(format("Released %d replica sync permits. Available permits: %d",
-                    permits, availableReplicaSyncPermits));
-
-            if (availableReplicaSyncPermits <= maxParallelReplications) {
-                logger.finest(format("Replica sync permits exceeded the configured number! (available: %d, max: %d)",
-                        availableReplicaSyncPermits, maxParallelReplications));
-
-            }
+            int currentAvailable = availableReplicaSyncPermits();
+            logger.finest(format("Released %d replica sync permits. (acquired: %d, available: %d, max: %d)",
+                    permits, maxParallelReplications - currentAvailable,
+                    currentAvailable, maxParallelReplications));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
@@ -53,7 +53,8 @@ import static org.junit.Assert.assertEquals;
 public class MapSplitBrainStressTest extends SplitBrainTestSupport {
 
     @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace.xml");
+    public static ChangeLoggingRule changeLoggingRule
+            = new ChangeLoggingRule("log4j2-trace-map-split-brain-stress.xml");
 
     static final int ITERATION_COUNT = 50;
     static final int MAP_COUNT = 100;

--- a/hazelcast/src/test/resources/log4j2-trace-map-split-brain-stress.xml
+++ b/hazelcast/src/test/resources/log4j2-trace-map-split-brain-stress.xml
@@ -18,13 +18,15 @@
 <Configuration status="ERROR">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+            <PatternLayout
+                    pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="com.hazelcast.internal.partition.impl.PartitionReplicaManager" level="trace"/>
+        <Logger name="com.hazelcast.internal.partition.impl.PartitionReplicaManager"
+                level="trace"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/16837

It is a known issue that permit count can exceed allowed max parallelization count. Given that the issue happens rarely, when it happens, there is no real reason to make replica sync process fail. 

In this PR, not to introduce a complex fix, we are improving the situation and trying to keep released permit count eventually under max allowed and logging any anomalies as a warning.


