### PR TITLE
Do not nullify containers upon shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -69,7 +69,6 @@ import com.hazelcast.transaction.impl.Transaction;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EventListener;
 import java.util.HashMap;
@@ -190,7 +189,6 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
     @Override
     public void shutdown(boolean terminate) {
         reset();
-        Arrays.fill(partitionContainers, null);
     }
 
     public MultiMapContainer getOrCreateCollectionContainer(int partitionId, String name) {


### PR DESCRIPTION
The core reason of the issue is late termination of `MetricsRegistryImpl` scheduled task. Before task termination, we shutdown `MultiMapService` and this causes task to find some service resources as `null`.

To easily fix the issue, this PR removes nullifying of containers in `MultiMapService` to align behavior with other services.