### PR TITLE
After executing an EntryProcessor, use the existing ttl of the Entry rather than resetting.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -254,7 +254,7 @@ public final class EntryOperator {
     private void onAdded() {
         onAddedOrUpdated(UNSET);
     }
-    
+
     private void onUpdated() {
         if (backup) {
             onAddedOrUpdated(UNSET);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -250,7 +250,7 @@ public final class EntryOperator {
         mapOperation.evict(dataKey);
         return this;
     }
-    
+
     private void onAdded() {
         onAddedOrUpdated(UNSET);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1038,7 +1038,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertEquals(2, (int) map.get(1));
     }
-    
+
     @Test
     public void testIssue16987() {
         HazelcastInstance instance1 = createHazelcastInstance(getConfig());
@@ -1050,9 +1050,9 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         assertEquals(1337000L, map.getEntryView(1).getTtl());
 
         map.executeOnKey(1, new IncrementorEntryProcessor<>());
-        
+
         assertEquals(2, map.get(1).intValue());
-        assertEquals(1337000L, map.getEntryView(1).getTtl());
+        assertEquals("ttl has been changed by using an entry processor", 1337000L, map.getEntryView(1).getTtl());
     }
 
     @Test


### PR DESCRIPTION
Fix for https://github.com/hazelcast/hazelcast/issues/16987. Attempts to use the entry's current ttl when an update is triggered from an `EntryProcessor`.