### PR TITLE
Fix max latency probe names for ReplicatedMap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -278,13 +278,13 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats, Jso
         return convertNanosToMillis(totalRemoveLatenciesNanos);
     }
 
-    @Probe(name = REPLICATED_MAP_MAX_GET_LATENCY, unit = MS)
+    @Probe(name = REPLICATED_MAP_MAX_PUT_LATENCY, unit = MS)
     @Override
     public long getMaxPutLatency() {
         return convertNanosToMillis(maxPutLatencyNanos);
     }
 
-    @Probe(name = REPLICATED_MAP_MAX_PUT_LATENCY, unit = MS)
+    @Probe(name = REPLICATED_MAP_MAX_GET_LATENCY, unit = MS)
     @Override
     public long getMaxGetLatency() {
         return convertNanosToMillis(maxGetLatencyNanos);


### PR DESCRIPTION
* Fixes mismatching `max*Latency` probe names for ReplicatedMap
* Introduced in #16795, so it's enough to fix it for 4.1