### PR TITLE
create ExtendedMapEntry in order to create a mechanism for setting Ttls in EntryProcessors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/ExtendedMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/ExtendedMapEntry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface to provide parity with IMap set and put operations. For use in EntryProcessors.
+ *
+ * @see com.hazelcast.map.IMap#set(Object, Object, long, TimeUnit)
+ * @see com.hazelcast.map.IMap#put(Object, Object, long, TimeUnit)
+ *
+ * @param <V> value type
+ */
+public interface ExtendedMapEntry<V> {
+
+    /** Set the value and set the TTL to a non-default value for the IMap */
+    V setValue(V value, long ttl, TimeUnit ttlUnit);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.ExtendedMapEntry;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -26,10 +27,13 @@ import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Metadata;
 import com.hazelcast.query.impl.getters.Extractors;
 
+import static com.hazelcast.map.impl.record.Record.UNSET;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link java.util.Map.Entry Map.Entry} implementation
@@ -56,12 +60,14 @@ import java.util.Objects;
  * @param <V> value
  */
 public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
-        implements Serializable, IdentifiedDataSerializable {
+        implements Serializable, IdentifiedDataSerializable, ExtendedMapEntry<V> {
 
     private static final long serialVersionUID = 0L;
 
     private transient boolean modified;
     private transient Metadata metadata;
+
+    private transient long newTtl = UNSET;
 
     public LazyMapEntry() {
     }
@@ -101,6 +107,12 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
         return oldValue;
     }
 
+    @Override
+    public V setValue(V value, long ttl, TimeUnit ttlUnit) {
+        newTtl = ttlUnit.toMillis(ttl);
+        return setValue(value);
+    }
+
     /**
      * Similar to calling {@link #setValue} with null but doesn't return old-value hence no extra deserialization.
      */
@@ -121,6 +133,10 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
 
     public boolean isModified() {
         return modified;
+    }
+
+    public long getNewTtl() {
+        return newTtl;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -255,9 +255,9 @@ public final class EntryOperator {
         Object newValue = inMemoryFormat == OBJECT
                 ? entry.getValue() : entry.getByPrioritizingDataValue();
         if (backup) {
-            recordStore.putBackup(dataKey, newValue, NOT_WAN);
+            recordStore.putBackup(dataKey, newValue, entry.getNewTtl(), UNSET, NOT_WAN);
         } else {
-            recordStore.setWithUncountedAccess(dataKey, newValue, UNSET, UNSET);
+            recordStore.setWithUncountedAccess(dataKey, newValue, entry.getNewTtl(), UNSET);
             if (mapOperation.isPostProcessing(recordStore)) {
                 Record record = recordStore.getRecord(dataKey);
                 newValue = record == null ? null : record.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -182,8 +182,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Record putBackup(Data key, Object value, CallerProvenance provenance) {
-        return putBackupInternal(key, value, UNSET, UNSET,
+    public Record putBackup(Data key, Object value, long ttl, long maxIdle, CallerProvenance provenance) {
+        return putBackupInternal(key, value, ttl, maxIdle,
                 false, provenance, null);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -78,7 +78,7 @@ public interface RecordStore<R extends Record> {
      * @param provenance origin of call to this method.
      * @return current record after put.
      */
-    R putBackup(Data key, Object value, CallerProvenance provenance);
+    R putBackup(Data key, Object value, long ttl, long maxIdle, CallerProvenance provenance);
 
     /**
      * @return current record after put.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -29,10 +29,14 @@ import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.operation.MultipleEntryWithPredicateOperation;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
@@ -69,6 +73,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -1039,6 +1044,54 @@ public class EntryProcessorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testIssue16987_customTtls() {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = getConfig();
+        cfg.getMapConfig(MAP_NAME).setReadBackupData(true);
+
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
+
+        IMap<Integer, Integer> instance1Map = instance1.getMap(MAP_NAME);
+        instance1Map.put(1, 1);
+        instance1Map.setTtl(1, 1337, TimeUnit.SECONDS);
+
+        EntryView<Integer, Integer> view = instance1Map.getEntryView(1);
+        assertEquals(1337000L, view.getTtl());
+        assertEquals(1, view.getValue().intValue());
+
+        instance1Map.executeOnKey(1, new TTLChangingEntryProcessor<>(3, Duration.ofSeconds(1234)));
+
+        view = instance1Map.getEntryView(1);
+        assertEquals("ttl was not updated", 1234000L, view.getTtl());
+
+        Data key = new DefaultSerializationServiceBuilder().build().toData(1);
+        if (instance1.getPartitionService().getPartition(1).getOwner().localMember()) {
+            assertTtlFromLocalRecordStore(instance2, key, 1234000L);
+        } else {
+            assertTtlFromLocalRecordStore(instance1, key, 1234000L);
+        }
+    }
+
+    private void assertTtlFromLocalRecordStore(HazelcastInstance instance, Data key, long expectedTtl) {
+        MapProxyImpl<Integer, Integer> map = (MapProxyImpl) instance.getMap(MAP_NAME);
+        MapService mapService = map.getNodeEngine().getService(MapService.SERVICE_NAME);
+        PartitionContainer[] partitionContainers = mapService.getMapServiceContext().getPartitionContainers();
+        for (PartitionContainer partitionContainer : partitionContainers) {
+            RecordStore rs = partitionContainer.getExistingRecordStore(MAP_NAME);
+            if (rs != null) {
+                Record record = rs.getRecordOrNull(key);
+
+                if (record != null) {
+                    assertEquals(expectedTtl, record.getTtl());
+                    return;
+                }
+            }
+        }
+        fail("Backup not found.");
+    }
+
+    @Test
     public void testExecuteOnKeys() throws Exception {
         testExecuteOrSubmitOnKeys(false);
     }
@@ -1413,6 +1466,23 @@ public class EntryProcessorTest extends HazelcastTestSupport {
             entry.setValue(null);
             return null;
         }
+    }
+
+    private static class TTLChangingEntryProcessor<K, V> implements EntryProcessor<K, V, V> {
+
+        private V newValue;
+        private Duration newTtl;
+
+        TTLChangingEntryProcessor(V newValue, Duration newTtl) {
+            this.newValue = newValue;
+            this.newTtl = newTtl;
+        }
+
+        @Override
+        public V process(Entry<K, V> entry) {
+            return ((ExtendedMapEntry<V>) entry).setValue(newValue, newTtl.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
     }
 
     /**


### PR DESCRIPTION
As per https://github.com/hazelcast/hazelcast/issues/16987, creates a mechanism for setting the ttl within an EntryProcessor to enable consistency with `IMap#set` and `IMap#put` operations.

Closes: https://github.com/hazelcast/hazelcast/issues/16987