### PR TITLE
Do not assume resolved cache config in pre-join op

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -762,7 +762,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         OnJoinCacheOperation preJoinCacheOperation;
         preJoinCacheOperation = new OnJoinCacheOperation();
         for (Map.Entry<String, CompletableFuture<CacheConfig>> cacheConfigEntry : configs.entrySet()) {
-            CacheConfig cacheConfig = new PreJoinCacheConfig(cacheConfigEntry.getValue().join());
+            CacheConfig cacheConfig = new PreJoinCacheConfig(cacheConfigEntry.getValue().join(), false);
             preJoinCacheOperation.addCacheConfig(cacheConfig);
         }
         return preJoinCacheOperation;


### PR DESCRIPTION
When cache service is creating its pre-join
operation, it creates a `PreJoinCacheConfig`
assuming that the `CacheConfig` has been resolved
(ie KV types and other user customizations
have been actually loaded). However it might
be the case that even though the `CacheConfig` is
registered in cache service, the cache has not
yet been touched, so user customizations are not
resolved yet.

Fixes #16912 