### PR TITLE
SQL: Initial integration with Apache Calcite 

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastTypeFactory.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastTypeFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.util.ConversionUtil;
+
+import java.nio.charset.Charset;
+
+public class HazelcastTypeFactory extends JavaTypeFactoryImpl {
+    @Override
+    public Charset getDefaultCharset() {
+        // Calcite uses Latin-1 by default (see {@code CalciteSystemProperty.DEFAULT_CHARSET}). We use unicode.
+        return Charset.forName(ConversionUtil.NATIVE_UTF16_CHARSET_NAME);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/OptimizerContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/OptimizerContext.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite;
+
+import com.google.common.collect.ImmutableList;
+import com.hazelcast.sql.impl.calcite.opt.QueryPlanner;
+import com.hazelcast.sql.impl.calcite.opt.metadata.HazelcastRelMdRowCount;
+import com.hazelcast.sql.impl.calcite.parse.CasingConfiguration;
+import com.hazelcast.sql.impl.calcite.parse.QueryConverter;
+import com.hazelcast.sql.impl.calcite.parse.QueryParseResult;
+import com.hazelcast.sql.impl.calcite.parse.QueryParser;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastCalciteCatalogReader;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastSchema;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastSchemaUtils;
+import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlConformance;
+import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlOperatorTable;
+import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlValidator;
+import com.hazelcast.sql.impl.schema.TableResolver;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.jdbc.HazelcastRootCalciteSchema;
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.HazelcastRelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
+import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
+import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.tools.RuleSet;
+
+import java.util.List;
+
+/**
+ * Optimizer context which holds the whole environment for the given optimization session.
+ * Should not be re-used between optimization sessions.
+ */
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+public final class OptimizerContext {
+
+    private static final RelMetadataProvider METADATA_PROVIDER = ChainedRelMetadataProvider.of(ImmutableList.of(
+        HazelcastRelMdRowCount.SOURCE,
+        DefaultRelMetadataProvider.INSTANCE
+    ));
+
+    private static final CalciteConnectionConfig CONNECTION_CONFIG = CasingConfiguration.DEFAULT.toConnectionConfig();
+
+    private final QueryParser parser;
+    private final QueryConverter converter;
+    private final QueryPlanner planner;
+
+    private OptimizerContext(
+        QueryParser parser,
+        QueryConverter converter,
+        QueryPlanner planner
+    ) {
+        this.parser = parser;
+        this.converter = converter;
+        this.planner = planner;
+    }
+
+    /**
+     * Create the optimization context.
+     *
+     * @param tableResolvers Resolver to collect information about tables.
+     * @param currentSearchPaths Search paths to support "current schema" feature.
+     * @param memberCount Number of member that is important for distribution-related rules and converters.
+     * @return Context.
+     */
+    public static OptimizerContext create(
+        List<TableResolver> tableResolvers,
+        List<List<String>> currentSearchPaths,
+        int memberCount
+    ) {
+        // Prepare search paths.
+        List<List<String>> searchPaths = HazelcastSchemaUtils.prepareSearchPaths(currentSearchPaths, tableResolvers);
+
+        // Resolve tables.
+        HazelcastSchema rootSchema = HazelcastSchemaUtils.createRootSchema(tableResolvers);
+
+        return create(rootSchema, searchPaths, memberCount);
+    }
+
+    public static OptimizerContext create(
+        HazelcastSchema rootSchema,
+        List<List<String>> schemaPaths,
+        int memberCount
+    ) {
+        JavaTypeFactory typeFactory = new HazelcastTypeFactory();
+        Prepare.CatalogReader catalogReader = createCatalogReader(typeFactory, CONNECTION_CONFIG, rootSchema, schemaPaths);
+        SqlValidator validator = createValidator(typeFactory, catalogReader);
+        VolcanoPlanner volcanoPlanner = createPlanner(CONNECTION_CONFIG);
+        HazelcastRelOptCluster cluster = createCluster(volcanoPlanner, typeFactory);
+
+        QueryParser parser = new QueryParser(validator);
+        QueryConverter converter = new QueryConverter(catalogReader, validator, cluster);
+        QueryPlanner planner = new QueryPlanner(volcanoPlanner);
+
+        return new OptimizerContext(parser, converter, planner);
+    }
+
+    /**
+     * Parse SQL statement.
+     *
+     * @param sql SQL string.
+     * @return SQL tree.
+     */
+    public QueryParseResult parse(String sql) {
+        return parser.parse(sql);
+    }
+
+    /**
+     * Perform initial conversion of an SQL tree to a relational tree.
+     *
+     * @param node SQL tree.
+     * @return Relational tree.
+     */
+    public RelNode convert(SqlNode node) {
+        return converter.convert(node);
+    }
+
+    /**
+     * Apply the given rules to the node.
+     *
+     * @param node Node.
+     * @param rules Rules.
+     * @param traitSet Required trait set.
+     * @return Optimized node.
+     */
+    public RelNode optimize(RelNode node, RuleSet rules, RelTraitSet traitSet) {
+        return planner.optimize(node, rules, traitSet);
+    }
+
+    private static Prepare.CatalogReader createCatalogReader(
+        JavaTypeFactory typeFactory,
+        CalciteConnectionConfig config,
+        HazelcastSchema rootSchema,
+        List<List<String>> schemaPaths
+    ) {
+        return new HazelcastCalciteCatalogReader(
+            new HazelcastRootCalciteSchema(rootSchema),
+            schemaPaths,
+            typeFactory,
+            config
+        );
+    }
+
+    private static SqlValidator createValidator(JavaTypeFactory typeFactory, Prepare.CatalogReader catalogReader) {
+        SqlOperatorTable opTab = ChainedSqlOperatorTable.of(
+            HazelcastSqlOperatorTable.instance(),
+            SqlStdOperatorTable.instance()
+        );
+
+        return new HazelcastSqlValidator(
+            opTab,
+            catalogReader,
+            typeFactory,
+            HazelcastSqlConformance.INSTANCE
+        );
+    }
+
+    private static VolcanoPlanner createPlanner(CalciteConnectionConfig config) {
+        VolcanoPlanner planner = new VolcanoPlanner(
+            null,
+            Contexts.of(config)
+        );
+
+        planner.clearRelTraitDefs();
+        planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+        planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);
+
+        return planner;
+    }
+
+    private static HazelcastRelOptCluster createCluster(
+        VolcanoPlanner planner,
+        JavaTypeFactory typeFactory
+    ) {
+        HazelcastRelOptCluster cluster = HazelcastRelOptCluster.create(
+            planner,
+            new RexBuilder(typeFactory)
+        );
+
+        // Wire up custom metadata providers.
+        cluster.setMetadataProvider(JaninoRelMetadataProvider.of(METADATA_PROVIDER));
+
+        return cluster;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/QueryPlanner.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/QueryPlanner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.apache.calcite.tools.RuleSet;
+
+/**
+ * Performs query planning.
+ */
+public class QueryPlanner {
+
+    private final VolcanoPlanner planner;
+
+    public QueryPlanner(VolcanoPlanner planner) {
+        this.planner = planner;
+    }
+
+    public RelNode optimize(RelNode node, RuleSet rules, RelTraitSet traitSet) {
+        Program program = Programs.of(rules);
+
+        return program.run(
+            planner,
+            node,
+            traitSet,
+            ImmutableList.of(),
+            ImmutableList.of()
+        );
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/metadata/HazelcastRelMdRowCount.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/metadata/HazelcastRelMdRowCount.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.metadata;
+
+import org.apache.calcite.rel.metadata.ReflectiveRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMdRowCount;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.calcite.util.BuiltInMethod;
+
+/**
+ * Metadata which provides row count estimates.
+ */
+public final class HazelcastRelMdRowCount extends RelMdRowCount {
+    /** Do not change the name (see {@code RelMetadataQueryBase} JavaDoc). */
+    public static final RelMetadataProvider SOURCE =
+        ReflectiveRelMetadataProvider.reflectiveSource(BuiltInMethod.ROW_COUNT.method, new HazelcastRelMdRowCount());
+
+    private HazelcastRelMdRowCount() {
+        // No-op.
+    }
+
+    // Empty at the moment, will be extended in the future.
+    // Now it serves as an example of how to wire up a metadata handler into Calcite.
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/CasingConfiguration.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/CasingConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.avatica.util.Quoting;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.sql.parser.SqlParser;
+
+import java.util.Properties;
+
+/**
+ * Casing configuration.
+ * <p>
+ * At the moment we do only case-sensitive identifier comparison. It violates SQL standard and negatively affects usability.
+ * Case insensitive processing is going to be implemented in future.
+ */
+public final class CasingConfiguration {
+
+    public static final CasingConfiguration DEFAULT =
+        new CasingConfiguration(true, Casing.UNCHANGED, Casing.UNCHANGED, Quoting.DOUBLE_QUOTE);
+
+    private final boolean caseSensitive;
+    private final Casing unquotedCasing;
+    private final Casing quotedCasing;
+    private final Quoting quoting;
+
+    private CasingConfiguration(boolean caseSensitive, Casing unquotedCasing, Casing quotedCasing, Quoting quoting) {
+        this.caseSensitive = caseSensitive;
+        this.unquotedCasing = unquotedCasing;
+        this.quotedCasing = quotedCasing;
+        this.quoting = quoting;
+    }
+
+    public void toParserConfig(SqlParser.ConfigBuilder configBuilder) {
+        configBuilder.setCaseSensitive(caseSensitive);
+        configBuilder.setUnquotedCasing(unquotedCasing);
+        configBuilder.setQuotedCasing(quotedCasing);
+        configBuilder.setQuoting(quoting);
+    }
+
+    public CalciteConnectionConfig toConnectionConfig() {
+        Properties connectionProperties = new Properties();
+
+        connectionProperties.put(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.toString(caseSensitive));
+        connectionProperties.put(CalciteConnectionProperty.UNQUOTED_CASING.camelName(), unquotedCasing.toString());
+        connectionProperties.put(CalciteConnectionProperty.QUOTED_CASING.camelName(), quotedCasing.toString());
+        connectionProperties.put(CalciteConnectionProperty.QUOTING.camelName(), quoting.toString());
+
+        return new CalciteConnectionConfigImpl(connectionProperties);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConverter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.HazelcastRelOptCluster;
+import org.apache.calcite.plan.RelOptCostImpl;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.rules.SubQueryRemoveRule;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.sql2rel.StandardConvertletTable;
+
+/**
+ * Converts a parse tree into a relational tree.
+ */
+public class QueryConverter {
+    /**
+     * Whether to expand subqueries. When set to {@code false}, subqueries are left as is in the form of
+     * {@link org.apache.calcite.rex.RexSubQuery}. Otherwise they are expanded into {@link org.apache.calcite.rel.core.Correlate}
+     * instances.
+     * Do not enable this because you may run into https://issues.apache.org/jira/browse/CALCITE-3484. Instead, subquery
+     * elimination rules are executed during logical planning. In addition, resulting plans are slightly better that those
+     * produced by "expand" flag.
+     */
+    private static final boolean EXPAND = false;
+
+    /** Whether to trim unused fields. The trimming is needed after subquery elimination. */
+    private static final boolean TRIM_UNUSED_FIELDS = true;
+
+    private static final SqlToRelConverter.Config CONFIG;
+    private final SqlToRelConverter converter;
+
+    static {
+        SqlToRelConverter.ConfigBuilder configBuilder = SqlToRelConverter.configBuilder()
+            .withExpand(EXPAND)
+            .withTrimUnusedFields(TRIM_UNUSED_FIELDS);
+
+        CONFIG = configBuilder.build();
+    }
+
+    public QueryConverter(Prepare.CatalogReader catalogReader, SqlValidator validator, HazelcastRelOptCluster cluster) {
+        converter = new SqlToRelConverter(
+            null,
+            validator,
+            catalogReader,
+            cluster,
+            StandardConvertletTable.INSTANCE,
+            CONFIG
+        );
+    }
+
+    public RelNode convert(SqlNode node) {
+        // 1. Perform initial conversion.
+        RelRoot root = converter.convertQuery(node, false, true);
+
+        // 2. Remove subquery expressions, converting them to Correlate nodes.
+        RelNode relNoSubqueries = rewriteSubqueries(root.rel);
+
+        // 3. Perform decorrelation, i.e. rewrite a nested loop where the right side depends on the value of the left side,
+        // to a variation of joins, semijoins and aggregations, which could be executed much more efficiently.
+        // See "Unnesting Arbitrary Queries", Thomas Neumann and Alfons Kemper.
+        RelNode relDecorrelated = converter.decorrelate(node, relNoSubqueries);
+
+        // 4. The side effect of subquery rewrite and decorrelation in Apache Calcite is a number of unnecessary fields,
+        // primarily in projections. This steps removes unused fields from the tree.
+        RelNode relTrimmed = converter.trimUnusedFields(true, relDecorrelated);
+
+        return relTrimmed;
+    }
+
+    /**
+     * Special substep of an initial query conversion which eliminates correlated subqueries, converting them to various forms
+     * of joins. It is used instead of "expand" flag due to bugs in Calcite (see {@link #EXPAND}).
+     *
+     * @param rel Initial relation.
+     * @return Resulting relation.
+     */
+    private static RelNode rewriteSubqueries(RelNode rel) {
+        HepProgramBuilder hepPgmBldr = new HepProgramBuilder();
+
+        hepPgmBldr.addRuleInstance(SubQueryRemoveRule.FILTER);
+        hepPgmBldr.addRuleInstance(SubQueryRemoveRule.PROJECT);
+        hepPgmBldr.addRuleInstance(SubQueryRemoveRule.JOIN);
+
+        HepPlanner planner = new HepPlanner(hepPgmBldr.build(), Contexts.empty(), true, null, RelOptCostImpl.FACTORY);
+
+        planner.setRoot(rel);
+
+        return planner.findBestExp();
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParseResult.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParseResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlNode;
+
+/**
+ * Parsing result.
+ */
+public class QueryParseResult {
+
+    private final SqlNode node;
+    private final RelDataType parameterRowType;
+
+    public QueryParseResult(SqlNode node, RelDataType parameterRowType) {
+        this.node = node;
+        this.parameterRowType = parameterRowType;
+    }
+
+    public SqlNode getNode() {
+        return node;
+    }
+
+    public RelDataType getParameterRowType() {
+        return parameterRowType;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlConformance;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/**
+ * Performs syntactic and semantic validation of the query, and converts the parse tree into a relational tree.
+ */
+public class QueryParser {
+
+    private static final SqlParser.Config CONFIG;
+    private final SqlValidator validator;
+
+    static {
+        SqlParser.ConfigBuilder configBuilder = SqlParser.configBuilder();
+
+        CasingConfiguration.DEFAULT.toParserConfig(configBuilder);
+        configBuilder.setConformance(HazelcastSqlConformance.INSTANCE);
+
+        CONFIG = configBuilder.build();
+    }
+
+    public QueryParser(SqlValidator validator) {
+        this.validator = validator;
+    }
+
+    public QueryParseResult parse(String sql) {
+        SqlNode node;
+        RelDataType parameterRowType;
+
+        try {
+            SqlParser parser = SqlParser.create(sql, CONFIG);
+
+            node = validator.validate(parser.parseStmt());
+
+            node.accept(UnsupportedOperationVisitor.INSTANCE);
+
+            parameterRowType = validator.getParameterRowType(node);
+        } catch (Exception e) {
+            throw QueryException.error(SqlErrorCode.PARSING, e.getMessage(), e);
+        }
+
+        return new QueryParseResult(node, parameterRowType);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import org.apache.calcite.runtime.CalciteContextException;
+import org.apache.calcite.runtime.Resources;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlDynamicParam;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.util.SqlVisitor;
+import org.apache.calcite.sql.validate.SqlValidatorException;
+
+/**
+ * Visitor that throws exceptions for unsupported SQL features.
+ */
+public final class UnsupportedOperationVisitor implements SqlVisitor<Void> {
+
+    public static final UnsupportedOperationVisitor INSTANCE = new UnsupportedOperationVisitor();
+    private static final Resource RESOURCE = Resources.create(Resource.class);
+
+    private UnsupportedOperationVisitor() {
+        // No-op.
+    }
+
+    @Override
+    public Void visit(SqlCall call) {
+        processCall(call);
+
+        call.getOperator().acceptCall(this, call);
+
+        return null;
+    }
+
+    @Override
+    public Void visit(SqlNodeList nodeList) {
+        if (nodeList.size() == 0) {
+            return null;
+        }
+
+        for (int i = 0; i < nodeList.size(); i++) {
+            SqlNode node = nodeList.get(i);
+
+            node.accept(this);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(SqlIdentifier id) {
+        return null;
+    }
+
+    @Override
+    public Void visit(SqlDataTypeSpec type) {
+        throw error(type, RESOURCE.custom("Type specification is not supported"));
+    }
+
+    @Override
+    public Void visit(SqlDynamicParam param) {
+        throw error(param, RESOURCE.custom("Parameters are not supported"));
+    }
+
+    @Override
+    public Void visit(SqlLiteral literal) {
+        SqlTypeName typeName = literal.getTypeName();
+
+        switch (typeName) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case DECIMAL:
+                return null;
+
+            default:
+                throw error(literal, RESOURCE.custom(typeName + " literals are not supported"));
+        }
+    }
+
+    @Override
+    public Void visit(SqlIntervalQualifier intervalQualifier) {
+        return null;
+    }
+
+    private void processCall(SqlCall call) {
+        SqlKind kind = call.getKind();
+
+        if (SqlKind.COMPARISON.contains(kind)) {
+            return;
+        }
+
+        switch (kind) {
+            case SELECT:
+                processSelect((SqlSelect) call);
+
+                return;
+
+            case AS:
+                return;
+
+            default:
+                throw unsupported(call, call.getKind());
+        }
+    }
+
+    private void processSelect(SqlSelect select) {
+        if (select.hasOrderBy()) {
+            throw unsupported(select.getOrderList(), SqlKind.ORDER_BY);
+        }
+
+        if (select.getGroup() != null && select.getGroup().size() > 0) {
+            throw unsupported(select.getGroup(), "GROUP BY");
+        }
+    }
+
+    private CalciteContextException unsupported(SqlNode node, SqlKind kind) {
+        return unsupported(node, kind.sql.replace('_', ' '));
+    }
+
+    private CalciteContextException unsupported(SqlNode node, String name) {
+        return error(node, RESOURCE.notSupported(name));
+    }
+
+    private CalciteContextException error(SqlNode node, Resources.ExInst<SqlValidatorException> err) {
+        return SqlUtil.newContextException(node.getParserPosition(), err);
+    }
+
+    public interface Resource {
+        @Resources.BaseMessage("{0}")
+        Resources.ExInst<SqlValidatorException> custom(String a0);
+
+        @Resources.BaseMessage("{0} is not supported")
+        Resources.ExInst<SqlValidatorException> notSupported(String a0);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastCalciteCatalogReader.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastCalciteCatalogReader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.validate.SqlNameMatchers;
+
+import java.util.List;
+
+/**
+ * Catalog reader that allows for setting predefined schema paths.
+ */
+public class HazelcastCalciteCatalogReader extends CalciteCatalogReader {
+    public HazelcastCalciteCatalogReader(
+        CalciteSchema rootSchema,
+        List<List<String>> schemaPaths,
+        RelDataTypeFactory typeFactory,
+        CalciteConnectionConfig config
+    ) {
+        // Call the protected constructor that is not visible otherwise.
+        super(
+            rootSchema,
+            SqlNameMatchers.withCaseSensitive(config != null && config.caseSensitive()),
+            schemaPaths,
+            typeFactory,
+            config
+        );
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastSchema.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaVersion;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Implementation of a schema, exposing sub schemas and tables.
+ */
+public class HazelcastSchema extends AbstractSchema {
+
+    private final Map<String, Schema> subSchemaMap;
+    private final Map<String, Table> tableMap;
+
+    public HazelcastSchema(Map<String, Table> tableMap) {
+        this(null, tableMap);
+    }
+
+    public HazelcastSchema(Map<String, Schema> subSchemaMap, Map<String, Table> tableMap) {
+        this.subSchemaMap = subSchemaMap != null ? subSchemaMap : Collections.emptyMap();
+        this.tableMap = tableMap != null ? tableMap : Collections.emptyMap();
+    }
+
+    @Override
+    protected Map<String, Schema> getSubSchemaMap() {
+        return subSchemaMap;
+    }
+
+    @Override
+    public Map<String, Table> getTableMap() {
+        return tableMap;
+    }
+
+    @Override
+    public Schema snapshot(SchemaVersion version) {
+        return this;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastSchemaUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastSchemaUtils.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.schema.AbstractMapTable;
+import com.hazelcast.sql.impl.schema.Table;
+import com.hazelcast.sql.impl.schema.TableResolver;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Statistic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility methods for schema resolution.
+ */
+public final class HazelcastSchemaUtils {
+    private HazelcastSchemaUtils() {
+        // No-op.
+    }
+
+    /**
+     * Creates the top-level catalog containing the given child schema.
+     *
+     * @param schema Schema.
+     * @return Catalog.
+     */
+    public static HazelcastSchema createCatalog(Schema schema) {
+        return new HazelcastSchema(
+            Collections.singletonMap(QueryUtils.CATALOG, schema),
+            Collections.emptyMap()
+        );
+    }
+
+    /**
+     * Construct a schema from the given table resolvers.
+     * <p>
+     * Currently we assume that all tables are resolved upfront by querying a table resolver. It works well for predefined
+     * objects such as IMap and ReplicatedMap as well as external tables created by Jet. This approach will not work well
+     * should we need a relaxed/dynamic object resolution at some point in future.
+     *
+     * @param tableResolvers Table resolver to be used to get the list of existing tables.
+     * @return Top-level schema.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static HazelcastSchema createRootSchema(List<TableResolver> tableResolvers) {
+        // Create tables.
+        Map<String, Map<String, HazelcastTable>> tableMap = new HashMap<>();
+
+        for (TableResolver tableResolver : tableResolvers) {
+            Collection<Table> tables = tableResolver.getTables();
+
+            if (tables == null || tables.isEmpty()) {
+                continue;
+            }
+
+            for (Table table : tables) {
+                HazelcastTable convertedTable = new HazelcastTable(
+                    table,
+                    createTableStatistic(table)
+                );
+
+                Map<String , HazelcastTable> schemaTableMap =
+                    tableMap.computeIfAbsent(table.getSchemaName(), (k) -> new HashMap<>());
+
+                schemaTableMap.put(table.getName(), convertedTable);
+            }
+        }
+
+        // Create schemas.
+        Map<String, Schema> schemaMap = new HashMap<>();
+
+        for (Map.Entry<String, Map<String, HazelcastTable>> schemaEntry : tableMap.entrySet()) {
+            String schemaName = schemaEntry.getKey();
+            Map schemaTables = schemaEntry.getValue();
+
+            HazelcastSchema schema = new HazelcastSchema(Collections.emptyMap(), schemaTables);
+
+            schemaMap.put(schemaName, schema);
+        }
+
+        HazelcastSchema rootSchema = new HazelcastSchema(schemaMap, Collections.emptyMap());
+
+        return createCatalog(rootSchema);
+    }
+
+    /**
+     * Create Calcite {@link Statistic} object for the given table.
+     * <p>
+     * As neither IMDG core, nor Jet has dependency on the SQL module, we cannot get that object from the outside. Instead,
+     * it should be created in the SQL module through {@code instanceof} checks (or similar).
+     *
+     * @param table Target table.
+     * @return Statistics for the table.
+     */
+    private static Statistic createTableStatistic(Table table) {
+        if (table instanceof AbstractMapTable) {
+            return new MapTableStatistic(table.getStatistics().getRowCount());
+        }
+
+        throw new UnsupportedOperationException("Unsupported table type: " + table.getClass().getName());
+    }
+
+    /**
+     * Prepares schema paths that will be used for search.
+     *
+     * @param currentSearchPaths Additional schema paths to be considered.
+     * @return Schema paths to be used.
+     */
+    public static List<List<String>> prepareSearchPaths(
+        List<List<String>> currentSearchPaths,
+        List<TableResolver> tableResolvers
+    ) {
+        // Current search paths have the highest priority.
+        List<List<String>> res = new ArrayList<>();
+
+        if (currentSearchPaths != null) {
+            res.addAll(currentSearchPaths);
+        }
+
+        // Then add paths from table resolvers.
+        if (tableResolvers != null) {
+            for (TableResolver tableResolver : tableResolvers) {
+                List<List<String>> tableResolverSearchPaths = tableResolver.getDefaultSearchPaths();
+
+                if (tableResolverSearchPaths != null) {
+                    res.addAll(tableResolverSearchPaths);
+                }
+            }
+        }
+
+        // Add catalog scope.
+        res.add(Collections.singletonList(QueryUtils.CATALOG));
+
+        // Add top-level scope.
+        res.add(Collections.emptyList());
+
+        return res;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import com.hazelcast.sql.impl.schema.Table;
+import com.hazelcast.sql.impl.schema.TableField;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.rel.type.StructKind;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for all tables in the Calcite integration:
+ * <ul>
+ *     <li>Maps field types defined in the {@code core} module to Calcite types</li>
+ *     <li>Provides access to the underlying table and statistics</li>
+ * </ul>
+ */
+public class HazelcastTable extends AbstractTable {
+
+    private static final Map<QueryDataTypeFamily, SqlTypeName> QUERY_TO_SQL_TYPE = new HashMap<>();
+
+    static {
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.VARCHAR, SqlTypeName.VARCHAR);
+
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.BOOLEAN, SqlTypeName.BOOLEAN);
+
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.TINYINT, SqlTypeName.TINYINT);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.SMALLINT, SqlTypeName.SMALLINT);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.INT, SqlTypeName.INTEGER);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.BIGINT, SqlTypeName.BIGINT);
+
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.DECIMAL, SqlTypeName.DECIMAL);
+
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.REAL, SqlTypeName.REAL);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.DOUBLE, SqlTypeName.DOUBLE);
+
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.TIME, SqlTypeName.TIME);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.DATE, SqlTypeName.DATE);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.TIMESTAMP, SqlTypeName.TIMESTAMP);
+        QUERY_TO_SQL_TYPE.put(QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+    }
+
+    private final Table target;
+    private final Statistic statistic;
+
+    private RelDataType rowType;
+
+    public HazelcastTable(Table target, Statistic statistic) {
+        this.target = target;
+        this.statistic = statistic;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        if (rowType != null) {
+            return rowType;
+        }
+
+        List<RelDataTypeField> convertedFields = new ArrayList<>(target.getFieldCount());
+
+        for (int i = 0; i < target.getFieldCount(); i++) {
+            TableField field = target.getField(i);
+
+            String fieldName = field.getName();
+            QueryDataType fieldType = field.getType();
+            QueryDataTypeFamily fieldTypeFamily = fieldType.getTypeFamily();
+
+            SqlTypeName sqlTypeName = QUERY_TO_SQL_TYPE.get(fieldTypeFamily);
+
+            if (sqlTypeName == null) {
+                throw new IllegalStateException("Unexpected type family: " + fieldTypeFamily);
+            }
+
+            RelDataType relDataType = typeFactory.createSqlType(sqlTypeName);
+            RelDataType nullableRelDataType = typeFactory.createTypeWithNullability(relDataType, true);
+
+            RelDataTypeField convertedField = new RelDataTypeFieldImpl(fieldName, convertedFields.size(), nullableRelDataType);
+            convertedFields.add(convertedField);
+        }
+
+        rowType = new RelRecordType(StructKind.PEEK_FIELDS, convertedFields, false);
+
+        return rowType;
+    }
+
+    @Override
+    public Statistic getStatistic() {
+        return statistic;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/MapTableStatistic.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/MapTableStatistic.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributionTraitDef;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Simple table statistics for IMap and ReplicatedMap.
+ */
+public class MapTableStatistic implements Statistic {
+    /** Row count that is fixed for the duration of query optimization process. */
+    private final Long rowCount;
+
+    public MapTableStatistic(long rowCount) {
+        this.rowCount = rowCount;
+    }
+
+    @Override
+    public Double getRowCount() {
+        return (double) rowCount;
+    }
+
+    @Override
+    public boolean isKey(ImmutableBitSet columns) {
+        // See getKeys().
+        return false;
+    }
+
+    @Override
+    public List<ImmutableBitSet> getKeys() {
+        // We do not return any keys at the moment because the optimizer to be released do not use any of rules that may benefit
+        // from unique keys. When it is time to implement more advanced things such as aggregations and joins, this statistic
+        // will be very important, because it is used in a number of optimization rules.
+        // See BuiltInMetadata.ColumnUniqueness and BuiltInMetadata.UniqueKeys.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<RelReferentialConstraint> getReferentialConstraints() {
+        // Hazelcast do not have referential constraints.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<RelCollation> getCollations() {
+        // Entries in IMap and ReplicatedMap are not sorted.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public RelDistribution getDistribution() {
+        // We do not use Calcite distributions, so just returning the default value here.
+        return RelDistributionTraitDef.INSTANCE.getDefault();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{rowCount=" + rowCount + '}';
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlConformance.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlConformance.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate;
+
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.sql.validate.SqlDelegatingConformance;
+
+/**
+ * The class that defines conformance level for Hazelcast SQL dialect.
+ */
+public final class HazelcastSqlConformance extends SqlDelegatingConformance {
+    /** Singleton. */
+    public static final HazelcastSqlConformance INSTANCE = new HazelcastSqlConformance();
+
+    private HazelcastSqlConformance() {
+        super(SqlConformanceEnum.DEFAULT);
+    }
+
+    @Override
+    public boolean allowExplicitRowValueConstructor() {
+        // Do not allow explicit row constructor: "ROW([vals])".
+        return false;
+    }
+
+    @Override
+    public boolean isLimitStartCountAllowed() {
+        // Allow "LIMIT [start], [count]" syntax.
+        return true;
+    }
+
+    @Override
+    public boolean isGroupByAlias() {
+        // Allow aliases in GROUP BY: "SELECT a AS b FROM table GROUP BY b".
+        return true;
+    }
+
+    @Override
+    public boolean isGroupByOrdinal() {
+        // Allow ordinals in GROUP BY: "SELECT a AS b FROM table GROUP BY 1".
+        return true;
+    }
+
+    @Override
+    public boolean isHavingAlias() {
+        // Allow aliases in HAVING, similar to example in "isGroupByAlias".
+        return true;
+    }
+
+    @Override
+    public boolean isFromRequired() {
+        // FROM keyword is required as per SQL'2003 standard.
+        return true;
+    }
+
+    @Override
+    public boolean isMinusAllowed() {
+        // Support "MINUS" in addition to "EXCEPT".
+        return true;
+    }
+
+    @Override
+    public boolean isPercentRemainderAllowed() {
+        // Allow "A % B".
+        return true;
+    }
+
+    @Override
+    public boolean allowNiladicParentheses() {
+        // Allow CURRENT_DATE() in addition to CURRENT_DATE.
+        return true;
+    }
+
+    @Override
+    public boolean isBangEqualAllowed() {
+        // Allow "A != B" in addition to "A <> B".
+        return true;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate;
+
+import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
+
+/**
+ * An additional functions that are resolved during query parsing/validation.
+ */
+public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable {
+
+    private static final HazelcastSqlOperatorTable INSTANCE = new HazelcastSqlOperatorTable();
+
+    static {
+        INSTANCE.init();
+    }
+
+    private HazelcastSqlOperatorTable() {
+        // No-op.
+    }
+
+    public static HazelcastSqlOperatorTable instance() {
+        return INSTANCE;
+    }
+
+    // Empty at the moment, will be extended in the future.
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate;
+
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
+import org.apache.calcite.sql.validate.SqlValidatorImpl;
+
+/**
+ * Hazelcast-specific SQL validator.
+ */
+public class HazelcastSqlValidator extends SqlValidatorImpl {
+    public HazelcastSqlValidator(
+        SqlOperatorTable opTab,
+        SqlValidatorCatalogReader catalogReader,
+        RelDataTypeFactory typeFactory,
+        SqlConformance conformance
+    ) {
+        super(opTab, catalogReader, typeFactory, conformance);
+    }
+}

--- a/hazelcast-sql/src/main/java/org/apache/calcite/jdbc/HazelcastRootCalciteSchema.java
+++ b/hazelcast-sql/src/main/java/org/apache/calcite/jdbc/HazelcastRootCalciteSchema.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.jdbc;
+
+import com.hazelcast.sql.impl.calcite.schema.HazelcastSchema;
+import org.apache.calcite.schema.SchemaVersion;
+
+/**
+ * Root Calcite schema.
+ * <p>
+ * Calcite uses {@link org.apache.calcite.schema.Schema} to store actual objects, and
+ * {@link org.apache.calcite.jdbc.CalciteSchema} as a wrapper. This class is a straightforward implementation of the latter.
+ * <p>
+ * Located in the Calcite package because the required super constructor is package-private.
+ */
+public final class HazelcastRootCalciteSchema extends SimpleCalciteSchema {
+    public HazelcastRootCalciteSchema(HazelcastSchema schema) {
+        super(null, schema, "");
+    }
+
+    @Override
+    public CalciteSchema createSnapshot(SchemaVersion version) {
+        return this;
+    }
+}

--- a/hazelcast-sql/src/main/java/org/apache/calcite/jdbc/package-info.java
+++ b/hazelcast-sql/src/main/java/org/apache/calcite/jdbc/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains Calcite-related classes.
+ */
+package org.apache.calcite.jdbc;

--- a/hazelcast-sql/src/main/java/org/apache/calcite/plan/HazelcastRelOptCluster.java
+++ b/hazelcast-sql/src/main/java/org/apache/calcite/plan/HazelcastRelOptCluster.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.plan;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Extended {@link RelOptCluster} with Hazelcast-specific data.
+ * <p>
+ * Located in the Calcite package because the required super constructor is package-private.
+ */
+public final class HazelcastRelOptCluster extends RelOptCluster {
+    private HazelcastRelOptCluster(
+        RelOptPlanner planner,
+        RelDataTypeFactory typeFactory,
+        RexBuilder rexBuilder,
+        AtomicInteger nextCorrel,
+        Map<String, RelNode> mapCorrelToRel
+    ) {
+        super(planner, typeFactory, rexBuilder, nextCorrel, mapCorrelToRel);
+    }
+
+    public static HazelcastRelOptCluster create(
+        RelOptPlanner planner,
+        RexBuilder rexBuilder
+    ) {
+        return new HazelcastRelOptCluster(
+            planner,
+            rexBuilder.getTypeFactory(),
+            rexBuilder,
+            new AtomicInteger(0),
+            new HashMap<>()
+        );
+    }
+}

--- a/hazelcast-sql/src/main/java/org/apache/calcite/plan/package-info.java
+++ b/hazelcast-sql/src/main/java/org/apache/calcite/plan/package-info.java
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.sql.impl.optimizer;
-
-import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.impl.plan.Plan;
-
 /**
- * No-op optimizer.
+ * Contains Calcite-related classes.
  */
-public class NoOpSqlOptimizer implements SqlOptimizer {
-    @Override
-    public Plan prepare(String sql) {
-        throw QueryException.error("Cannot execute SQL query because \"hazelcast-sql\" module is not in the classpath.");
-    }
-}
+package org.apache.calcite.plan;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/TestMapTable.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/TestMapTable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite;
+
+import com.hazelcast.sql.impl.schema.AbstractMapTable;
+import com.hazelcast.sql.impl.schema.ConstantTableStatistics;
+import com.hazelcast.sql.impl.schema.TableField;
+import com.hazelcast.sql.impl.schema.TableStatistics;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Fake map table for testing purposes.
+ */
+public class TestMapTable extends AbstractMapTable {
+    private TestMapTable(String schemaName, String name, List<TableField> fields, TableStatistics statistics) {
+        super(schemaName, name, fields, statistics);
+    }
+
+    public static TestMapTable create(String schemaName, String name, TableField... fields) {
+        return new TestMapTable(schemaName, name, Arrays.asList(fields), new ConstantTableStatistics(100));
+    }
+
+    public static TableField field(String name) {
+        return field(name, QueryDataType.INT);
+    }
+
+    public static TableField field(String name, QueryDataType type) {
+        return new Field(name, type);
+    }
+
+    private static class Field extends TableField {
+        private Field(String name, QueryDataType type) {
+            super(name, type);
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/TestTableResolver.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/TestTableResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite;
+
+import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.schema.Table;
+import com.hazelcast.sql.impl.schema.TableResolver;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test table resolver.
+ */
+public class TestTableResolver implements TableResolver {
+
+    private final String searchPath;
+    private final Collection<Table> tables;
+
+    public static TestTableResolver create(Table... tables) {
+        return create(null, tables);
+    }
+
+    public static TestTableResolver create(String searchPath, Table... tables) {
+        return new TestTableResolver(searchPath, Arrays.asList(tables));
+    }
+
+    private TestTableResolver(String searchPath, Collection<Table> tables) {
+        this.searchPath = searchPath;
+        this.tables = tables;
+    }
+
+    @Override
+    public List<List<String>> getDefaultSearchPaths() {
+        if (searchPath == null) {
+            return null;
+        } else {
+            return Collections.singletonList(Arrays.asList(QueryUtils.CATALOG, searchPath));
+        }
+    }
+
+    @Override
+    public Collection<Table> getTables() {
+        return tables;
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserNameResolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserNameResolutionTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.calcite.OptimizerContext;
+import com.hazelcast.sql.impl.calcite.TestMapTable;
+import com.hazelcast.sql.impl.calcite.TestTableResolver;
+import com.hazelcast.sql.impl.schema.TableResolver;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.hazelcast.sql.impl.QueryUtils.CATALOG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for object name resolution during parsing.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ParserNameResolutionTest {
+
+    private static final String BAD_CATALOG = "badCatalog";
+
+    private static final String SCHEMA_1 = "mySchema1";
+    private static final String SCHEMA_2 = "mySchema2";
+    private static final String BAD_SCHEMA = "badSchema";
+
+    private static final String TABLE_1 = "myTable1";
+    private static final String TABLE_2 = "myTable2";
+    private static final String BAD_TABLE = "badTable";
+
+    private static final String FIELD_1 = "myField1";
+    private static final String FIELD_2 = "myField2";
+    private static final String BAD_FIELD = "badField";
+
+    @Test
+    public void testNameResolution() {
+        // Lookup for table without default path.
+        checkFailure(errorObjectNotFound(TABLE_1), FIELD_1, TABLE_1);
+        checkSuccess(FIELD_1, SCHEMA_1, TABLE_1);
+        checkSuccess(FIELD_1, CATALOG, SCHEMA_1, TABLE_1);
+
+        // Lookup for table with default path.
+        checkSuccess(FIELD_2, TABLE_2);
+        checkSuccess(FIELD_2, SCHEMA_2, TABLE_2);
+        checkSuccess(FIELD_2, CATALOG, SCHEMA_2, TABLE_2);
+
+        // Test overridden search path.
+        checkSuccess(createContext(SCHEMA_1), FIELD_1, TABLE_1);
+
+        // Wrong field
+        checkFailure(errorColumnNotFound(BAD_FIELD), BAD_FIELD, SCHEMA_1, TABLE_1);
+
+        // Wrong table
+        checkFailure(errorObjectNotFound(BAD_TABLE), BAD_FIELD, BAD_TABLE);
+
+        // Wrong table in existing schema
+        checkFailure(errorObjectNotFoundWithin(BAD_TABLE, CATALOG, SCHEMA_1), BAD_FIELD, SCHEMA_1, BAD_TABLE);
+
+        // Wrong table in existing schema/catalog
+        checkFailure(errorObjectNotFoundWithin(BAD_TABLE, CATALOG, SCHEMA_1), BAD_FIELD, CATALOG, SCHEMA_1, BAD_TABLE);
+
+        // Wrong schema
+        checkFailure(errorObjectNotFound(BAD_SCHEMA), BAD_FIELD, BAD_SCHEMA, BAD_TABLE);
+
+        // Wrong schema in existing catalog
+        checkFailure(errorObjectNotFoundWithin(BAD_SCHEMA, CATALOG), BAD_FIELD, CATALOG, BAD_SCHEMA, BAD_TABLE);
+
+        // Wrong catalog
+        checkFailure(errorObjectNotFound(BAD_CATALOG), BAD_FIELD, BAD_CATALOG, BAD_SCHEMA, BAD_TABLE);
+    }
+
+    private static void checkSuccess(String fieldName, String... tableComponents) {
+        checkSuccess(createContext(), fieldName, tableComponents);
+    }
+
+    private static void checkSuccess(OptimizerContext context, String fieldName, String... tableComponents) {
+        QueryParseResult res = context.parse(composeSelect(fieldName, tableComponents));
+
+        SqlSelect select = (SqlSelect) res.getNode();
+
+        SqlNodeList selectList = select.getSelectList();
+        assertEquals(1, selectList.size());
+
+        SqlIdentifier fieldIdentifier = (SqlIdentifier) selectList.get(0);
+        assertEquals(fieldName, fieldIdentifier.toString());
+
+        SqlIdentifier from = (SqlIdentifier) select.getFrom();
+        assertEquals(SqlIdentifier.getString(Arrays.asList(tableComponents)), from.toString());
+    }
+
+    private static void checkFailure(String errorMessage, String fieldName, String... tableComponents) {
+        try {
+            createContext().parse(composeSelect(fieldName, tableComponents));
+
+            fail();
+        } catch (QueryException e) {
+            assertEquals(SqlErrorCode.PARSING, e.getCode());
+
+            Throwable cause = e.getCause();
+            assertTrue(cause.getMessage(), cause.getMessage().endsWith(errorMessage));
+        }
+    }
+
+    private static String errorColumnNotFound(String columnName) {
+        return "Column '" + columnName + "' not found in any table";
+    }
+
+    private static String errorObjectNotFound(String tableName) {
+        return "Object '" + tableName + "' not found";
+    }
+
+    private static String errorObjectNotFoundWithin(String tableName, String... schemaComponents) {
+        return errorObjectNotFound(tableName) + " within '" + SqlIdentifier.getString(Arrays.asList(schemaComponents)) + "'";
+    }
+
+    private static String composeSelect(String fieldName, String... tableComponents) {
+        StringBuilder res = new StringBuilder("SELECT " + fieldName + " FROM ");
+
+        boolean first = true;
+
+        for (String tableComponent : tableComponents) {
+            if (first) {
+                first = false;
+            } else {
+                res.append(".");
+            }
+
+            res.append(tableComponent);
+        }
+
+        return res.toString();
+    }
+
+    private static OptimizerContext createContext() {
+        return createContext(null);
+    }
+
+    private static OptimizerContext createContext(String searchPath) {
+        TableResolver resolverWithoutSearchPath = TestTableResolver.create(
+            TestMapTable.create(SCHEMA_1, TABLE_1, TestMapTable.field(FIELD_1))
+        );
+
+        TableResolver resolverWithSearchPath = TestTableResolver.create(
+            SCHEMA_2,
+            TestMapTable.create(SCHEMA_2, TABLE_2, TestMapTable.field(FIELD_2))
+        );
+
+        List<List<String>> searchPaths =
+            searchPath != null ? Collections.singletonList(Arrays.asList(CATALOG, searchPath)) : null;
+
+        return OptimizerContext.create(
+            Arrays.asList(resolverWithoutSearchPath, resolverWithSearchPath),
+            searchPaths,
+            1
+        );
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.calcite.OptimizerContext;
+import com.hazelcast.sql.impl.calcite.TestMapTable;
+import com.hazelcast.sql.impl.calcite.TestTableResolver;
+import com.hazelcast.sql.impl.schema.TableResolver;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for unsupported operations in parser.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ParserOperationsTest {
+    @Test
+    public void testSelectColumn() {
+        checkSuccess("SELECT a, b FROM t");
+    }
+
+    @Test
+    public void testSelectLiteral() {
+        checkSuccess("SELECT 1 FROM t");
+    }
+
+    @Test
+    public void testSelectAs() {
+        checkSuccess("SELECT a a_alias FROM t t_alias");
+    }
+
+    @Test
+    public void testSelectFromDerivedTable() {
+        checkSuccess("SELECT a_alias FROM (SELECT a a_alias FROM t)");
+    }
+
+    @Test
+    public void testWhereComparison() {
+        checkSuccess("SELECT a, b FROM t WHERE a = b");
+        checkSuccess("SELECT a, b FROM t WHERE a != b");
+        checkSuccess("SELECT a, b FROM t WHERE a <> b");
+        checkSuccess("SELECT a, b FROM t WHERE a > b");
+        checkSuccess("SELECT a, b FROM t WHERE a >= b");
+        checkSuccess("SELECT a, b FROM t WHERE a < b");
+        checkSuccess("SELECT a, b FROM t WHERE a <= b");
+        checkSuccess("SELECT a, b FROM t WHERE a IN (1, 2)");
+    }
+
+    @Test
+    public void testUnsupportedSelectScalar() {
+        checkFailure(
+            "SELECT (SELECT a FROM t) FROM t",
+            "SCALAR QUERY is not supported"
+        );
+    }
+
+    @Test
+    public void testUnsupportedWhereScalar() {
+        checkFailure(
+            "SELECT a, b FROM t WHERE a > (SELECT a FROM t)",
+            "SCALAR QUERY is not supported"
+        );
+    }
+
+    @Test
+    public void testUnsupportedOrderBy() {
+        checkFailure(
+            "SELECT a FROM t ORDER BY a",
+            "ORDER BY is not supported"
+        );
+    }
+
+    @Test
+    public void testUnsupportedGroupBy() {
+        checkFailure(
+            "SELECT a FROM t GROUP BY a",
+            "GROUP BY is not supported"
+        );
+    }
+
+    @Test
+    public void testUnsupportedAggregate() {
+        checkFailure(
+            "SELECT SUM(a) FROM t",
+            "SUM is not supported"
+        );
+    }
+
+    @Test
+    public void testUnsupportedJoin() {
+        checkFailure(
+            "SELECT t1.a, t2.a FROM t t1 JOIN t t2 ON t1.a = t2.a",
+            "JOIN is not supported"
+        );
+    }
+
+    private static void checkSuccess(String sql) {
+        createContext().parse(sql);
+    }
+
+    private static void checkFailure(String sql, String message) {
+        try {
+            createContext().parse(sql);
+
+            fail("Exception is not thrown: " + message);
+        } catch (QueryException e) {
+            assertEquals(SqlErrorCode.PARSING, e.getCode());
+
+            assertTrue(e.getCause().getMessage(), e.getCause().getMessage().endsWith(message));
+        }
+    }
+
+    private static OptimizerContext createContext() {
+        TableResolver resolver = TestTableResolver.create(
+            "public",
+            TestMapTable.create("public", "t", TestMapTable.field("a"), TestMapTable.field("b"))
+        );
+
+        return OptimizerContext.create(
+            Collections.singletonList(resolver),
+            null,
+            1
+        );
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/schema/HazelcastSchemaUtilsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/schema/HazelcastSchemaUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.calcite.TestTableResolver;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.hazelcast.sql.impl.calcite.schema.HazelcastSchemaUtils.prepareSearchPaths;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HazelcastSchemaUtilsTest {
+    @Test
+    public void testSearchPaths() {
+        List<List<String>> paths = prepareSearchPaths(null, null);
+
+        checkSearchPaths(paths);
+
+        paths = prepareSearchPaths(
+            Collections.singletonList(Arrays.asList(QueryUtils.CATALOG, "test1")),
+            null
+        );
+
+        checkSearchPaths(paths, "test1");
+
+        paths = prepareSearchPaths(
+            null,
+            Arrays.asList(TestTableResolver.create("test1"), TestTableResolver.create("test2"))
+        );
+
+        checkSearchPaths(paths, "test1", "test2");
+
+        paths = prepareSearchPaths(
+            Collections.singletonList(Arrays.asList(QueryUtils.CATALOG, "test1")),
+            Arrays.asList(TestTableResolver.create("test2"), TestTableResolver.create("test3"))
+        );
+
+        checkSearchPaths(paths, "test1", "test2", "test3");
+    }
+
+    private static void checkSearchPaths(List<List<String>> paths, String... expectedPaths) {
+        List<List<String>> expectedPaths0 = new ArrayList<>();
+
+        if (expectedPaths != null) {
+            for (String expectedPath : expectedPaths) {
+                expectedPaths0.add(Arrays.asList(QueryUtils.CATALOG, expectedPath));
+            }
+        }
+
+        expectedPaths0.add(Collections.singletonList(QueryUtils.CATALOG));
+        expectedPaths0.add(Collections.emptyList());
+
+        assertEquals(expectedPaths0, paths);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlErrorCode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlErrorCode.java
@@ -47,6 +47,9 @@ public final class SqlErrorCode {
     /** Map loading is not finished yet. */
     public static final int MAP_LOADING_IN_PROGRESS = 1007;
 
+    /** Generic parsing error. */
+    public static final int PARSING = 1008;
+
     /** An error with data conversion or transformation. */
     public static final int DATA_EXCEPTION = 2000;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -21,6 +21,8 @@ package com.hazelcast.sql.impl;
  */
 public final class QueryUtils {
 
+    public static final String CATALOG = "hazelcast";
+
     public static final String WORKER_TYPE_OPERATION = "query-operation-thread";
     public static final String WORKER_TYPE_FRAGMENT = "query-fragment-thread";
     public static final String WORKER_TYPE_STATE_CHECKER = "query-state-checker";

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.sql.impl.optimizer.NoOpSqlOptimizer;
+import com.hazelcast.sql.impl.optimizer.DisabledSqlOptimizer;
 import com.hazelcast.sql.impl.optimizer.SqlOptimizer;
 
 import java.lang.reflect.Constructor;
@@ -116,7 +116,7 @@ public class SqlServiceImpl implements Consumer<Packet> {
         try {
             clazz = Class.forName(className);
         } catch (ClassNotFoundException e) {
-            return new NoOpSqlOptimizer();
+            return new DisabledSqlOptimizer();
         } catch (Exception e) {
             throw new HazelcastException("Failed to resolve optimizer class " + className + ": " + e.getMessage(), e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/optimizer/DisabledSqlOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/optimizer/DisabledSqlOptimizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.optimizer;
+
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.plan.Plan;
+
+/**
+ * An optimizer that is instantiated when {@code hazelcast-sql} is not in the classpath.
+ */
+public class DisabledSqlOptimizer implements SqlOptimizer {
+    @Override
+    public Plan prepare(String sql) {
+        throw QueryException.error("Cannot execute SQL query because \"hazelcast-sql\" module is not in the classpath.");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/AbstractMapTable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/AbstractMapTable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.schema;
+
+import java.util.List;
+
+/**
+ * A table that is backed by a Hazelcast map.
+ */
+public abstract class AbstractMapTable extends Table {
+    public AbstractMapTable(String schemaName, String name, List<TableField> fields, TableStatistics statistics) {
+        super(schemaName, name, fields, statistics);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/ConstantTableStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/ConstantTableStatistics.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.schema;
+
+/**
+ * Table statistics with predefined values.
+ */
+public class ConstantTableStatistics implements TableStatistics {
+
+    private final long rowCount;
+
+    public ConstantTableStatistics(long rowCount) {
+        this.rowCount = rowCount;
+    }
+
+    @Override
+    public long getRowCount() {
+        return rowCount;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/Table.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/Table.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.schema;
+
+import java.util.List;
+
+/**
+ * Generic table metadata.
+ */
+public abstract class Table {
+
+    private final String schemaName;
+    private final String name;
+    private final List<TableField> fields;
+    private final TableStatistics statistics;
+
+    protected Table(String schemaName, String name, List<TableField> fields, TableStatistics statistics) {
+        this.schemaName = schemaName;
+        this.name = name;
+        this.fields = fields;
+        this.statistics = statistics;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getFieldCount() {
+        return fields.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends TableField> T getField(int index) {
+        return (T) fields.get(index);
+    }
+
+    public TableStatistics getStatistics() {
+        return statistics;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableField.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableField.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.schema;
+
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+/**
+ * Base class for all table field. Different backends may have additional metadata associated with the field.
+ */
+public abstract class TableField {
+
+    private final String name;
+    private final QueryDataType type;
+
+    protected TableField(String name, QueryDataType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public QueryDataType getType() {
+        return type;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableResolver.java
@@ -27,7 +27,18 @@ import java.util.List;
  */
 public interface TableResolver {
     /**
-     * @return Search paths to be added for object resolution.
+     * Gets the list of search paths for object resolution.
+     * <p>
+     * A single search path consists of two elements: predefined catalog (see {@link com.hazelcast.sql.impl.QueryUtils#CATALOG}
+     * and schema name. For example {@code {"hazelcast", "schema"}}. In this case the "schema" will be added to a search paths,
+     * so that a table {@code schema.table} could be referred as {@code table} in SQL scripts: {@code SELECT * FROM table}.
+     * <p>
+     * Order of search paths is important. If several search paths are defined, then the first path will be searched first, etc.
+     * For example if a table with the same name is defined in {@code schema1} and {@code schema2}, and the following search
+     * paths are provided {@code {"hazelcast", "schema1"}, {"hazelcast", "schema1"}}, then {@code SELECT * FROM table} will pick
+     * the table from the {@code schema1}.
+     *
+     * @return The list of search paths for object resolution.
      */
     List<List<String>> getDefaultSearchPaths();
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableResolver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.schema;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Generic interface that resolves tables belonging to a particular backend.
+ * <p>
+ * At the moment the interface does exactly what we need - provides tables and registers default search paths.
+ * In future, if we have more objects to expose, it might be expanded or reworked completely.
+ */
+public interface TableResolver {
+    /**
+     * @return Search paths to be added for object resolution.
+     */
+    List<List<String>> getDefaultSearchPaths();
+
+    /**
+     * @return Collection of tables to be registered.
+     */
+    Collection<Table> getTables();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableStatistics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.schema;
+
+/**
+ * Statistics for the table. Must not invoke any distributed operations.
+ */
+public interface TableStatistics {
+    /**
+     * Gets the estimated number of rows in the table that is used during planning for cost calculation.
+     * Must return non-negative number. If the underlying table cannot estimate the number of rows, some
+     * constant might be provided.
+     *
+     * @return Estimated number of rows in the table. Never negative.
+     */
+    long getRowCount();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
@@ -50,7 +50,7 @@ import java.io.IOException;
  * Data type represents a type of concrete expression which is based on some basic data type.
  */
 public class QueryDataType implements IdentifiedDataSerializable {
-    public static final int PRECISION_BIT = 1;
+    public static final int PRECISION_BOOLEAN = 1;
     public static final int PRECISION_TINYINT = 4;
     public static final int PRECISION_SMALLINT = 7;
     public static final int PRECISION_INT = 11;
@@ -62,7 +62,7 @@ public class QueryDataType implements IdentifiedDataSerializable {
     public static final QueryDataType VARCHAR = new QueryDataType(StringConverter.INSTANCE);
     public static final QueryDataType VARCHAR_CHARACTER = new QueryDataType(CharacterConverter.INSTANCE);
 
-    public static final QueryDataType BIT = new QueryDataType(BooleanConverter.INSTANCE, PRECISION_BIT);
+    public static final QueryDataType BOOLEAN = new QueryDataType(BooleanConverter.INSTANCE, PRECISION_BOOLEAN);
     public static final QueryDataType TINYINT = new QueryDataType(ByteConverter.INSTANCE, PRECISION_TINYINT);
     public static final QueryDataType SMALLINT = new QueryDataType(ShortConverter.INSTANCE, PRECISION_SMALLINT);
     public static final QueryDataType INT = new QueryDataType(IntegerConverter.INSTANCE, PRECISION_INT);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeFamily.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeFamily.java
@@ -27,7 +27,7 @@ import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_VARCHAR;
 public enum QueryDataTypeFamily {
     LATE(false, 0, TYPE_LEN_OBJECT),
     VARCHAR(false, 100, TYPE_LEN_VARCHAR),
-    BIT(false, 200, 1),
+    BOOLEAN(false, 200, 1),
     TINYINT(false, 300, 1),
     SMALLINT(false, 400, 2),
     INT(false, 500, 4),
@@ -38,7 +38,7 @@ public enum QueryDataTypeFamily {
     TIME(true, 1000, TYPE_LEN_TIME),
     DATE(true, 1100, TYPE_LEN_DATE),
     TIMESTAMP(true, 1200, TYPE_LEN_TIMESTAMP),
-    TIMESTAMP_WITH_TIMEZONE(true, 1300, TYPE_LEN_TIMESTAMP_WITH_OFFSET),
+    TIMESTAMP_WITH_TIME_ZONE(true, 1300, TYPE_LEN_TIMESTAMP_WITH_OFFSET),
     OBJECT(false, 1400, TYPE_LEN_OBJECT);
 
     private final boolean temporal;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeUtils.java
@@ -29,7 +29,7 @@ import com.hazelcast.sql.impl.type.converter.StringConverter;
 import com.hazelcast.sql.impl.type.converter.ZonedDateTimeConverter;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.BIGINT;
-import static com.hazelcast.sql.impl.type.QueryDataType.BIT;
+import static com.hazelcast.sql.impl.type.QueryDataType.BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataType.DATE;
 import static com.hazelcast.sql.impl.type.QueryDataType.DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataType.DECIMAL_BIG_INTEGER;
@@ -38,7 +38,7 @@ import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 import static com.hazelcast.sql.impl.type.QueryDataType.LATE;
 import static com.hazelcast.sql.impl.type.QueryDataType.OBJECT;
 import static com.hazelcast.sql.impl.type.QueryDataType.PRECISION_BIGINT;
-import static com.hazelcast.sql.impl.type.QueryDataType.PRECISION_BIT;
+import static com.hazelcast.sql.impl.type.QueryDataType.PRECISION_BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataType.PRECISION_INT;
 import static com.hazelcast.sql.impl.type.QueryDataType.PRECISION_SMALLINT;
 import static com.hazelcast.sql.impl.type.QueryDataType.PRECISION_TINYINT;
@@ -87,8 +87,8 @@ public final class QueryDataTypeUtils {
         for (int i = 1; i <= PRECISION_BIGINT; i++) {
             QueryDataType type;
 
-            if (i == PRECISION_BIT) {
-                type = BIT;
+            if (i == PRECISION_BOOLEAN) {
+                type = BOOLEAN;
             } else if (i < PRECISION_TINYINT) {
                 type = new QueryDataType(TINYINT.getConverter(), i);
             } else if (i == PRECISION_TINYINT) {
@@ -141,8 +141,8 @@ public final class QueryDataTypeUtils {
                     return VARCHAR_CHARACTER;
                 }
 
-            case BIT:
-                return BIT;
+            case BOOLEAN:
+                return BOOLEAN;
 
             case TINYINT:
                 return TINYINT;
@@ -180,7 +180,7 @@ public final class QueryDataTypeUtils {
             case TIMESTAMP:
                 return TIMESTAMP;
 
-            case TIMESTAMP_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
                 if (converter == DateConverter.INSTANCE) {
                     return TIMESTAMP_WITH_TZ_DATE;
                 } else if (converter == CalendarConverter.INSTANCE) {
@@ -211,8 +211,8 @@ public final class QueryDataTypeUtils {
             case VARCHAR:
                 return VARCHAR;
 
-            case BIT:
-                return BIT;
+            case BOOLEAN:
+                return BOOLEAN;
 
             case TINYINT:
                 return TINYINT;
@@ -244,7 +244,7 @@ public final class QueryDataTypeUtils {
             case TIMESTAMP:
                 return TIMESTAMP;
 
-            case TIMESTAMP_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
                 return TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME;
 
             case OBJECT:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractObjectConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractObjectConverter.java
@@ -34,7 +34,7 @@ public abstract class AbstractObjectConverter extends Converter {
 
     @Override
     public boolean asBit(Object val) {
-        return resolveConverter(val, QueryDataTypeFamily.BIT).asBit(val);
+        return resolveConverter(val, QueryDataTypeFamily.BOOLEAN).asBit(val);
     }
 
     @Override
@@ -89,7 +89,7 @@ public abstract class AbstractObjectConverter extends Converter {
 
     @Override
     public OffsetDateTime asTimestampWithTimezone(Object val) {
-        return resolveConverter(val, QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE).asTimestampWithTimezone(val);
+        return resolveConverter(val, QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE).asTimestampWithTimezone(val);
     }
 
     protected Converter resolveConverter(Object val, QueryDataTypeFamily target) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -148,7 +148,7 @@ public abstract class AbstractStringConverter extends Converter {
         try {
             return OffsetDateTime.parse(cast(val));
         } catch (DateTimeParseException e) {
-            throw cannotConvert(QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE, val);
+            throw cannotConvert(QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE, val);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractTimestampWithTimezoneConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractTimestampWithTimezoneConverter.java
@@ -27,7 +27,7 @@ import java.time.LocalTime;
  */
 public abstract class AbstractTimestampWithTimezoneConverter extends AbstractTemporalConverter {
     protected AbstractTimestampWithTimezoneConverter(int id) {
-        super(id, QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE);
+        super(id, QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/BooleanConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/BooleanConverter.java
@@ -29,7 +29,7 @@ public final class BooleanConverter extends Converter {
     protected static final String FALSE = "false";
 
     private BooleanConverter() {
-        super(ID_BOOLEAN, QueryDataTypeFamily.BIT);
+        super(ID_BOOLEAN, QueryDataTypeFamily.BOOLEAN);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
@@ -115,7 +115,7 @@ public abstract class Converter {
 
     @NotConvertible
     public boolean asBit(Object val) {
-        throw cannotConvert(QueryDataTypeFamily.BIT);
+        throw cannotConvert(QueryDataTypeFamily.BOOLEAN);
     }
 
     @NotConvertible
@@ -175,7 +175,7 @@ public abstract class Converter {
 
     @NotConvertible
     public OffsetDateTime asTimestampWithTimezone(Object val) {
-        throw cannotConvert(QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE);
+        throw cannotConvert(QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE);
     }
 
     public Object asObject(Object val) {
@@ -241,7 +241,7 @@ public abstract class Converter {
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:ReturnCount"})
     public final boolean canConvertTo(QueryDataTypeFamily typeFamily) {
         switch (typeFamily) {
-            case BIT:
+            case BOOLEAN:
                 return canConvertToBit();
 
             case TINYINT:
@@ -277,7 +277,7 @@ public abstract class Converter {
             case TIMESTAMP:
                 return canConvertToTimestamp();
 
-            case TIMESTAMP_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
                 return canConvertToTimestampWithTimezone();
 
             case OBJECT:

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
@@ -177,7 +177,7 @@ public class MapScanExecTest extends SqlTestSupport {
         int id = 1;
         MapContainer mapContainer = mapProxy.getService().getMapServiceContext().getMapContainer(mapProxy.getName());
         List<String> fieldNames = Arrays.asList(QueryPath.KEY + ".val1", "val2", "val3");
-        List<QueryDataType> fieldTypes = Arrays.asList(QueryDataType.INT, QueryDataType.BIGINT, QueryDataType.BIT);
+        List<QueryDataType> fieldTypes = Arrays.asList(QueryDataType.INT, QueryDataType.BIGINT, QueryDataType.BOOLEAN);
         List<Integer> projects = Arrays.asList(0, 1);
         InternalSerializationService serializationService =
             (InternalSerializationService) mapProxy.getNodeEngine().getSerializationService();
@@ -616,7 +616,7 @@ public class MapScanExecTest extends SqlTestSupport {
 
         @Override
         public QueryDataType getType() {
-            return QueryDataType.BIT;
+            return QueryDataType.BOOLEAN;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ConstantPredicateExpression.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ConstantPredicateExpression.java
@@ -43,7 +43,7 @@ public class ConstantPredicateExpression implements Expression<Boolean> {
 
     @Override
     public QueryDataType getType() {
-        return QueryDataType.BIT;
+        return QueryDataType.BOOLEAN;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/FunctionalPredicateExpression.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/FunctionalPredicateExpression.java
@@ -42,7 +42,7 @@ public class FunctionalPredicateExpression implements Expression<Boolean> {
 
     @Override
     public QueryDataType getType() {
-        return QueryDataType.BIT;
+        return QueryDataType.BOOLEAN;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeFamilyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeFamilyTest.java
@@ -24,7 +24,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BIGINT;
-import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BIT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DATE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DOUBLE;
@@ -35,7 +35,7 @@ import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.REAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.SMALLINT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIME;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP;
-import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TINYINT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.VARCHAR;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.values;
@@ -52,7 +52,7 @@ public class QueryDataTypeFamilyTest {
                 case TIME:
                 case DATE:
                 case TIMESTAMP:
-                case TIMESTAMP_WITH_TIMEZONE:
+                case TIMESTAMP_WITH_TIME_ZONE:
                     assertTrue(typeFamily.isTemporal());
 
                     break;
@@ -65,7 +65,7 @@ public class QueryDataTypeFamilyTest {
 
     @Test
     public void testEstimatedSize() {
-        assertTrue(BIT.getEstimatedSize() <= TINYINT.getEstimatedSize());
+        assertTrue(BOOLEAN.getEstimatedSize() <= TINYINT.getEstimatedSize());
         assertTrue(TINYINT.getEstimatedSize() < SMALLINT.getEstimatedSize());
         assertTrue(SMALLINT.getEstimatedSize() < INT.getEstimatedSize());
         assertTrue(INT.getEstimatedSize() < BIGINT.getEstimatedSize());
@@ -76,8 +76,8 @@ public class QueryDataTypeFamilyTest {
     @Test
     public void testPrecedence() {
         assertTrue(LATE.getPrecedence() < VARCHAR.getPrecedence());
-        assertTrue(VARCHAR.getPrecedence() < BIT.getPrecedence());
-        assertTrue(BIT.getPrecedence() < TINYINT.getPrecedence());
+        assertTrue(VARCHAR.getPrecedence() < BOOLEAN.getPrecedence());
+        assertTrue(BOOLEAN.getPrecedence() < TINYINT.getPrecedence());
         assertTrue(TINYINT.getPrecedence() < SMALLINT.getPrecedence());
         assertTrue(SMALLINT.getPrecedence() < INT.getPrecedence());
         assertTrue(INT.getPrecedence() < BIGINT.getPrecedence());
@@ -87,7 +87,7 @@ public class QueryDataTypeFamilyTest {
         assertTrue(DOUBLE.getPrecedence() < TIME.getPrecedence());
         assertTrue(TIME.getPrecedence() < DATE.getPrecedence());
         assertTrue(DATE.getPrecedence() < TIMESTAMP.getPrecedence());
-        assertTrue(TIMESTAMP.getPrecedence() < TIMESTAMP_WITH_TIMEZONE.getPrecedence());
-        assertTrue(TIMESTAMP_WITH_TIMEZONE.getPrecedence() < OBJECT.getPrecedence());
+        assertTrue(TIMESTAMP.getPrecedence() < TIMESTAMP_WITH_TIME_ZONE.getPrecedence());
+        assertTrue(TIMESTAMP_WITH_TIME_ZONE.getPrecedence() < OBJECT.getPrecedence());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
@@ -74,7 +74,7 @@ public class QueryDataTypeTest extends SqlTestSupport {
         checkType(QueryDataType.VARCHAR, StringConverter.INSTANCE);
         checkType(QueryDataType.VARCHAR_CHARACTER, CharacterConverter.INSTANCE);
 
-        checkType(QueryDataType.BIT, BooleanConverter.INSTANCE, QueryDataType.PRECISION_BIT);
+        checkType(QueryDataType.BOOLEAN, BooleanConverter.INSTANCE, QueryDataType.PRECISION_BOOLEAN);
         checkType(QueryDataType.TINYINT, ByteConverter.INSTANCE, QueryDataType.PRECISION_TINYINT);
         checkType(QueryDataType.SMALLINT, ShortConverter.INSTANCE, QueryDataType.PRECISION_SMALLINT);
         checkType(QueryDataType.INT, IntegerConverter.INSTANCE, QueryDataType.PRECISION_INT);
@@ -105,8 +105,8 @@ public class QueryDataTypeTest extends SqlTestSupport {
 
             assertEquals(i, precision);
 
-            if (precision <= QueryDataType.PRECISION_BIT) {
-                assertEquals(QueryDataTypeFamily.BIT, type.getTypeFamily());
+            if (precision <= QueryDataType.PRECISION_BOOLEAN) {
+                assertEquals(QueryDataTypeFamily.BOOLEAN, type.getTypeFamily());
             } else if (precision <= QueryDataType.PRECISION_TINYINT) {
                 assertEquals(QueryDataTypeFamily.TINYINT, type.getTypeFamily());
             } else if (precision <= QueryDataType.PRECISION_SMALLINT) {
@@ -136,7 +136,7 @@ public class QueryDataTypeTest extends SqlTestSupport {
         checkResolvedTypeForClass(QueryDataType.VARCHAR, String.class);
         checkResolvedTypeForClass(QueryDataType.VARCHAR_CHARACTER, char.class, Character.class);
 
-        checkResolvedTypeForClass(QueryDataType.BIT, boolean.class, Boolean.class);
+        checkResolvedTypeForClass(QueryDataType.BOOLEAN, boolean.class, Boolean.class);
         checkResolvedTypeForClass(QueryDataType.TINYINT, byte.class, Byte.class);
         checkResolvedTypeForClass(QueryDataType.SMALLINT, short.class, Short.class);
         checkResolvedTypeForClass(QueryDataType.INT, int.class, Integer.class);
@@ -162,7 +162,7 @@ public class QueryDataTypeTest extends SqlTestSupport {
     public void testTypeResolutionByFamily() {
         checkResolvedTypeForTypeFamily(QueryDataType.VARCHAR, QueryDataTypeFamily.VARCHAR);
 
-        checkResolvedTypeForTypeFamily(QueryDataType.BIT, QueryDataTypeFamily.BIT);
+        checkResolvedTypeForTypeFamily(QueryDataType.BOOLEAN, QueryDataTypeFamily.BOOLEAN);
         checkResolvedTypeForTypeFamily(QueryDataType.TINYINT, QueryDataTypeFamily.TINYINT);
         checkResolvedTypeForTypeFamily(QueryDataType.SMALLINT, QueryDataTypeFamily.SMALLINT);
         checkResolvedTypeForTypeFamily(QueryDataType.INT, QueryDataTypeFamily.INT);
@@ -175,7 +175,7 @@ public class QueryDataTypeTest extends SqlTestSupport {
         checkResolvedTypeForTypeFamily(QueryDataType.DATE, QueryDataTypeFamily.DATE);
         checkResolvedTypeForTypeFamily(QueryDataType.TIMESTAMP, QueryDataTypeFamily.TIMESTAMP);
         checkResolvedTypeForTypeFamily(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME,
-            QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE);
+            QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE);
 
         checkResolvedTypeForTypeFamily(QueryDataType.OBJECT, QueryDataTypeFamily.OBJECT);
     }
@@ -184,8 +184,8 @@ public class QueryDataTypeTest extends SqlTestSupport {
     public void testBigger() {
         checkPrecedence(QueryDataType.VARCHAR, QueryDataType.LATE);
 
-        checkPrecedence(QueryDataType.BIT, QueryDataType.VARCHAR);
-        checkPrecedence(QueryDataType.TINYINT, QueryDataType.BIT);
+        checkPrecedence(QueryDataType.BOOLEAN, QueryDataType.VARCHAR);
+        checkPrecedence(QueryDataType.TINYINT, QueryDataType.BOOLEAN);
         checkPrecedence(QueryDataType.SMALLINT, QueryDataType.TINYINT);
         checkPrecedence(QueryDataType.INT, QueryDataType.SMALLINT);
         checkPrecedence(QueryDataType.BIGINT, QueryDataType.INT);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
@@ -45,7 +45,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BIGINT;
-import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BIT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DATE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DOUBLE;
@@ -56,7 +56,7 @@ import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.REAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.SMALLINT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIME;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP;
-import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP_WITH_TIMEZONE;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TINYINT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.VARCHAR;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.values;
@@ -129,7 +129,7 @@ public class ConvertersTest {
     public void testBooleanConverter() {
         BooleanConverter converter = BooleanConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_BOOLEAN, BIT, Boolean.class);
+        checkConverter(converter, Converter.ID_BOOLEAN, BOOLEAN, Boolean.class);
         checkConverterConversions(converter, VARCHAR, OBJECT);
 
         assertEquals("true", converter.asVarchar(true));
@@ -335,7 +335,7 @@ public class ConvertersTest {
         LocalTimeConverter converter = LocalTimeConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_LOCAL_TIME, TIME, LocalTime.class);
-        checkConverterConversions(converter, VARCHAR, TIMESTAMP, TIMESTAMP_WITH_TIMEZONE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, OBJECT);
 
         String timeString = "11:22:33.444";
         LocalTime time = LocalTime.parse(timeString);
@@ -356,7 +356,7 @@ public class ConvertersTest {
         LocalDateConverter converter = LocalDateConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_LOCAL_DATE, DATE, LocalDate.class);
-        checkConverterConversions(converter, VARCHAR, TIMESTAMP, TIMESTAMP_WITH_TIMEZONE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, OBJECT);
 
         String dateString = "2020-02-02";
         LocalDate date = LocalDate.parse(dateString);
@@ -376,7 +376,7 @@ public class ConvertersTest {
         LocalDateTimeConverter converter = LocalDateTimeConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_LOCAL_DATE_TIME, TIMESTAMP, LocalDateTime.class);
-        checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP_WITH_TIMEZONE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP_WITH_TIME_ZONE, OBJECT);
 
         String dateTimeString = "2020-02-02T11:22:33.444";
         LocalDateTime dateTime = LocalDateTime.parse(dateTimeString);
@@ -395,7 +395,7 @@ public class ConvertersTest {
     public void testDateConverter() {
         DateConverter converter = DateConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_DATE, TIMESTAMP_WITH_TIMEZONE, Date.class);
+        checkConverter(converter, Converter.ID_DATE, TIMESTAMP_WITH_TIME_ZONE, Date.class);
         checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP, OBJECT);
 
         Date val = new Date();
@@ -409,7 +409,7 @@ public class ConvertersTest {
     public void testCalendarConverter() {
         CalendarConverter converter = CalendarConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_CALENDAR, TIMESTAMP_WITH_TIMEZONE, Calendar.class);
+        checkConverter(converter, Converter.ID_CALENDAR, TIMESTAMP_WITH_TIME_ZONE, Calendar.class);
         checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP, OBJECT);
 
         Calendar val = Calendar.getInstance();
@@ -423,7 +423,7 @@ public class ConvertersTest {
     public void testInstantConverter() {
         InstantConverter converter = InstantConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_INSTANT, TIMESTAMP_WITH_TIMEZONE, Instant.class);
+        checkConverter(converter, Converter.ID_INSTANT, TIMESTAMP_WITH_TIME_ZONE, Instant.class);
         checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP, OBJECT);
 
         Instant val = Instant.now();
@@ -437,7 +437,7 @@ public class ConvertersTest {
     public void testOffsetDateTimeConverter() {
         OffsetDateTimeConverter converter = OffsetDateTimeConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_OFFSET_DATE_TIME, TIMESTAMP_WITH_TIMEZONE, OffsetDateTime.class);
+        checkConverter(converter, Converter.ID_OFFSET_DATE_TIME, TIMESTAMP_WITH_TIME_ZONE, OffsetDateTime.class);
         checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP, OBJECT);
 
         OffsetDateTime val = OffsetDateTime.now();
@@ -451,7 +451,7 @@ public class ConvertersTest {
     public void testZonedDateTimeConverter() {
         ZonedDateTimeConverter converter = ZonedDateTimeConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_ZONED_DATE_TIME, TIMESTAMP_WITH_TIMEZONE, ZonedDateTime.class);
+        checkConverter(converter, Converter.ID_ZONED_DATE_TIME, TIMESTAMP_WITH_TIME_ZONE, ZonedDateTime.class);
         checkConverterConversions(converter, VARCHAR, TIME, DATE, TIMESTAMP, OBJECT);
 
         ZonedDateTime val = ZonedDateTime.now();
@@ -467,7 +467,7 @@ public class ConvertersTest {
 
         checkConverter(c, Converter.ID_STRING, VARCHAR, String.class);
         checkConverterConversions(c,
-            BIT, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP, TIMESTAMP_WITH_TIMEZONE, OBJECT);
+            BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, OBJECT);
 
         // Boolean
         assertEquals(false, c.asBit("false"));
@@ -547,7 +547,7 @@ public class ConvertersTest {
 
         checkConverter(c, Converter.ID_CHARACTER, VARCHAR, Character.class);
         checkConverterConversions(c,
-            BIT, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP, TIMESTAMP_WITH_TIMEZONE, OBJECT);
+            BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, OBJECT);
 
         char invalid = 'c';
 
@@ -583,7 +583,7 @@ public class ConvertersTest {
 
         checkConverter(c, Converter.ID_OBJECT, OBJECT, Object.class);
         checkConverterConversions(c,
-            BIT, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP, TIMESTAMP_WITH_TIMEZONE, VARCHAR);
+            BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, VARCHAR);
 
         checkObjectConverter(c);
 
@@ -595,8 +595,8 @@ public class ConvertersTest {
         LateConverter c = LateConverter.INSTANCE;
 
         checkConverter(c, Converter.ID_LATE, LATE, null);
-        checkConverterConversions(c, BIT, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP,
-            TIMESTAMP_WITH_TIMEZONE, VARCHAR, OBJECT);
+        checkConverterConversions(c, BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP,
+            TIMESTAMP_WITH_TIME_ZONE, VARCHAR, OBJECT);
 
         checkObjectConverter(c);
 
@@ -748,7 +748,7 @@ public class ConvertersTest {
 
                 break;
 
-            case BIT:
+            case BOOLEAN:
                 assertEquals(expected, converter.canConvertToBit());
 
                 break;
@@ -803,7 +803,7 @@ public class ConvertersTest {
 
                 break;
 
-            case TIMESTAMP_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
                 assertEquals(expected, converter.canConvertToTimestampWithTimezone());
 
                 break;
@@ -829,7 +829,7 @@ public class ConvertersTest {
 
                     break;
 
-                case BIT:
+                case BOOLEAN:
                     converter.asBit(val);
 
                     break;
@@ -884,7 +884,7 @@ public class ConvertersTest {
 
                     break;
 
-                case TIMESTAMP_WITH_TIMEZONE:
+                case TIMESTAMP_WITH_TIME_ZONE:
                     converter.asTimestampWithTimezone(val);
 
                     break;
@@ -928,7 +928,7 @@ public class ConvertersTest {
 
         @Override
         public boolean asBit(Object val) {
-            invoked = BIT;
+            invoked = BOOLEAN;
 
             return true;
         }
@@ -1012,7 +1012,7 @@ public class ConvertersTest {
 
         @Override
         public OffsetDateTime asTimestampWithTimezone(Object val) {
-            invoked = TIMESTAMP_WITH_TIMEZONE;
+            invoked = TIMESTAMP_WITH_TIME_ZONE;
 
             return OffsetDateTime.now();
         }


### PR DESCRIPTION
This PR introduces the basic integration with Apache Calcite:
- `OptimizerContext` that glues parser, validator, and optimizer
- Schema resolution rules
- Validation of unsupported features

Out of scope:
- SqlNode to RelNode conversions 
- Optimization rules
- Case-insensitive parsing

These will be implemented in separate PRs.

Closes #16979