### PR TITLE
IOUtils.close cleanup

### DIFF
--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
@@ -36,7 +36,7 @@ import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.getFileFromResources;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -72,7 +72,7 @@ public class HazelcastManifestTransformerTest {
 
     @After
     public void tearDown() {
-        closeResource(is);
+        closeQuietly(is);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -94,7 +94,7 @@ import static com.hazelcast.cache.impl.record.CacheRecord.TIME_NOT_AVAILABLE;
 import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 import static com.hazelcast.config.CacheConfigAccessor.getTenantControl;
 import static com.hazelcast.internal.config.ConfigValidator.checkCacheEvictionConfig;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
@@ -338,7 +338,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         try {
             return EvictionPolicyEvaluatorProvider.getEvictionPolicyEvaluator(evictionConfig, nodeEngine.getConfigClassLoader());
         } finally {
-            closeResource(tenantContext);
+            closeQuietly(tenantContext);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -38,7 +38,6 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.monitor.LocalCacheStats;
 import com.hazelcast.internal.monitor.impl.LocalCacheStatsImpl;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.partition.IPartitionLostEvent;
 import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.internal.partition.PartitionAwareService;
@@ -92,6 +91,7 @@ import static com.hazelcast.config.CacheConfigAccessor.getTenantControl;
 import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CACHE_PREFIX;
 import static com.hazelcast.internal.metrics.impl.ProviderHelper.provide;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.FutureUtil.RETHROW_EVERYTHING;
@@ -675,9 +675,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
     private void removeFromLocalResources(UUID registrationId) {
         Closeable listener = closeableListeners.remove(registrationId);
-        if (listener != null) {
-            IOUtil.closeResource(listener);
-        }
+        closeQuietly(listener);
     }
 
     @Override
@@ -751,7 +749,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
         if (cacheResources != null) {
             for (Closeable resource : cacheResources) {
-                IOUtil.closeResource(resource);
+                closeQuietly(resource);
             }
             cacheResources.clear();
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.config.CacheConfigAccessor.getTenantControl;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
 /**
@@ -86,7 +86,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
                 try {
                     storeRecordsToReplicate(recordStore);
                 } finally {
-                    closeResource(tenantContext);
+                    closeQuietly(tenantContext);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxySupport.java
@@ -52,7 +52,6 @@ import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.FutureUtil;
@@ -95,6 +94,7 @@ import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLET
 import static com.hazelcast.client.cache.impl.ClientCacheProxySupportUtil.addCallback;
 import static com.hazelcast.client.cache.impl.ClientCacheProxySupportUtil.getSafely;
 import static com.hazelcast.client.cache.impl.ClientCacheProxySupportUtil.handleFailureOnCompletionListener;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrowAllowedTypeFirst;
@@ -799,7 +799,7 @@ abstract class ClientCacheProxySupport<K, V> extends ClientProxy implements ICac
         UUID registrationId = listenerCompleter.removeListener(cacheEntryListenerConfiguration);
         if (registrationId != null) {
             Closeable closeable = closeableListeners.remove(registrationId);
-            IOUtil.closeResource(closeable);
+            closeQuietly(closeable);
         }
     }
 
@@ -1183,7 +1183,7 @@ abstract class ClientCacheProxySupport<K, V> extends ClientProxy implements ICac
 
         listenerCompleter.clearListeners();
         for (Closeable closeable : closeableListeners.values()) {
-            IOUtil.closeResource(closeable);
+            closeQuietly(closeable);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -65,7 +65,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
 /**
@@ -187,7 +187,7 @@ public final class ClientConfigXmlGenerator {
             return input;
         } finally {
             if (xmlOutput != null) {
-                closeResource(xmlOutput.getWriter());
+                closeQuietly(xmlOutput.getWriter());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -20,12 +20,11 @@ import com.hazelcast.client.config.impl.ClientConfigSections;
 import com.hazelcast.client.config.impl.ClientDomConfigProcessor;
 import com.hazelcast.client.config.impl.XmlClientConfigLocator;
 import com.hazelcast.config.AbstractXmlConfigBuilder;
-import com.hazelcast.internal.config.ConfigLoader;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.internal.config.ConfigLoader;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
-import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -39,6 +38,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
@@ -127,7 +127,7 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
             LOGGER.severe(msg);
             throw new InvalidConfigurationException(e.getMessage(), e);
         } finally {
-            IOUtil.closeResource(inputStream);
+            closeQuietly(inputStream);
         }
     }
 
@@ -158,7 +158,7 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         } finally {
-            IOUtil.closeResource(in);
+            closeQuietly(in);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
@@ -25,7 +25,6 @@ import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Document;
@@ -40,6 +39,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
@@ -135,7 +135,7 @@ public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
             LOGGER.severe(msg);
             throw new InvalidConfigurationException(e.getMessage(), e);
         } finally {
-            IOUtil.closeResource(inputStream);
+            closeQuietly(inputStream);
         }
     }
 
@@ -154,7 +154,7 @@ public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         } finally {
-            IOUtil.closeResource(in);
+            closeQuietly(in);
         }
         return clientFailoverConfig;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
@@ -26,7 +26,6 @@ import com.hazelcast.internal.config.yaml.YamlDomChecker;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Node;
@@ -39,6 +38,7 @@ import java.net.URL;
 import java.util.Properties;
 
 import static com.hazelcast.internal.config.yaml.W3cDomUtil.asW3cNode;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
@@ -132,7 +132,7 @@ public class YamlClientConfigBuilder extends AbstractYamlConfigBuilder {
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         } finally {
-            IOUtil.closeResource(in);
+            closeQuietly(in);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
@@ -27,7 +27,6 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Node;
@@ -40,6 +39,7 @@ import java.net.URL;
 import java.util.Properties;
 
 import static com.hazelcast.internal.config.yaml.W3cDomUtil.asW3cNode;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
@@ -134,7 +134,7 @@ public class YamlClientFailoverConfigBuilder extends AbstractYamlConfigBuilder {
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         } finally {
-            IOUtil.closeResource(in);
+            closeQuietly(in);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -32,7 +32,6 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.cp.IAtomicLong;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.IMap;
@@ -68,6 +67,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static java.lang.String.format;
 import static java.lang.Thread.currentThread;
@@ -500,7 +500,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             } catch (IOException e) {
                 e.printStackTrace();
             } finally {
-                IOUtil.closeResource(br);
+                closeQuietly(br);
             }
         } else {
             println("File not found! " + f.getAbsolutePath());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -105,7 +105,7 @@ import static com.hazelcast.client.properties.ClientProperty.IO_OUTPUT_THREAD_CO
 import static com.hazelcast.client.properties.ClientProperty.IO_WRITE_THROUGH_ENABLED;
 import static com.hazelcast.client.properties.ClientProperty.SHUFFLE_MEMBER_LIST;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
@@ -665,7 +665,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
             channel.start();
             return connection;
         } catch (Exception e) {
-            closeResource(socketChannel);
+            closeQuietly(socketChannel);
             logger.finest(e);
             throw rethrow(e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
@@ -39,7 +39,7 @@ import java.util.jar.JarInputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
@@ -79,7 +79,7 @@ public class ClientUserCodeDeploymentService {
             } catch (IOException e) {
                 ignore(e);
             } finally {
-                closeResource(is);
+                closeQuietly(is);
             }
         }
     }
@@ -91,7 +91,7 @@ public class ClientUserCodeDeploymentService {
                 loadClassesFromJar(os, jarPath);
             }
         } finally {
-            closeResource(os);
+            closeQuietly(os);
         }
     }
 
@@ -115,7 +115,7 @@ public class ClientUserCodeDeploymentService {
                 classDefinitionList.add(new AbstractMap.SimpleEntry<>(className, classDefinition));
             } while (true);
         } finally {
-            closeResource(inputStream);
+            closeQuietly(inputStream);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -43,7 +43,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
 
 /**
@@ -119,9 +119,9 @@ public abstract class AbstractXmlConfigHelper {
             throw new InvalidConfigurationException(e.getMessage(), e);
         } finally {
             for (StreamSource source : schemas) {
-                closeResource(source.getInputStream());
+                closeQuietly(source.getInputStream());
             }
-            closeResource(inputStream);
+            closeQuietly(inputStream);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -63,7 +63,7 @@ import static com.hazelcast.config.PermissionConfig.PermissionType.ALL;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
 import static com.hazelcast.config.PermissionConfig.PermissionType.TRANSACTION;
 import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmptyAfterTrim;
@@ -1710,7 +1710,7 @@ public class ConfigXmlGenerator {
             return input;
         } finally {
             if (xmlOutput != null) {
-                closeResource(xmlOutput.getWriter());
+                closeQuietly(xmlOutput.getWriter());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.config.MemberDomConfigProcessor;
 import com.hazelcast.internal.config.XmlConfigLocator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Document;
@@ -38,6 +37,7 @@ import java.net.URL;
 import java.util.Properties;
 
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
@@ -215,7 +215,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements Config
             }
             throw new InvalidConfigurationException(e.getMessage(), e);
         } finally {
-            IOUtil.closeResource(is);
+            closeQuietly(is);
         }
         return doc;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.config.yaml.YamlDomChecker;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Node;
@@ -37,6 +36,7 @@ import java.net.URL;
 import java.util.Properties;
 
 import static com.hazelcast.internal.config.yaml.W3cDomUtil.asW3cNode;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
@@ -134,7 +134,7 @@ public class YamlConfigBuilder extends AbstractYamlConfigBuilder implements Conf
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         } finally {
-            IOUtil.closeResource(in);
+            closeQuietly(in);
         }
         return config;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config.replacer;
 
-import com.hazelcast.internal.nio.IOUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -41,7 +40,8 @@ import java.util.Properties;
 
 import static com.hazelcast.internal.config.DomConfigHelper.childElements;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
+import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
@@ -105,9 +105,9 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
             if (passwordFile != null) {
                 FileInputStream fis = new FileInputStream(passwordFile);
                 try {
-                    baos.write(IOUtil.toByteArray(fis));
+                    baos.write(toByteArray(fis));
                 } finally {
-                    IOUtil.closeResource(fis);
+                    closeQuietly(fis);
                 }
             }
             if (passwordUserProperties) {
@@ -185,7 +185,7 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
             Element root = doc.getDocumentElement();
             return loadProperties(findReplacerDefinition(root));
         } finally {
-            closeResource(fileInputStream);
+            closeQuietly(fileInputStream);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -31,7 +31,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.cp.IAtomicLong;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.IMap;
@@ -66,6 +65,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
@@ -486,7 +486,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             } catch (IOException e) {
                 e.printStackTrace();
             } finally {
-                IOUtil.closeResource(br);
+                closeQuietly(br);
             }
         } else {
             println("File not found! " + f.getAbsolutePath());

--- a/hazelcast/src/main/java/com/hazelcast/core/server/HazelcastMemberStarter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/server/HazelcastMemberStarter.java
@@ -24,7 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 /**
  * Starts a Hazelcast Member.
@@ -55,7 +55,7 @@ public final class HazelcastMemberStarter {
                 printWriter = new PrintWriter("ports" + File.separator + printPort, "UTF-8");
                 printWriter.println(hz.getCluster().getLocalMember().getAddress().getPort());
             } finally {
-                closeResource(printWriter);
+                closeQuietly(printWriter);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.Properties;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 /**
@@ -110,7 +110,7 @@ public final class BuildInfoProvider {
         } catch (Exception ignored) {
             ignore(ignored);
         } finally {
-            closeResource(properties);
+            closeQuietly(properties);
         }
         return runtimeProperties;
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.instance.impl.ServerSocketHelper.createServerSocketChannel;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.AddressUtil.fixScopeIdAndGetInetAddress;
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
@@ -126,9 +127,7 @@ class DefaultAddressPicker
             }
         } catch (Exception e) {
             ServerSocketChannel serverSocketChannel = getServerSocketChannel(endpointQualifier);
-            if (serverSocketChannel != null) {
-                serverSocketChannel.close();
-            }
+            closeQuietly(serverSocketChannel);
             logger.severe(e);
             throw e;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 
 import static com.hazelcast.internal.diagnostics.Diagnostics.MAX_ROLLED_FILE_COUNT;
 import static com.hazelcast.internal.diagnostics.Diagnostics.MAX_ROLLED_FILE_SIZE_MB;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
 import static java.lang.Math.round;
 import static java.lang.String.format;
@@ -89,7 +89,7 @@ final class DiagnosticsLogFile {
         } catch (IOException e) {
             logger.warning("Failed to write to file:" + file.getAbsolutePath(), e);
             file = null;
-            closeResource(printWriter);
+            closeQuietly(printWriter);
             printWriter = null;
         } catch (RuntimeException e) {
             logger.warning("Failed to write file: " + file, e);
@@ -135,7 +135,7 @@ final class DiagnosticsLogFile {
     }
 
     private void rollover() {
-        closeResource(printWriter);
+        closeQuietly(printWriter);
         printWriter = null;
         file = null;
         index++;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -40,7 +40,7 @@ import java.util.Iterator;
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.readIntB;
 import static com.hazelcast.internal.nio.Bits.writeIntB;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
 import static com.hazelcast.internal.nio.IOUtil.getPath;
 import static com.hazelcast.internal.nio.IOUtil.readFullyOrNothing;
@@ -142,7 +142,7 @@ public class NearCachePreloader<K> {
         } catch (Exception e) {
             logger.warning(format("Could not pre-load Near Cache %s (%s)", nearCacheName, storeFile.getAbsolutePath()), e);
         } finally {
-            closeResource(bis);
+            closeQuietly(bis);
         }
     }
 
@@ -189,7 +189,7 @@ public class NearCachePreloader<K> {
             }
 
             fos.flush();
-            closeResource(fos);
+            closeQuietly(fos);
             rename(tmpStoreFile, storeFile);
 
             updatePersistenceStats(startedNanos);
@@ -198,7 +198,7 @@ public class NearCachePreloader<K> {
 
             nearCacheStats.addPersistenceFailure(e);
         } finally {
-            closeResource(fos);
+            closeQuietly(fos);
             deleteQuietly(tmpStoreFile);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
@@ -29,7 +29,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 class NearCachePreloaderLock {
 
@@ -82,7 +82,7 @@ class NearCachePreloaderLock {
             throw new HazelcastException("Unknown failure while acquiring lock on " + lockFile.getAbsolutePath(), e);
         } finally {
             if (fileLock == null) {
-                closeResource(channel);
+                closeQuietly(channel);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractChannel.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelCloseListener;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -34,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -144,11 +144,8 @@ public abstract class AbstractChannel implements Channel {
             if (logger.isFinestEnabled()) {
                 logger.finest("Successfully connected to: " + address + " using socket " + socketChannel.socket());
             }
-        } catch (RuntimeException e) {
-            IOUtil.closeResource(this);
-            throw e;
-        } catch (IOException e) {
-            IOUtil.closeResource(this);
+        } catch (RuntimeException | IOException e) {
+            closeQuietly(this);
             throw e;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -62,7 +62,7 @@ import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_NOW_STRING;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_WITH_FIX;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.HashUtil.hashToIndex;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadPoolName;
 import static com.hazelcast.internal.util.concurrent.BackoffIdleStrategy.createBackoffIdleStrategy;
@@ -257,7 +257,7 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
         // if there are any channels left, we close them.
         for (Channel channel : channels) {
             if (!channel.isClosed()) {
-                closeResource(channel);
+                closeQuietly(channel);
             }
         }
         //and clear them to prevent memory leaks.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -40,8 +40,6 @@ import java.io.ObjectStreamClass;
 import java.io.OutputStream;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -354,14 +352,14 @@ public final class IOUtil {
      *
      * @param closeable the resource to close. If {@code null}, no action is taken.
      */
-    public static void closeResource(Closeable closeable) {
+    public static void closeQuietly(Closeable closeable) {
         if (closeable == null) {
             return;
         }
         try {
             closeable.close();
         } catch (IOException e) {
-            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
+            Logger.getLogger(IOUtil.class).finest("close failed", e);
         }
     }
 
@@ -372,38 +370,6 @@ public final class IOUtil {
         try {
             conn.close(reason, null);
         } catch (Throwable e) {
-            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
-        }
-    }
-
-    /**
-     * Quietly attempts to close a {@link ServerSocket}, swallowing any exception.
-     *
-     * @param serverSocket server socket to close. If {@code null}, no action is taken.
-     */
-    public static void close(ServerSocket serverSocket) {
-        if (serverSocket == null) {
-            return;
-        }
-        try {
-            serverSocket.close();
-        } catch (IOException e) {
-            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
-        }
-    }
-
-    /**
-     * Quietly attempts to close a {@link Socket}, swallowing any exception.
-     *
-     * @param socket socket to close. If {@code null}, no action is taken.
-     */
-    public static void close(Socket socket) {
-        if (socket == null) {
-            return;
-        }
-        try {
-            socket.close();
-        } catch (IOException e) {
             Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
         }
     }
@@ -557,7 +523,7 @@ public final class IOUtil {
         } catch (IOException e) {
             throw rethrow(e);
         } finally {
-            closeResource(fos);
+            closeQuietly(fos);
         }
     }
 
@@ -612,7 +578,7 @@ public final class IOUtil {
         } catch (Exception e) {
             throw new HazelcastException("Error occurred while copying InputStream", e);
         } finally {
-            closeResource(out);
+            closeQuietly(out);
         }
     }
 
@@ -649,8 +615,8 @@ public final class IOUtil {
         } catch (Exception e) {
             throw new HazelcastException("Error occurred while copying file", e);
         } finally {
-            closeResource(in);
-            closeResource(out);
+            closeQuietly(in);
+            closeQuietly(out);
         }
     }
 
@@ -679,7 +645,7 @@ public final class IOUtil {
             drainTo(is, os);
             return os.toByteArray();
         } finally {
-            closeResource(os);
+            closeQuietly(os);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
@@ -26,7 +26,7 @@ import java.io.Closeable;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 /**
  * Default {BufferPool} implementation.
@@ -89,7 +89,7 @@ public class BufferPoolImpl implements BufferPool {
 
     private static <C extends Closeable> void offerOrClose(Queue<C> queue, C item) {
         if (queue.size() == MAX_POOLED_ITEMS) {
-            closeResource(item);
+            closeQuietly(item);
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ServerSocketRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/ServerSocketRegistry.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 /**
  * Registry that holds all initiated ServerSocket when advanced-networking is in-use
@@ -92,7 +92,7 @@ public class ServerSocketRegistry
     public void destroy() {
         if (isOpen.compareAndSet(true, false)) {
             for (ServerSocketChannel channel : serverSocketChannelMap.values()) {
-                closeResource(channel);
+                closeQuietly(channel);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -46,7 +46,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRI
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX_ACCEPTOR;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_WITH_FIX;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadPoolName;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.Math.max;
@@ -288,11 +288,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
             } else {
                 logger.severe("Unexpected error while accepting connection! "
                         + e.getClass().getName() + ": " + e.getMessage());
-                try {
-                    serverSocketChannel.close();
-                } catch (Exception ex) {
-                    logger.finest("Closing server socket failed", ex);
-                }
+                closeQuietly(serverSocketChannel);
                 serverContext.onFatalError(e);
             }
         }
@@ -319,7 +315,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
             } catch (Exception e) {
                 exceptionCount.inc();
                 logger.warning(e.getClass().getName() + ": " + e.getMessage(), e);
-                closeResource(channel);
+                closeQuietly(channel);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -257,7 +257,7 @@ public class TcpServerConnectionManager
     }
 
     public synchronized void reset(boolean cleanListeners) {
-        acceptedChannels.forEach(IOUtil::closeResource);
+        acceptedChannels.forEach(IOUtil::closeQuietly);
         connectionsMap.values().forEach(conn -> close(conn, "EndpointManager is stopping"));
         activeConnections.forEach(conn -> close(conn, "EndpointManager is stopping"));
         acceptedChannels.clear();

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnector.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.logging.Level;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_BIND;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_BIND_ANY;
 
@@ -199,7 +200,7 @@ class TcpServerConnector {
                     new SendMemberHandshakeTask(logger, serverContext, connection, address, true).run();
                 } catch (Exception e) {
                     closeConnection(connection, e);
-                    closeSocket(socketChannel);
+                    closeQuietly(socketChannel);
                     logger.log(level, "Could not connect to: " + socketAddress + ". Reason: " + e.getClass().getSimpleName()
                             + "[" + e.getMessage() + "]");
                     throw e;
@@ -240,16 +241,6 @@ class TcpServerConnector {
         private void closeConnection(final Connection connection, Throwable t) {
             if (connection != null) {
                 connection.close(null, t);
-            }
-        }
-
-        private void closeSocket(final SocketChannel socketChannel) {
-            if (socketChannel != null) {
-                try {
-                    socketChannel.close();
-                } catch (final IOException e) {
-                    logger.finest("Closing socket channel failed", e);
-                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.usercodedeployment.impl;
 
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.internal.nio.IOUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
@@ -152,7 +152,7 @@ public final class ClassDataProvider {
                 }
             }
         } finally {
-            IOUtil.closeResource(is);
+            closeQuietly(is);
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassLocator.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.usercodedeployment.impl;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentClassLoader;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentService;
 import com.hazelcast.internal.usercodedeployment.impl.operation.ClassDataFinderOperation;
@@ -42,6 +41,7 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static java.security.AccessController.doPrivileged;
 
 /**
@@ -135,7 +135,7 @@ public final class ClassLocator {
                 return classSource.define(name, classDef);
             }
         } finally {
-            IOUtil.closeResource(classMutex);
+            closeQuietly(classMutex);
         }
     }
 
@@ -175,7 +175,7 @@ public final class ClassLocator {
                 return classSource.getClazz(name);
             }
         } finally {
-            IOUtil.closeResource(classMutex);
+            closeQuietly(classMutex);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/DirectoryLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/DirectoryLock.java
@@ -26,7 +26,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 /**
  * A DirectoryLock represents a lock on a specific directory.
@@ -130,7 +130,7 @@ public final class DirectoryLock {
             throw new HazelcastException("Unknown failure while acquiring lock on " + lockFile.getAbsolutePath(), e);
         } finally {
             if (fileLock == null) {
-                closeResource(channel);
+                closeQuietly(channel);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ICMPHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ICMPHelper.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.util;
 import java.io.File;
 import java.io.InputStream;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.copy;
 import static com.hazelcast.internal.nio.IOUtil.getFileFromResourcesAsStream;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
@@ -57,7 +57,7 @@ public final class ICMPHelper {
         } catch (Throwable t) {
             throw rethrow(t);
         } finally {
-            closeResource(src);
+            closeQuietly(src);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/PhoneHome.java
@@ -42,7 +42,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static java.lang.System.getenv;
@@ -182,7 +182,7 @@ public class PhoneHome {
         } catch (IOException ignored) {
             ignore(ignored);
         } finally {
-            closeResource(is);
+            closeQuietly(is);
         }
         return downloadId;
     }
@@ -199,7 +199,7 @@ public class PhoneHome {
         } catch (Exception ignored) {
             ignore(ignored);
         } finally {
-            closeResource(in);
+            closeQuietly(in);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
 import static java.lang.Boolean.getBoolean;
@@ -143,7 +143,7 @@ public final class ServiceLoader {
                     names.add(new ServiceDefinition(name, urlDefinition.classLoader));
                 }
             } finally {
-                closeResource(r);
+                closeQuietly(r);
             }
             return names;
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.IterableUtil.limit;
 import static com.hazelcast.internal.util.IterableUtil.map;
 import static com.hazelcast.logging.Logger.getLogger;
@@ -444,7 +444,7 @@ public class MapKeyLoader {
             sendKeyLoadCompleted(clusterSize, loadError);
 
             if (keys instanceof Closeable) {
-                closeResource((Closeable) keys);
+                closeQuietly((Closeable) keys);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -56,7 +56,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.internal.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -187,7 +187,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
                 removeAllUserDefinedListeners();
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 
@@ -515,7 +515,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
                         subscriberContext.newEndToEndConstructor(request));
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
@@ -47,7 +47,7 @@ import java.util.UUID;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheEventListenerAdapters.createQueryCacheListenerAdaptor;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.checkHasText;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
@@ -112,7 +112,7 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
                 return registration.getId();
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 
@@ -129,7 +129,7 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
                 eventService.deregisterAllListeners(SERVICE_NAME, cacheId);
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndProvider.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.map.impl.querycache.subscriber.NullQueryCache.NULL_QUERY_CACHE;
 
@@ -95,7 +95,7 @@ public class QueryCacheEndToEndProvider<K, V> {
                 return null;
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 
@@ -109,7 +109,7 @@ public class QueryCacheEndToEndProvider<K, V> {
                 }
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 
@@ -125,7 +125,7 @@ public class QueryCacheEndToEndProvider<K, V> {
                 }
             }
         } finally {
-            closeResource(mutex);
+            closeQuietly(mutex);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
@@ -19,7 +19,6 @@ package com.hazelcast.osgi.impl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.nio.IOUtil;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
@@ -36,6 +35,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 /*
 Imported from Apache Felix project.
@@ -322,7 +323,7 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
                         }
                     }
                 } finally {
-                    IOUtil.closeResource(reader);
+                    closeQuietly(reader);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoveryReceiver.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoveryReceiver.java
@@ -17,12 +17,13 @@
 package com.hazelcast.spi.discovery.multicast.impl;
 
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.internal.nio.IOUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ObjectInputStream;
 import java.net.DatagramPacket;
 import java.net.MulticastSocket;
+
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 public class MulticastDiscoveryReceiver {
 
@@ -55,8 +56,8 @@ public class MulticastDiscoveryReceiver {
                 logger.finest("Couldn't get member info from multicast channel " + e.getMessage());
             }
         } finally {
-            IOUtil.closeResource(bis);
-            IOUtil.closeResource(in);
+            closeQuietly(bis);
+            closeQuietly(in);
         }
         return null;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.cluster;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertFalse;
@@ -130,7 +130,7 @@ public class MulticastDeserializationTest {
         try {
             oos.writeObject(object);
         } finally {
-            closeResource(oos);
+            closeQuietly(oos);
         }
         byte[] data = bos.toByteArray();
         MulticastSocket multicastSocket = null;

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.impl.ProbabilisticSplitBrainProtectionFunction;
 import com.hazelcast.splitbrainprotection.impl.RecentlyActiveSplitBrainProtectionFunction;
@@ -67,6 +66,7 @@ import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
 import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.config.XmlYamlConfigBuilderEqualsTest.readResourceToString;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2956,11 +2956,11 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testAllPermissionsCovered() {
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-fullconfig.xml");
-        Config config = null;
+        Config config;
         try {
             config = new XmlConfigBuilder(xmlResource).build();
         } finally {
-            IOUtil.closeResource(xmlResource);
+            closeQuietly(xmlResource);
         }
         Set<PermissionType> permTypes = new HashSet<>(Arrays.asList(PermissionType.values()));
         for (PermissionConfig pc : config.getSecurityConfig().getClientPermissionConfigs()) {

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigSchemaLocationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigSchemaLocationTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -48,6 +47,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static org.junit.Assert.assertEquals;
 
@@ -78,7 +78,7 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        IOUtil.closeResource(httpClient);
+        closeQuietly(httpClient);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
                 stream = classLoader.getResourceAsStream(resource);
                 validateSchemaLocationUrl(stream, resource);
             } finally {
-                IOUtil.closeResource(stream);
+                closeQuietly(stream);
             }
         }
     }
@@ -168,7 +168,7 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
             response = httpClient.execute(httpGet);
             return response.getStatusLine().getStatusCode();
         } finally {
-            IOUtil.closeResource(response);
+            closeQuietly(response);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -153,7 +154,7 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
             try {
                 out.print(passwordFileContent);
             } finally {
-                IOUtil.closeResource(out);
+                closeQuietly(out);
             }
         }
         return file;

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.impl.ProbabilisticSplitBrainProtectionFunction;
 import com.hazelcast.splitbrainprotection.impl.RecentlyActiveSplitBrainProtectionFunction;
@@ -65,6 +64,7 @@ import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
 import static com.hazelcast.config.WanQueueFullBehavior.DISCARD_AFTER_MUTATION;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.config.XmlYamlConfigBuilderEqualsTest.readResourceToString;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2976,7 +2976,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         try {
             config = new YamlConfigBuilder(yamlResource).build();
         } finally {
-            IOUtil.closeResource(yamlResource);
+            closeQuietly(yamlResource);
         }
         Set<PermissionConfig.PermissionType> permTypes = new HashSet<>(Arrays
                 .asList(PermissionConfig.PermissionType.values()));

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/EncryptionReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/EncryptionReplacerTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.config.replacer;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,6 +36,7 @@ import java.util.Enumeration;
 import java.util.Properties;
 
 import static com.hazelcast.config.replacer.EncryptionReplacer.encrypt;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -187,7 +187,7 @@ public class EncryptionReplacerTest extends AbstractPbeReplacerTest {
             try {
                 out.print(string);
             } finally {
-                IOUtil.closeResource(out);
+                closeQuietly(out);
             }
         }
         return file;

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerHostnameTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerHostnameTest.java
@@ -88,7 +88,7 @@ public class DefaultAddressPickerHostnameTest {
 
     @After
     public void after() {
-        addressPicker.getServerSocketChannels().values().forEach(IOUtil::closeResource);
+        addressPicker.getServerSocketChannels().values().forEach(IOUtil::closeQuietly);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.instance.impl.DefaultAddressPicker.InterfaceDefinition;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
@@ -45,6 +44,7 @@ import java.util.Enumeration;
 
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV4_STACK;
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static com.hazelcast.internal.util.AddressUtil.getAddressHolder;
@@ -89,7 +89,7 @@ public class DefaultAddressPickerTest {
     @After
     public void tearDown() {
         if (addressPicker != null) {
-            IOUtil.closeResource(addressPicker.getServerSocketChannel(null));
+            closeQuietly(addressPicker.getServerSocketChannel(null));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/IpVersionPreferenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/IpVersionPreferenceTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -42,6 +41,7 @@ import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV4_STACK
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
 import static com.hazelcast.instance.impl.DefaultAddressPickerTest.findIPv6NonLoopbackInterface;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.spi.properties.ClusterProperty.PREFER_IPv4_STACK;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertEquals;
@@ -105,7 +105,7 @@ public class IpVersionPreferenceTest {
             Address bindAddress = addressPicker.getBindAddress(MEMBER);
             assertEquals("Bind address: " + bindAddress, expectedIPv6, bindAddress.isIPv6());
         } finally {
-            IOUtil.closeResource(addressPicker.getServerSocketChannel(MEMBER));
+            closeQuietly(addressPicker.getServerSocketChannel(MEMBER));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
 import static java.lang.reflect.Proxy.isProxyClass;
 
@@ -215,13 +215,7 @@ public final class TestUtil {
             if (ds != null) {
                 ds.close();
             }
-            try {
-                if (ss != null) {
-                    ss.close();
-                }
-            } catch (IOException e) {
-                ignore(e);
-            }
+            closeQuietly(ss);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.ascii.rest.HttpCommandProcessor;
-import com.hazelcast.internal.nio.IOUtil;
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -60,6 +59,7 @@ import java.util.UUID;
 
 import static com.hazelcast.instance.EndpointQualifier.REST;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_PLAIN_TEXT;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.StringUtil.bytesToString;
 import static com.hazelcast.test.Accessors.getNode;
 
@@ -444,8 +444,8 @@ public class HTTPCommunicator {
             response = client.execute(request);
             return new ConnectionResponse(response);
         } finally {
-            IOUtil.closeResource(response);
-            IOUtil.closeResource(client);
+            closeQuietly(response);
+            closeQuietly(client);
         }
     }
 
@@ -458,8 +458,8 @@ public class HTTPCommunicator {
             response = client.execute(request);
             return new ConnectionResponse(response);
         } finally {
-            IOUtil.closeResource(response);
-            IOUtil.closeResource(client);
+            closeQuietly(response);
+            closeQuietly(client);
         }
     }
 
@@ -491,8 +491,8 @@ public class HTTPCommunicator {
 
             return new ConnectionResponse(response);
         } finally {
-            IOUtil.closeResource(response);
-            IOUtil.closeResource(client);
+            closeQuietly(response);
+            closeQuietly(client);
         }
     }
 
@@ -505,8 +505,8 @@ public class HTTPCommunicator {
             response = client.execute(request);
             return new ConnectionResponse(response);
         } finally {
-            IOUtil.closeResource(response);
-            IOUtil.closeResource(client);
+            closeQuietly(response);
+            closeQuietly(client);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
@@ -45,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static com.hazelcast.instance.EndpointQualifier.REST;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
 import static org.junit.Assert.fail;
 
@@ -140,8 +140,8 @@ public class InvalidEndpointTest {
             response = client.execute(request);
             return new HTTPCommunicator.ConnectionResponse(response);
         } finally {
-            IOUtil.closeResource(response);
-            IOUtil.closeResource(client);
+            closeQuietly(response);
+            closeQuietly(client);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
@@ -37,7 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static com.hazelcast.internal.diagnostics.AbstractDiagnosticsPluginTest.cleanupDiagnosticFiles;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
 import static com.hazelcast.test.Accessors.getMetricsRegistry;
 import static org.junit.Assert.assertFalse;
@@ -138,7 +138,7 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {
-            closeResource(br);
+            closeQuietly(br);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLockTest.java
@@ -36,7 +36,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -67,7 +67,7 @@ public class NearCachePreloaderLockTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        closeResource(channel);
+        closeQuietly(channel);
         deleteQuietly(lockFile);
         deleteQuietly(preloaderLockFile);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/AbstractChannelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/AbstractChannelTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -48,8 +48,8 @@ public class AbstractChannelTest {
 
     @After
     public void tearDown() {
-        closeResource(channel);
-        closeResource(socketChannel);
+        closeQuietly(channel);
+        closeQuietly(socketChannel);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/BufferingInputStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/BufferingInputStreamTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -45,7 +45,7 @@ public class BufferingInputStreamTest {
 
     @After
     public void tearDown() throws Exception {
-        closeResource(in);
+        closeQuietly(in);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/FilteringClassLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/FilteringClassLoader.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
 import static java.util.Collections.enumeration;
 
@@ -129,8 +129,8 @@ public class FilteringClassLoader extends ClassLoader {
         } catch (Exception e) {
             throw new ClassNotFoundException(name, e);
         } finally {
-            closeResource(os);
-            closeResource(is);
+            closeQuietly(os);
+            closeQuietly(is);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.util;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.PortableHook;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
@@ -52,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Collections.singleton;
@@ -523,7 +523,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
                     }
                 }
             } finally {
-                IOUtil.closeResource(is);
+                closeQuietly(is);
             }
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -42,7 +42,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ServerSocket;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -50,8 +49,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.hazelcast.internal.nio.IOUtil.close;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.IOUtil.compress;
 import static com.hazelcast.internal.nio.IOUtil.copy;
@@ -388,29 +386,29 @@ public class IOUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testCloseResource() throws Exception {
+    public void testCloseQuietly() throws Exception {
         Closeable closeable = mock(Closeable.class);
 
-        closeResource(closeable);
+        closeQuietly(closeable);
 
         verify(closeable).close();
         verifyNoMoreInteractions(closeable);
     }
 
     @Test
-    public void testCloseResource_withException() throws Exception {
+    public void testCloseQuietly_withException() throws Exception {
         Closeable closeable = mock(Closeable.class);
         doThrow(new IOException("expected")).when(closeable).close();
 
-        closeResource(closeable);
+        closeQuietly(closeable);
 
         verify(closeable).close();
         verifyNoMoreInteractions(closeable);
     }
 
     @Test
-    public void testCloseResource_withNull() {
-        closeResource(null);
+    public void testCloseQuietly_withNull() {
+        closeQuietly(null);
     }
 
     @Test
@@ -504,7 +502,7 @@ public class IOUtilTest extends HazelcastTestSupport {
 
             assertTrue("source and target should have the same content", isEqualsContents(source, target));
         } finally {
-            closeResource(inputStream);
+            closeQuietly(inputStream);
         }
     }
 
@@ -824,17 +822,6 @@ public class IOUtilTest extends HazelcastTestSupport {
         readAttributeValue(input);
     }
 
-    @Test
-    public void testCloseServerSocket_whenServerSocketThrows() throws Exception {
-        ServerSocket serverSocket = mock(ServerSocket.class);
-        doThrow(new IOException()).when(serverSocket).close();
-        try {
-            close(serverSocket);
-        } catch (Exception ex) {
-            fail("IOUtils should silently close server socket when exception thrown");
-        }
-    }
-
     @Test(expected = HazelcastException.class)
     public void testRename_whenFileNowNotExist() {
         File toBe = mock(File.class);
@@ -955,7 +942,7 @@ public class IOUtilTest extends HazelcastTestSupport {
         } catch (IOException e) {
             throw rethrow(e);
         } finally {
-            closeResource(writer);
+            closeQuietly(writer);
         }
     }
 
@@ -1001,8 +988,8 @@ public class IOUtilTest extends HazelcastTestSupport {
             e.printStackTrace();
             return false;
         } finally {
-            closeResource(is1);
-            closeResource(is2);
+            closeQuietly(is1);
+            closeQuietly(is2);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JavaSerializer;
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -68,6 +67,7 @@ import java.util.UUID;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -650,7 +650,7 @@ public class SerializationTest extends HazelcastTestSupport {
             } catch (IOException e) {
                 return super.findClass(name);
             } finally {
-                IOUtil.closeResource(in);
+                closeQuietly(in);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -17,7 +17,6 @@
 package com.hazelcast.osgi;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -33,6 +32,7 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.jar.Manifest;
 
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -83,7 +83,7 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
             inputStream = hazelcastAllManifestUrl.openStream();
             return new Manifest(inputStream);
         } finally {
-            IOUtil.closeResource(inputStream);
+            closeQuietly(inputStream);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.Accessors.getSerializationService;
 import static org.junit.Assert.assertArrayEquals;
@@ -177,8 +177,8 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {
-            closeResource(out);
-            closeResource(in);
+            closeQuietly(out);
+            closeQuietly(in);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestStringUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestStringUtils.java
@@ -22,7 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 
 public final class TestStringUtils {
 
@@ -50,9 +50,9 @@ public final class TestStringUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {
-            closeResource(reader);
-            closeResource(streamReader);
-            closeResource(stream);
+            closeQuietly(reader);
+            closeQuietly(streamReader);
+            closeQuietly(stream);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingRunListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingRunListener.java
@@ -30,7 +30,7 @@ import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.compatibility.SamplingSerializationService.SERIALIZED_SAMPLES_PER_CLASS_NAME;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
@@ -75,8 +75,8 @@ public class SamplingRunListener extends RunListener {
         } catch (IOException e) {
             LOGGER.severe(e);
         } finally {
-            closeResource(indexOutput);
-            closeResource(serializedSamplesOutput);
+            closeQuietly(indexOutput);
+            closeQuietly(serializedSamplesOutput);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -29,7 +29,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.compatibility.SamplingSerializationService.isTestClass;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.debug;
@@ -125,7 +125,7 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
                     return loadedClass;
                 }
             } finally {
-                closeResource(classMutex);
+                closeQuietly(classMutex);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarterUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarterUtils.java
@@ -35,7 +35,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
@@ -110,10 +110,10 @@ public class HazelcastStarterUtils {
         } catch (Exception e) {
             throw new GuardianException("Object transfer via serialization failed for: " + object, e);
         } finally {
-            closeResource(objectInputStream);
-            closeResource(byteArrayInputStream);
-            closeResource(objectOutputStream);
-            closeResource(byteArrayOutputStream);
+            closeQuietly(objectInputStream);
+            closeQuietly(byteArrayInputStream);
+            closeQuietly(objectOutputStream);
+            closeQuietly(byteArrayOutputStream);
         }
     }
 
@@ -162,8 +162,8 @@ public class HazelcastStarterUtils {
             if (byteArrayInputStream != null) {
                 byteArrayInputStreamCloseMethod.invoke(byteArrayInputStream);
             }
-            closeResource(objectOutputStream);
-            closeResource(byteArrayOutputStream);
+            closeQuietly(objectOutputStream);
+            closeQuietly(byteArrayOutputStream);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.closeQuietly;
 import static com.hazelcast.internal.nio.IOUtil.drainTo;
 import static com.hazelcast.test.JenkinsDetector.isOnJenkins;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.rethrowGuardianException;
@@ -124,8 +124,8 @@ public class HazelcastVersionLocator {
         } catch (IOException e) {
             throw rethrowGuardianException(e);
         } finally {
-            closeResource(fos);
-            closeResource(is);
+            closeQuietly(fos);
+            closeQuietly(is);
         }
     }
 


### PR DESCRIPTION
Instead of having seperate methods for Socket and ServerSocket,
the closeDefault(Closeable) is used.

IOUtils.closeResource has been renamed to closedQuietly to clearly indicate what it does.

For EE see 
https://github.com/hazelcast/hazelcast-enterprise/pull/3587