### PR TITLE
Utilize existing StandardCharsets.UTF-8 instead of hardcoded values or home-made constants

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -53,7 +53,6 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -54,6 +54,7 @@ import java.io.InputStreamReader;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -181,7 +182,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
      */
     static class DefaultLineReader implements LineReader {
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(System.in, Charset.forName("UTF-8")));
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
 
         public String readLine() throws Exception {
             return in.readLine();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/StringCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/StringCodec.java
@@ -17,11 +17,8 @@
 package com.hazelcast.client.impl.protocol.codec.builtin;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.internal.nio.Bits;
 
-import java.util.concurrent.TimeUnit;
-
-import static com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
+import java.nio.charset.StandardCharsets;
 
 public final class StringCodec {
 
@@ -29,10 +26,10 @@ public final class StringCodec {
     }
 
     public static void encode(ClientMessage clientMessage, String value) {
-        clientMessage.add(new ClientMessage.Frame(value.getBytes(Bits.UTF_8)));
+        clientMessage.add(new ClientMessage.Frame(value.getBytes(StandardCharsets.UTF_8)));
     }
 
     public static String decode(ClientMessage.ForwardFrameIterator iterator) {
-        return new String(iterator.next().content, Bits.UTF_8);
+        return new String(iterator.next().content, StandardCharsets.UTF_8);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -123,7 +124,7 @@ public class HazelcastCloudDiscovery {
     }
 
     private static String readInputStream(InputStream is) throws IOException {
-        BufferedReader in = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+        BufferedReader in = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         String line;
         StringBuilder response = new StringBuilder();
         while ((line = in.readLine()) != null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
@@ -24,13 +24,13 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Properties;
 
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
-import static com.hazelcast.internal.util.StringUtil.UTF8_CHARSET;
 
 /**
  * The common parent for {@link ConfigReplacer} implementations which allow to mask values by encrypting the value. This parent
@@ -126,9 +126,9 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
         SecureRandom secureRandom = new SecureRandom();
         byte[] salt = new byte[saltLengthBytes];
         secureRandom.nextBytes(salt);
-        byte[] encryptedVal = transform(Cipher.ENCRYPT_MODE, secretStr.getBytes(UTF8_CHARSET), salt, iterations);
-        return new String(Base64.getEncoder().encode(salt), UTF8_CHARSET) + ":" + iterations + ":"
-                + new String(Base64.getEncoder().encode(encryptedVal), UTF8_CHARSET);
+        byte[] encryptedVal = transform(Cipher.ENCRYPT_MODE, secretStr.getBytes(StandardCharsets.UTF_8), salt, iterations);
+        return new String(Base64.getEncoder().encode(salt), StandardCharsets.UTF_8) + ":" + iterations + ":"
+                + new String(Base64.getEncoder().encode(encryptedVal), StandardCharsets.UTF_8);
     }
 
     /**
@@ -141,11 +141,11 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
     protected String decrypt(String encryptedStr) throws Exception {
         String[] split = encryptedStr.split(":");
         checkTrue(split.length == 3, "Wrong format of the encrypted variable (" + encryptedStr + ")");
-        byte[] salt = Base64.getDecoder().decode(split[0].getBytes(UTF8_CHARSET));
+        byte[] salt = Base64.getDecoder().decode(split[0].getBytes(StandardCharsets.UTF_8));
         checkTrue(salt.length == saltLengthBytes, "Salt length doesn't match.");
         int iterations = Integer.parseInt(split[1]);
-        byte[] encryptedVal = Base64.getDecoder().decode(split[2].getBytes(UTF8_CHARSET));
-        return new String(transform(Cipher.DECRYPT_MODE, encryptedVal, salt, iterations), UTF8_CHARSET);
+        byte[] encryptedVal = Base64.getDecoder().decode(split[2].getBytes(StandardCharsets.UTF_8));
+        return new String(transform(Cipher.DECRYPT_MODE, encryptedVal, salt, iterations), StandardCharsets.UTF_8);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -44,7 +45,6 @@ import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
-import static com.hazelcast.internal.util.StringUtil.UTF8_CHARSET;
 import static com.hazelcast.internal.util.StringUtil.trim;
 import static java.lang.String.format;
 
@@ -111,8 +111,8 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
                 }
             }
             if (passwordUserProperties) {
-                baos.write(System.getProperty("user.home").getBytes(UTF8_CHARSET));
-                baos.write(System.getProperty("user.name").getBytes(UTF8_CHARSET));
+                baos.write(System.getProperty("user.home").getBytes(StandardCharsets.UTF_8));
+                baos.write(System.getProperty("user.name").getBytes(StandardCharsets.UTF_8));
             }
             if (passwordNetworkInterface != null) {
                 try {
@@ -122,7 +122,7 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
                     throw rethrow(e);
                 }
             }
-            return new String(Base64.getEncoder().encode(baos.toByteArray()), UTF8_CHARSET).toCharArray();
+            return new String(Base64.getEncoder().encode(baos.toByteArray()), StandardCharsets.UTF_8).toCharArray();
         } catch (Exception e) {
             throw rethrow(e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/console/DefaultLineReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/DefaultLineReader.java
@@ -19,6 +19,7 @@ package com.hazelcast.console;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A {@link LineReader} implemetation.
@@ -28,7 +29,7 @@ class DefaultLineReader implements LineReader {
     private BufferedReader in;
 
     DefaultLineReader() throws UnsupportedEncodingException {
-        in = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
+        in = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.diagnostics.Diagnostics.MAX_ROLLED_FILE_COUNT;
 import static com.hazelcast.internal.diagnostics.Diagnostics.MAX_ROLLED_FILE_SIZE_MB;
@@ -130,7 +131,7 @@ final class DiagnosticsLogFile {
 
     private PrintWriter newWriter() throws FileNotFoundException {
         FileOutputStream fos = new FileOutputStream(file, true);
-        CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         return new PrintWriter(new BufferedWriter(new OutputStreamWriter(fos, encoder), Short.MAX_VALUE));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -26,7 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
@@ -72,11 +72,6 @@ public final class Bits {
      */
     public static final int CACHE_LINE_LENGTH = 64;
 
-    /**
-     * A reusable instance of the ISO Latin-1 charset
-     */
-    public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
-
     private Bits() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.memory.impl.EndiannessUtil;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_ARRAY_ACCESS;
 import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_BUFFER_ACCESS;
@@ -71,10 +72,6 @@ public final class Bits {
      */
     public static final int CACHE_LINE_LENGTH = 64;
 
-    /**
-     * A reusable instance of the UTF-8 charset
-     */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
     /**
      * A reusable instance of the ISO Latin-1 charset
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Bits.java
@@ -19,8 +19,6 @@ package com.hazelcast.internal.nio;
 import com.hazelcast.internal.memory.impl.EndiannessUtil;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_ARRAY_ACCESS;
 import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_BUFFER_ACCESS;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -25,13 +25,13 @@ import com.hazelcast.internal.util.collection.ArrayUtils;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.nio.Bits.CHAR_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.internal.nio.Bits.SHORT_SIZE_IN_BYTES;
-import static com.hazelcast.internal.nio.Bits.UTF_8;
 import static com.hazelcast.version.Version.UNKNOWN;
 
 class ByteArrayObjectDataInput extends VersionedObjectDataInput implements BufferObjectDataInput {
@@ -557,7 +557,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
             return null;
         }
 
-        String result = new String(data, pos, numberOfBytes, UTF_8);
+        String result = new String(data, pos, numberOfBytes, StandardCharsets.UTF_8);
         pos += numberOfBytes;
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -25,13 +25,13 @@ import com.hazelcast.internal.serialization.Data;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.nio.Bits.CHAR_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.internal.nio.Bits.SHORT_SIZE_IN_BYTES;
-import static com.hazelcast.internal.nio.Bits.UTF_8;
 import static com.hazelcast.version.Version.UNKNOWN;
 
 class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements BufferObjectDataOutput {
@@ -257,7 +257,7 @@ class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements Buf
             return;
         }
 
-        byte[] utf8Bytes = str.getBytes(UTF_8);
+        byte[] utf8Bytes = str.getBytes(StandardCharsets.UTF_8);
         writeInt(utf8Bytes.length);
         ensureAvailable(utf8Bytes.length);
         write(utf8Bytes);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.hazelcast.internal.json.JsonReducedValueParser;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.query.impl.getters.JsonPathCursor;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationThread;
@@ -31,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 
 public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
 
@@ -93,7 +93,7 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
 
     static class UTF8Reader extends Reader {
 
-        static final ThreadLocal<CharsetDecoder> DECODER_THREAD_LOCAL = ThreadLocal.withInitial(Bits.UTF_8::newDecoder);
+        static final ThreadLocal<CharsetDecoder> DECODER_THREAD_LOCAL = ThreadLocal.withInitial(StandardCharsets.UTF_8::newDecoder);
 
         private final CharsetDecoder decoder;
         private final ByteBuffer inputBuffer;
@@ -107,7 +107,7 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
             inputBuffer.position(input.position());
             decoder = Thread.currentThread() instanceof OperationThread
                     ? DECODER_THREAD_LOCAL.get()
-                    : Bits.UTF_8.newDecoder();
+                    : StandardCharsets.UTF_8.newDecoder();
         }
 
         // default read() implementation does not handle surrogate pairs well

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -93,7 +93,8 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
 
     static class UTF8Reader extends Reader {
 
-        static final ThreadLocal<CharsetDecoder> DECODER_THREAD_LOCAL = ThreadLocal.withInitial(StandardCharsets.UTF_8::newDecoder);
+        static final ThreadLocal<CharsetDecoder> DECODER_THREAD_LOCAL = ThreadLocal
+          .withInitial(StandardCharsets.UTF_8::newDecoder);
 
         private final CharsetDecoder decoder;
         private final ByteBuffer inputBuffer;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -26,9 +26,9 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
-import static com.hazelcast.internal.nio.Bits.UTF_8;
 
 public class ObjectDataInputStream extends VersionedObjectDataInput
         implements Closeable, DataReader, SerializationServiceSupport {
@@ -303,7 +303,7 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
 
         byte[] utf8Bytes = new byte[numberOfBytes];
         dataInput.readFully(utf8Bytes);
-        return new String(utf8Bytes, UTF_8);
+        return new String(utf8Bytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -28,9 +28,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
-import static com.hazelcast.internal.nio.Bits.UTF_8;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class ObjectDataOutputStream extends VersionedObjectDataOutput
@@ -239,7 +239,7 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
             return;
         }
 
-        byte[] utf8Bytes = str.getBytes(UTF_8);
+        byte[] utf8Bytes = str.getBytes(StandardCharsets.UTF_8);
         writeInt(utf8Bytes.length);
         write(utf8Bytes);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MD5Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MD5Util.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -40,7 +41,7 @@ public final class MD5Util {
             if (md == null || str == null) {
                 return null;
             }
-            byte[] byteData = md.digest(str.getBytes(Charset.forName("UTF-8")));
+            byte[] byteData = md.digest(str.getBytes(StandardCharsets.UTF_8));
 
             StringBuilder sb = new StringBuilder();
             for (byte aByteData : byteData) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MD5Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MD5Util.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.util;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -129,7 +130,7 @@ public final class ServiceLoader {
             BufferedReader r = null;
             try {
                 URL url = urlDefinition.uri.toURL();
-                r = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+                r = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
                 while (true) {
                     String line = r.readLine();
                     if (line == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.util;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -35,11 +35,6 @@ import static java.lang.Character.toLowerCase;
  * Utility class for Strings.
  */
 public final class StringUtil {
-
-    /**
-     * UTF-8 Charset
-     */
-    public static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
 
     /**
      * Points to the System property 'line.separator'.
@@ -73,7 +68,7 @@ public final class StringUtil {
      * @return the string created from the byte array.
      */
     public static String bytesToString(byte[] bytes, int offset, int length) {
-        return new String(bytes, offset, length, UTF8_CHARSET);
+        return new String(bytes, offset, length, StandardCharsets.UTF_8);
     }
 
     /**
@@ -84,7 +79,7 @@ public final class StringUtil {
      */
     public static String bytesToString(byte[] bytes) {
 
-        return new String(bytes, UTF8_CHARSET);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     /**
@@ -94,7 +89,7 @@ public final class StringUtil {
      * @return the byte array created from the string.
      */
     public static byte[] stringToBytes(String s) {
-        return s.getBytes(UTF8_CHARSET);
+        return s.getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
@@ -32,6 +32,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -312,7 +313,7 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
                 BufferedReader reader = null;
                 try {
                     reader = new BufferedReader(
-                            new InputStreamReader(u.openStream(), "UTF-8"));
+                            new InputStreamReader(u.openStream(), StandardCharsets.UTF_8));
                     String line;
                     while ((line = reader.readLine()) != null) {
                         line = line.trim();

--- a/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleAppTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleAppTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -185,12 +186,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
      * Gets content of standard output buffer.
      */
     private static String getSystemOut() {
-        try {
-            return new String(baos.toByteArray(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            //This should never happen. Everybody loves and supports the UTF-8
-            throw new AssertionError("Get a deep breath and continue with reading. Your Java doesn't support UTF-8.");
-        }
+        return new String(baos.toByteArray(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
@@ -45,6 +45,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -52,7 +53,6 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
 import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
-import static com.hazelcast.internal.util.StringUtil.UTF8_CHARSET;
 import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Collections.emptyList;
@@ -89,7 +89,7 @@ public class ClientMessageProtectionTest {
         try (Socket socket = new Socket(address.getAddress(), address.getPort())) {
             socket.setSoTimeout(5000);
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
-                os.write(CLIENT_BINARY.getBytes(UTF8_CHARSET));
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
                 writeClientMessage(os, clientMessage);
                 ClientMessage respMessage = readResponse(is);
                 assertEquals(ClientAuthenticationCodec.RESPONSE_MESSAGE_TYPE, respMessage.getMessageType());
@@ -127,7 +127,7 @@ public class ClientMessageProtectionTest {
         try (Socket socket = new Socket(address.getAddress(), address.getPort())) {
             socket.setSoTimeout(5000);
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
-                os.write(CLIENT_BINARY.getBytes(UTF8_CHARSET));
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
                 List<ClientMessage> subFrames = ClientMessageSplitter.getFragments(50, clientMessage);
                 assertTrue(subFrames.size() > 1);
                 writeClientMessage(os, subFrames.get(0));
@@ -149,7 +149,7 @@ public class ClientMessageProtectionTest {
         try (Socket socket = new Socket(address.getAddress(), address.getPort())) {
             socket.setSoTimeout(5000);
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
-                os.write(CLIENT_BINARY.getBytes(UTF8_CHARSET));
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
                 writeClientMessage(os, clientMessage);
                 expected.expect(connectionClosedException());
                 readResponse(is);
@@ -166,7 +166,7 @@ public class ClientMessageProtectionTest {
         try (Socket socket = new Socket(address.getAddress(), address.getPort())) {
             socket.setSoTimeout(5000);
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
-                os.write(CLIENT_BINARY.getBytes(UTF8_CHARSET));
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
                 ByteBuffer buffer = ByteBuffer.allocateDirect(1024 * 1024);
                 buffer.order(ByteOrder.LITTLE_ENDIAN);
                 // it should be enough to write just the first frame
@@ -194,7 +194,7 @@ public class ClientMessageProtectionTest {
         InetSocketAddress address = getNode(hz).getLocalMember().getSocketAddress(EndpointQualifier.CLIENT);
         try (Socket socket = new Socket(address.getAddress(), address.getPort())) {
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
-                os.write(CLIENT_BINARY.getBytes(UTF8_CHARSET));
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
                 // it should be enough to write just the first frame
                 byte[] firstFrameBytes = frameAsBytes(clientMessage.getStartFrame(), false);
                 os.write(firstFrameBytes);

--- a/hazelcast/src/test/java/com/hazelcast/console/ConsoleAppTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/console/ConsoleAppTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -170,12 +171,7 @@ public class ConsoleAppTest extends HazelcastTestSupport {
      * Gets content of standard output buffer.
      */
     private static String getSystemOut() {
-        try {
-            return new String(baos.toByteArray(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            //This should never happen. Everybody loves and supports the UTF-8
-            throw new AssertionError("Get a deep breath and continue with reading. Your Java doesn't support UTF-8.");
-        }
+        return new String(baos.toByteArray(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
@@ -30,9 +30,9 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.nio.CharBuffer;
 import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
-import static com.hazelcast.internal.nio.Bits.UTF_8;
 import static com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder.DEFAULT_BYTE_ORDER;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
 import static org.junit.Assert.assertEquals;
@@ -43,10 +43,10 @@ import static org.junit.Assert.fail;
 public class DataInputNavigableJsonAdapterTest {
 
     private static final byte[][] SAMPLE_BYTES = new byte[][] {
-            "\uD83E\uDD13".getBytes(UTF_8),
-            "Bariš".getBytes(UTF_8),
-            "Simple code points".getBytes(UTF_8),
-            "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム".getBytes(UTF_8),
+            "\uD83E\uDD13".getBytes(StandardCharsets.UTF_8),
+            "Bariš".getBytes(StandardCharsets.UTF_8),
+            "Simple code points".getBytes(StandardCharsets.UTF_8),
+            "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム".getBytes(StandardCharsets.UTF_8),
     };
 
     private static final byte[][] MALFORMED_SAMPLE_BYTES = new byte[][] {
@@ -158,7 +158,7 @@ public class DataInputNavigableJsonAdapterTest {
 
     private void assertReadFully(DataInputNavigableJsonAdapter.UTF8Reader reader, byte[] sample)
             throws IOException {
-        String expected = new String(sample, UTF_8);
+        String expected = new String(sample, StandardCharsets.UTF_8);
         char[] chars = new char[expected.length()];
         int charsRead = reader.read(chars, 0, chars.length);
         assertEquals(chars.length, charsRead);
@@ -167,7 +167,7 @@ public class DataInputNavigableJsonAdapterTest {
 
     private void assertReadOne(DataInputNavigableJsonAdapter.UTF8Reader reader, byte[] sample)
             throws IOException {
-        String expected = new String(sample, UTF_8);
+        String expected = new String(sample, StandardCharsets.UTF_8);
         CharBuffer buffer = CharBuffer.allocate(expected.length() * 3);
         int next = reader.read();
         while (next != -1) {
@@ -182,7 +182,7 @@ public class DataInputNavigableJsonAdapterTest {
 
     private void assertReadMixed(byte[] sample, boolean singleReadFirst)
             throws IOException {
-        String expected = new String(sample, UTF_8);
+        String expected = new String(sample, StandardCharsets.UTF_8);
         input = new ByteArrayObjectDataInput(sample, serializationService, DEFAULT_BYTE_ORDER);
         DataInputNavigableJsonAdapter.UTF8Reader reader = new DataInputNavigableJsonAdapter.UTF8Reader(input);
         char[] chars = new char[expected.length()];


### PR DESCRIPTION
Since Java 8 is a baseline now, we can get rid of our home-grown constants and utilize these available in JDK itself.