### PR TITLE
SQL project and filter operators

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.expression.ColumnExpression;
 import com.hazelcast.sql.impl.operation.QueryBatchExchangeOperation;
 import com.hazelcast.sql.impl.operation.QueryCancelOperation;
 import com.hazelcast.sql.impl.operation.QueryCheckOperation;
@@ -29,6 +30,8 @@ import com.hazelcast.sql.impl.operation.QueryCheckResponseOperation;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperation;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperationFragment;
 import com.hazelcast.sql.impl.operation.QueryFlowControlExchangeOperation;
+import com.hazelcast.sql.impl.plan.node.FilterPlanNode;
+import com.hazelcast.sql.impl.plan.node.ProjectPlanNode;
 import com.hazelcast.sql.impl.plan.node.RootPlanNode;
 import com.hazelcast.sql.impl.plan.node.io.ReceivePlanNode;
 import com.hazelcast.sql.impl.plan.node.io.RootSendPlanNode;
@@ -68,8 +71,12 @@ public class SqlDataSerializerHook implements DataSerializerHook {
     public static final int NODE_ROOT = 13;
     public static final int NODE_ROOT_SEND = 14;
     public static final int NODE_RECEIVE = 15;
+    public static final int NODE_PROJECT = 16;
+    public static final int NODE_FILTER = 17;
 
-    public static final int LEN = NODE_RECEIVE + 1;
+    public static final int EXPRESSION_COLUMN = 18;
+
+    public static final int LEN = EXPRESSION_COLUMN + 1;
 
     @Override
     public int getFactoryId() {
@@ -101,6 +108,10 @@ public class SqlDataSerializerHook implements DataSerializerHook {
         constructors[NODE_ROOT] = arg -> new RootPlanNode();
         constructors[NODE_ROOT_SEND] = arg -> new RootSendPlanNode();
         constructors[NODE_RECEIVE] = arg -> new ReceivePlanNode();
+        constructors[NODE_PROJECT] = arg -> new ProjectPlanNode();
+        constructors[NODE_FILTER] = arg -> new FilterPlanNode();
+
+        constructors[EXPRESSION_COLUMN] = arg -> new ColumnExpression<>();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/AbstractFilterExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/AbstractFilterExec.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * Abstract filter executor that removes rows from the output based on a condition.
  * <p>
- * Currently the executor batches rows, and reports progress only when the batch is full or when EOS has been raeched.
+ * Currently the executor batches rows, and reports progress only when the batch is full or when EOS has been reached.
  * This is done to minimize the operator evaluation overhead.
  * <p>
  * The compiled counterpart does not require batching.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/AbstractFilterExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/AbstractFilterExec.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.row.ListRowBatch;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.row.RowBatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract filter executor that removes rows from the output based on a condition.
+ * <p>
+ * Currently the executor batches rows, and reports progress only when the batch is full or when EOS has been raeched.
+ * This is done to minimize the operator evaluation overhead.
+ * <p>
+ * The compiled counterpart does not require batching.
+ */
+public abstract class AbstractFilterExec extends AbstractUpstreamAwareExec {
+
+    static final int BATCH_SIZE = 1024;
+
+    private List<Row> currentRows;
+    private ListRowBatch currentBatch;
+
+    protected AbstractFilterExec(int id, Exec upstream) {
+        super(id, upstream);
+    }
+
+    @Override
+    public IterationResult advance0() {
+        if (currentRows == null) {
+            currentRows = new ArrayList<>(BATCH_SIZE);
+            currentBatch = null;
+        }
+
+        int count = currentRows.size();
+
+        while (true) {
+            // Wait if cannot get more rows.
+            if (!state.advance()) {
+                return IterationResult.WAIT;
+            }
+
+            // Consume results until the batch is full.
+            for (Row upstreamRow : state) {
+                boolean matches = eval(upstreamRow);
+
+                if (matches) {
+                    currentRows.add(upstreamRow);
+
+                    if (++count == BATCH_SIZE) {
+                        return finalize(state.isDone() ? IterationResult.FETCHED_DONE : IterationResult.FETCHED);
+                    }
+                }
+            }
+
+            if (state.isDone()) {
+                return finalize(IterationResult.FETCHED_DONE);
+            }
+        }
+    }
+
+    private IterationResult finalize(IterationResult result) {
+        currentBatch = new ListRowBatch(currentRows);
+        currentRows = null;
+
+        return result;
+    }
+
+    @Override
+    public RowBatch currentBatch0() {
+        return currentBatch;
+    }
+
+    protected abstract boolean eval(Row row);
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/AbstractFilterExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/AbstractFilterExec.java
@@ -65,18 +65,18 @@ public abstract class AbstractFilterExec extends AbstractUpstreamAwareExec {
                     currentRows.add(upstreamRow);
 
                     if (++count == BATCH_SIZE) {
-                        return finalize(state.isDone() ? IterationResult.FETCHED_DONE : IterationResult.FETCHED);
+                        return prepareBatch(state.isDone() ? IterationResult.FETCHED_DONE : IterationResult.FETCHED);
                     }
                 }
             }
 
             if (state.isDone()) {
-                return finalize(IterationResult.FETCHED_DONE);
+                return prepareBatch(IterationResult.FETCHED_DONE);
             }
         }
     }
 
-    private IterationResult finalize(IterationResult result) {
+    private IterationResult prepareBatch(IterationResult result) {
         currentBatch = new ListRowBatch(currentRows);
         currentRows = null;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitor.java
@@ -29,8 +29,10 @@ import com.hazelcast.sql.impl.operation.QueryExecuteOperation;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperationFragment;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperationFragmentMapping;
 import com.hazelcast.sql.impl.operation.QueryOperationHandler;
+import com.hazelcast.sql.impl.plan.node.FilterPlanNode;
 import com.hazelcast.sql.impl.plan.node.PlanNode;
 import com.hazelcast.sql.impl.plan.node.PlanNodeVisitor;
+import com.hazelcast.sql.impl.plan.node.ProjectPlanNode;
 import com.hazelcast.sql.impl.plan.node.RootPlanNode;
 import com.hazelcast.sql.impl.plan.node.io.EdgeAwarePlanNode;
 import com.hazelcast.sql.impl.plan.node.io.ReceivePlanNode;
@@ -71,7 +73,7 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
     private final Map<Integer, InboundHandler> inboxes = new HashMap<>();
 
     /** Outboxes. */
-    private Map<Integer, Map<UUID, OutboundHandler>> outboxes = new HashMap<>();
+    private final Map<Integer, Map<UUID, OutboundHandler>> outboxes = new HashMap<>();
 
     public CreateExecPlanNodeVisitor(
         QueryOperationHandler operationHandler,
@@ -176,6 +178,28 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
         }
 
         return res;
+    }
+
+    @Override
+    public void onProjectNode(ProjectPlanNode node) {
+        Exec res = new ProjectExec(
+            node.getId(),
+            pop(),
+            node.getProjects()
+        );
+
+        push(res);
+    }
+
+    @Override
+    public void onFilterNode(FilterPlanNode node) {
+        Exec res = new FilterExec(
+            node.getId(),
+            pop(),
+            node.getFilter()
+        );
+
+        push(res);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/FilterExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/FilterExec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.row.Row;
+
+/**
+ * Filter executor.
+ */
+public class FilterExec extends AbstractFilterExec {
+
+    private final Expression<Boolean> filter;
+
+    public FilterExec(int id, Exec upstream, Expression<Boolean> filter) {
+        super(id, upstream);
+
+        this.filter = filter;
+    }
+
+    @Override
+    protected boolean eval(Row row) {
+        Boolean res = filter.eval(row, ctx);
+
+        return res != null && res;
+    }
+
+    public Expression<Boolean> getFilter() {
+        return filter;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/ProjectExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/ProjectExec.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.row.EmptyRowBatch;
+import com.hazelcast.sql.impl.row.HeapRow;
+import com.hazelcast.sql.impl.row.ListRowBatch;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.row.RowBatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Project executor. Get rows from the incoming batch, projects them, and put into the output batch.
+ */
+@SuppressWarnings("rawtypes")
+public class ProjectExec extends AbstractUpstreamAwareExec {
+
+    private final List<Expression> projects;
+    private RowBatch currentBatch;
+
+    public ProjectExec(int id, Exec upstream, List<Expression> projects) {
+        super(id, upstream);
+
+        this.projects = projects;
+    }
+
+    @Override
+    public IterationResult advance0() {
+        while (true) {
+            // Give up if no data is available.
+            if (!state.advance()) {
+                return IterationResult.WAIT;
+            }
+
+            // Skip empty input.
+            RowBatch upstreamBatch = state.consumeBatch();
+
+            if (upstreamBatch.getRowCount() == 0) {
+                if (state.isDone()) {
+                    currentBatch = EmptyRowBatch.INSTANCE;
+
+                    return IterationResult.FETCHED_DONE;
+                } else {
+                    continue;
+                }
+            }
+
+            // Perform projection.
+            currentBatch = projectBatch(upstreamBatch);
+
+            return state.isDone() ? IterationResult.FETCHED_DONE : IterationResult.FETCHED;
+        }
+    }
+
+    @Override
+    public RowBatch currentBatch0() {
+        return currentBatch;
+    }
+
+    public List<Expression> getProjects() {
+        return projects;
+    }
+
+    private RowBatch projectBatch(RowBatch upstreamBatch) {
+        List<Row> rows = new ArrayList<>(upstreamBatch.getRowCount());
+
+        for (int i = 0; i < upstreamBatch.getRowCount(); i++) {
+            Row upstreamRow = upstreamBatch.getRow(i);
+            Row row = projectRow(upstreamRow);
+
+            rows.add(row);
+        }
+
+        return new ListRowBatch(rows);
+    }
+
+    private Row projectRow(Row upstreamRow) {
+        HeapRow row = new HeapRow(projects.size());
+
+        int colIdx = 0;
+
+        for (Expression<?> projection : projects) {
+            Object projectionRes = projection.eval(upstreamRow, ctx);
+
+            row.set(colIdx++, projectionRes);
+        }
+
+        return row;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ColumnExpression.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ColumnExpression.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Column access expression.
+ */
+public class ColumnExpression<T> implements Expression<T>, IdentifiedDataSerializable {
+    /** Index in the row. */
+    private int index;
+
+    /** Type of the returned value. */
+    private QueryDataType type;
+
+    public ColumnExpression() {
+        // No-op.
+    }
+
+    private ColumnExpression(int index, QueryDataType type) {
+        this.index = index;
+        this.type = type;
+    }
+
+    public static ColumnExpression<?> create(int index, QueryDataType type) {
+        return new ColumnExpression<>(index, type);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override public T eval(Row row, ExpressionEvalContext context) {
+        return (T) row.get(index);
+    }
+
+    @Override
+    public QueryDataType getType() {
+        return type;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_COLUMN;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(index);
+        out.writeObject(type);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        index = in.readInt();
+        type = in.readObject();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, type);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ColumnExpression<?> that = (ColumnExpression<?>) o;
+
+        return index == that.index && type.equals(that.type);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/Expression.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/Expression.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.Serializable;
+
+/**
+ * Defines expression contract for SQL.
+ *
+ * <p>Java serialization is needed for Jet.
+ *
+ * @param <T> the return type of this expression.
+ */
+public interface Expression<T> extends DataSerializable, Serializable {
+    /**
+     * Evaluates this expression.
+     *
+     * @param row     the row to evaluate this expression on.
+     * @param context the expression evaluation context.
+     * @return the result produced by the evaluation.
+     */
+    T eval(Row row, ExpressionEvalContext context);
+
+    /**
+     * @return the return query data type of this expression.
+     */
+    QueryDataType getType();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/Expression.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/Expression.java
@@ -23,8 +23,6 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 /**
  * Defines expression contract for SQL.
  *
- * <p>Java serialization is needed for Jet.
- *
  * @param <T> the return type of this expression.
  */
 public interface Expression<T> extends DataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/Expression.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/Expression.java
@@ -20,8 +20,6 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
-import java.io.Serializable;
-
 /**
  * Defines expression contract for SQL.
  *
@@ -29,7 +27,7 @@ import java.io.Serializable;
  *
  * @param <T> the return type of this expression.
  */
-public interface Expression<T> extends DataSerializable, Serializable {
+public interface Expression<T> extends DataSerializable {
     /**
      * Evaluates this expression.
      *

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ExpressionEvalContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ExpressionEvalContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+/**
+ * Defines expression evaluation context contract for SQL {@link Expression
+ * expressions}.
+ *
+ * @see Expression#eval
+ */
+public interface ExpressionEvalContext {
+    /**
+     * @param index Argument index.
+     * @return The query argument.
+     */
+    Object getArgument(int index);
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/FilterPlanNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/FilterPlanNode.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.plan.node;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Filter node.
+ */
+public class FilterPlanNode extends UniInputPlanNode implements IdentifiedDataSerializable {
+
+    private Expression<Boolean> filter;
+
+    public FilterPlanNode() {
+        // No-op.
+    }
+
+    public FilterPlanNode(int id, PlanNode upstream, Expression<Boolean> filter) {
+        super(id, upstream);
+
+        assert filter != null;
+
+        this.filter = filter;
+    }
+
+    public Expression<Boolean> getFilter() {
+        return filter;
+    }
+
+    @Override
+    public void visit0(PlanNodeVisitor visitor) {
+        visitor.onFilterNode(this);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.NODE_FILTER;
+    }
+
+    @Override
+    public void writeData1(ObjectDataOutput out) throws IOException {
+        out.writeObject(filter);
+    }
+
+    @Override
+    public void readData1(ObjectDataInput in) throws IOException {
+        filter = in.readObject();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, filter, upstream);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FilterPlanNode that = (FilterPlanNode) o;
+
+        return id == that.id && filter.equals(that.filter) && upstream.equals(that.upstream);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/PlanNodeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/PlanNodeVisitor.java
@@ -34,6 +34,8 @@ public interface PlanNodeVisitor {
     void onRootNode(RootPlanNode node);
     void onReceiveNode(ReceivePlanNode node);
     void onRootSendNode(RootSendPlanNode node);
+    void onProjectNode(ProjectPlanNode node);
+    void onFilterNode(FilterPlanNode node);
 
     /**
      * Callback for a node without special handlers. For testing only.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/ProjectPlanNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/ProjectPlanNode.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.plan.node;
+
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Projection.
+ */
+@SuppressWarnings("rawtypes")
+public class ProjectPlanNode extends UniInputPlanNode implements IdentifiedDataSerializable {
+
+    private List<Expression> projects;
+
+    public ProjectPlanNode() {
+        // No-op.
+    }
+
+    public ProjectPlanNode(int id, PlanNode upstream, List<Expression> projects) {
+        super(id, upstream);
+
+        this.projects = projects;
+    }
+
+    public List<Expression> getProjects() {
+        return projects;
+    }
+
+    @Override
+    public void visit0(PlanNodeVisitor visitor) {
+        visitor.onProjectNode(this);
+    }
+
+    @Override
+    public PlanNodeSchema getSchema0() {
+        List<QueryDataType> types = new ArrayList<>(projects.size());
+
+        for (Expression project : projects) {
+            types.add(project.getType());
+        }
+
+        return new PlanNodeSchema(types);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.NODE_PROJECT;
+    }
+
+    @Override
+    public void writeData1(ObjectDataOutput out) throws IOException {
+        SerializationUtil.writeList(projects, out);
+    }
+
+    @Override
+    public void readData1(ObjectDataInput in) throws IOException {
+        projects = SerializationUtil.readList(in);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, projects, upstream);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ProjectPlanNode that = (ProjectPlanNode) o;
+
+        return id == that.id && projects.equals(that.projects) && upstream.equals(that.upstream);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.worker;
 
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.state.QueryStateCallback;
 
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
 /**
  * Context of a running query fragment.
  */
-public final class QueryFragmentContext {
+public final class QueryFragmentContext implements ExpressionEvalContext {
 
     private final List<Object> arguments;
     private final QueryFragmentScheduleCallback scheduleCallback;
@@ -41,6 +42,7 @@ public final class QueryFragmentContext {
         this.stateCallback = stateCallback;
     }
 
+    @Override
     public Object getArgument(int index) {
         assert index >= 0 && index < arguments.size();
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractExecTest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.sql.impl.exec;
 
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.row.EmptyRowBatch;
 import com.hazelcast.sql.impl.row.ListRowBatch;
 import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.sql.impl.state.QueryStateCallback;
 import com.hazelcast.sql.impl.worker.QueryFragmentContext;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -27,6 +30,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -69,6 +74,32 @@ public class AbstractExecTest extends SqlTestSupport {
         exec.currentBatch = new ListRowBatch();
 
         assertSame(exec.currentBatch, exec.currentBatch());
+    }
+
+    @Test
+    public void testCancel() {
+        QueryStateCallback stateCallback = new QueryStateCallback() {
+            @Override
+            public void onFragmentFinished() {
+                // No-op.
+            }
+
+            @Override
+            public void cancel(Exception e) {
+                // No-op.
+            }
+
+            @Override
+            public void checkCancelled() {
+                throw QueryException.cancelledByUser();
+            }
+        };
+
+        TestExec exec = new TestExec(1);
+        exec.setup(new QueryFragmentContext(Collections.emptyList(), null, stateCallback));
+
+        QueryException error = assertThrows(QueryException.class, exec::advance);
+        assertEquals(SqlErrorCode.CANCELLED_BY_USER, error.getCode());
     }
 
     private static final class TestExec extends AbstractExec {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/FilterExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/FilterExecTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.UpstreamExec;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.FunctionalPredicateExpression;
+import com.hazelcast.sql.impl.row.EmptyRowBatch;
+import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.sql.impl.exec.AbstractFilterExec.BATCH_SIZE;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class FilterExecTest extends SqlTestSupport {
+    @Test
+    public void testFilter() {
+        UpstreamExec upstream = new UpstreamExec(1);
+        Expression<Boolean> filter = new FunctionalPredicateExpression((row) -> {
+            int val = row.get(0);
+
+            if (val % 2 == 0) {
+                return true;
+            } else if ((val / 2) % 2 == 0) {
+                return false;
+            } else {
+                return null;
+            }
+        });
+
+        FilterExec exec = new FilterExec(2, upstream, filter);
+        exec.setup(emptyFragmentContext());
+
+        // Test empty state.
+        assertEquals(IterationResult.WAIT, exec.advance());
+
+        upstream.addResult(IterationResult.FETCHED, EmptyRowBatch.INSTANCE);
+        assertEquals(IterationResult.WAIT, exec.advance());
+
+        // Consume several batches, still insufficient to produce a result.
+        upstream.addResult(IterationResult.FETCHED, createMonotonicBatch(0, BATCH_SIZE / 2));
+        upstream.addResult(IterationResult.FETCHED, createMonotonicBatch(BATCH_SIZE / 2, BATCH_SIZE / 2));
+        upstream.addResult(IterationResult.FETCHED, createMonotonicBatch(BATCH_SIZE, BATCH_SIZE / 2));
+
+        assertEquals(IterationResult.WAIT, exec.advance());
+
+        // One more batch, finally producing some rows.
+        upstream.addResult(IterationResult.FETCHED, createMonotonicBatch(3 * BATCH_SIZE / 2, 3 * BATCH_SIZE / 2));
+
+        assertEquals(IterationResult.FETCHED, exec.advance());
+        checkBatch(exec.currentBatch(), 0, BATCH_SIZE);
+
+        // One more batch to finalize the results.
+        upstream.addResult(IterationResult.FETCHED_DONE, createMonotonicBatch(3 * BATCH_SIZE, BATCH_SIZE * 2));
+
+        assertEquals(IterationResult.FETCHED, exec.advance());
+        checkBatch(exec.currentBatch(), 2 * BATCH_SIZE, BATCH_SIZE);
+
+        assertEquals(IterationResult.FETCHED_DONE, exec.advance());
+        checkBatch(exec.currentBatch(), 4 * BATCH_SIZE, BATCH_SIZE / 2);
+    }
+
+    private static void checkBatch(RowBatch batch, int startValue, int size) {
+        assertEquals(size, batch.getRowCount());
+
+        for (int i = 0; i < size; i++) {
+            int value = batch.getRow(i).get(0);
+
+            assertEquals(startValue + (i * 2), value);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/ProjectExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/ProjectExecTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.UpstreamExec;
+import com.hazelcast.sql.impl.expression.ColumnExpression;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.row.EmptyRowBatch;
+import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ProjectExecTest extends SqlTestSupport {
+    @Test
+    public void testProject() {
+        UpstreamExec upstream = new UpstreamExec(1);
+        ProjectExec exec = createExec(upstream);
+
+        // Test empty.
+        assertEquals(IterationResult.WAIT, exec.advance());
+
+        upstream.addResult(IterationResult.FETCHED, EmptyRowBatch.INSTANCE);
+        assertEquals(IterationResult.WAIT, exec.advance());
+
+        // Test not last batch.
+        upstream.addResult(IterationResult.FETCHED, createMonotonicBatch(0, 100));
+        assertEquals(IterationResult.FETCHED, exec.advance());
+        checkBatch(exec.currentBatch(), 0, 100);
+
+        // Test last batch.
+        upstream.addResult(IterationResult.FETCHED_DONE, createMonotonicBatch(100, 100));
+        assertEquals(IterationResult.FETCHED_DONE, exec.advance());
+        checkBatch(exec.currentBatch(), 100, 100);
+
+        // Test empty last batch.
+        upstream = new UpstreamExec(1);
+        exec = createExec(upstream);
+
+        upstream.addResult(IterationResult.FETCHED, createMonotonicBatch(0, 100));
+        assertEquals(IterationResult.FETCHED, exec.advance());
+        checkBatch(exec.currentBatch(), 0, 100);
+
+        upstream.addResult(IterationResult.FETCHED_DONE, EmptyRowBatch.INSTANCE);
+        assertEquals(IterationResult.FETCHED_DONE, exec.advance());
+        assertEquals(0, exec.currentBatch().getRowCount());
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static ProjectExec createExec(UpstreamExec upstream) {
+        ColumnExpression<?> expression = ColumnExpression.create(0, QueryDataType.INT);
+        List<Expression> projects = Arrays.asList(expression, expression);
+
+        ProjectExec exec = new ProjectExec(2, upstream, projects);
+        exec.setup(emptyFragmentContext());
+
+        return exec;
+    }
+
+    private static void checkBatch(RowBatch batch, int startValue, int size) {
+        assertEquals(size, batch.getRowCount());
+
+        for (int i = 0; i < size; i++) {
+            int value0 = batch.getRow(i).get(0);
+            int value1 = batch.getRow(i).get(1);
+
+            assertEquals(startValue + i, value0);
+            assertEquals(startValue + i, value1);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/root/RootExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/root/RootExecTest.java
@@ -54,11 +54,8 @@ public class RootExecTest extends SqlTestSupport {
 
         RootExec exec = new RootExec(2, upstream, consumer, 8);
 
-        // Make sure that the context is propagated.
         QueryFragmentContext context = emptyFragmentContext();
-
         exec.setup(context);
-
         assertSame(context, consumer.getContext());
 
         assertEquals(IterationResult.WAIT, exec.advance());

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ColumnExpressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ColumnExpressionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.row.HeapRow;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static groovy.util.GroovyTestCase.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ColumnExpressionTest extends SqlTestSupport {
+    @Test
+    public void testColumnExpression() {
+        int index = 1;
+
+        ColumnExpression<?> expression = ColumnExpression.create(index, QueryDataType.INT);
+
+        assertEquals(QueryDataType.INT, expression.getType());
+
+        HeapRow row = HeapRow.of(new Object(), new Object(), new Object());
+        assertSame(row.get(index), expression.eval(row, SimpleExpressionEvalContext.create()));
+    }
+
+    @Test
+    public void testEquality() {
+        checkEquals(ColumnExpression.create(1, QueryDataType.INT), ColumnExpression.create(1, QueryDataType.INT), true);
+        checkEquals(ColumnExpression.create(1, QueryDataType.INT), ColumnExpression.create(1, QueryDataType.BIGINT), false);
+        checkEquals(ColumnExpression.create(1, QueryDataType.INT), ColumnExpression.create(2, QueryDataType.INT), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        ColumnExpression<?> original = ColumnExpression.create(1, QueryDataType.INT);
+        ColumnExpression<?> restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_COLUMN);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ConstantPredicateExpression.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ConstantPredicateExpression.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ConstantPredicateExpression implements Expression<Boolean> {
+
+    private boolean value;
+
+    public ConstantPredicateExpression() {
+        // No-op.
+    }
+
+    public ConstantPredicateExpression(boolean value) {
+        this.value = value;
+    }
+
+    @Override
+    public Boolean eval(Row row, ExpressionEvalContext context) {
+        return value;
+    }
+
+    @Override
+    public QueryDataType getType() {
+        return QueryDataType.BIT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeBoolean(value);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        value = in.readBoolean();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ConstantPredicateExpression that = (ConstantPredicateExpression) o;
+
+        return value == that.value;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/FunctionalPredicateExpression.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/FunctionalPredicateExpression.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.IOException;
+
+public class FunctionalPredicateExpression implements Expression<Boolean> {
+
+    private NullablePredicate predicate;
+
+    public FunctionalPredicateExpression() {
+        // No-op.
+    }
+
+    public FunctionalPredicateExpression(NullablePredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public Boolean eval(Row row, ExpressionEvalContext context) {
+        return predicate.test(row);
+    }
+
+    @Override
+    public QueryDataType getType() {
+        return QueryDataType.BIT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(predicate);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        predicate = in.readObject();
+    }
+
+    @FunctionalInterface
+    public interface NullablePredicate {
+        Boolean test(Row row);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/SimpleExpressionEvalContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/SimpleExpressionEvalContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class SimpleExpressionEvalContext implements ExpressionEvalContext {
+
+    private final List<Object> args;
+
+    public static SimpleExpressionEvalContext create(Object... args) {
+        if (args == null) {
+            args = new Object[0];
+        }
+
+        return new SimpleExpressionEvalContext(Arrays.asList(args));
+    }
+
+    private SimpleExpressionEvalContext(List<Object> args) {
+        this.args = args;
+    }
+
+    @Override
+    public Object getArgument(int index) {
+        return args.get(index);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/FilterPlanNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/FilterPlanNodeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.plan.node;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ConstantPredicateExpression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class FilterPlanNodeTest extends SqlTestSupport {
+    @Test
+    public void testState() {
+        MockPlanNode upstream = MockPlanNode.create(1, QueryDataType.INT);
+        ConstantPredicateExpression filter = new ConstantPredicateExpression(true);
+
+        FilterPlanNode node = new FilterPlanNode(2, upstream, filter);
+
+        assertEquals(2, node.getId());
+        assertEquals(upstream, node.getUpstream());
+        assertEquals(upstream.getSchema(), node.getSchema());
+        assertEquals(filter, node.getFilter());
+    }
+
+    @Test
+    public void testEquality() {
+        int id1 = 1;
+        int id2 = 2;
+
+        MockPlanNode upstream1 = MockPlanNode.create(3, QueryDataType.INT);
+        MockPlanNode upstream2 = MockPlanNode.create(3, QueryDataType.BIGINT);
+
+        ConstantPredicateExpression filter1 = new ConstantPredicateExpression(true);
+        ConstantPredicateExpression filter2 = new ConstantPredicateExpression(false);
+
+        checkEquals(new FilterPlanNode(id1, upstream1, filter1), new FilterPlanNode(id1, upstream1, filter1), true);
+        checkEquals(new FilterPlanNode(id1, upstream1, filter1), new FilterPlanNode(id2, upstream1, filter1), false);
+        checkEquals(new FilterPlanNode(id1, upstream1, filter1), new FilterPlanNode(id1, upstream2, filter1), false);
+        checkEquals(new FilterPlanNode(id1, upstream1, filter1), new FilterPlanNode(id1, upstream1, filter2), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        MockPlanNode upstream = MockPlanNode.create(1, QueryDataType.INT);
+        ConstantPredicateExpression filter = new ConstantPredicateExpression(true);
+
+        FilterPlanNode original = new FilterPlanNode(1, upstream, filter);
+        FilterPlanNode restored = serializeAndCheck(original, SqlDataSerializerHook.NODE_FILTER);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/ProjectPlanNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/ProjectPlanNodeTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.plan.node;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ColumnExpression;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("rawtypes")
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ProjectPlanNodeTest extends SqlTestSupport {
+    @Test
+    public void testState() {
+        MockPlanNode upstream = MockPlanNode.create(1, QueryDataType.INT, QueryDataType.BIGINT, QueryDataType.DOUBLE);
+        List<Expression> projects =
+            Arrays.asList(ColumnExpression.create(1, QueryDataType.BIGINT), ColumnExpression.create(2, QueryDataType.DOUBLE));
+
+        ProjectPlanNode node = new ProjectPlanNode(2, upstream, projects);
+
+        PlanNodeSchema expectedSchema = new PlanNodeSchema(Arrays.asList(QueryDataType.BIGINT, QueryDataType.DOUBLE));
+
+        assertEquals(2, node.getId());
+        assertEquals(upstream, node.getUpstream());
+        assertEquals(projects, node.getProjects());
+        assertEquals(expectedSchema, node.getSchema());
+    }
+
+    @Test
+    public void testEquality() {
+        int id1 = 1;
+        int id2 = 2;
+
+        MockPlanNode upstream1 = MockPlanNode.create(3, QueryDataType.INT, QueryDataType.BIGINT);
+        MockPlanNode upstream2 = MockPlanNode.create(3, QueryDataType.INT, QueryDataType.DOUBLE);
+
+        List<Expression> projects1 = Collections.singletonList(ColumnExpression.create(0, QueryDataType.INT));
+        List<Expression> projects2 = Collections.singletonList(ColumnExpression.create(1, QueryDataType.BIGINT));
+
+        checkEquals(new ProjectPlanNode(id1, upstream1, projects1), new ProjectPlanNode(id1, upstream1, projects1), true);
+        checkEquals(new ProjectPlanNode(id1, upstream1, projects1), new ProjectPlanNode(id2, upstream1, projects1), false);
+        checkEquals(new ProjectPlanNode(id1, upstream1, projects1), new ProjectPlanNode(id1, upstream2, projects1), false);
+        checkEquals(new ProjectPlanNode(id1, upstream1, projects1), new ProjectPlanNode(id1, upstream1, projects2), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        MockPlanNode upstream = MockPlanNode.create(1, QueryDataType.INT);
+        List<Expression> projects = Collections.singletonList(ColumnExpression.create(0, QueryDataType.INT));
+
+        ProjectPlanNode original = new ProjectPlanNode(2, upstream, projects);
+        ProjectPlanNode restored = serializeAndCheck(original, SqlDataSerializerHook.NODE_PROJECT);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/TestPlanNodeVisitorAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/TestPlanNodeVisitorAdapter.java
@@ -36,6 +36,16 @@ public abstract class TestPlanNodeVisitorAdapter implements PlanNodeVisitor {
     }
 
     @Override
+    public void onProjectNode(ProjectPlanNode node) {
+        // No-op.
+    }
+
+    @Override
+    public void onFilterNode(FilterPlanNode node) {
+        // No-op.
+    }
+
+    @Override
     public void onOtherNode(PlanNode node) {
         // No-op.
     }


### PR DESCRIPTION
Implemented project and filter operators.

Limitations:
1. We have hard-coded batch size inside the `FilterExec` for now because we do not have a memory management yet. In the future we will switch to dynamic memory allocation.

Closes #16893