### PR TITLE
Renamed IOService to ServerContext

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
@@ -28,7 +28,7 @@ import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.NioNetworking;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.server.Server;
-import com.hazelcast.internal.server.tcp.NodeIOService;
+import com.hazelcast.internal.server.tcp.TcpServerContext;
 import com.hazelcast.internal.server.tcp.TcpServerConnectionChannelErrorHandler;
 import com.hazelcast.internal.server.tcp.TcpServer;
 import com.hazelcast.internal.util.InstantiationUtils;
@@ -143,18 +143,18 @@ public class DefaultNodeContext implements NodeContext {
 
     @Override
     public Server createServer(Node node, ServerSocketRegistry registry) {
-        NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
+        TcpServerContext context = new TcpServerContext(node, node.nodeEngine);
         Networking networking = createNetworking(node);
         Config config = node.getConfig();
 
         MetricsRegistry metricsRegistry = node.nodeEngine.getMetricsRegistry();
         return new TcpServer(config,
-                ioService,
+                context,
                 registry,
                 node.loggingService,
                 metricsRegistry,
                 networking,
-                node.getNodeExtension().createChannelInitializerFn(ioService),
+                node.getNodeExtension().createChannelInitializerFn(context),
                 node.getProperties());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -73,7 +73,7 @@ import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.server.tcp.DefaultChannelInitializerProvider;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.tcp.PacketDecoder;
 import com.hazelcast.internal.server.tcp.PacketEncoder;
 import com.hazelcast.internal.server.ServerConnection;
@@ -303,7 +303,7 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public InboundHandler[] createInboundHandlers(EndpointQualifier qualifier,
-                                                  ServerConnection connection, IOService ioService) {
+                                                  ServerConnection connection, ServerContext serverContext) {
         NodeEngineImpl nodeEngine = node.nodeEngine;
         PacketDecoder decoder = new PacketDecoder(connection, nodeEngine.getPacketDispatcher());
         return new InboundHandler[]{decoder};
@@ -311,13 +311,13 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public OutboundHandler[] createOutboundHandlers(EndpointQualifier qualifier,
-                                                    ServerConnection connection, IOService ioService) {
+                                                    ServerConnection connection, ServerContext serverContext) {
         return new OutboundHandler[]{new PacketEncoder()};
     }
 
     @Override
-    public Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(IOService ioService) {
-        DefaultChannelInitializerProvider provider = new DefaultChannelInitializerProvider(ioService, node.getConfig());
+    public Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(ServerContext serverContext) {
+        DefaultChannelInitializerProvider provider = new DefaultChannelInitializerProvider(serverContext, node.getConfig());
         provider.init();
         return provider;
     }
@@ -457,12 +457,12 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
-    public ByteArrayProcessor createMulticastInputProcessor(IOService ioService) {
+    public ByteArrayProcessor createMulticastInputProcessor(ServerContext serverContext) {
         return null;
     }
 
     @Override
-    public ByteArrayProcessor createMulticastOutputProcessor(IOService ioService) {
+    public ByteArrayProcessor createMulticastOutputProcessor(ServerContext serverContext) {
         return null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
@@ -34,7 +34,7 @@ import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.ByteArrayProcessor;
@@ -140,28 +140,28 @@ public interface NodeExtension {
      * can be returned. This is the first item in the chain.
      *
      * @param connection tcp-ip connection
-     * @param ioService  IOService
+     * @param serverContext  ServerContext
      * @return the created InboundHandler.
      */
-    InboundHandler[] createInboundHandlers(EndpointQualifier qualifier, ServerConnection connection, IOService ioService);
+    InboundHandler[] createInboundHandlers(EndpointQualifier qualifier, ServerConnection connection, ServerContext context);
 
     /**
      * Creates a <tt>OutboundHandler</tt> for given <tt>Connection</tt> instance.
      *
      * @param connection tcp-ip connection
-     * @param ioService  IOService
+     * @param context  ServerContext
      * @return the created OutboundHandler
      */
-    OutboundHandler[] createOutboundHandlers(EndpointQualifier qualifier, ServerConnection connection, IOService ioService);
+    OutboundHandler[] createOutboundHandlers(EndpointQualifier qualifier, ServerConnection connection, ServerContext context);
 
 
     /**
      * Creates the channel initializer function.
      *
-     * @param ioService
+     * @param serverContext
      * @return
      */
-    Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(IOService ioService);
+    Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(ServerContext serverContext);
 
     /**
      * Called on thread start to inject/intercept extension specific logic,
@@ -294,10 +294,10 @@ public interface NodeExtension {
     TextCommandService createTextCommandService();
 
     /** Returns a byte array processor for incoming data on the Multicast joiner */
-    ByteArrayProcessor createMulticastInputProcessor(IOService ioService);
+    ByteArrayProcessor createMulticastInputProcessor(ServerContext serverContext);
 
     /** Returns a byte array processor for outgoing data on the Multicast joiner */
-    ByteArrayProcessor createMulticastOutputProcessor(IOService ioService);
+    ByteArrayProcessor createMulticastOutputProcessor(ServerContext serverContext);
 
     /**
      * Creates a listener for changes in dynamic data structure configurations

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/ServerSocketHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/ServerSocketHelper.java
@@ -29,7 +29,7 @@ import java.net.ServerSocket;
 import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.internal.server.IOService.KILO_BYTE;
+import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 
 final class ServerSocketHelper {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -26,7 +26,7 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.cluster.AddressChecker;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
-import com.hazelcast.internal.server.tcp.NodeIOService;
+import com.hazelcast.internal.server.tcp.TcpServerContext;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.internal.util.ByteArrayProcessor;
@@ -85,9 +85,9 @@ public final class MulticastService implements Runnable {
         this.node = node;
         this.multicastSocket = multicastSocket;
 
-        NodeIOService nodeIOService = new NodeIOService(node, node.nodeEngine);
-        this.inputProcessor = node.getNodeExtension().createMulticastInputProcessor(nodeIOService);
-        this.outputProcessor = node.getNodeExtension().createMulticastOutputProcessor(nodeIOService);
+        TcpServerContext context = new TcpServerContext(node, node.nodeEngine);
+        this.inputProcessor = node.getNodeExtension().createMulticastInputProcessor(context);
+        this.outputProcessor = node.getNodeExtension().createMulticastOutputProcessor(context);
 
         this.sendOutput = node.getSerializationService().createObjectDataOutput(SEND_OUTPUT_SIZE);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -62,7 +62,7 @@ import static com.hazelcast.internal.networking.ChannelOption.SO_SNDBUF;
 import static com.hazelcast.internal.networking.ChannelOption.TCP_NODELAY;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.server.IOService.KILO_BYTE;
+import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static java.lang.String.format;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiTextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiTextDecoder.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.ascii.rest.HttpDeleteCommandParser;
 import com.hazelcast.internal.ascii.rest.HttpGetCommandParser;
 import com.hazelcast.internal.ascii.rest.HttpHeadCommandParser;
 import com.hazelcast.internal.ascii.rest.HttpPostCommandParser;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public class RestApiTextDecoder extends TextDecoder {
     }
 
     private static RestApiFilter createFilter(ServerConnection connection) {
-        IOService ioService = connection.getConnectionManager().getServer().getIoService();
-        return new RestApiFilter(ioService.getLoggingService(), ioService.getRestApiConfig(), TEXT_PARSERS);
+        ServerContext serverContext = connection.getConnectionManager().getServer().getContext();
+        return new RestApiFilter(serverContext.getLoggingService(), serverContext.getRestApiConfig(), TEXT_PARSERS);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextChannelInitializer.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.InboundHandler;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.server.tcp.AbstractChannelInitializer;
 import com.hazelcast.internal.server.tcp.TcpServerConnection;
@@ -31,8 +31,8 @@ public class TextChannelInitializer
 
     private final boolean rest;
 
-    public TextChannelInitializer(IOService ioService, EndpointConfig config, boolean rest) {
-        super(ioService, config);
+    public TextChannelInitializer(ServerContext serverContext, EndpointConfig config, boolean rest) {
+        super(serverContext, config);
         this.rest = rest;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.ascii.rest.HttpCommand;
 import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.nio.ConnectionType;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.logging.ILogger;
@@ -60,13 +60,13 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
     public TextDecoder(ServerConnection connection, TextEncoder encoder, TextProtocolFilter textProtocolFilter,
                        TextParsers textParsers, boolean rootDecoder) {
-        IOService ioService = connection.getConnectionManager().getServer().getIoService();
-        this.textCommandService = ioService.getTextCommandService();
+        ServerContext serverContext = connection.getConnectionManager().getServer().getContext();
+        this.textCommandService = serverContext.getTextCommandService();
         this.encoder = encoder;
         this.connection = connection;
         this.textProtocolFilter = textProtocolFilter;
         this.textParsers = textParsers;
-        this.logger = ioService.getLoggingService().getLogger(getClass());
+        this.logger = serverContext.getLoggingService().getLogger(getClass());
         this.rootDecoder = rootDecoder;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/Server.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/Server.java
@@ -30,9 +30,9 @@ import com.hazelcast.internal.server.tcp.TextViewUnifiedServerConnectionManager;
 public interface Server {
 
     /**
-     * Returns the I/O Service
+     * Returns the ServerContext.
      */
-    IOService getIoService();
+    ServerContext getContext();
 
     /**
      * Return an aggregate endpoint which acts as a view of all endpoints merged together for reporting purposes

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
@@ -39,11 +39,11 @@ import java.util.Map;
 import java.util.UUID;
 
 @SuppressWarnings({"checkstyle:methodcount"})
-public interface IOService {
+public interface ServerContext {
 
     int KILO_BYTE = 1024;
 
-    boolean isActive();
+    boolean isNodeActive();
 
     HazelcastProperties properties();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ClientChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ClientChannelInitializer.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.util.ClientMessageEncoder;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 
 import static com.hazelcast.instance.ProtocolType.CLIENT;
@@ -28,15 +28,15 @@ import static com.hazelcast.instance.ProtocolType.CLIENT;
 public class ClientChannelInitializer
         extends AbstractChannelInitializer {
 
-    ClientChannelInitializer(IOService ioService, EndpointConfig config) {
-        super(ioService, config);
+    ClientChannelInitializer(ServerContext serverContext, EndpointConfig config) {
+        super(serverContext, config);
     }
 
     @Override
     public void initChannel(Channel channel) {
         ServerConnection connection = (TcpServerConnection) channel.attributeMap().get(ServerConnection.class);
         SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(CLIENT,
-                new ClientMessageDecoder(connection, ioService.getClientEngine(), ioService.properties()));
+                new ClientMessageDecoder(connection, serverContext.getClientEngine(), serverContext.properties()));
 
         channel.outboundPipeline().addLast(new ClientMessageEncoder());
         channel.inboundPipeline().addLast(protocolDecoder);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/DefaultChannelInitializerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/DefaultChannelInitializerProvider.java
@@ -24,7 +24,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.nio.ascii.TextChannelInitializer;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,15 +33,15 @@ import java.util.function.Function;
 
 public class DefaultChannelInitializerProvider implements Function<EndpointQualifier, ChannelInitializer> {
 
-    protected final IOService ioService;
+    protected final ServerContext serverContext;
     private final ChannelInitializer uniChannelInitializer;
     private final Config config;
     private volatile Map<EndpointQualifier, ChannelInitializer> initializerMap;
 
-    public DefaultChannelInitializerProvider(IOService ioService, Config config) {
+    public DefaultChannelInitializerProvider(ServerContext serverContext, Config config) {
         checkSslConfigAvailability(config);
-        this.ioService = ioService;
-        this.uniChannelInitializer = new UnifiedChannelInitializer(ioService);
+        this.serverContext = serverContext;
+        this.uniChannelInitializer = new UnifiedChannelInitializer(serverContext);
         this.config = config;
     }
 
@@ -92,15 +92,15 @@ public class DefaultChannelInitializerProvider implements Function<EndpointQuali
     }
 
     protected ChannelInitializer provideMemberChannelInitializer(EndpointConfig endpointConfig) {
-        return new MemberChannelInitializer(ioService, endpointConfig);
+        return new MemberChannelInitializer(serverContext, endpointConfig);
     }
 
     protected ChannelInitializer provideClientChannelInitializer(EndpointConfig endpointConfig) {
-        return new ClientChannelInitializer(ioService, endpointConfig);
+        return new ClientChannelInitializer(serverContext, endpointConfig);
     }
 
     protected ChannelInitializer provideTextChannelInitializer(EndpointConfig endpointConfig, boolean rest) {
-        return new TextChannelInitializer(ioService, endpointConfig, rest);
+        return new TextChannelInitializer(serverContext, endpointConfig, rest);
     }
 
     protected ChannelInitializer provideWanChannelInitializer(EndpointConfig endpointConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberChannelInitializer.java
@@ -22,21 +22,21 @@ import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 
 public class MemberChannelInitializer
         extends AbstractChannelInitializer {
 
-    MemberChannelInitializer(IOService ioService, EndpointConfig config) {
-        super(ioService, config);
+    MemberChannelInitializer(ServerContext serverContext, EndpointConfig config) {
+        super(serverContext, config);
     }
 
     @Override
     public void initChannel(Channel channel) {
         ServerConnection connection = (TcpServerConnection) channel.attributeMap().get(ServerConnection.class);
-        OutboundHandler[] outboundHandlers = ioService.createOutboundHandlers(EndpointQualifier.MEMBER, connection);
-        InboundHandler[] inboundHandlers = ioService.createInboundHandlers(EndpointQualifier.MEMBER, connection);
+        OutboundHandler[] outboundHandlers = serverContext.createOutboundHandlers(EndpointQualifier.MEMBER, connection);
+        InboundHandler[] inboundHandlers = serverContext.createInboundHandlers(EndpointQualifier.MEMBER, connection);
 
         MemberProtocolEncoder protocolEncoder = new MemberProtocolEncoder(outboundHandlers);
         SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(ProtocolType.MEMBER, inboundHandlers, protocolEncoder);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.nio.SelectorMode;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 
@@ -71,7 +71,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
     private final ServerSocketRegistry registry;
     private final TcpServer server;
     private final ILogger logger;
-    private final IOService ioService;
+    private final ServerContext serverContext;
     @Probe(name = TCP_METRIC_ACCEPTOR_EVENT_COUNT)
     private final SwCounter eventCount = newSwCounter();
     @Probe(name = TCP_METRIC_ACCEPTOR_EXCEPTION_COUNT)
@@ -93,11 +93,11 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
 
     private final Set<SelectionKey> selectionKeys = newSetFromMap(new ConcurrentHashMap<>());
 
-    TcpServerAcceptor(ServerSocketRegistry registry, TcpServer server, IOService ioService) {
+    TcpServerAcceptor(ServerSocketRegistry registry, TcpServer server, ServerContext serverContext) {
         this.registry = registry;
         this.server = server;
-        this.ioService = server.getIoService();
-        this.logger = ioService.getLoggingService().getLogger(getClass());
+        this.serverContext = server.getContext();
+        this.logger = serverContext.getLoggingService().getLogger(getClass());
         this.acceptorThread = new AcceptorIOThread();
     }
 
@@ -145,7 +145,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
     private final class AcceptorIOThread extends Thread {
 
         private AcceptorIOThread() {
-            super(createThreadPoolName(ioService.getHazelcastName(), "IO") + "Acceptor");
+            super(createThreadPoolName(serverContext.getHazelcastName(), "IO") + "Acceptor");
         }
 
         @Override
@@ -293,7 +293,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
                 } catch (Exception ex) {
                     logger.finest("Closing server socket failed", ex);
                 }
-                ioService.onFatalError(e);
+                serverContext.onFatalError(e);
             }
         }
 
@@ -306,8 +306,8 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
                 logger.fine("Accepting socket connection from " + channel.socket().getRemoteSocketAddress());
             }
 
-            if (ioService.isSocketInterceptorEnabled(qualifier)) {
-                ioService.executeAsync(() -> newConnection0(connectionManager, channel));
+            if (serverContext.isSocketInterceptorEnabled(qualifier)) {
+                serverContext.executeAsync(() -> newConnection0(connectionManager, channel));
             } else {
                 newConnection0(connectionManager, channel);
             }
@@ -315,7 +315,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
 
         private void newConnection0(TcpServerConnectionManager connectionManager, Channel channel) {
             try {
-                ioService.interceptSocket(connectionManager.getEndpointQualifier(), channel.socket(), true);
+                serverContext.interceptSocket(connectionManager.getEndpointQualifier(), channel.socket(), true);
                 connectionManager.newConnection(channel, null);
             } catch (Exception e) {
                 exceptionCount.inc();

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionLifecycleListener;
 import com.hazelcast.internal.nio.ConnectionType;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.logging.ILogger;
 
@@ -67,7 +67,7 @@ public class TcpServerConnection implements ServerConnection {
 
     private final int connectionId;
 
-    private final IOService ioService;
+    private final ServerContext serverContext;
 
     private Address remoteAddress;
 
@@ -88,8 +88,8 @@ public class TcpServerConnection implements ServerConnection {
         this.connectionId = connectionId;
         this.connectionManager = connectionManager;
         this.lifecycleListener = lifecycleListener;
-        this.ioService = connectionManager.getServer().getIoService();
-        this.logger = ioService.getLoggingService().getLogger(TcpServerConnection.class);
+        this.serverContext = connectionManager.getServer().getContext();
+        this.logger = serverContext.getLoggingService().getLogger(TcpServerConnection.class);
         this.channel = channel;
         this.attributeMap = channel.attributeMap();
         attributeMap.put(ServerConnection.class, this);
@@ -227,7 +227,7 @@ public class TcpServerConnection implements ServerConnection {
         }
 
         lifecycleListener.onConnectionClose(this, null, false);
-        ioService.onDisconnect(remoteAddress, cause);
+        serverContext.onDisconnect(remoteAddress, cause);
         if (cause != null && errorHandler != null) {
             errorHandler.onError(cause);
         }
@@ -262,7 +262,7 @@ public class TcpServerConnection implements ServerConnection {
     }
 
     private Level resolveLogLevelOnClose() {
-        if (!ioService.isActive()) {
+        if (!serverContext.isNodeActive()) {
             return Level.FINEST;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.logging.ILogger;
 
 import static java.lang.System.currentTimeMillis;
@@ -25,7 +25,7 @@ import static java.lang.System.currentTimeMillis;
 public class TcpServerConnectionErrorHandler {
 
     private final ILogger logger;
-    private final IOService ioService;
+    private final ServerContext serverContext;
     private final Address endPoint;
     private final long minInterval;
     private final int maxFaults;
@@ -34,10 +34,10 @@ public class TcpServerConnectionErrorHandler {
 
     TcpServerConnectionErrorHandler(TcpServerConnectionManager connectionManager, Address endPoint) {
         this.endPoint = endPoint;
-        this.ioService = connectionManager.getServer().getIoService();
-        this.minInterval = ioService.getConnectionMonitorInterval();
-        this.maxFaults = ioService.getConnectionMonitorMaxFaults();
-        this.logger = ioService.getLoggingService().getLogger(getClass());
+        this.serverContext = connectionManager.getServer().getContext();
+        this.minInterval = serverContext.getConnectionMonitorInterval();
+        this.maxFaults = serverContext.getConnectionMonitorMaxFaults();
+        this.logger = serverContext.getLoggingService().getLogger(getClass());
     }
 
     public Address getEndPoint() {
@@ -53,7 +53,7 @@ public class TcpServerConnectionErrorHandler {
             if (faults++ >= maxFaults) {
                 String removeEndpointMessage = "Removing connection to endpoint " + endPoint + getCauseDescription(t);
                 logger.warning(removeEndpointMessage);
-                ioService.removeEndpoint(endPoint);
+                serverContext.removeEndpoint(endPoint);
             }
             lastFaultTime = now;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
@@ -37,7 +37,7 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.logging.LoggingService;
@@ -62,18 +62,18 @@ import static com.hazelcast.instance.EndpointQualifier.REST;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
 
 @SuppressWarnings({"checkstyle:methodcount"})
-public class NodeIOService implements IOService {
+public class TcpServerContext implements ServerContext {
 
     private final Node node;
     private final NodeEngineImpl nodeEngine;
     private final RestApiConfig restApiConfig;
     private final MemcacheProtocolConfig memcacheProtocolConfig;
 
-    public NodeIOService(Node node, NodeEngineImpl nodeEngine) {
+    public TcpServerContext(Node node, NodeEngineImpl nodeEngine) {
         this.node = node;
         this.nodeEngine = nodeEngine;
-        restApiConfig = initRestApiConfig(node.getConfig());
-        memcacheProtocolConfig = initMemcacheProtocolConfig(node.getConfig());
+        this.restApiConfig = initRestApiConfig(node.getConfig());
+        this.memcacheProtocolConfig = initMemcacheProtocolConfig(node.getConfig());
     }
 
     private static RestApiConfig initRestApiConfig(Config config) {
@@ -116,7 +116,7 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public boolean isActive() {
+    public boolean isNodeActive() {
         return node.getState() != NodeState.SHUT_DOWN;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedChannelInitializer.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.server.tcp;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.ChannelOptions;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import static com.hazelcast.internal.networking.ChannelOption.DIRECT_BUF;
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.networking.ChannelOption.SO_LINGER;
 import static com.hazelcast.internal.networking.ChannelOption.SO_RCVBUF;
 import static com.hazelcast.internal.networking.ChannelOption.SO_SNDBUF;
 import static com.hazelcast.internal.networking.ChannelOption.TCP_NODELAY;
-import static com.hazelcast.internal.server.IOService.KILO_BYTE;
+import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_BUFFER_DIRECT;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_KEEP_ALIVE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_LINGER_SECONDS;
@@ -44,12 +44,12 @@ import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SEND_BUFFER_SI
 public class UnifiedChannelInitializer
         implements ChannelInitializer {
 
-    private final IOService ioService;
+    private final ServerContext serverContext;
     private final HazelcastProperties props;
 
-    public UnifiedChannelInitializer(IOService ioService) {
-        this.props = ioService.properties();
-        this.ioService = ioService;
+    public UnifiedChannelInitializer(ServerContext serverContext) {
+        this.props = serverContext.properties();
+        this.serverContext = serverContext;
     }
 
     @Override
@@ -62,8 +62,8 @@ public class UnifiedChannelInitializer
                 .setOption(SO_RCVBUF, props.getInteger(SOCKET_RECEIVE_BUFFER_SIZE) * KILO_BYTE)
                 .setOption(SO_LINGER, props.getSeconds(SOCKET_LINGER_SECONDS));
 
-        UnifiedProtocolEncoder encoder = new UnifiedProtocolEncoder(ioService);
-        UnifiedProtocolDecoder decoder = new UnifiedProtocolDecoder(ioService, encoder);
+        UnifiedProtocolEncoder encoder = new UnifiedProtocolEncoder(serverContext);
+        UnifiedProtocolDecoder decoder = new UnifiedProtocolDecoder(serverContext, encoder);
 
         channel.outboundPipeline().addLast(encoder);
         channel.inboundPipeline().addLast(decoder);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolEncoder.java
@@ -21,7 +21,7 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.ascii.TextEncoder;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
@@ -35,7 +35,7 @@ import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
 import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.ascii.TextEncoder.TEXT_ENCODER;
-import static com.hazelcast.internal.server.IOService.KILO_BYTE;
+import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_SEND_BUFFER_SIZE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SEND_BUFFER_SIZE;
@@ -52,14 +52,14 @@ import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SEND_BUFFER_SI
 public class UnifiedProtocolEncoder
         extends OutboundHandler<Void, ByteBuffer> {
 
-    private final IOService ioService;
+    private final ServerContext serverContext;
     private final HazelcastProperties props;
     private volatile String inboundProtocol;
     private boolean clusterProtocolBuffered;
 
-    public UnifiedProtocolEncoder(IOService ioService) {
-        this.ioService = ioService;
-        this.props = ioService.properties();
+    public UnifiedProtocolEncoder(ServerContext serverContext) {
+        this.serverContext = serverContext;
+        this.props = serverContext.properties();
     }
 
     @Override
@@ -141,7 +141,7 @@ public class UnifiedProtocolEncoder
                 .setOption(SO_SNDBUF, props.getInteger(SOCKET_SEND_BUFFER_SIZE) * KILO_BYTE);
 
         ServerConnection connection = (TcpServerConnection) channel.attributeMap().get(ServerConnection.class);
-        OutboundHandler[] handlers = ioService.createOutboundHandlers(EndpointQualifier.MEMBER, connection);
+        OutboundHandler[] handlers = serverContext.createOutboundHandlers(EndpointQualifier.MEMBER, connection);
         channel.outboundPipeline().replace(this, handlers);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedServerConnectionManager.java
@@ -21,7 +21,7 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -42,9 +42,9 @@ class UnifiedServerConnectionManager
 
     UnifiedServerConnectionManager(TcpServer root, EndpointConfig endpointConfig,
                                    Function<EndpointQualifier, ChannelInitializer> channelInitializerProvider,
-                                   IOService ioService, LoggingService loggingService,
+                                   ServerContext serverContext, LoggingService loggingService,
                                    HazelcastProperties properties) {
-        super(root, endpointConfig, channelInitializerProvider, ioService, loggingService,
+        super(root, endpointConfig, channelInitializerProvider, serverContext, loggingService,
                 properties, ProtocolType.valuesAsSet());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/AbstractOutOfMemoryHandlerTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.AggregateServerConnectionManager;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.Server;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.server.ServerConnectionManager;
@@ -140,7 +140,7 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
         }
 
         @Override
-        public IOService getIoService() {
+        public ServerContext getContext() {
             return null;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioNetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioNetworkingFactory.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.internal.server.MockIOService;
+import com.hazelcast.internal.server.MockServerContext;
 import com.hazelcast.internal.server.NetworkingFactory;
 import com.hazelcast.internal.server.tcp.TcpServerConnectionChannelErrorHandler;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -30,14 +30,14 @@ import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUN
 public class SelectNow_NioNetworkingFactory implements NetworkingFactory {
 
     @Override
-    public NioNetworking create(final MockIOService ioService, MetricsRegistry metricsRegistry) {
-        LoggingService loggingService = ioService.loggingService;
-        HazelcastProperties properties = ioService.properties();
+    public NioNetworking create(final MockServerContext serverContext, MetricsRegistry metricsRegistry) {
+        LoggingService loggingService = serverContext.loggingService;
+        HazelcastProperties properties = serverContext.properties();
         return new NioNetworking(
                 new NioNetworking.Context()
                         .loggingService(loggingService)
                         .metricsRegistry(metricsRegistry)
-                        .threadNamePrefix(ioService.getHazelcastName())
+                        .threadNamePrefix(serverContext.getHazelcastName())
                         .errorHandler(
                                 new TcpServerConnectionChannelErrorHandler(
                                         loggingService.getLogger(TcpServerConnectionChannelErrorHandler.class)))

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioNetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioNetworkingFactory.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.internal.server.MockIOService;
+import com.hazelcast.internal.server.MockServerContext;
 import com.hazelcast.internal.server.NetworkingFactory;
 import com.hazelcast.internal.server.tcp.TcpServerConnectionChannelErrorHandler;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -30,14 +30,14 @@ import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUN
 public class SelectWithSelectorFix_NioNetworkingFactory implements NetworkingFactory {
 
     @Override
-    public NioNetworking create(final MockIOService ioService, MetricsRegistry metricsRegistry) {
-        HazelcastProperties properties = ioService.properties();
-        LoggingService loggingService = ioService.loggingService;
+    public NioNetworking create(final MockServerContext serverContext, MetricsRegistry metricsRegistry) {
+        HazelcastProperties properties = serverContext.properties();
+        LoggingService loggingService = serverContext.loggingService;
         return new NioNetworking(
                 new NioNetworking.Context()
                         .loggingService(loggingService)
                         .metricsRegistry(metricsRegistry)
-                        .threadNamePrefix(ioService.getHazelcastName())
+                        .threadNamePrefix(serverContext.getHazelcastName())
                         .errorHandler(
                                 new TcpServerConnectionChannelErrorHandler(
                                         loggingService.getLogger(TcpServerConnectionChannelErrorHandler.class)))

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioNetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioNetworkingFactory.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.internal.server.MockIOService;
+import com.hazelcast.internal.server.MockServerContext;
 import com.hazelcast.internal.server.NetworkingFactory;
 import com.hazelcast.internal.server.tcp.TcpServerConnectionChannelErrorHandler;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -30,14 +30,14 @@ import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUN
 public class Select_NioNetworkingFactory implements NetworkingFactory {
 
     @Override
-    public NioNetworking create(final MockIOService ioService, MetricsRegistry metricsRegistry) {
-        HazelcastProperties properties = ioService.properties();
-        LoggingService loggingService = ioService.loggingService;
+    public NioNetworking create(final MockServerContext serverContext, MetricsRegistry metricsRegistry) {
+        HazelcastProperties properties = serverContext.properties();
+        LoggingService loggingService = serverContext.loggingService;
         return new NioNetworking(
                 new NioNetworking.Context()
                         .loggingService(loggingService)
                         .metricsRegistry(metricsRegistry)
-                        .threadNamePrefix(ioService.getHazelcastName())
+                        .threadNamePrefix(serverContext.getHazelcastName())
                         .errorHandler(
                                 new TcpServerConnectionChannelErrorHandler(
                                         loggingService.getLogger(TcpServerConnectionChannelErrorHandler.class)))

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -62,8 +62,8 @@ public class FirewallingServer
     }
 
     @Override
-    public IOService getIoService() {
-        return delegate.getIoService();
+    public ServerContext getContext() {
+        return delegate.getContext();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -62,7 +62,7 @@ import static com.hazelcast.internal.nio.Packet.Type.MEMBER_HANDSHAKE;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUNT;
 
-public class MockIOService implements IOService {
+public class MockServerContext implements ServerContext {
 
     public final ServerSocketChannel serverSocketChannel;
     public final Address thisAddress;
@@ -73,9 +73,9 @@ public class MockIOService implements IOService {
     public volatile Consumer<Packet> packetConsumer;
     private final ILogger logger;
 
-    public MockIOService(int port) throws Exception {
+    public MockServerContext(int port) throws Exception {
         loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo(), true);
-        logger = loggingService.getLogger(MockIOService.class);
+        logger = loggingService.getLogger(MockServerContext.class);
         serverSocketChannel = ServerSocketChannel.open();
         ServerSocket serverSocket = serverSocketChannel.socket();
         serverSocket.setReuseAddress(true);
@@ -103,7 +103,7 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public boolean isActive() {
+    public boolean isNodeActive() {
         return true;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/NetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/NetworkingFactory.java
@@ -20,5 +20,5 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.networking.Networking;
 
 public interface NetworkingFactory {
-    Networking create(MockIOService ioService, MetricsRegistry metricsRegistry);
+    Networking create(MockServerContext serverContext, MetricsRegistry metricsRegistry);
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_AbstractConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_AbstractConnectMemberTest.java
@@ -132,7 +132,7 @@ public abstract class TcpServerConnectionManager_AbstractConnectMemberTest
         assertEquals(ConnectionType.MEMBER, connBA.getConnectionType());
         assertEquals(1, networkingServiceB.getConnectionManager(MEMBER).getActiveConnections().size());
 
-        assertEquals(networkingServiceA.getIoService().getThisAddress(), connBA.getRemoteAddress());
-        assertEquals(networkingServiceB.getIoService().getThisAddress(), connAB.getRemoteAddress());
+        assertEquals(networkingServiceA.getContext().getThisAddress(), connBA.getRemoteAddress());
+        assertEquals(networkingServiceB.getContext().getThisAddress(), connAB.getRemoteAddress());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_TransmitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_TransmitTest.java
@@ -51,7 +51,7 @@ public class TcpServerConnectionManager_TransmitTest
         super.setup();
         networkingServiceA.start();
 
-        ioServiceB.packetConsumer = new Consumer<Packet>() {
+        serverContextB.packetConsumer = new Consumer<Packet>() {
             @Override
             public void accept(Packet packet) {
                 packetsB.add(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractBasicTest.java
@@ -48,7 +48,7 @@ public abstract class TcpServerConnection_AbstractBasicTest extends TcpServerCon
         super.setup();
         packetsB = Collections.synchronizedList(new ArrayList<Packet>());
         startAllNetworkingServices();
-        ioServiceB.packetConsumer = new Consumer<Packet>() {
+        serverContextB.packetConsumer = new Consumer<Packet>() {
             @Override
             public void accept(Packet packet) {
                 packetsB.add(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.internal.networking.nio.Select_NioNetworkingFactory;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.internal.server.MockIOService;
+import com.hazelcast.internal.server.MockServerContext;
 import com.hazelcast.internal.server.NetworkingFactory;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.server.TestDataFactory;
@@ -64,9 +64,9 @@ public abstract class TcpServerConnection_AbstractTest extends HazelcastTestSupp
     protected TcpServer networkingServiceB;
     protected TcpServer networkingServiceC;
 
-    protected MockIOService ioServiceA;
-    protected MockIOService ioServiceB;
-    protected MockIOService ioServiceC;
+    protected MockServerContext serverContextA;
+    protected MockServerContext serverContextB;
+    protected MockServerContext serverContextC;
 
     protected MetricsRegistryImpl metricsRegistryA;
     protected MetricsRegistryImpl metricsRegistryB;
@@ -80,18 +80,18 @@ public abstract class TcpServerConnection_AbstractTest extends HazelcastTestSupp
 
         metricsRegistryA = newMetricsRegistry();
         networkingServiceA = newNetworkingService(metricsRegistryA);
-        ioServiceA = (MockIOService) networkingServiceA.getIoService();
-        addressA = ioServiceA.getThisAddress();
+        serverContextA = (MockServerContext) networkingServiceA.getContext();
+        addressA = serverContextA.getThisAddress();
 
         metricsRegistryB = newMetricsRegistry();
         networkingServiceB = newNetworkingService(metricsRegistryB);
-        ioServiceB = (MockIOService) networkingServiceB.getIoService();
-        addressB = ioServiceB.getThisAddress();
+        serverContextB = (MockServerContext) networkingServiceB.getContext();
+        addressB = serverContextB.getThisAddress();
 
         metricsRegistryC = newMetricsRegistry();
         networkingServiceC = newNetworkingService(metricsRegistryC);
-        ioServiceC = (MockIOService) networkingServiceC.getIoService();
-        addressC = ioServiceC.getThisAddress();
+        serverContextC = (MockServerContext) networkingServiceC.getContext();
+        addressC = serverContextC.getThisAddress();
 
         serializationService = new DefaultSerializationServiceBuilder()
                 .addDataSerializableFactory(TestDataFactory.FACTORY_ID, new TestDataFactory())
@@ -120,10 +120,10 @@ public abstract class TcpServerConnection_AbstractTest extends HazelcastTestSupp
     }
 
     protected TcpServer newNetworkingService(MetricsRegistry metricsRegistry) throws Exception {
-        MockIOService ioService = null;
-        while (ioService == null) {
+        MockServerContext serverContext = null;
+        while (serverContext == null) {
             try {
-                ioService = new MockIOService(portNumber++);
+                serverContext = new MockServerContext(portNumber++);
             } catch (IOException e) {
                 if (portNumber >= PORT_NUMBER_UPPER_LIMIT) {
                     throw e;
@@ -131,16 +131,16 @@ public abstract class TcpServerConnection_AbstractTest extends HazelcastTestSupp
             }
         }
 
-        ServerSocketRegistry registry = new ServerSocketRegistry(singletonMap(MEMBER, ioService.serverSocketChannel), true);
+        ServerSocketRegistry registry = new ServerSocketRegistry(singletonMap(MEMBER, serverContext.serverSocketChannel), true);
 
-        final MockIOService finalIoService = ioService;
+        final MockServerContext finalServiceContext = serverContext;
         TcpServer serverNetworkingService = new TcpServer(null,
-                ioService,
+                serverContext,
                 registry,
-                ioService.loggingService,
+                serverContext.loggingService,
                 metricsRegistry,
-                networkingFactory.create(ioService, metricsRegistry),
-                qualifier -> new UnifiedChannelInitializer(finalIoService));
+                networkingFactory.create(serverContext, metricsRegistry),
+                qualifier -> new UnifiedChannelInitializer(finalServiceContext));
         return serverNetworkingService;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerContextTest.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio;
+package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.impl.Node;
-import com.hazelcast.internal.server.tcp.NodeIOService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -43,10 +42,10 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class NodeIOServiceTest extends HazelcastTestSupport {
+public class TcpServerContextTest extends HazelcastTestSupport {
 
     private NetworkConfig networkConfig;
-    private NodeIOService ioService;
+    private TcpServerContext serverContext;
 
     @Before
     public void setUp() {
@@ -57,47 +56,47 @@ public class NodeIOServiceTest extends HazelcastTestSupport {
         networkConfig = config.getNetworkConfig();
         when(mockNode.getConfig()).thenReturn(config);
         when(mockNode.getProperties()).thenReturn(properties);
-        ioService = new NodeIOService(mockNode, mockNodeEngine);
+        serverContext = new TcpServerContext(mockNode, mockNodeEngine);
     }
 
     @Test
     public void testGetOutboundPorts_zeroTakesPrecedenceInRange() {
         networkConfig.addOutboundPortDefinition("0-100");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
         assertEquals(0, outboundPorts.size());
     }
 
     @Test
     public void testGetOutboundPorts_zeroTakesPrecedenceInCSV() {
         networkConfig.addOutboundPortDefinition("5701, 0, 63");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
         assertEquals(0, outboundPorts.size());
     }
 
     @Test
     public void testGetOutboundPorts_acceptsZero() {
         networkConfig.addOutboundPortDefinition("0");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
         assertEquals(0, outboundPorts.size());
     }
 
     @Test
     public void testGetOutboundPorts_acceptsWildcard() {
         networkConfig.addOutboundPortDefinition("*");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
         assertEquals(0, outboundPorts.size());
     }
 
     @Test
     public void testGetOutboundPorts_returnsEmptyCollectionByDefault() {
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
         assertEquals(0, outboundPorts.size());
     }
 
     @Test
     public void testGetOutboundPorts_acceptsRange() {
         networkConfig.addOutboundPortDefinition("29000-29001");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
 
         assertThat(outboundPorts, hasSize(2));
         assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
@@ -106,7 +105,7 @@ public class NodeIOServiceTest extends HazelcastTestSupport {
     @Test
     public void testGetOutboundPorts_acceptsSpaceAfterComma() {
         networkConfig.addOutboundPortDefinition("29000, 29001");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
 
         assertThat(outboundPorts, hasSize(2));
         assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
@@ -115,7 +114,7 @@ public class NodeIOServiceTest extends HazelcastTestSupport {
     @Test
     public void testGetOutboundPorts_acceptsSpaceAsASeparator() {
         networkConfig.addOutboundPortDefinition("29000 29001");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
 
         assertThat(outboundPorts, hasSize(2));
         assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
@@ -124,7 +123,7 @@ public class NodeIOServiceTest extends HazelcastTestSupport {
     @Test
     public void testGetOutboundPorts_acceptsSemicolonAsASeparator() {
         networkConfig.addOutboundPortDefinition("29000;29001");
-        Collection<Integer> outboundPorts = ioService.getOutboundPorts(MEMBER);
+        Collection<Integer> outboundPorts = serverContext.getOutboundPorts(MEMBER);
 
         assertThat(outboundPorts, hasSize(2));
         assertThat(outboundPorts, containsInAnyOrder(29000, 29001));

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -36,7 +36,7 @@ import com.hazelcast.internal.memory.MemoryStats;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -129,18 +129,18 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
-    public InboundHandler[] createInboundHandlers(EndpointQualifier qualifier, ServerConnection connection, IOService ioService) {
-        return nodeExtension.createInboundHandlers(qualifier, connection, ioService);
+    public InboundHandler[] createInboundHandlers(EndpointQualifier qualifier, ServerConnection connection, ServerContext serverContext) {
+        return nodeExtension.createInboundHandlers(qualifier, connection, serverContext);
     }
 
     @Override
-    public OutboundHandler[] createOutboundHandlers(EndpointQualifier qualifier, ServerConnection connection, IOService ioService) {
-        return nodeExtension.createOutboundHandlers(qualifier, connection, ioService);
+    public OutboundHandler[] createOutboundHandlers(EndpointQualifier qualifier, ServerConnection connection, ServerContext serverContext) {
+        return nodeExtension.createOutboundHandlers(qualifier, connection, serverContext);
     }
 
     @Override
-    public Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(IOService ioService) {
-       return nodeExtension.createChannelInitializerFn(ioService);
+    public Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(ServerContext serverContext) {
+       return nodeExtension.createChannelInitializerFn(serverContext);
     }
 
     @Override
@@ -228,13 +228,13 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
-    public ByteArrayProcessor createMulticastInputProcessor(IOService ioService) {
-        return nodeExtension.createMulticastInputProcessor(ioService);
+    public ByteArrayProcessor createMulticastInputProcessor(ServerContext serverContext) {
+        return nodeExtension.createMulticastInputProcessor(serverContext);
     }
 
     @Override
-    public ByteArrayProcessor createMulticastOutputProcessor(IOService ioService) {
-        return nodeExtension.createMulticastOutputProcessor(ioService);
+    public ByteArrayProcessor createMulticastOutputProcessor(ServerContext serverContext) {
+        return nodeExtension.createMulticastOutputProcessor(serverContext);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -27,7 +27,7 @@ import com.hazelcast.instance.impl.NodeExtensionFactory;
 import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.server.Server;
-import com.hazelcast.internal.server.tcp.NodeIOService;
+import com.hazelcast.internal.server.tcp.TcpServerContext;
 import com.hazelcast.internal.server.FirewallingServer;
 import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.compatibility.SamplingNodeExtension;
@@ -79,8 +79,8 @@ public class MockNodeContext implements NodeContext {
 
     @Override
     public Server createServer(Node node, ServerSocketRegistry serverSocketRegistry) {
-        NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-        MockServer mockNetworkingService = new MockServer(ioService, node, registry);
+        TcpServerContext serverContext = new TcpServerContext(node, node.nodeEngine);
+        MockServer mockNetworkingService = new MockServer(serverContext, node, registry);
         return new FirewallingServer(mockNetworkingService, initiallyBlockedAddresses);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
@@ -26,7 +26,7 @@ import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionLifecycleListener;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
-import com.hazelcast.internal.server.IOService;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.Server;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.server.ServerConnectionManager;
@@ -65,7 +65,7 @@ class MockServer
     private final Node node;
 
     private final ScheduledExecutorService scheduler;
-    private final IOService ioService;
+    private final ServerContext serverContext;
     private final ILogger logger;
 
     private volatile boolean live;
@@ -73,16 +73,16 @@ class MockServer
     private final ServerConnectionManager mockConnectionMgr;
     private final AggregateServerConnectionManager mockAggrEndpointManager;
 
-    MockServer(IOService ioService, Node node, TestNodeRegistry testNodeRegistry) {
-        this.ioService = ioService;
+    MockServer(ServerContext serverContext, Node node, TestNodeRegistry testNodeRegistry) {
+        this.serverContext = serverContext;
         this.nodeRegistry = testNodeRegistry;
         this.node = node;
         this.mockConnectionMgr = new MockEndpointManager(this);
         this.mockAggrEndpointManager = new DefaultAggregateConnectionManager(
                 new ConcurrentHashMap(singletonMap(MEMBER, mockConnectionMgr)));
         this.scheduler = new ScheduledThreadPoolExecutor(4,
-                new ThreadFactoryImpl(createThreadPoolName(ioService.getHazelcastName(), "MockConnectionManager")));
-        this.logger = ioService.getLoggingService().getLogger(MockServer.class);
+                new ThreadFactoryImpl(createThreadPoolName(serverContext.getHazelcastName(), "MockConnectionManager")));
+        this.logger = serverContext.getLoggingService().getLogger(MockServer.class);
     }
 
 
@@ -131,7 +131,7 @@ class MockServer
         }
 
         private void suspectAddress(final Address address) {
-            // see NodeIOService#removeEndpoint()
+            // see TcpServerContext#removeEndpoint()
             ns.node.getNodeEngine().getExecutionService().execute(ExecutionService.IO_EXECUTOR, new Runnable() {
                 @Override
                 public void run() {
@@ -196,7 +196,7 @@ class MockServer
 
             connection.setLifecycleListener(lifecycleListener);
             ns.mapConnections.put(remoteAddress, connection);
-            ns.ioService.getEventService().executeEventCallback(new StripedRunnable() {
+            ns.serverContext.getEventService().executeEventCallback(new StripedRunnable() {
                 @Override
                 public void run() {
                     for (ConnectionListener listener : connectionListeners) {
@@ -219,7 +219,7 @@ class MockServer
 
         private void fireConnectionRemovedEvent(final MockServerConnection connection, final Address endPoint) {
             if (ns.live) {
-                ns.ioService.getEventService().executeEventCallback(new StripedRunnable() {
+                ns.serverContext.getEventService().executeEventCallback(new StripedRunnable() {
                     @Override
                     public void run() {
                         for (ConnectionListener listener : connectionListeners) {
@@ -269,7 +269,7 @@ class MockServer
             }
 
             int retries = sendTask.retries.get();
-            if (retries < RETRY_NUMBER && ns.ioService.isActive()) {
+            if (retries < RETRY_NUMBER && ns.serverContext.isNodeActive()) {
                 getOrConnect(target, true);
                 // TODO: Caution: may break the order guarantee of the packets sent from the same thread!
                 try {
@@ -356,8 +356,8 @@ class MockServer
     }
 
     @Override
-    public IOService getIoService() {
-        return ioService;
+    public ServerContext getContext() {
+        return serverContext;
     }
 
     @Override


### PR DESCRIPTION
This is in line with e.g NioNetworking.Context and invocation context.. The context contains
the dependencies for some service.

For EE see: https://github.com/hazelcast/hazelcast-enterprise/pull/3580