### PR TITLE
Connection count and getActiveConnections cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -72,7 +72,7 @@ import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.server.tcp.DefaultChannelInitializerProvider;
+import com.hazelcast.internal.server.tcp.ChannelInitializerFunction;
 import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.tcp.PacketDecoder;
 import com.hazelcast.internal.server.tcp.PacketEncoder;
@@ -317,7 +317,7 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public Function<EndpointQualifier, ChannelInitializer> createChannelInitializerFn(ServerContext serverContext) {
-        DefaultChannelInitializerProvider provider = new DefaultChannelInitializerProvider(serverContext, node.getConfig());
+        ChannelInitializerFunction provider = new ChannelInitializerFunction(serverContext, node.getConfig());
         provider.init();
         return provider;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/AbstractChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/AbstractChannelInitializer.java
@@ -177,7 +177,7 @@ public abstract class AbstractChannelInitializer
                     if (logger.isLoggable(Level.FINEST)) {
                         logger.finest("Registering connection " + connection + " to address alias " + remoteAddressAlias);
                     }
-                    connectionManager.connectionsMap.putIfAbsent(remoteAddressAlias, connection);
+                    connectionManager.mappedConnections.putIfAbsent(remoteAddressAlias, connection);
                 }
             }
 
@@ -193,7 +193,7 @@ public abstract class AbstractChannelInitializer
                                 + ", new one is " + connection);
                     }
                     // todo probably it's already in activeConnections (ConnectTask , AcceptorIOThread)
-                    connectionManager.activeConnections.add(connection);
+                    connectionManager.connections.add(connection);
                 }
                 return true;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ChannelInitializerFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ChannelInitializerFunction.java
@@ -31,14 +31,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-public class DefaultChannelInitializerProvider implements Function<EndpointQualifier, ChannelInitializer> {
+public class ChannelInitializerFunction implements Function<EndpointQualifier, ChannelInitializer> {
 
     protected final ServerContext serverContext;
     private final ChannelInitializer uniChannelInitializer;
     private final Config config;
     private volatile Map<EndpointQualifier, ChannelInitializer> initializerMap;
 
-    public DefaultChannelInitializerProvider(ServerContext serverContext, Config config) {
+    public ChannelInitializerFunction(ServerContext serverContext, Config config) {
         checkSslConfigAvailability(config);
         this.serverContext = serverContext;
         this.uniChannelInitializer = new UnifiedChannelInitializer(serverContext);
@@ -52,8 +52,7 @@ public class DefaultChannelInitializerProvider implements Function<EndpointQuali
 
     public void init() {
         AdvancedNetworkConfig advancedNetworkConfig = config.getAdvancedNetworkConfig();
-        if (!advancedNetworkConfig.isEnabled()
-                || advancedNetworkConfig.getEndpointConfigs().isEmpty()) {
+        if (!advancedNetworkConfig.isEnabled() || advancedNetworkConfig.getEndpointConfigs().isEmpty()) {
             initializerMap = Collections.emptyMap();
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServer.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.nio.ConnectionListener;
@@ -37,8 +36,8 @@ import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.logging.ILogger;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,8 +52,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX;
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadPoolName;
 import static com.hazelcast.spi.properties.ClusterProperty.NETWORK_STATS_REFRESH_INTERVAL_SECONDS;
 import static java.util.Collections.emptyMap;
@@ -146,7 +147,7 @@ public final class TcpServer implements Server {
 
         if (unifiedConnectionManager == null) {
             refreshStatsFuture = metricsRegistry
-                    .scheduleAtFixedRate(refreshStatsTask, refreshStatsIntervalSeconds, SECONDS, ProbeLevel.INFO);
+                    .scheduleAtFixedRate(refreshStatsTask, refreshStatsIntervalSeconds, SECONDS, INFO);
         }
     }
 
@@ -187,44 +188,28 @@ public final class TcpServer implements Server {
     }
 
     @Override
-    public Collection<ServerConnection> getConnections() {
+    public @Nonnull
+    Collection<ServerConnection> getConnections() {
         if (unifiedConnectionManager != null) {
             return unifiedConnectionManager.getConnections();
         }
 
-        Set<ServerConnection> connections = null;
+        Set<ServerConnection> connections = new HashSet<>();
         for (TcpServerConnectionManager connectionManager : connectionManagers.values()) {
-            Collection<ServerConnection> endpointConnections = connectionManager.getConnections();
-            if (endpointConnections != null && !endpointConnections.isEmpty()) {
-                if (connections == null) {
-                    connections = new HashSet<>();
-                }
-
-                connections.addAll(endpointConnections);
-            }
+            connections.addAll(connectionManager.getConnections());
         }
-
-        return connections == null ? Collections.emptySet() : connections;
+        return connections;
     }
 
     @Override
-    public Collection<ServerConnection> getActiveConnections() {
+    public int connectionCount(Predicate<ServerConnection> predicate) {
         if (unifiedConnectionManager != null) {
-            return unifiedConnectionManager.getActiveConnections();
+            return unifiedConnectionManager.connectionCount(predicate);
         }
-
-        Set<ServerConnection> connections = null;
-        for (TcpServerConnectionManager connectionManager : connectionManagers.values()) {
-            Collection<ServerConnection> endpointConnections = connectionManager.getActiveConnections();
-            if (endpointConnections != null && !endpointConnections.isEmpty()) {
-                if (connections == null) {
-                    connections = new HashSet<>();
-                }
-
-                connections.addAll(endpointConnections);
-            }
-        }
-        return connections == null ? Collections.emptySet() : connections;
+        return connectionManagers.values()
+                .stream()
+                .mapToInt(connectionManager -> connectionManager.connectionCount(predicate))
+                .sum();
     }
 
     @Override
@@ -233,22 +218,21 @@ public final class TcpServer implements Server {
             return emptyMap();
         }
 
-        Map<EndpointQualifier, NetworkStats> stats = null;
+        Map<EndpointQualifier, NetworkStats> stats = new HashMap<>();
         for (Map.Entry<EndpointQualifier, TcpServerConnectionManager> entry : connectionManagers.entrySet()) {
-            if (stats == null) {
-                stats = new HashMap<>();
-            }
             stats.put(entry.getKey(), entry.getValue().getNetworkStats());
         }
-        return stats == null ? emptyMap() : stats;
+        return stats;
     }
+
 
     @Override
     public void addConnectionListener(ConnectionListener<ServerConnection> listener) {
         if (unifiedConnectionManager != null) {
             unifiedConnectionManager.addConnectionListener(listener);
         } else {
-            connectionManagers.values().forEach(manager -> manager.addConnectionListener(listener));
+            connectionManagers.values()
+                    .forEach(manager -> manager.addConnectionListener(listener));
         }
     }
 
@@ -265,7 +249,7 @@ public final class TcpServer implements Server {
         return connectionManager;
     }
 
-    public void scheduleDeferred(Runnable task, long delay, TimeUnit unit) {
+    void scheduleDeferred(Runnable task, long delay, TimeUnit unit) {
         scheduler.schedule(task, delay, unit);
     }
 
@@ -315,9 +299,9 @@ public final class TcpServer implements Server {
 
         void registerMetrics(MetricsRegistry metricsRegistry) {
             for (ProtocolType type : ProtocolType.valuesAsSet()) {
-                metricsRegistry.registerStaticProbe(this, "tcp.bytesReceived." + type.name(), ProbeLevel.INFO,
+                metricsRegistry.registerStaticProbe(this, "tcp.bytesReceived." + type.name(), INFO,
                         (LongProbeFunction<RefreshNetworkStatsTask>) source -> bytesReceivedPerProtocol.get(type).get());
-                metricsRegistry.registerStaticProbe(this, "tcp.bytesSend." + type.name(), ProbeLevel.INFO,
+                metricsRegistry.registerStaticProbe(this, "tcp.bytesSend." + type.name(), INFO,
                         (LongProbeFunction<RefreshNetworkStatsTask>) source -> bytesSentPerProtocol.get(type).get());
             }
         }
@@ -356,8 +340,8 @@ public final class TcpServer implements Server {
             if (unifiedConnectionManager != null) {
                 unifiedConnectionManager.provideDynamicMetrics(descriptor.copy(), context);
             } else {
-                connectionManagers.values().forEach(
-                        manager -> manager.provideDynamicMetrics(descriptor.copy(), context));
+                connectionManagers.values()
+                        .forEach(manager -> manager.provideDynamicMetrics(descriptor.copy(), context));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
@@ -22,7 +22,7 @@ import com.hazelcast.logging.ILogger;
 
 import static java.lang.System.currentTimeMillis;
 
-public class TcpServerConnectionErrorHandler {
+class TcpServerConnectionErrorHandler {
 
     private final ILogger logger;
     private final ServerContext serverContext;
@@ -40,18 +40,14 @@ public class TcpServerConnectionErrorHandler {
         this.logger = serverContext.getLoggingService().getLogger(getClass());
     }
 
-    public Address getEndPoint() {
-        return endPoint;
-    }
-
-    public synchronized void onError(Throwable t) {
-        String errorMessage = "An error occurred on connection to " + endPoint + getCauseDescription(t);
+    synchronized void onError(Throwable cause) {
+        String errorMessage = "An error occurred on connection to " + endPoint + getCauseDescription(cause);
         logger.finest(errorMessage);
         final long now = currentTimeMillis();
         final long last = lastFaultTime;
         if (now - last > minInterval) {
             if (faults++ >= maxFaults) {
-                String removeEndpointMessage = "Removing connection to endpoint " + endPoint + getCauseDescription(t);
+                String removeEndpointMessage = "Removing connection to endpoint " + endPoint + getCauseDescription(cause);
                 logger.warning(removeEndpointMessage);
                 serverContext.removeEndpoint(endPoint);
             }
@@ -59,17 +55,17 @@ public class TcpServerConnectionErrorHandler {
         }
     }
 
-    public synchronized void reset() {
+    synchronized void reset() {
         String resetMessage = "Resetting connection monitor for endpoint " + endPoint;
         logger.finest(resetMessage);
         faults = 0;
         lastFaultTime = 0L;
     }
 
-    private String getCauseDescription(Throwable t) {
+    private String getCauseDescription(Throwable cause) {
         StringBuilder s = new StringBuilder(" Cause => ");
-        if (t != null) {
-            s.append(t.getClass().getName()).append(" {").append(t.getMessage()).append("}");
+        if (cause != null) {
+            s.append(cause.getClass().getName()).append(" {").append(cause.getMessage()).append("}");
         } else {
             s.append("Unknown");
         }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/AbstractOutOfMemoryHandlerTest.java
@@ -30,9 +30,10 @@ import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSupport {
@@ -81,22 +82,12 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
             }
 
             @Override
-            public Set getActiveConnections() {
-                return null;
-            }
-
-            @Override
-            public Collection getConnections() {
-                return null;
+            public @Nonnull Collection getConnections() {
+                return Collections.emptyList();
             }
 
             @Override
             public ServerConnection get(Address address) {
-                return null;
-            }
-
-            @Override
-            public ServerConnection getOrConnect(Address address) {
                 return null;
             }
 
@@ -144,13 +135,8 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
         }
 
         @Override
-        public Collection<ServerConnection> getConnections() {
-            return null;
-        }
-
-        @Override
-        public Collection<ServerConnection> getActiveConnections() {
-            return null;
+        public @Nonnull Collection<ServerConnection> getConnections() {
+            return Collections.emptyList();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -70,7 +70,7 @@ import static com.hazelcast.internal.util.UuidUtil.newUnsecureUUID;
 import static com.hazelcast.spi.properties.ClusterProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
 import static com.hazelcast.test.Accessors.getAddress;
 import static com.hazelcast.test.Accessors.getClusterService;
-import static com.hazelcast.test.Accessors.getConnectionManagerManager;
+import static com.hazelcast.test.Accessors.getConnectionManager;
 import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.OverridePropertyRule.clear;
@@ -777,9 +777,9 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(2, hz1, hz3);
 
-        assertNull(getConnectionManagerManager(hz1).get(target));
+        assertNull(getConnectionManager(hz1).get(target));
 
-        ServerConnectionManager cm3 = getConnectionManagerManager(hz3);
+        ServerConnectionManager cm3 = getConnectionManager(hz3);
         assertTrueEventually(() -> assertNull(cm3.get(target)));
     }
 
@@ -798,10 +798,10 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         Address target = getAddress(hz3);
 
         ConnectionRemovedListener connListener1 = new ConnectionRemovedListener(target);
-        getConnectionManagerManager(hz1).addConnectionListener(connListener1);
+        getConnectionManager(hz1).addConnectionListener(connListener1);
 
         ConnectionRemovedListener connListener2 = new ConnectionRemovedListener(target);
-        getConnectionManagerManager(hz2).addConnectionListener(connListener2);
+        getConnectionManager(hz2).addConnectionListener(connListener2);
 
         dropOperationsBetween(hz3, hz1, F_ID, singletonList(HEARTBEAT));
         // Artificially suspect from hz3

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -67,12 +68,7 @@ public class FirewallingServer
     }
 
     @Override
-    public Collection getActiveConnections() {
-        return delegate.getActiveConnections();
-    }
-
-    @Override
-    public Collection getConnections() {
+    public @Nonnull Collection getConnections() {
         return delegate.getConnections();
     }
 
@@ -190,10 +186,6 @@ public class FirewallingServer
             delegate.accept(packet);
         }
 
-        @Override
-        public synchronized ServerConnection getOrConnect(Address address, boolean silent) {
-            return getOrConnect(address);
-        }
 
         public synchronized void blockNewConnection(Address address) {
             blockedAddresses.add(address);
@@ -285,13 +277,8 @@ public class FirewallingServer
         }
 
         @Override
-        public Collection<ServerConnection> getConnections() {
+        public @Nonnull Collection<ServerConnection> getConnections() {
             return delegate.getConnections();
-        }
-
-        @Override
-        public Collection<ServerConnection> getActiveConnections() {
-            return delegate.getActiveConnections();
         }
 
         @Override
@@ -300,7 +287,7 @@ public class FirewallingServer
         }
 
         @Override
-        public ServerConnection getOrConnect(Address address) {
+        public synchronized ServerConnection getOrConnect(Address address, boolean silent) {
             return delegate.getOrConnect(address);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
@@ -188,7 +188,8 @@ public class MemberHandshakeHandlerTest {
     private void assertExpectedAddressesRegistered()
             throws IllegalAccessException {
         // inspect connections in TcpIpEndpointManager
-        ConcurrentHashMap<Address, TcpServerConnection> connectionsMap = getFieldValueReflectively(connectionManager, "connectionsMap");
+        ConcurrentHashMap<Address, TcpServerConnection> connectionsMap
+                = getFieldValueReflectively(connectionManager, "mappedConnections");
         try {
             for (Address address : expectedAddresses) {
                 assertTrue(connectionsMap.containsKey(address));

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ServerConnectionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ServerConnectionManagerTest.java
@@ -41,7 +41,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Predicate;
 
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.Accessors.getSerializationService;
@@ -84,13 +87,13 @@ public class Invocation_ServerConnectionManagerTest
         }
 
         @Override
-        public Collection<ServerConnection> getConnections() {
-            return null;
+        public @Nonnull Collection<ServerConnection> getConnections() {
+            return Collections.emptyList();
         }
 
         @Override
-        public Collection<ServerConnection> getActiveConnections() {
-            return null;
+        public int connectionCount(Predicate<ServerConnection> predicate) {
+            return 0;
         }
 
         @Override
@@ -101,11 +104,6 @@ public class Invocation_ServerConnectionManagerTest
         @Override
         public ServerConnection get(Address address) {
             return null;
-        }
-
-        @Override
-        public ServerConnection getOrConnect(Address address) {
-            throw new UnsupportedOperationException(EXPECTED_MSG);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
@@ -73,7 +73,7 @@ public class Accessors {
         return (ClientEngineImpl) getNode(instance).getClientEngine();
     }
 
-    public static ServerConnectionManager getConnectionManagerManager(HazelcastInstance hz) {
+    public static ServerConnectionManager getConnectionManager(HazelcastInstance hz) {
         return getNode(hz).getServer().getConnectionManager(EndpointQualifier.MEMBER);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -280,7 +280,7 @@ public abstract class HazelcastTestSupport {
 
     public static Packet toPacket(HazelcastInstance local, HazelcastInstance remote, Operation operation) {
         InternalSerializationService serializationService = Accessors.getSerializationService(local);
-        ServerConnectionManager connectionManager = Accessors.getConnectionManagerManager(local);
+        ServerConnectionManager connectionManager = Accessors.getConnectionManager(local);
 
         return new Packet(serializationService.toBytes(operation), operation.getPartitionId())
                 .setPacketType(Packet.Type.OPERATION)


### PR DESCRIPTION
Dropped 'getConnections' functionality which is purely the mapped connections.

The getActiveConnections has been renamed to getConnections. 

Some improvements for retrieving connection count statistics and some minor other cleanups.