### PR TITLE
Add SASL authentication support to LdapAuthenticationConfig

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -4979,6 +4979,8 @@
 
             <xs:element name="system-user-dn" type="xs:string" minOccurs="0"/>
             <xs:element name="system-user-password" type="xs:string" minOccurs="0"/>
+            <xs:element name="system-authentication" type="xs:string" minOccurs="0"/>
+            <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
             <xs:element name="password-attribute" type="xs:string" minOccurs="0"/>
             <xs:element name="user-context" type="xs:string" minOccurs="0"/>
             <xs:element name="user-filter" type="xs:string" minOccurs="0"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -635,6 +635,8 @@
                                 <hz:user-name-attribute>userNameAttribute</hz:user-name-attribute>
                                 <hz:system-user-dn>systemUserDn</hz:system-user-dn>
                                 <hz:system-user-password>systemUserPassword</hz:system-user-password>
+                                <hz:system-authentication>simple</hz:system-authentication>
+                                <hz:security-realm>realmName</hz:security-realm>
                                 <hz:password-attribute>passwordAttribute</hz:password-attribute>
                                 <hz:user-context>userContext</hz:user-context>
                                 <hz:user-filter>userFilter</hz:user-filter>
@@ -662,8 +664,8 @@
                                 <hz:security-realm>krb5Acceptor</hz:security-realm>
                                 <hz:ldap>
                                     <hz:url>ldap://127.0.0.1/</hz:url>
-                                    <hz:system-user-dn>uid=admin,ou=system</hz:system-user-dn>
-                                    <hz:system-user-password>secret</hz:system-user-password>
+                                    <hz:system-authentication>GSSAPI</hz:system-authentication>
+                                    <hz:security-realm>krb5Initiator</hz:security-realm>
                                     <hz:skip-authentication>true</hz:skip-authentication>
                                     <hz:user-filter>(krb5PrincipalName={login})</hz:user-filter>
                                     <hz:role-mapping-attribute>cn</hz:role-mapping-attribute>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -344,6 +344,8 @@ public class ConfigXmlGenerator {
             .nodeIfContents("user-name-attribute", c.getUserNameAttribute())
             .nodeIfContents("system-user-dn", c.getSystemUserDn())
             .nodeIfContents("system-user-password", c.getSystemUserPassword())
+            .nodeIfContents("system-authentication", c.getSystemAuthentication())
+            .nodeIfContents("security-realm", c.getSecurityRealm())
             .nodeIfContents("password-attribute", c.getPasswordAttribute())
             .nodeIfContents("user-context", c.getUserContext())
             .nodeIfContents("user-filter", c.getUserFilter())

--- a/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
@@ -36,6 +36,7 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
     private String socketFactoryClassName;
     private String systemUserDn;
     private String systemUserPassword;
+    private String systemAuthentication;
 
     // BasicLdapLoginModule
     private boolean parseDn;
@@ -54,6 +55,7 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
     private String userFilter;
     private LdapSearchScope userSearchScope;
     private Boolean skipAuthentication;
+    private String securityRealm;
 
     public String getUrl() {
         return url;
@@ -217,6 +219,24 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
         return this;
     }
 
+    public String getSecurityRealm() {
+        return securityRealm;
+    }
+
+    public LdapAuthenticationConfig setSecurityRealm(String securityRealm) {
+        this.securityRealm = securityRealm;
+        return this;
+    }
+
+    public String getSystemAuthentication() {
+        return systemAuthentication;
+    }
+
+    public LdapAuthenticationConfig setSystemAuthentication(String systemAuthentication) {
+        this.systemAuthentication = systemAuthentication;
+        return this;
+    }
+
     @Override
     protected Properties initLoginModuleProperties() {
         Properties props = super.initLoginModuleProperties();
@@ -232,24 +252,26 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
         setIfConfigured(props, "roleSearchScope", roleSearchScope);
         setIfConfigured(props, "userNameAttribute", userNameAttribute);
 
-        if (!isNullOrEmpty(systemUserDn)) {
-            props.setProperty(Context.SECURITY_AUTHENTICATION, "simple");
-            props.setProperty(Context.SECURITY_PRINCIPAL, systemUserDn);
+        boolean useSystemAccount = !isNullOrEmpty(systemUserDn) || !isNullOrEmpty(systemAuthentication);
+        if (useSystemAccount) {
+            setIfConfigured(props, Context.SECURITY_AUTHENTICATION, systemAuthentication);
+            setIfConfigured(props, Context.SECURITY_PRINCIPAL, systemUserDn);
             setIfConfigured(props, Context.SECURITY_CREDENTIALS, systemUserPassword);
             setIfConfigured(props, "passwordAttribute", passwordAttribute);
             setIfConfigured(props, "userContext", userContext);
             setIfConfigured(props, "userFilter", userFilter);
             setIfConfigured(props, "userSearchScope", userSearchScope);
             setIfConfigured(props, "skipAuthentication", skipAuthentication);
+            setIfConfigured(props, "securityRealm", securityRealm);
         }
         return props;
     }
 
     @Override
     public LoginModuleConfig[] asLoginModuleConfigs() {
-        boolean useSystemUser = !isNullOrEmpty(systemUserDn);
+        boolean useSystemAccount = !isNullOrEmpty(systemUserDn) || !isNullOrEmpty(systemAuthentication);
         LoginModuleConfig loginModuleConfig = new LoginModuleConfig(
-                useSystemUser ? "com.hazelcast.security.loginimpl.LdapLoginModule"
+                useSystemAccount ? "com.hazelcast.security.loginimpl.LdapLoginModule"
                         : "com.hazelcast.security.loginimpl.BasicLdapLoginModule",
                 LoginModuleUsage.REQUIRED);
 
@@ -261,24 +283,24 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
     @Override
     public String toString() {
         return "LdapAuthenticationConfig [url=" + url + ", socketFactoryClassName=" + socketFactoryClassName + ", systemUserDn="
-                + systemUserDn + ", systemUserPassword=***, parseDn=" + parseDn + ", roleContext="
-                + roleContext + ", roleFilter=" + roleFilter + ", roleMappingAttribute=" + roleMappingAttribute
-                + ", roleMappingMode=" + roleMappingMode + ", roleNameAttribute=" + roleNameAttribute
-                + ", roleRecursionMaxDepth=" + roleRecursionMaxDepth + ", roleSearchScope=" + roleSearchScope
-                + ", userNameAttribute=" + userNameAttribute + ", passwordAttribute=" + passwordAttribute + ", userContext="
-                + userContext + ", userFilter=" + userFilter + ", userSearchScope=" + userSearchScope + ", skipAuthentication="
-                + skipAuthentication + ", getSkipIdentity()=" + getSkipIdentity() + ", getSkipEndpoint()=" + getSkipEndpoint()
-                + ", getSkipRole()=" + getSkipRole() + "]";
+                + systemUserDn + ", systemUserPassword=***, parseDn=" + parseDn + ", roleContext=" + roleContext
+                + ", roleFilter=" + roleFilter + ", roleMappingAttribute=" + roleMappingAttribute + ", roleMappingMode="
+                + roleMappingMode + ", roleNameAttribute=" + roleNameAttribute + ", roleRecursionMaxDepth="
+                + roleRecursionMaxDepth + ", roleSearchScope=" + roleSearchScope + ", userNameAttribute=" + userNameAttribute
+                + ", passwordAttribute=" + passwordAttribute + ", userContext=" + userContext + ", userFilter=" + userFilter
+                + ", userSearchScope=" + userSearchScope + ", skipAuthentication=" + skipAuthentication + ", securityRealm="
+                + securityRealm + ", systemAuthentication=" + systemAuthentication + ", getSkipIdentity()=" + getSkipIdentity()
+                + ", getSkipEndpoint()=" + getSkipEndpoint() + ", getSkipRole()=" + getSkipRole() + "]";
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result
-                + Objects.hash(parseDn, passwordAttribute, roleContext, roleFilter, roleMappingAttribute, roleMappingMode,
-                        roleNameAttribute, roleRecursionMaxDepth, roleSearchScope, skipAuthentication, socketFactoryClassName,
-                        systemUserDn, systemUserPassword, url, userContext, userFilter, userNameAttribute, userSearchScope);
+        result = prime * result + Objects.hash(parseDn, passwordAttribute, roleContext, roleFilter, roleMappingAttribute,
+                roleMappingMode, roleNameAttribute, roleRecursionMaxDepth, roleSearchScope, skipAuthentication,
+                socketFactoryClassName, systemUserDn, systemUserPassword, url, userContext, userFilter, userNameAttribute,
+                userSearchScope, securityRealm, systemAuthentication);
         return result;
     }
 
@@ -305,6 +327,8 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
                 && Objects.equals(systemUserDn, other.systemUserDn)
                 && Objects.equals(systemUserPassword, other.systemUserPassword) && Objects.equals(url, other.url)
                 && Objects.equals(userContext, other.userContext) && Objects.equals(userFilter, other.userFilter)
+                && Objects.equals(securityRealm, other.securityRealm)
+                && Objects.equals(systemAuthentication, other.systemAuthentication)
                 && Objects.equals(userNameAttribute, other.userNameAttribute) && userSearchScope == other.userSearchScope;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -3032,6 +3032,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 ldapCfg.setSystemUserDn(getTextContent(child));
             } else if ("system-user-password".contentEquals(nodeName)) {
                 ldapCfg.setSystemUserPassword(getTextContent(child));
+            } else if ("system-authentication".contentEquals(nodeName)) {
+                ldapCfg.setSystemAuthentication(getTextContent(child));
+            } else if ("security-realm".contentEquals(nodeName)) {
+                ldapCfg.setSecurityRealm(getTextContent(child));
             } else if ("password-attribute".contentEquals(nodeName)) {
                 ldapCfg.setPasswordAttribute(getTextContent(child));
             } else if ("user-context".contentEquals(nodeName)) {

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -4868,6 +4868,8 @@
         
                     <xs:element name="system-user-dn" type="xs:string" minOccurs="0"/>
                     <xs:element name="system-user-password" type="xs:string" minOccurs="0"/>
+                    <xs:element name="system-authentication" type="xs:string" minOccurs="0"/>
+                    <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
                     <xs:element name="password-attribute" type="xs:string" minOccurs="0"/>
                     <xs:element name="user-context" type="xs:string" minOccurs="0"/>
                     <xs:element name="user-filter" type="xs:string" minOccurs="0"/>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2223,6 +2223,8 @@
                         <user-name-attribute>userNameAttribute</user-name-attribute>
                         <system-user-dn>systemUserDn</system-user-dn>
                         <system-user-password>systemUserPassword</system-user-password>
+                        <system-authentication>simple</system-authentication>
+                        <security-realm>realmName</security-realm>
                         <password-attribute>passwordAttribute</password-attribute>
                         <user-context>userContext</user-context>
                         <user-filter>userFilter</user-filter>
@@ -2253,8 +2255,8 @@
                         <security-realm>krb5Acceptor</security-realm>
                         <ldap>
                             <url>ldap://127.0.0.1/</url>
-                            <system-user-dn>uid=admin,ou=system</system-user-dn>
-                            <system-user-password>secret</system-user-password>
+                            <system-authentication>GSSAPI</system-authentication>
+                            <security-realm>krb5Initiator</security-realm>
                             <skip-authentication>true</skip-authentication>
                             <user-filter>(krb5PrincipalName={login})</user-filter>
                             <role-mapping-attribute>cn</role-mapping-attribute>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2189,6 +2189,8 @@ hazelcast:
              user-name-attribute: userNameAttribute
              system-user-dn: systemUserDn
              system-user-password: systemUserPassword
+             system-authentication: simple
+             security-realm: realmName
              password-attribute: passwordAttribute
              user-context: userContext
              user-filter: userFilter
@@ -2215,8 +2217,8 @@ hazelcast:
             security-realm: krb5Acceptor
             ldap:
               url: ldap://127.0.0.1/
-              system-user-dn: uid=admin,ou=system
-              system-user-password: secret
+              system-authentication: GSSAPI
+              security-realm: krb5Initiator
               skip-authentication: true
               user-filter: "(krb5PrincipalName={login})"
               role-mapping-attribute: cn

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -559,6 +559,8 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                 .setSocketFactoryClassName("socketFactoryClassName")
                 .setSystemUserDn("systemUserDn")
                 .setSystemUserPassword("systemUserPassword")
+                .setSystemAuthentication("GSSAPI")
+                .setSecurityRealm("krb5Initiator")
                 .setUrl("url")
                 .setUserContext("userContext")
                 .setUserFilter("userFilter")

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -656,6 +656,8 @@
                         <user-name-attribute>userNameAttribute</user-name-attribute>
                         <system-user-dn>systemUserDn</system-user-dn>
                         <system-user-password>systemUserPassword</system-user-password>
+                        <system-authentication>simple</system-authentication>
+                        <security-realm>realmName</security-realm>
                         <password-attribute>passwordAttribute</password-attribute>
                         <user-context>userContext</user-context>
                         <user-filter>userFilter</user-filter>
@@ -686,8 +688,8 @@
                         <security-realm>krb5Acceptor</security-realm>
                         <ldap>
                             <url>ldap://127.0.0.1/</url>
-                            <system-user-dn>uid=admin,ou=system</system-user-dn>
-                            <system-user-password>secret</system-user-password>
+                            <system-authentication>GSSAPI</system-authentication>
+                            <security-realm>krb5Initiator</security-realm>
                             <skip-authentication>true</skip-authentication>
                             <user-filter>(krb5PrincipalName={login})</user-filter>
                             <role-mapping-attribute>cn</role-mapping-attribute>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -630,6 +630,8 @@ hazelcast:
              user-name-attribute: userNameAttribute
              system-user-dn: systemUserDn
              system-user-password: systemUserPassword
+             system-authentication: simple
+             security-realm: realmName
              password-attribute: passwordAttribute
              user-context: userContext
              user-filter: userFilter
@@ -656,8 +658,8 @@ hazelcast:
             security-realm: krb5Acceptor
             ldap:
               url: ldap://127.0.0.1/
-              system-user-dn: uid=admin,ou=system
-              system-user-password: secret
+              system-authentication: GSSAPI
+              security-realm: krb5Initiator
               skip-authentication: true
               user-filter: "(krb5PrincipalName={login})"
               role-mapping-attribute: cn


### PR DESCRIPTION
This PR extends Kerberos support introduced in #16860 
EE part: hazelcast/hazelcast-enterprise#3584

It adds a possibility to specify `GSSAPI` authentication for LDAP connections. 

#### New properties in LdapAuthenticationConfig

The PR introduces 2 new properties of `LdapAuthenticationConfig`:

| Property name | Default value | Description |
|---|---|---|
| `securityRealm`| *(empty)* | If specified then given realm name is used for authentication of a (temporary) Subject which is then used for doing LDAP queries|
| `systemAuthentication`| `simple` | authentication mechanism used to access the LDAP. It's used as a value for JNDI environment property [Context#SECURITY_AUTHENTICATION](https://docs.oracle.com/javase/8/docs/api/javax/naming/Context.html#SECURITY_AUTHENTICATION). Users can specify `GSSAPI` to authenticate with Kerberos protocol (wrapped in SASL GSSAPI).|



The Kerberos authentication configuration with roles loaded from LDAP can have the following form for instance:

```xml
<security enabled="true">
  <realms>
    <realm name="kerberosClientAuthn">
      <authentication>
        <kerberos>
          <skip-role>true</skip-role>
          <security-realm>krb5Acceptor</security-realm>
          <ldap>
            <url>ldap://ldap.hazelcast.com</url>
            <parse-dn>false</parse-dn>
            <role-mapping-attribute>cn</role-mapping-attribute>
            <system-authentication>GSSAPI</system-authentication>
            <security-realm>krb5Initiator</security-realm>
            <user-filter>(krb5PrincipalName={login})</user-filter>
            <skip-authentication>true</skip-authentication>
          </ldap>
        </kerberos>
      </authentication>
    </realm>
    <realm name="krb5Acceptor">
      <authentication>
        <jaas>
          <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
            <properties>
              <property name="isInitiator">false</property>
              <property name="useKeyTab">true</property>
              <property name="refreshKrb5Config">true</property>
              <property name="doNotPrompt">true</property>
              <property name="storeKey">true</property>
              <property name="keyTab">/opt/member.keytab</property>
              <property name="principal">hz/member1.hazelcast.com@HAZELCAST.COM</property>
              <property name="useTicketCache">false</property>
            </properties>
          </login-module>
        </jaas>
      </authentication>
    </realm>
    <realm name="krb5Initiator">
      <authentication>
        <jaas>
          <login-module class-name="com.sun.security.auth.module.Krb5LoginModule" usage="REQUIRED">
            <properties>
              <property name="isInitiator">true</property>
              <property name="useKeyTab">true</property>
              <property name="refreshKrb5Config">true</property>
              <property name="doNotPrompt">true</property>
              <property name="storeKey">true</property>
              <property name="keyTab">/opt/member.keytab</property>
              <property name="principal">hz/member1.hazelcast.com@HAZELCAST.COM</property>
              <property name="useTicketCache">false</property>
            </properties>
          </login-module>
        </jaas>
      </authentication>
    </realm>
  </realms>
  <client-authentication realm="kerberosClientAuthn" />
  <client-permissions on-join-operation="RECEIVE">
    <all-permissions principal="Administrator" />
  </client-permissions>
</security>
```