### PR TITLE
Removed ServerContext connectMonitor property getters

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
@@ -95,10 +95,6 @@ public interface ServerContext {
 
     int getSocketConnectTimeoutSeconds(EndpointQualifier endpointQualifier);
 
-    long getConnectionMonitorInterval();
-
-    int getConnectionMonitorMaxFaults();
-
     void onDisconnect(Address endpoint, Throwable cause);
 
     void executeAsync(Runnable runnable);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
@@ -20,6 +20,8 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.logging.ILogger;
 
+import static com.hazelcast.spi.properties.ClusterProperty.CONNECTION_MONITOR_INTERVAL;
+import static com.hazelcast.spi.properties.ClusterProperty.CONNECTION_MONITOR_MAX_FAULTS;
 import static java.lang.System.currentTimeMillis;
 
 public class TcpServerConnectionErrorHandler {
@@ -35,8 +37,8 @@ public class TcpServerConnectionErrorHandler {
     TcpServerConnectionErrorHandler(TcpServerConnectionManager connectionManager, Address endPoint) {
         this.endPoint = endPoint;
         this.serverContext = connectionManager.getServer().getContext();
-        this.minInterval = serverContext.getConnectionMonitorInterval();
-        this.maxFaults = serverContext.getConnectionMonitorMaxFaults();
+        this.minInterval = serverContext.properties().getMillis(CONNECTION_MONITOR_INTERVAL);
+        this.maxFaults = serverContext.properties().getInteger(CONNECTION_MONITOR_MAX_FAULTS);
         this.logger = serverContext.getLoggingService().getLogger(getClass());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -181,16 +181,6 @@ public class MockServerContext implements ServerContext {
     }
 
     @Override
-    public long getConnectionMonitorInterval() {
-        return 0;
-    }
-
-    @Override
-    public int getConnectionMonitorMaxFaults() {
-        return 0;
-    }
-
-    @Override
     public void onDisconnect(Address endpoint, Throwable cause) {
         logger.warning("Disconnected address: " + endpoint, cause);
     }


### PR DESCRIPTION
It makes the API bigger than needs to be and it also creates
distance between the property configuration and usage; it is best
to keep it close.