### PR TITLE
Correct default value of smartRouting on xsd

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -166,7 +166,7 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    <xs:element name="smart-routing" default="false">
+    <xs:element name="smart-routing" default="true">
         <xs:annotation>
             <xs:documentation>
                 If true, client will route the key based operations to owner of the key at


### PR DESCRIPTION
The value is used when an empty smartRouting tag is put to xml.
<smart-routing></smart-routing>

When this is missing, since it will use the value on ClientNetworkConfig
it is defaulting to `true`

This pr makes the behaviour aligned. Empty smartRouting tag should mean
it is enabled also.