### PR TITLE
Introduction of CPU thread affinity

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -315,6 +315,29 @@
     </build>
 
     <dependencies>
+        <!-- needed for thread affinity -->
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>affinity</artifactId>
+            <version>3.2.2</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.5.8</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -106,6 +106,7 @@ import static com.hazelcast.client.properties.ClientProperty.IO_WRITE_THROUGH_EN
 import static com.hazelcast.client.properties.ClientProperty.SHUFFLE_MEMBER_LIST;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.util.ThreadAffinity.newSystemThreadAffinity;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
@@ -270,10 +271,13 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                         .threadNamePrefix(client.getName())
                         .errorHandler(new ClientConnectionChannelErrorHandler())
                         .inputThreadCount(inputThreads)
+                        .inputThreadAffinity(newSystemThreadAffinity("hazelcast.client.io.input.thread.affinity"))
                         .outputThreadCount(outputThreads)
+                        .outputThreadAffinity(newSystemThreadAffinity("hazelcast.client.io.output.thread.affinity"))
                         .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS))
                         .writeThroughEnabled(properties.getBoolean(IO_WRITE_THROUGH_ENABLED))
-                        .concurrencyDetection(client.getConcurrencyDetection()));
+                        .concurrencyDetection(client.getConcurrencyDetection())
+        );
     }
 
     private WaitStrategy initializeWaitStrategy(ClientConfig clientConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientResponseHandlerSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientResponseHandlerSupplier.java
@@ -20,11 +20,13 @@ import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.internal.util.ConcurrencyDetection;
+import com.hazelcast.internal.util.ThreadAffinity;
+import com.hazelcast.internal.util.MutableInteger;
 import com.hazelcast.internal.util.concurrent.MPSCQueue;
+import com.hazelcast.internal.util.executor.HazelcastManagedThread;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
-import com.hazelcast.internal.util.MutableInteger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.BlockingQueue;
@@ -36,8 +38,9 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.ErrorsCodec.EXCEP
 import static com.hazelcast.client.properties.ClientProperty.RESPONSE_THREAD_COUNT;
 import static com.hazelcast.client.properties.ClientProperty.RESPONSE_THREAD_DYNAMIC;
 import static com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher.onOutOfMemory;
-import static com.hazelcast.spi.impl.operationservice.impl.InboundResponseHandlerSupplier.getIdleStrategy;
+import static com.hazelcast.internal.util.ThreadAffinity.newSystemThreadAffinity;
 import static com.hazelcast.internal.util.HashUtil.hashToIndex;
+import static com.hazelcast.spi.impl.operationservice.impl.InboundResponseHandlerSupplier.getIdleStrategy;
 
 /**
  * A {@link Supplier} for {@link Supplier} instance that processes responses for client
@@ -75,6 +78,7 @@ public class ClientResponseHandlerSupplier implements Supplier<Consumer<ClientMe
     private final Consumer<ClientMessage> responseHandler;
     private final boolean responseThreadsDynamic;
     private final ConcurrencyDetection concurrencyDetection;
+    private final ThreadAffinity threadAffinity = newSystemThreadAffinity("hazelcast.client.response.thread.affinity");
 
     public ClientResponseHandlerSupplier(ClientInvocationServiceImpl invocationService,
                                          ConcurrencyDetection concurrencyDetection) {
@@ -85,6 +89,10 @@ public class ClientResponseHandlerSupplier implements Supplier<Consumer<ClientMe
 
         HazelcastProperties properties = client.getProperties();
         int responseThreadCount = properties.getInteger(RESPONSE_THREAD_COUNT);
+        if (threadAffinity.isEnabled()) {
+            responseThreadCount = threadAffinity.getThreadCount();
+        }
+
         if (responseThreadCount < 0) {
             throw new IllegalArgumentException(RESPONSE_THREAD_COUNT.getName() + " can't be smaller than 0");
         }
@@ -93,6 +101,7 @@ public class ClientResponseHandlerSupplier implements Supplier<Consumer<ClientMe
         this.responseThreads = new ResponseThread[responseThreadCount];
         for (int k = 0; k < responseThreads.length; k++) {
             responseThreads[k] = new ResponseThread(invocationService.client.getName() + ".responsethread-" + k + "-");
+            responseThreads[k].setThreadAffinity(threadAffinity);
         }
 
         if (responseThreadCount == 0) {
@@ -167,7 +176,7 @@ public class ClientResponseHandlerSupplier implements Supplier<Consumer<ClientMe
         }
     }
 
-    private class ResponseThread extends Thread {
+    private class ResponseThread extends HazelcastManagedThread {
         private final BlockingQueue<ClientMessage> responseQueue;
         private final AtomicBoolean started = new AtomicBoolean();
 
@@ -179,7 +188,7 @@ public class ClientResponseHandlerSupplier implements Supplier<Consumer<ClientMe
         }
 
         @Override
-        public void run() {
+        public void executeRun() {
             try {
                 doRun();
             } catch (OutOfMemoryError e) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeContext.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
+import static com.hazelcast.internal.util.ThreadAffinity.newSystemThreadAffinity;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_BALANCER_INTERVAL_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUNT;
@@ -169,9 +170,12 @@ public class DefaultNodeContext implements NodeContext {
                         .threadNamePrefix(node.hazelcastInstance.getName())
                         .errorHandler(errorHandler)
                         .inputThreadCount(props.getInteger(IO_INPUT_THREAD_COUNT))
+                        .inputThreadAffinity(newSystemThreadAffinity("hazelcast.io.input.thread.affinity"))
                         .outputThreadCount(props.getInteger(IO_OUTPUT_THREAD_COUNT))
+                        .outputThreadAffinity(newSystemThreadAffinity("hazelcast.io.output.thread.affinity"))
                         .balancerIntervalSeconds(props.getInteger(IO_BALANCER_INTERVAL_SECONDS))
                         .writeThroughEnabled(props.getBoolean(IO_WRITE_THROUGH_ENABLED))
-                        .concurrencyDetection(node.nodeEngine.getConcurrencyDetection()));
+                        .concurrencyDetection(node.nodeEngine.getConcurrencyDetection())
+        );
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -31,6 +31,7 @@ import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.networking.nio.iobalancer.IOBalancer;
 import com.hazelcast.internal.util.ConcurrencyDetection;
+import com.hazelcast.internal.util.ThreadAffinity;
 import com.hazelcast.internal.util.concurrent.BackoffIdleStrategy;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
@@ -115,14 +116,15 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
     private final BackoffIdleStrategy idleStrategy;
     private final boolean selectorWorkaroundTest;
     private final boolean selectionKeyWakeupEnabled;
+    private final ThreadAffinity outputThreadAffinity;
     private volatile ExecutorService closeListenerExecutor;
     private final ConcurrencyDetection concurrencyDetection;
     private final boolean writeThroughEnabled;
+    private final ThreadAffinity inputThreadAffinity;
     private volatile IOBalancer ioBalancer;
     private volatile NioThread[] inputThreads;
     private volatile NioThread[] outputThreads;
     private volatile ScheduledFuture publishFuture;
-
     // Currently this is a coarse grained aggregation of the bytes/send received.
     // In the future you probably want to split this up in member and client and potentially
     // wan specific.
@@ -143,6 +145,8 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
         this.outputThreadCount = ctx.outputThreadCount;
         this.logger = loggingService.getLogger(NioNetworking.class);
         this.errorHandler = ctx.errorHandler;
+        this.inputThreadAffinity = ctx.inputThreadAffinity;
+        this.outputThreadAffinity = ctx.outputThreadAffinity;
         this.balancerIntervalSeconds = ctx.balancerIntervalSeconds;
         this.selectorMode = ctx.selectorMode;
         this.selectorWorkaroundTest = ctx.selectorWorkaroundTest;
@@ -216,6 +220,7 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
                     idleStrategy);
             thread.id = i;
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
+            thread.setThreadAffinity(inputThreadAffinity);
             inThreads[i] = thread;
             thread.start();
         }
@@ -231,6 +236,7 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
                     idleStrategy);
             thread.id = i;
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
+            thread.setThreadAffinity(outputThreadAffinity);
             outThreads[i] = thread;
             thread.start();
         }
@@ -476,6 +482,9 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
         private int inputThreadCount = 1;
         private int outputThreadCount = 1;
         private int balancerIntervalSeconds;
+        private ThreadAffinity inputThreadAffinity = ThreadAffinity.DISABLED;
+        private ThreadAffinity outputThreadAffinity = ThreadAffinity.DISABLED;
+
         // The selector mode determines how IO threads will block (or not) on the Selector:
         //  select:         this is the default mode, uses Selector.select(long timeout)
         //  selectnow:      use Selector.selectNow()
@@ -547,12 +556,36 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
         }
 
         public Context inputThreadCount(int inputThreadCount) {
+            if (inputThreadAffinity.isEnabled()) {
+                return this;
+            }
             this.inputThreadCount = inputThreadCount;
             return this;
         }
 
         public Context outputThreadCount(int outputThreadCount) {
+            if (outputThreadAffinity.isEnabled()) {
+                return this;
+            }
             this.outputThreadCount = outputThreadCount;
+            return this;
+        }
+
+        public Context inputThreadAffinity(ThreadAffinity inputThreadAffinity) {
+            this.inputThreadAffinity = inputThreadAffinity;
+
+            if (inputThreadAffinity.isEnabled()) {
+                inputThreadCount = inputThreadAffinity.getThreadCount();
+            }
+            return this;
+        }
+
+        public Context outputThreadAffinity(ThreadAffinity outputThreadAffinity) {
+            this.outputThreadAffinity = outputThreadAffinity;
+
+            if (outputThreadAffinity.isEnabled()) {
+                outputThreadCount = outputThreadAffinity.getThreadCount();
+            }
             return this;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.util.concurrent.IdleStrategy;
 import com.hazelcast.internal.util.counters.SwCounter;
+import com.hazelcast.internal.util.executor.HazelcastManagedThread;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 
@@ -56,7 +57,7 @@ import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 
 @ExcludedMetricTargets(MANAGEMENT_CENTER)
-public class NioThread extends Thread implements OperationHostileThread {
+public class NioThread extends HazelcastManagedThread implements OperationHostileThread {
 
     // WARNING: This value has significant effect on idle CPU usage!
     private static final int SELECT_WAIT_TIME_MILLIS
@@ -226,7 +227,7 @@ public class NioThread extends Thread implements OperationHostileThread {
     }
 
     @Override
-    public void run() {
+    public void executeRun() {
         // This outer loop is a bit complex but it takes care of a lot of stuff:
         // * it calls runSelectNowLoop or runSelectLoop based on selectNow enabled or not.
         // * handles backoff and retrying in case if io exception is thrown

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadAffinity.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadAffinity.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.logging.Logger;
+import net.openhft.affinity.Affinity;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Contains the thread affinity logic for certain threads.
+ *
+ * Inside is a list of CPU bitmaps and using the {@link #nextAllowedCpus()} there is a round robin
+ * over the list of the CPU bitmaps. The reason for a round robin is that the same ThreadAffinity can
+ * be used when threads get stopped and new threads created.
+ *
+ * This class is threadsafe.
+ */
+public class ThreadAffinity {
+    public static final ThreadAffinity DISABLED = new ThreadAffinity(null);
+
+    final List<BitSet> allowedCpusList;
+    final AtomicInteger threadIndex = new AtomicInteger();
+
+    public ThreadAffinity(String affinity) {
+        allowedCpusList = parse(affinity);
+
+        if (allowedCpusList.isEmpty()) {
+            return;
+        }
+
+        if (!isAffinityAvailable()) {
+            throw new RuntimeException("Can't use affinity '" + affinity + "'. Thread affinity support is not available.");
+        }
+    }
+
+    /**
+     * Creates a new ThreadAffinity based on a system property.
+     *
+     * If no property is set, then affinity is disabled.
+     *
+     * @param property the name of the system property.
+     * @return the created ThreadAffinity.
+     * @throws InvalidAffinitySyntaxException if there is a problem with the value.
+     */
+    public static ThreadAffinity newSystemThreadAffinity(String property) {
+        String value = System.getProperty(property);
+        try {
+            return new ThreadAffinity(value);
+        } catch (InvalidAffinitySyntaxException e) {
+            throw new InvalidAffinitySyntaxException("Invalid affinity syntax for System property '" + property + "'."
+                    + " Value '" + value + "'. "
+                    + " Errormessage '" + e.getMessage() + "'");
+        }
+    }
+
+    public int getThreadCount() {
+        return allowedCpusList.size();
+    }
+
+    public BitSet nextAllowedCpus() {
+        if (allowedCpusList.isEmpty()) {
+            return null;
+        }
+
+        int index = threadIndex.getAndIncrement() % allowedCpusList.size();
+        return allowedCpusList.get(index);
+    }
+
+    public boolean isEnabled() {
+        return !allowedCpusList.isEmpty();
+    }
+
+    private static boolean isAffinityAvailable() {
+        try {
+            boolean jnaAvailable = Affinity.isJNAAvailable();
+            if (!jnaAvailable) {
+                Logger.getLogger(ThreadAffinity.class).warning("jna is not available");
+            }
+            return jnaAvailable;
+        } catch (NoClassDefFoundError e) {
+            Logger.getLogger(ThreadAffinity.class).warning("Affinity jar isn't available: " + e.getMessage());
+            return false;
+        }
+    }
+
+    static List<BitSet> parse(String affinity) {
+        List<BitSet> cpus = new ArrayList<>();
+        if (affinity == null) {
+            return cpus;
+        }
+
+        affinity = affinity.trim();
+        if (affinity.isEmpty()) {
+            return cpus;
+        }
+
+        List<CpuGroup> groups = new AffinityParser(affinity).parse();
+        for (CpuGroup group : groups) {
+            BitSet allowedCpus = new BitSet();
+
+            for (Integer cpu : group.cpus) {
+                allowedCpus.set(cpu);
+            }
+            for (int k = 0; k < group.threadCount; k++) {
+                cpus.add(allowedCpus);
+            }
+        }
+
+        return cpus;
+    }
+
+    static class AffinityParser {
+        private final String string;
+        private final List<CpuGroup> groups = new ArrayList<>();
+        private int index;
+        private int digit;
+        private int integer;
+        private int fromRange;
+        private int toRange;
+
+        AffinityParser(String string) {
+            this.string = string;
+        }
+
+        List<CpuGroup> parse() {
+            if (!expression() || index < string.length()) {
+                throw new InvalidAffinitySyntaxException("Syntax Error at " + index);
+            }
+
+            // verification that we have no duplicate cpus.
+            BitSet usedCpus = new BitSet();
+            for (CpuGroup group : groups) {
+                for (Integer cpu : group.cpus) {
+                    if (usedCpus.get(cpu)) {
+                        throw new InvalidAffinitySyntaxException("Duplicate CPU found, offending CPU=" + cpu);
+                    }
+                    usedCpus.set(cpu);
+                }
+            }
+
+            return groups;
+        }
+
+        boolean expression() {
+            if (!item()) {
+                return false;
+            }
+
+            while (character(',')) {
+                if (!item()) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        boolean item() {
+            if (range()) {
+                for (int cpu = fromRange; cpu <= toRange; cpu++) {
+                    CpuGroup group = new CpuGroup();
+                    group.cpus.add(cpu);
+                    group.threadCount = 1;
+                    groups.add(group);
+                }
+                return true;
+            } else {
+                return group();
+            }
+        }
+
+        boolean range() {
+            if (!integer()) {
+                return false;
+            }
+            fromRange = integer;
+            toRange = integer;
+            if (character('-')) {
+                if (!integer()) {
+                    return false;
+                }
+                toRange = integer;
+                if (toRange < fromRange) {
+                    error("ToRange can't smaller than fromRange, toRange=" + toRange + " fromRange=" + fromRange + ".");
+                }
+            }
+
+            return true;
+        }
+
+        private void error(String error) {
+            throw new InvalidAffinitySyntaxException(error + " at index:" + index);
+        }
+
+        @SuppressWarnings("checkstyle:NPathComplexity")
+        boolean group() {
+            if (!character('[')) {
+                return false;
+            }
+
+            if (!range()) {
+                return false;
+            }
+
+            CpuGroup group = new CpuGroup();
+            addCpuRangeToGroup(group);
+
+            while (character(',')) {
+                if (!range()) {
+                    return false;
+                }
+
+                addCpuRangeToGroup(group);
+            }
+
+            if (!character(']')) {
+                return false;
+            }
+
+            if (character(':')) {
+                if (!integer()) {
+                    return false;
+                }
+                group.threadCount = integer;
+                if (group.threadCount == 0) {
+                    error("Thread count can't be 0.");
+                } else if (group.threadCount > group.cpus.size()) {
+                    error("Thread count can't be larger than number of cpu's in the group. "
+                            + "Thread count = " + group.threadCount + " cpus:" + group.cpus);
+                }
+            } else {
+                group.threadCount = group.cpus.size();
+            }
+
+            groups.add(group);
+            return true;
+        }
+
+        private void addCpuRangeToGroup(CpuGroup group) {
+            for (int k = fromRange; k <= toRange; k++) {
+                group.cpus.add(k);
+            }
+        }
+
+        @SuppressWarnings("checkstyle:magicnumber")
+        boolean integer() {
+            if (!digit()) {
+                return false;
+            }
+
+            integer = digit;
+            for (; ; ) {
+                if (!digit()) {
+                    return true;
+                }
+                integer = integer * 10;
+                integer += digit;
+            }
+        }
+
+        boolean digit() {
+            if (index >= string.length()) {
+                return false;
+            }
+
+            char c = string.charAt(index);
+            if (Character.isDigit(c)) {
+                index++;
+                digit = Character.getNumericValue(c);
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        boolean character(char expected) {
+            if (index >= string.length()) {
+                return false;
+            }
+
+            char c = string.charAt(index);
+            if (c == expected) {
+                index++;
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    static class InvalidAffinitySyntaxException extends RuntimeException {
+        InvalidAffinitySyntaxException(String message) {
+            super(message);
+        }
+    }
+
+    static class CpuGroup {
+        List<Integer> cpus = new LinkedList<>();
+        int threadCount = -1;
+
+        @Override
+        public String toString() {
+            return "CpuGroup{"
+                    + "cpus=" + cpus
+                    + ", count=" + threadCount
+                    + '}';
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -109,7 +109,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     public abstract OperationRunner operationRunner(int partitionId);
 
     @Override
-    public final void run() {
+    public final void executeRun() {
         nodeExtension.onThreadStart(this);
         try {
             while (!shutdown) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ThreadAffinityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ThreadAffinityTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.BitSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ThreadAffinityTest {
+
+    @Test
+    public void whenNull() {
+        ThreadAffinity threadAffinity = new ThreadAffinity(null);
+
+        assertFalse(threadAffinity.isEnabled());
+        assertNull(threadAffinity.nextAllowedCpus());
+    }
+
+    @Test
+    public void whenEmptyString() {
+        ThreadAffinity threadAffinity = new ThreadAffinity("");
+
+        assertFalse(threadAffinity.isEnabled());
+        assertNull(threadAffinity.nextAllowedCpus());
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenSyntaxError() {
+        new ThreadAffinity("abc");
+    }
+
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenTrailingComma() {
+        new ThreadAffinity("10,");
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenTrailingText() {
+        new ThreadAffinity("1a");
+    }
+
+    @Test
+    public void whenIndividualCores() {
+        ThreadAffinity threadAffinity = new ThreadAffinity("1,3,4,8");
+
+        assertTrue(threadAffinity.isEnabled());
+        assertEquals(4, threadAffinity.allowedCpusList.size());
+        assertEquals(threadAffinity.allowedCpusList.get(0), newBitset(1));
+        assertEquals(threadAffinity.allowedCpusList.get(1), newBitset(3));
+        assertEquals(threadAffinity.allowedCpusList.get(2), newBitset(4));
+        assertEquals(threadAffinity.allowedCpusList.get(3), newBitset(8));
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenIndividualCoresAndNegative() {
+        new ThreadAffinity("-10");
+    }
+
+    @Test
+    public void whenRange() {
+        ThreadAffinity threadAffinity = new ThreadAffinity("1-4");
+
+        assertTrue(threadAffinity.isEnabled());
+        assertEquals(4, threadAffinity.allowedCpusList.size());
+        assertEquals(threadAffinity.allowedCpusList.get(0), newBitset(1));
+        assertEquals(threadAffinity.allowedCpusList.get(1), newBitset(2));
+        assertEquals(threadAffinity.allowedCpusList.get(2), newBitset(3));
+        assertEquals(threadAffinity.allowedCpusList.get(3), newBitset(4));
+    }
+
+    @Test
+    public void whenGroup() {
+        ThreadAffinity threadAffinity = new ThreadAffinity("[1-5]");
+
+        assertTrue(threadAffinity.isEnabled());
+        assertEquals(5, threadAffinity.allowedCpusList.size());
+        assertEquals(threadAffinity.allowedCpusList.get(0), newBitset(1, 2, 3, 4, 5));
+        assertEquals(threadAffinity.allowedCpusList.get(1), newBitset(1, 2, 3, 4, 5));
+        assertEquals(threadAffinity.allowedCpusList.get(2), newBitset(1, 2, 3, 4, 5));
+        assertEquals(threadAffinity.allowedCpusList.get(3), newBitset(1, 2, 3, 4, 5));
+        assertEquals(threadAffinity.allowedCpusList.get(4), newBitset(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void whenGroupAndThreadCount() {
+        ThreadAffinity threadAffinity = new ThreadAffinity("[1-5]:2");
+
+        assertTrue(threadAffinity.isEnabled());
+        assertEquals(2, threadAffinity.allowedCpusList.size());
+        assertEquals(threadAffinity.allowedCpusList.get(0), newBitset(1, 2, 3, 4, 5));
+        assertEquals(threadAffinity.allowedCpusList.get(1), newBitset(1, 2, 3, 4, 5));
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenGroupAndNegativeThreadCount() {
+        new ThreadAffinity("[1-10]:-2");
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenGroupAndThreadCountZero() {
+        new ThreadAffinity("[1-5]:0");
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenGroupAndThreadTooLarge() {
+        new ThreadAffinity("[1,2]:3");
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenInvalidRange() {
+        new ThreadAffinity("4-3");
+    }
+
+    @Test(expected = ThreadAffinity.InvalidAffinitySyntaxException.class)
+    public void whenDuplicate() {
+        new ThreadAffinity("1,1");
+    }
+
+    @Test
+    public void whenComplex() {
+        ThreadAffinity threadAffinity = new ThreadAffinity("1,3-4,[5-8]:2,10,[20,21,32]:2");
+
+        assertTrue(threadAffinity.isEnabled());
+        assertEquals(8, threadAffinity.allowedCpusList.size());
+        assertEquals(threadAffinity.allowedCpusList.get(0), newBitset(1));
+        assertEquals(threadAffinity.allowedCpusList.get(1), newBitset(3));
+        assertEquals(threadAffinity.allowedCpusList.get(2), newBitset(4));
+        assertEquals(threadAffinity.allowedCpusList.get(3), newBitset(5, 6, 7, 8));
+        assertEquals(threadAffinity.allowedCpusList.get(4), newBitset(5, 6, 7, 8));
+        assertEquals(threadAffinity.allowedCpusList.get(5), newBitset(10));
+        assertEquals(threadAffinity.allowedCpusList.get(6), newBitset(20, 21, 32));
+        assertEquals(threadAffinity.allowedCpusList.get(7), newBitset(20, 21, 32));
+    }
+
+    @NotNull
+    public BitSet newBitset(int... cpus) {
+        BitSet bitSet = new BitSet();
+        for (int c : cpus) {
+            bitSet.set(c);
+        }
+        return bitSet;
+    }
+}
+


### PR DESCRIPTION
Provides CPU thread affinity.

So certain threads can have affinity for particular cpu's.

Server
```
-Dhazelcast.io.input.thread.affinity=1-3 
-Dhazelcast.io.output.thread.affinity=3-5 
-Dhazelcast.operation.thread.affinity=7-10,13 
-Dhazelcast.operation.response.thread.affinity=15,16
```
Client
```
-Dhazelcast.client.io.input.thread.affinity=1-4 
-Dhazelcast.client.io.output.thread.affinity=5-8
-Dhazelcast.client.response.thread.affinity=7-9
```
If you don't configure affinity for a category of threads, it means they can run on any CPU.


This gives a lot better control on latency and provides better throughput. The number of threads configured in the affinity settings overrides the number of threads that have been configured explicitly.

![image](https://user-images.githubusercontent.com/105243/81530321-4f545f00-9369-11ea-99d3-201abfa3f4e3.png)

![image](https://user-images.githubusercontent.com/105243/81530340-5aa78a80-9369-11ea-86d7-74d3c330c4da.png)

It matters a lot on which NUMA node the IO threads are. It can make performance very bad, but also very good. More research is needed.

For the time being this will not be a public feature. We can use it internally to exclude certain problems like threads moving over CPUS and control NUMA locality of memory.

When using the affinity syntax it is important to realize that it also includes the number of threads. So it will override the corresponding thread count.

The affinity syntax is as follows:
* `1,2,3,4`: We get 1 thread on CPU1, one thread on CPU2 etc. In total there are 4 threads configured which will each run on a different CPU.
* `1-4`: this is a shortcut  for the above syntax.
* `[1-4]`: this is a group. This will give 4 threads and each thread can run on CPU's 1-4.
* `[1-4]:2`: this is also group but with 2 threads that can run over CPUS 1-4. 

You can also make combinations
`1,3,5-8,[10-20]:2,[31,41]:5`

It is important to realize that `3-4` is something else than `[3-4]`. The first configuration will give you 1 thread assigned to CPU 3 and another to CPU 4. The second configuration will give you 2 threads that both can run on CPUS 3 and 4.

If you have the following CPU NUMA node mapping:
* CPUS `0-19` on NUMA node 0
* CPUS `20-39`on NUMA node 1
You could configure 20 threads on NUMA node 0 and 20 threads on NUMA node 2 like this: 
`[0-19],[20-39]`.

If you want to see the mapping, run 
```numactl --hardware```

Example from a dual socket machine:
```
available: 2 nodes (0-1)
node 0 cpus: 0 1 2 3 4 5 6 7 8 9 20 21 22 23 24 25 26 27 28 29
node 0 size: 393090 MB
node 0 free: 372729 MB
node 1 cpus: 10 11 12 13 14 15 16 17 18 19 30 31 32 33 34 35 36 37 38 39
node 1 size: 393216 MB
node 1 free: 343296 MB
node distances:
node   0   1 
  0:  10  21 
  1:  21  10 
```

If you want to confine the partition threads to the NUMA nodes for the above configuration, you would use:
```
-Dhazelcast.operation.thread.affinity=[0-9,20-29],[10-19,30-39]
```

The affinity properties can only be set from the command line. E.g.
```
 -Dhazelcast.client.io.input.thread.affinity=1,2,3
```

A few warnings:
* Pinning a single thread down to a single CPU is great for experiments. But can be a problem in a production setup because the thread has no other CPU it can run on. So if another thread or the OS would be running on that CPU (there are many more threads in HZ and in the JVM), this thread will get stalled. So in most cases it will be better to use the group syntax i.e. `[from-to]:threadcount`
* Be careful pinning a thread down to CPU 0 especially if that is the only thread it can run on. In some environment this CPU is used for other purposes.
* Since this is not a public feature, breaking changes can be made without warning. 
* Mileage may vary! Thread affinity is not a guarantee for reduced latency or increased throughput.

You need to following jars on your classpath:
```
  <!-- needed for thread affinity -->
        <dependency>
            <groupId>net.openhft</groupId>
            <artifactId>affinity</artifactId>
            <version>3.2.2</version>
        </dependency>
        <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-api</artifactId>
            <version>1.7.25</version>
        </dependency>
        <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-simple</artifactId>
            <version>1.5.8</version>
        </dependency>
```
If you are using the Simulator, you don't need to do anything extra since Simulator has these on the classpath.

In the System.out you will find information if the affinity has been picked up correctly. E.g.
```
hz.heuristic_mccarthy.partition-operation.thread-0 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-1 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-2 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-4 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-3 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-6 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-5 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-7 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-8 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-9 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-11 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-12 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-10 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-13 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-14 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-15 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-17 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-16 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-18 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-19 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-24 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-27 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-25 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-30 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-21 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-38 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-39 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-22 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-31 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-28 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-20 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-26 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-23 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-37 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-36 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-34 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-29 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-32 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-33 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.partition-operation.thread-35 has affinity for cpus:{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}
hz.heuristic_mccarthy.IO.thread-in-0 has affinity for cpus:{1, 2, 3, 4}
hz.heuristic_mccarthy.IO.thread-in-1 has affinity for cpus:{1, 2, 3, 4}
hz.heuristic_mccarthy.IO.thread-in-2 has affinity for cpus:{1, 2, 3, 4}
hz.heuristic_mccarthy.IO.thread-out-0 has affinity for cpus:{5, 6, 7, 8}
hz.heuristic_mccarthy.IO.thread-in-3 has affinity for cpus:{1, 2, 3, 4}
hz.heuristic_mccarthy.IO.thread-out-1 has affinity for cpus:{5, 6, 7, 8}
hz.heuristic_mccarthy.IO.thread-out-3 has affinity for cpus:{5, 6, 7, 8}
hz.heuristic_mccarthy.IO.thread-out-2 has affinity for cpus:{5, 6, 7, 8}
```