### PR TITLE
Remove hazelcast-aws test dependency

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -328,13 +328,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-aws</artifactId>
-            <version>3.1</version>
-            <optional>true</optional>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>${hamcrest.version}</version>


### PR DESCRIPTION
I think it's not needed. 

Found thanks to @pivovarit 