### PR TITLE
Remove unwanted dependency from Networking

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/CandidateClusterContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/CandidateClusterContext.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.impl.clientside;
 
 import com.hazelcast.client.impl.connection.AddressProvider;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.security.ICredentialsFactory;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
@@ -32,17 +32,17 @@ public class CandidateClusterContext {
     private final DiscoveryService discoveryService;
     private final ICredentialsFactory credentialsFactory;
     private final SocketInterceptor socketInterceptor;
-    private final ChannelInitializerProvider channelInitializerProvider;
+    private final ChannelInitializer channelInitializer;
 
     public CandidateClusterContext(String clusterName, AddressProvider addressProvider, DiscoveryService discoveryService,
                                    ICredentialsFactory credentialsFactory, SocketInterceptor socketInterceptor,
-                                   ChannelInitializerProvider channelInitializerProvider) {
+                                   ChannelInitializer channelInitializer) {
         this.clusterName = clusterName;
         this.addressProvider = addressProvider;
         this.discoveryService = discoveryService;
         this.credentialsFactory = credentialsFactory;
         this.socketInterceptor = socketInterceptor;
-        this.channelInitializerProvider = channelInitializerProvider;
+        this.channelInitializer = channelInitializer;
     }
 
     public void start() {
@@ -73,8 +73,8 @@ public class CandidateClusterContext {
         return clusterName;
     }
 
-    public ChannelInitializerProvider getChannelInitializerProvider() {
-        return channelInitializerProvider;
+    public ChannelInitializer getChannelInitializer() {
+        return channelInitializer;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
@@ -107,7 +107,7 @@ class ClusterDiscoveryServiceBuilder {
             final SSLConfig sslConfig = networkConfig.getSSLConfig();
             final SocketOptions socketOptions = networkConfig.getSocketOptions();
             contexts.add(new CandidateClusterContext(config.getClusterName(), provider, discoveryService, credentialsFactory,
-                    interceptor, qualifier -> clientExtension.createChannelInitializer(sslConfig, socketOptions)));
+                    interceptor, clientExtension.createChannelInitializer(sslConfig, socketOptions)));
         }
         return new ClusterDiscoveryService(unmodifiableList(contexts), configsTryCount, lifecycleService);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -50,7 +50,6 @@ import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.nio.NioNetworking;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListener;
@@ -651,8 +650,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
 
             bindSocketToPort(socket);
 
-            ChannelInitializerProvider channelInitializer = currentClusterContext.getChannelInitializerProvider();
-            Channel channel = networking.register(null, channelInitializer, socketChannel, true);
+            Channel channel = networking.register(currentClusterContext.getChannelInitializer(), socketChannel, true);
             channel.attributeMap().put(Address.class, target);
             channel.connect(resolveAddress(target), connectionTimeoutMillis);
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -68,7 +68,7 @@ import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.memory.DefaultMemoryStats;
 import com.hazelcast.internal.memory.MemoryStats;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.internal.server.tcp.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.ClassLoaderUtil;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
@@ -30,7 +30,7 @@ import com.hazelcast.internal.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.memory.MemoryStats;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.internal.server.tcp.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.Connection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.networking;
 
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.networking.nio.NioNetworking;
 
 import java.io.IOException;
@@ -46,17 +45,15 @@ public interface Networking {
      * In the future we need to think about passing the socket channel because
      * it binds Networking to tcp and this is not desirable.
      *
-     * @param endpointQualifier          the endpoint qualifier for this server socket
-     * @param channelInitializerProvider the class used for initializing the Channel after creation
-     * @param socketChannel              the socketChannel to register
-     * @param clientMode                 if the channel is made in clientMode or server mode
+     * @param channelInitializer initializer for the Channel
+     * @param socketChannel      the socketChannel to register
+     * @param clientMode         if the channel is made in clientMode or server mode
      * @return the created Channel
-     * @throws IOException when something failed while registering the
-     *                     socketChannel
+     * @throws IOException           when something failed while registering the
+     *                               socketChannel
      * @throws IllegalStateException if Networking isn't running.
      */
-    Channel register(EndpointQualifier endpointQualifier,
-                     ChannelInitializerProvider channelInitializerProvider,
+    Channel register(ChannelInitializer channelInitializer,
                      SocketChannel socketChannel,
                      boolean clientMode) throws IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.networking.nio;
 
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
@@ -27,7 +26,6 @@ import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelCloseListener;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.networking.OutboundHandler;
@@ -294,17 +292,14 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
     }
 
     @Override
-    public Channel register(EndpointQualifier endpointQualifier,
-                            ChannelInitializerProvider channelInitializerProvider,
+    public Channel register(ChannelInitializer channelInitializer,
                             SocketChannel socketChannel,
                             boolean clientMode) throws IOException {
         if (!started.get()) {
             throw new IllegalArgumentException("Can't register a channel when networking isn't started");
         }
 
-        ChannelInitializer initializer = channelInitializerProvider.provide(endpointQualifier);
-        assert initializer != null : "Found NULL channel initializer for endpoint-qualifier " + endpointQualifier;
-        NioChannel channel = new NioChannel(socketChannel, clientMode, initializer, closeListenerExecutor);
+        NioChannel channel = new NioChannel(socketChannel, clientMode, channelInitializer, closeListenerExecutor);
 
         socketChannel.configureBlocking(false);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ChannelInitializerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ChannelInitializerProvider.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.networking;
+package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.internal.networking.ChannelInitializer;
 
 /**
  * Initializes the Channel when the Channel is used for the first time.

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/DefaultChannelInitializerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/DefaultChannelInitializerProvider.java
@@ -23,7 +23,6 @@ import com.hazelcast.config.SSLConfig;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.nio.ascii.TextChannelInitializer;
 import com.hazelcast.internal.server.IOService;
 
@@ -37,7 +36,6 @@ public class DefaultChannelInitializerProvider implements ChannelInitializerProv
     private final ChannelInitializer uniChannelInitializer;
     private final Config config;
     private volatile Map<EndpointQualifier, ChannelInitializer> initializerMap;
-
 
     public DefaultChannelInitializerProvider(IOService ioService, Config config) {
         checkSslConfigAvailability(config);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServer.java
@@ -26,7 +26,6 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -25,7 +25,7 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.NetworkStats;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.nio.Connection;
@@ -321,7 +321,9 @@ public class TcpServerConnectionManager
     Channel newChannel(SocketChannel socketChannel, boolean clientMode)
             throws IOException {
         Networking networking = server.getNetworking();
-        Channel channel = networking.register(endpointQualifier, channelInitializerProvider, socketChannel, clientMode);
+        ChannelInitializer channelInitializer = channelInitializerProvider.provide(endpointQualifier);
+        assert channelInitializer != null : "Found NULL channel initializer for endpoint-qualifier " + endpointQualifier;
+        Channel channel = networking.register(channelInitializer, socketChannel, clientMode);
         // Advanced Network
         if (endpointConfig != null) {
             setChannelOptions(channel, endpointConfig);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedServerConnectionManager.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.server.tcp;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.metrics.Probe;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.server.IOService;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.logging.LoggingService;

--- a/hazelcast/src/main/java/com/hazelcast/map/MapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapStore.java
@@ -87,8 +87,8 @@ public interface MapStore<K, V> extends MapLoader<K, V> {
      * one-by-one. In this way a MapStore implementation can handle partial
      * deleteAll() cases when some entries were deleted successfully before a
      * failure happens. Entries removed from the keys will be not passed to
-     * subsequent call to delete() method any more. The intended usage is to 
-     * delete items from the provided collection as they are deleted from 
+     * subsequent call to delete() method any more. The intended usage is to
+     * delete items from the provided collection as they are deleted from
      * the store.
      *
      * @param keys the keys of the entries to delete.

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -33,7 +33,7 @@ import com.hazelcast.internal.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.memory.MemoryStats;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.internal.server.tcp.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.server.IOService;


### PR DESCRIPTION
EndpointQualifier is a member specific concern. No reason to have it in
Networking. Networking is a lower level networking API unaware of issues in clients/members.

Fixes https://github.com/hazelcast/hazelcast/issues/14871

For EE see https://github.com/hazelcast/hazelcast-enterprise/pull/3577