### PR TITLE
Fixes test failures caused by ClientFailoverConfig changes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientFailoverConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientFailoverConfig.java
@@ -16,8 +16,12 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.InvalidConfigurationException;
+
 import java.util.LinkedList;
 import java.util.List;
+
+import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.OFF;
 
 /**
  * Config class to configure multiple client configs to be used by single client instance
@@ -68,8 +72,8 @@ public class ClientFailoverConfig {
     }
 
     private void validateClientConfig(ClientConfig clientConfig) {
-//        if (clientConfig.getConnectionStrategyConfig().getReconnectMode() == OFF) {
-//            throw new InvalidConfigurationException("Reconnect mode for ClientFailoverConfig must not be OFF");
-//        }
+        if (clientConfig.getConnectionStrategyConfig().getReconnectMode() == OFF) {
+            throw new InvalidConfigurationException("Reconnect mode for ClientFailoverConfig must not be OFF");
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientFailoverConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientFailoverConfigTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,7 +36,6 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-@Ignore
 public class ClientFailoverConfigTest {
 
     @Rule
@@ -53,7 +51,7 @@ public class ClientFailoverConfigTest {
         assertThat(failoverConfig.getClientConfigs(), hasSize(1));
 
         ClientConfig clientConfig2 = new ClientConfig()
-            .setConnectionStrategyConfig(new ClientConnectionStrategyConfig().setReconnectMode(OFF));
+                .setConnectionStrategyConfig(new ClientConnectionStrategyConfig().setReconnectMode(OFF));
 
         expectedException.expect(InvalidConfigurationException.class);
         expectedException.expectMessage("Reconnect mode for ClientFailoverConfig must not be OFF");
@@ -64,7 +62,7 @@ public class ClientFailoverConfigTest {
     public void testSetClientConfigs_WithOffReconnectMode_ShouldThrowInvalidConfigException() {
         ClientConfig clientConfig1 = new ClientConfig();
         ClientConfig clientConfig2 = new ClientConfig()
-            .setConnectionStrategyConfig(new ClientConnectionStrategyConfig().setReconnectMode(OFF));
+                .setConnectionStrategyConfig(new ClientConnectionStrategyConfig().setReconnectMode(OFF));
 
         expectedException.expect(InvalidConfigurationException.class);
         expectedException.expectMessage("Reconnect mode for ClientFailoverConfig must not be OFF");

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
@@ -208,9 +208,9 @@ public class DeclarativeConfigFileHelper {
     }
 
     private String createFileWithDependencyImport(
-        String dependent,
-        String pathToDependency,
-        Function<String, String> fileContentWithImportResource) throws Exception {
+            String dependent,
+            String pathToDependency,
+            Function<String, String> fileContentWithImportResource) throws Exception {
         final String xmlContent = fileContentWithImportResource.apply(pathToDependency);
         givenConfigFileInWorkDir(dependent, xmlContent);
         return xmlContent;
@@ -227,7 +227,7 @@ public class DeclarativeConfigFileHelper {
         return ""
                 + HAZELCAST_CLIENT_START_TAG
                 + "  <instance-name>" + instanceName + "</instance-name>"
-                + "  <connection-strategy async-start=\"true\" reconnect-mode=\"OFF\">"
+                + "  <connection-strategy async-start=\"true\" >"
                 + "  </connection-strategy>"
                 + HAZELCAST_CLIENT_END_TAG;
     }
@@ -253,8 +253,7 @@ public class DeclarativeConfigFileHelper {
                 + "hazelcast-client:\n"
                 + "  instance-name: " + instanceName + "\n"
                 + "  connection-strategy:\n"
-                + "    async-start: true\n"
-                + "    reconnect-mode: OFF\n";
+                + "    async-start: true\n";
     }
 
     private String yamlFailoverClientConfig(int tryCount) {

--- a/hazelcast/src/test/resources/hazelcast-client-c1.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.xml
@@ -28,7 +28,7 @@
         </cluster-members>
     </network>
 
-    <connection-strategy async-start="true" reconnect-mode="OFF">
+    <connection-strategy async-start="true">
     </connection-strategy>
 
 </hazelcast-client>

--- a/hazelcast/src/test/resources/hazelcast-client-c1.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.yaml
@@ -21,6 +21,5 @@ hazelcast-client:
 
   connection-strategy:
     async-start: true
-    reconnect-mode: OFF
     connection-retry:
       enabled: false


### PR DESCRIPTION
Test failures caused by following pr.
see https://github.com/hazelcast/hazelcast/pull/16886

We have made ReconnectMode off illegal in Failover scenarios.
Some tests were using ReconnectMode OFF. This pr fixes those tests,
and reenables the improvement.