### PR TITLE
Further networking cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.cluster.Joiner;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.Networking;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.NioNetworking;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.server.Server;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -62,7 +62,7 @@ import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.impl.MetricsConfigHelper;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.server.Server;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeContext.java
@@ -18,7 +18,7 @@ package com.hazelcast.instance.impl;
 
 import com.hazelcast.internal.cluster.Joiner;
 import com.hazelcast.instance.AddressPicker;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.internal.server.Server;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -66,7 +66,7 @@ import com.hazelcast.internal.monitor.impl.LocalOperationStatsImpl;
 import com.hazelcast.internal.monitor.impl.MemberPartitionStateImpl;
 import com.hazelcast.internal.monitor.impl.MemberStateImpl;
 import com.hazelcast.internal.monitor.impl.NodeStateImpl;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;
 import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
@@ -35,8 +35,7 @@ import java.nio.channels.SocketChannel;
 public interface Networking {
 
     /**
-     * Registers the SocketChannel to the EventLoop group and returns the
-     * created Channel.
+     * Registers the SocketChannel and returns the created Channel.
      *
      * The Channel is not yet started so that modifications can be made to the
      * channel e.g. adding attributes. Once this is done the {@link Channel#start()}
@@ -60,7 +59,7 @@ public interface Networking {
     /**
      * Restarts Networking.
      *
-     * This method can be called when the NioNetworking is started for the first time.
+     * This method can be called when the Networking is started for the first time.
      *
      * But can also be called after {@link #shutdown()} has been completed. This is useful if you
      * temporarily want to disable networking (e.g. dealing with merging). You should not call this

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractChannel.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.networking;
+package com.hazelcast.internal.networking.nio;
 
+import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.networking.ChannelCloseListener;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.internal.nio.IOUtil;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.internal.networking.AbstractChannel;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.OutboundFrame;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/AggregateServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/AggregateServerConnectionManager.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.server;
 
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.networking.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListenable;
 
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/NetworkStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/NetworkStats.java
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.networking;
-
-import com.hazelcast.internal.server.AggregateServerConnectionManager;
-import com.hazelcast.internal.server.ServerConnectionManager;
+package com.hazelcast.internal.server;
 
 /**
  * Stats per {@link ServerConnectionManager} for both directions of network traffic (inbound or outbound).

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.server;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.networking.NetworkStats;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListenable;
 import com.hazelcast.internal.nio.Packet;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ClientViewUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ClientViewUnifiedEndpointManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.Server;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/DefaultAggregateConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/DefaultAggregateConnectionManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;
 import com.hazelcast.internal.server.ServerConnection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberViewUnifiedServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberViewUnifiedServerConnectionManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.Server;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ServerSocketRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ServerSocketRegistry.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.networking;
+package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.instance.EndpointQualifier;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServer.java
@@ -27,7 +27,6 @@ import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.networking.Networking;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;
 import com.hazelcast.internal.server.IOService;
 import com.hazelcast.internal.server.Server;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.SelectorMode;
 import com.hazelcast.internal.server.IOService;
 import com.hazelcast.internal.util.counters.SwCounter;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -26,7 +26,7 @@ import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionLifecycleListener;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TextViewUnifiedServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TextViewUnifiedServerConnectionManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.Server;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedAggregateConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedAggregateConnectionManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;
 import com.hazelcast.internal.server.ServerConnection;

--- a/hazelcast/src/test/java/com/hazelcast/instance/FirewallingNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/FirewallingNodeContext.java
@@ -18,7 +18,7 @@ package com.hazelcast.instance;
 
 import com.hazelcast.instance.impl.DefaultNodeContext;
 import com.hazelcast.instance.impl.Node;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.server.Server;
 import com.hazelcast.internal.server.FirewallingServer;

--- a/hazelcast/src/test/java/com/hazelcast/instance/StaticMemberNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/StaticMemberNodeContext.java
@@ -22,7 +22,7 @@ import com.hazelcast.instance.impl.DefaultNodeExtension;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeContext;
 import com.hazelcast.instance.impl.NodeExtension;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.server.Server;
 import com.hazelcast.test.TestHazelcastInstanceFactory;

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -23,7 +23,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeContext;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.dynamicconfig.DynamicConfigListener;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.map.impl.MapService;

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/AbstractOutOfMemoryHandlerTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.TestNodeContext;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/AbstractChannelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/AbstractChannelTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.networking;
 
+import com.hazelcast.internal.networking.nio.AbstractChannel;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkStatsIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkStatsIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.server;
 
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.networking.NetworkStats;
 import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.nio.Connection;

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.server.tcp;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.Select_NioNetworkingFactory;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.InternalSerializationService;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ServerConnectionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ServerConnectionManagerTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.server.Server;
 import com.hazelcast.internal.server.ServerConnectionManager;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -24,7 +24,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeContext;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.instance.impl.NodeExtensionFactory;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.server.Server;
 import com.hazelcast.internal.server.tcp.NodeIOService;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
@@ -21,7 +21,7 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
-import com.hazelcast.internal.networking.NetworkStats;
+import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionLifecycleListener;
 import com.hazelcast.internal.nio.ConnectionListener;

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeContext.java
@@ -21,7 +21,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeContext;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.Joiner;
-import com.hazelcast.internal.networking.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.internal.server.Server;
 
 import java.util.function.Function;


### PR DESCRIPTION
Moved AbstractChannel to nio package to prevent any unwanted reliance
on this class (it isn't API).

Moved NetworkingStats to com.hazelcast.internal.server since it is only
a concern here. It isn't related to Networking.

Moved ServerSocketRegistry to com.hazelcast.internal.server.tcp since it
an implementation detail of the TcpServer. It isn't a general purpose
API that can be used with Networking.

No EE change needed.