### PR TITLE
Shade jackson-jr along with jackson-core

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -240,6 +240,8 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.jr:jackson-objects</include>
+                                    <include>com.fasterxml.jackson.jr:jackson-annotation-support</include>
                                     <include>org.snakeyaml:snakeyaml-engine</include>
                                 </includes>
                             </artifactSet>
@@ -318,6 +320,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-annotation-support</artifactId>
             <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <log4j2.version>2.13.0</log4j2.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
 
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>
@@ -1147,6 +1147,20 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-annotation-support</artifactId>
             <version>${jackson.version}</version>
             <scope>provided</scope>
             <optional>true</optional>


### PR DESCRIPTION
Currently IMDG shades `jackson-core` which enables to parse JSON strings but does not support object mapping. In Jet we are using `jackson-jr` which is a lightweight alternative and can do object mapping too. `jackson-jr` depends on `jackson-core`, together they are about 400kB (core: 300kB, jr: 100kB). 

In Jet, to shade without duplication, we are first excluding the `jackson-core` files coming from IMDG code-base and then re-shade `jackson-core` with `jackson-jr` to the same location. I believe if we add jackson-jr on IMDG code-base, it will not fatten the JAR and will be less error prone

PS: I've also added `jackson-jr-annotation-support` which has only couple of classes and adds the support to use `jackson-annotations` library.