### PR TITLE
Enable missing JavaDoc checkstyle rules

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -117,11 +117,24 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <!-- Only for methods on public APIs we agreed to have JavaDoc. -->
-        <!-- TODO: figure out how to do that -->
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowedAnnotations" value="Override,JavaDocClear,JavaDocDefine"/>
+            <property name="ignoreMethodNamesRegex"
+                      value="^((get|set|is|has|add|remove|create|new).*)|(build|init|iterator|size)$"/>
+            <!--            <property name="allowMissingPropertyJavadoc" value="true"/>-->
+            <!-- constructors are not validated against missing javadoc -->
+            <property name="tokens" value="METHOD_DEF,ANNOTATION_FIELD_DEF"/>
+        </module>
         <!--<module name="JavadocMethod">-->
         <!--<property name="scope" value="public"/>-->
         <!--<property name="allowMissingParamTags" value="true"/>-->
         <!--</module>-->
+        <module name="MissingJavadocType">
+            <property name="skipAnnotations" value="JavaDocDefine"/>
+            <property name="scope" value="public"/>
+        </module>
+        <module name="MissingJavadocPackage"/>
         <module name="JavadocType">
             <property name="scope" value="public"/>
         </module>

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/ElementParser.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/ElementParser.java
@@ -36,12 +36,21 @@ public final class ElementParser {
     private ElementParser() {
     }
 
+    /**
+     * Parses delimited string and returns a list containing the trimmed tokens. This parser obeys quotes, so the delimiter
+     * character will be ignored if it is inside of a quote. This method assumes that the quote character is not included in
+     * the set of delimiter characters.
+     *
+     * @param value     the delimited string to parse.
+     * @param delimiter the characters delimiting the tokens.
+     * @return an array of string tokens or null if there were no tokens.
+     */
     public static List<String> parseDelimitedString(String value, char delimiter) {
         return parseDelimitedString(value, delimiter, true);
     }
 
     /**
-     * Parses delimited string and returns an array containing the tokens. This parser obeys quotes, so the delimiter character
+     * Parses delimited string and returns a list containing the tokens. This parser obeys quotes, so the delimiter character
      * will be ignored if it is inside of a quote. This method assumes that the quote character is not included in the set of
      * delimiter characters.
      *
@@ -55,7 +64,7 @@ public final class ElementParser {
             value = "";
         }
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
 
         int expecting = (CHAR | DELIMITER | START_QUOTE);

--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/ExportPackageViewer.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/ExportPackageViewer.java
@@ -37,7 +37,7 @@ public class ExportPackageViewer {
         String data = reader.readLine();
 
         List<String> strings = ElementParser.parseDelimitedString(data, ',');
-        Set<String> packages = new HashSet<String>();
+        Set<String> packages = new HashSet<>();
         for (String entry : strings) {
             int usesIndex = entry.indexOf(";");
             if (usesIndex != -1) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -141,7 +141,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("reliableTopicConfigMap", reliableTopicConfigMap);
         }
 
-        public AbstractBeanDefinition handleClient(Node rootNode) {
+        private AbstractBeanDefinition handleClient(Node rootNode) {
             AbstractBeanDefinition configBean = createConfigBean(rootNode);
             builder.addConstructorArgValue(configBean);
             return builder.getBeanDefinition();

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -30,8 +30,6 @@ import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
-import com.hazelcast.config.WanBatchPublisherConfig;
-import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EncryptionAtRestConfig;
 import com.hazelcast.config.EndpointConfig;
@@ -103,7 +101,9 @@ import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.config.VaultSecureStoreConfig;
+import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
@@ -187,6 +187,7 @@ import static org.springframework.util.Assert.isTrue;
         "WeakerAccess"})
 public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
 
+    @Override
     public AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
         SpringXmlConfigBuilder springXmlConfigBuilder = new SpringXmlConfigBuilder(parserContext);
         springXmlConfigBuilder.handleConfig(element);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.spring.cache;
 
-import com.hazelcast.map.IMap;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.internal.util.ExceptionUtil;
 import org.springframework.cache.Cache;
 import org.springframework.cache.support.SimpleValueWrapper;
 
@@ -141,6 +141,7 @@ public class HazelcastCache implements Cache {
         map.clear();
     }
 
+    @Override
     public ValueWrapper putIfAbsent(Object key, Object value) {
         Object result = map.putIfAbsent(key, toStoreValue(value));
         return result != null ? new SimpleValueWrapper(fromStoreValue(result)) : null;

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientSecurityConfig.java
@@ -16,10 +16,6 @@
 
 package com.hazelcast.client.config;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.security.CredentialsIdentityConfig;
 import com.hazelcast.config.security.IdentityConfig;
@@ -27,8 +23,13 @@ import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.ICredentialsFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Contains the security configuration for the client.
@@ -109,6 +110,7 @@ public class ClientSecurityConfig {
         return this;
     }
 
+    @JavaDocClear
     public ICredentialsFactory asCredentialsFactory(ClassLoader cl) {
         return identityConfig != null ? identityConfig.asCredentialsFactory(cl) : null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -32,6 +32,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.cp.IAtomicLong;
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
@@ -44,12 +45,12 @@ import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.io.PrintStream;
-import java.io.FileReader;
-import java.io.File;
 import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -148,10 +149,12 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         return list;
     }
 
+    @JavaDocClear
     public void stop() {
         running = false;
     }
 
+    @JavaDocClear
     public void start(String[] args) {
         getMap().size();
         getList().size();
@@ -1529,12 +1532,14 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         print("");
     }
 
+    @JavaDocClear
     public void println(Object obj) {
         if (!silent) {
             outOrig.println(obj);
         }
     }
 
+    @JavaDocClear
     public void print(Object obj) {
         if (!silent) {
             outOrig.print(obj);

--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/session/ClientProxySessionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/session/ClientProxySessionManager.java
@@ -30,6 +30,7 @@ import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.cp.internal.session.AbstractProxySessionManager;
 import com.hazelcast.cp.internal.session.SessionResponse;
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
@@ -95,6 +96,7 @@ public class ClientProxySessionManager extends AbstractProxySessionManager {
         return new ClientDelegatingFuture<>(future, client.getSerializationService(), CLOSE_SESSION_RESPONSE_DECODER);
     }
 
+    @JavaDocClear
     public void shutdownAndAwait() {
         Map<RaftGroupId, InternalCompletableFuture<Object>> futures = super.shutdown();
 

--- a/hazelcast/src/main/java/com/hazelcast/config/BitmapIndexOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/BitmapIndexOptions.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.JavaDocDefine;
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.nio.ObjectDataInput;
@@ -108,6 +109,7 @@ public class BitmapIndexOptions implements IdentifiedDataSerializable {
             throw new IllegalArgumentException("unexpected unique key transformation: " + name);
         }
 
+        @JavaDocDefine
         public static UniqueKeyTransformation fromId(int id) {
             for (UniqueKeyTransformation transformation : UniqueKeyTransformation.values()) {
                 if (transformation.id == id) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -296,6 +297,7 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, N
         return result;
     }
 
+    @JavaDocClear
     public final void validate() {
         if (!Arrays.asList(ALLOWED_POLICIES).contains(mergePolicyConfig.getPolicy())) {
             throw new InvalidConfigurationException(format("Policy %s is not allowed as a merge-policy "

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -32,6 +32,7 @@ import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TlsAuthenticationConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.internal.util.MapUtil;
@@ -1769,17 +1770,20 @@ public class ConfigXmlGenerator {
             this.xml = xml;
         }
 
+        @JavaDocClear
         public XmlGenerator open(String name, Object... attributes) {
             appendOpenNode(xml, name, attributes);
             openNodes.addLast(name);
             return this;
         }
 
+        @JavaDocClear
         public XmlGenerator node(String name, Object contents, Object... attributes) {
             appendNode(xml, name, contents, attributes);
             return this;
         }
 
+        @JavaDocClear
         public XmlGenerator nodeIfContents(String name, Object contents, Object... attributes) {
             if (contents != null) {
                 appendNode(xml, name, contents, attributes);
@@ -1787,11 +1791,13 @@ public class ConfigXmlGenerator {
             return this;
         }
 
+        @JavaDocClear
         public XmlGenerator close() {
             appendCloseNode(xml, openNodes.pollLast());
             return this;
         }
 
+        @JavaDocClear
         public XmlGenerator appendLabels(Set<String> labels) {
             if (!labels.isEmpty()) {
                 open("client-labels");
@@ -1803,6 +1809,7 @@ public class ConfigXmlGenerator {
             return this;
         }
 
+        @JavaDocClear
         public XmlGenerator appendProperties(Properties props) {
             if (!props.isEmpty()) {
                 open("properties");
@@ -1815,6 +1822,7 @@ public class ConfigXmlGenerator {
             return this;
         }
 
+        @JavaDocClear
         public XmlGenerator appendProperties(Map<String, ? extends Comparable> props) {
             if (!MapUtil.isNullOrEmpty(props)) {
                 open("properties");

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -313,6 +313,7 @@ public class MultiMapConfig implements IdentifiedDataSerializable, NamedConfig {
         return this;
     }
 
+    @Override
     public String toString() {
         return "MultiMapConfig{"
                 + "name='" + name + '\''

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.JavaDocDefine;
 import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
@@ -28,6 +29,7 @@ public final class NearCacheConfigAccessor {
     private NearCacheConfigAccessor() {
     }
 
+    @JavaDocDefine
     public static void initDefaultMaxSizeForOnHeapMaps(NearCacheConfig nearCacheConfig) {
         if (nearCacheConfig == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -122,6 +122,7 @@ public class QueueStoreConfig implements IdentifiedDataSerializable {
         return this;
     }
 
+    @Override
     public String toString() {
         return "QueueStoreConfig{"
                 + "enabled=" + enabled

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
@@ -122,6 +122,7 @@ public class RingbufferStoreConfig implements IdentifiedDataSerializable {
         return this;
     }
 
+    @Override
     public String toString() {
         return "RingbufferStoreConfig{"
                 + "enabled=" + enabled

--- a/hazelcast/src/main/java/com/hazelcast/config/SplitBrainProtectionConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SplitBrainProtectionConfigBuilder.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.JavaDocClear;
+
 /**
  * Commons for split brain protection config builders.
  */
@@ -31,11 +33,13 @@ public abstract class SplitBrainProtectionConfigBuilder {
      */
     protected boolean enabled = true;
 
+    @JavaDocClear
     public SplitBrainProtectionConfigBuilder enabled(boolean enabled) {
         this.enabled = enabled;
         return this;
     }
 
+    @JavaDocClear
     public SplitBrainProtectionConfigBuilder withSplitBrainProtectionSize(int minimumClusterSize) {
         this.minimumClusterSize = minimumClusterSize;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -252,6 +252,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig {
         return result;
     }
 
+    @Override
     public String toString() {
         return "TopicConfig [name=" + name + ", globalOrderingEnabled=" + globalOrderingEnabled
                 + ", multiThreadingEnabled=" + multiThreadingEnabled + ", statisticsEnabled="

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config.replacer;
 
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.nio.IOUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -128,6 +129,7 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
         }
     }
 
+    @JavaDocClear
     public static final void main(String... args) throws Exception {
         if (args == null || args.length < 1 || args.length > 2) {
             System.err.println("Usage:");

--- a/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
@@ -16,14 +16,19 @@
 
 package com.hazelcast.config.security;
 
-import com.hazelcast.internal.JavaDocDefine;
-
 import java.util.Objects;
 import java.util.Properties;
 
+import javax.security.auth.Subject;
+
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
-@JavaDocDefine
+/**
+ * Abstract authentication configuration for types which configures login modules based on Hazelcast {@code ClusterLoginModule}
+ *
+ * @param <T> concrete authentication config type extending this one. It's used to return proper type in the fluent API setter
+ *        methods.
+ */
 public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginConfig<T>> implements AuthenticationConfig {
 
     private Boolean skipIdentity;
@@ -34,6 +39,10 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         return skipIdentity;
     }
 
+    /**
+     * If set to {@code true} then {@code ClusterIdentityPrincipal} instances are not added to JAAS {@link Subject} during
+     * authentication.
+     */
     public T setSkipIdentity(Boolean skipIdentity) {
         this.skipIdentity = skipIdentity;
         return self();
@@ -43,6 +52,10 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         return skipEndpoint;
     }
 
+    /**
+     * If set to {@code true} then {@code ClusterEndpointPrincipal} instances are not added to JAAS {@link Subject} during
+     * authentication.
+     */
     public T setSkipEndpoint(Boolean skipEndpoint) {
         this.skipEndpoint = skipEndpoint;
         return self();
@@ -52,6 +65,10 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         return skipRole;
     }
 
+    /**
+     * If set to {@code true} then {@code ClusterRolePrincipal} instances are not added to JAAS {@link Subject} during
+     * authentication.
+     */
     public T setSkipRole(Boolean skipRole) {
         this.skipRole = skipRole;
         return self();
@@ -101,7 +118,7 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         if (getClass() != obj.getClass()) {
             return false;
         }
-        AbstractClusterLoginConfig other = (AbstractClusterLoginConfig) obj;
+        AbstractClusterLoginConfig<?> other = (AbstractClusterLoginConfig<?>) obj;
         return Objects.equals(skipEndpoint, other.skipEndpoint) && Objects.equals(skipIdentity, other.skipIdentity)
                 && Objects.equals(skipRole, other.skipRole);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.config.security;
 
-import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+import com.hazelcast.internal.JavaDocDefine;
 
 import java.util.Objects;
 import java.util.Properties;
 
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+
+@JavaDocDefine
 public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginConfig<T>> implements AuthenticationConfig {
 
     private Boolean skipIdentity;

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
@@ -18,12 +18,14 @@ package com.hazelcast.config.security;
 
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
-import com.hazelcast.internal.JavaDocDefine;
 
 import java.util.Objects;
 import java.util.Properties;
 
-@JavaDocDefine
+/**
+ * Kerberos authentication configuration which allows accepting Kerberos tickets. It's also able to delegate authorization to
+ * LDAP authentication when the {@code ldapAuthenticationConfig} is defined.
+ */
 public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<KerberosAuthenticationConfig> {
 
     private Boolean relaxFlagsCheck;
@@ -34,6 +36,10 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return relaxFlagsCheck;
     }
 
+    /**
+     * When {@code true} is set then some Kerberos ticket checks are skipped during authentication (e.g. allows to ignore
+     * request for the mutual authentication).
+     */
     public KerberosAuthenticationConfig setRelaxFlagsCheck(Boolean relaxFlagsCheck) {
         this.relaxFlagsCheck = relaxFlagsCheck;
         return this;
@@ -43,6 +49,10 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return securityRealm;
     }
 
+    /**
+     * Sets a realm name within the Hazelcast security configuration. The realm is used to authenticate the current instance to
+     * Kerberos KDC server (i.e. retrieving TGT) before asking for the service ticket.
+     */
     public KerberosAuthenticationConfig setSecurityRealm(String securityRealm) {
         this.securityRealm = securityRealm;
         return this;
@@ -52,6 +62,9 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return ldapAuthenticationConfig;
     }
 
+    /**
+     * Allows to configure LDAP authentication for role retrieval.
+     */
     public KerberosAuthenticationConfig setLdapAuthenticationConfig(LdapAuthenticationConfig ldapAuthenticationConfig) {
         this.ldapAuthenticationConfig = ldapAuthenticationConfig;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.config.security;
 
+import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+import com.hazelcast.internal.JavaDocDefine;
+
 import java.util.Objects;
 import java.util.Properties;
 
-import com.hazelcast.config.LoginModuleConfig;
-import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
-
+@JavaDocDefine
 public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<KerberosAuthenticationConfig> {
 
     private Boolean relaxFlagsCheck;

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
@@ -17,12 +17,29 @@
 package com.hazelcast.config.security;
 
 import com.hazelcast.config.CredentialsFactoryConfig;
-import com.hazelcast.internal.JavaDocDefine;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.security.ICredentialsFactory;
 
 import java.util.Objects;
 
-@JavaDocDefine
+/**
+ * {@link IdentityConfig} implementation for Kerberos identities. In this class you can configure Service Principal Name (SPN)
+ * of Hazelcast member(s). The SPN is the name of target service (Hazelcast member) for which the Kerberos ticket should be
+ * retrieved. The principal name is either generated from the target member address (default) or it's defined explicitly by
+ * setting the {@code spn} field.
+ * <p>
+ * The genarated name is in form {@code "[serviceNamePrefix][targetIpAddress]@[realm]"}. The default value of the
+ * {@code serviceNamePrefix} is {@code "hz/"}. Example:
+ *
+ * <pre>
+ * KerberosIdentityConfig identityConfig = new KerberosIdentityConfig().setRealm("ACME.COM");
+ * </pre>
+ *
+ * When a {@link HazelcastInstance} with this config connects to a member address {@code 10.0.0.1}, then SPN
+ * {@code "hz/10.0.0.1@ACME.COM"} is used for retrieving service ticket from Kerberos server (KDC).
+ * <p>
+ * The explicit SPN configuration should only be used when all Hazelcast cluster members share one Kerberos identity.
+ */
 public class KerberosIdentityConfig implements IdentityConfig {
 
     private final CredentialsFactoryConfig factoryConfig = new CredentialsFactoryConfig(

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.config.security;
 
-import java.util.Objects;
-
 import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.internal.JavaDocDefine;
 import com.hazelcast.security.ICredentialsFactory;
 
+import java.util.Objects;
+
+@JavaDocDefine
 public class KerberosIdentityConfig implements IdentityConfig {
 
     private final CredentialsFactoryConfig factoryConfig = new CredentialsFactoryConfig(
@@ -70,7 +72,7 @@ public class KerberosIdentityConfig implements IdentityConfig {
     @Override
     public IdentityConfig copy() {
         return new KerberosIdentityConfig().setRealm(getRealm()).setSecurityRealm(getSecurityRealm())
-                .setServiceNamePrefix(getServiceNamePrefix()).setSpn(getSpn());
+                                           .setServiceNamePrefix(getServiceNamePrefix()).setSpn(getSpn());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/security/LdapSearchScope.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/LdapSearchScope.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.config.security;
 
-import static com.hazelcast.internal.util.StringUtil.trim;
+import com.hazelcast.internal.JavaDocDefine;
 
 import javax.naming.directory.SearchControls;
+
+import static com.hazelcast.internal.util.StringUtil.trim;
 
 /**
  * Search scope types for LDAP queries.
@@ -55,6 +57,7 @@ public enum LdapSearchScope {
         return valueString;
     }
 
+    @JavaDocDefine
     public int toSearchControlValue() {
         return searchControlValue;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
@@ -16,14 +16,15 @@
 
 package com.hazelcast.config.security;
 
-import static java.util.Objects.requireNonNull;
+import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.internal.JavaDocClear;
+import com.hazelcast.security.Credentials;
+import com.hazelcast.security.ICredentialsFactory;
 
 import java.util.Objects;
 
-import com.hazelcast.config.CredentialsFactoryConfig;
-import com.hazelcast.config.LoginModuleConfig;
-import com.hazelcast.security.Credentials;
-import com.hazelcast.security.ICredentialsFactory;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Security realm represents the security configuration for part of the system (e.g. member-to-member comunication).
@@ -137,6 +138,7 @@ public class RealmConfig {
         return identityConfig != null;
     }
 
+    @JavaDocClear
     public LoginModuleConfig[] asLoginModuleConfigs() {
         if (authenticationConfig == null) {
             return null;
@@ -144,6 +146,7 @@ public class RealmConfig {
         return authenticationConfig.asLoginModuleConfigs();
     }
 
+    @JavaDocClear
     public ICredentialsFactory asCredentialsFactory() {
         return identityConfig != null ? identityConfig.asCredentialsFactory(null) : null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/security/TokenEncoding.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/TokenEncoding.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.config.security;
 
-import static com.hazelcast.internal.util.StringUtil.trim;
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import com.hazelcast.internal.JavaDocClear;
 
 import java.util.Base64;
 import java.util.function.Function;
+
+import static com.hazelcast.internal.util.StringUtil.trim;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Possible token encodings.
@@ -52,10 +54,12 @@ public enum TokenEncoding {
         return valueString;
     }
 
+    @JavaDocClear
     public String encode(byte[] token) {
         return token == null ? null : encoder.apply(token);
     }
 
+    @JavaDocClear
     public byte[] decode(String str) {
         return str == null ? null : decoder.apply(str);
     }

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -31,6 +31,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.cp.IAtomicLong;
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
@@ -43,12 +44,12 @@ import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.io.FileInputStream;
-import java.io.File;
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Collection;
 import java.util.HashMap;
@@ -144,10 +145,12 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         return list;
     }
 
+    @JavaDocClear
     public void stop() {
         running = false;
     }
 
+    @JavaDocClear
     public void start() throws Exception {
         getMap().size();
         getList().size();
@@ -1520,12 +1523,14 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         println("");
     }
 
+    @JavaDocClear
     public void println(Object obj) {
         if (!silent) {
             outOrig.println(obj);
         }
     }
 
+    @JavaDocClear
     public void print(Object obj) {
         if (!silent) {
             outOrig.print(obj);

--- a/hazelcast/src/main/java/com/hazelcast/console/LineReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/LineReader.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.console;
 
+import com.hazelcast.internal.JavaDocClear;
+
 /**
  * Reads a line of input.
  */
 public interface LineReader {
 
+    @JavaDocClear
     String readLine() throws Exception;
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
@@ -36,5 +36,11 @@ import java.io.Serializable;
 @FunctionalInterface
 public interface IFunction<T, R> extends Serializable {
 
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param input the function argument
+     * @return the function result
+     */
     R apply(T input);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/exception/CPSubsystemException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/exception/CPSubsystemException.java
@@ -57,6 +57,7 @@ public class CPSubsystemException extends HazelcastException implements Wrappabl
         return leaderUuid;
     }
 
+    @Override
     public CPSubsystemException wrap() {
         return new CPSubsystemException(getMessage(), this, leaderUuid);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/JavaDocClear.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/JavaDocClear.java
@@ -14,29 +14,18 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spring.context;
+package com.hazelcast.internal;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates a class for injection of Spring dependencies.
+ * Annotation to be used instead of writing straightforward JavaDoc.
+ * This annotation makes checkstyle not reporting violation for the
+ * annotated types and methods.
+ *
+ * @see JavaDocDefine
  */
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-@Inherited
-@Documented
-public @interface SpringAware {
-
-    /**
-     * Returns the name of the bean with which the annotated bean will
-     * be autowired.
-     *
-     * @return the name of the bean
-     */
-    String beanName() default "";
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface JavaDocClear {
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/JavaDocDefine.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/JavaDocDefine.java
@@ -33,7 +33,9 @@ import java.lang.annotation.Target;
  * For straightforward JavaDoc, consider using {@link JavaDocClear}.
  *
  * @see JavaDocClear
+ * @deprecated It's better to write the JavaDoc.
  */
+@Deprecated
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface JavaDocDefine {
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/JavaDocDefine.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/JavaDocDefine.java
@@ -14,29 +14,26 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spring.context;
+package com.hazelcast.internal;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates a class for injection of Spring dependencies.
+ * Annotation to be used to relax checkstyle until the proper JavaDoc is
+ * added to the annotated places.
+ * <p/>
+ * NOTE: This annotation is introduced only to enable turning on checks
+ * for missing method annotations. This annotation is planned to be
+ * removed eventually. If you see this annotation in a class you're
+ * touching, please add the proper JavaDoc and remove the annotation.
+ * <p/>
+ * DO NOT ADD THIS ANNOTATION TO ANY METHOD OR TYPE
+ * <p/>
+ * For straightforward JavaDoc, consider using {@link JavaDocClear}.
+ *
+ * @see JavaDocClear
  */
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-@Inherited
-@Documented
-public @interface SpringAware {
-
-    /**
-     * Returns the name of the bean with which the annotated bean will
-     * be autowired.
-     *
-     * @return the name of the bean
-     */
-    String beanName() default "";
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface JavaDocDefine {
 }

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryUnit.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.memory;
 
+import com.hazelcast.internal.JavaDocClear;
+
 import static com.hazelcast.internal.util.QuickMath.divideByAndRoundToInt;
 
 /**
@@ -31,22 +33,27 @@ public enum MemoryUnit {
      * MemoryUnit in bytes
      */
     BYTES {
+        @JavaDocClear
         public long convert(long value, MemoryUnit m) {
             return m.toBytes(value);
         }
 
+        @JavaDocClear
         public long toBytes(long value) {
             return value;
         }
 
+        @JavaDocClear
         public long toKiloBytes(long value) {
             return divideByAndRoundToInt(value, K);
         }
 
+        @JavaDocClear
         public long toMegaBytes(long value) {
             return divideByAndRoundToInt(value, M);
         }
 
+        @JavaDocClear
         public long toGigaBytes(long value) {
             return divideByAndRoundToInt(value, G);
         }
@@ -56,22 +63,27 @@ public enum MemoryUnit {
      * MemoryUnit in kilobytes
      */
     KILOBYTES {
+        @JavaDocClear
         public long convert(long value, MemoryUnit m) {
             return m.toKiloBytes(value);
         }
 
+        @JavaDocClear
         public long toBytes(long value) {
             return value * K;
         }
 
+        @JavaDocClear
         public long toKiloBytes(long value) {
             return value;
         }
 
+        @JavaDocClear
         public long toMegaBytes(long value) {
             return divideByAndRoundToInt(value, K);
         }
 
+        @JavaDocClear
         public long toGigaBytes(long value) {
             return divideByAndRoundToInt(value, M);
         }
@@ -81,22 +93,27 @@ public enum MemoryUnit {
      * MemoryUnit in megabytes
      */
     MEGABYTES {
+        @JavaDocClear
         public long convert(long value, MemoryUnit m) {
             return m.toMegaBytes(value);
         }
 
+        @JavaDocClear
         public long toBytes(long value) {
             return value * M;
         }
 
+        @JavaDocClear
         public long toKiloBytes(long value) {
             return value * K;
         }
 
+        @JavaDocClear
         public long toMegaBytes(long value) {
             return value;
         }
 
+        @JavaDocClear
         public long toGigaBytes(long value) {
             return divideByAndRoundToInt(value, K);
         }
@@ -106,22 +123,27 @@ public enum MemoryUnit {
      * MemoryUnit in gigabytes
      */
     GIGABYTES {
+        @JavaDocClear
         public long convert(long value, MemoryUnit m) {
             return m.toGigaBytes(value);
         }
 
+        @JavaDocClear
         public long toBytes(long value) {
             return value * G;
         }
 
+        @JavaDocClear
         public long toKiloBytes(long value) {
             return value * M;
         }
 
+        @JavaDocClear
         public long toMegaBytes(long value) {
             return value * K;
         }
 
+        @JavaDocClear
         public long toGigaBytes(long value) {
             return value;
         }
@@ -132,13 +154,18 @@ public enum MemoryUnit {
     static final int M = 1 << (POWER * 2);
     static final int G = 1 << (POWER * 3);
 
+    @JavaDocClear
     public abstract long convert(long value, MemoryUnit m);
 
+    @JavaDocClear
     public abstract long toBytes(long value);
 
+    @JavaDocClear
     public abstract long toKiloBytes(long value);
 
+    @JavaDocClear
     public abstract long toMegaBytes(long value);
 
+    @JavaDocClear
     public abstract long toGigaBytes(long value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query;
 
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.serialization.BinaryInterface;
 
 /**
@@ -30,8 +31,10 @@ public interface PredicateBuilder extends Predicate {
 
     EntryObject getEntryObject();
 
+    @JavaDocClear
     PredicateBuilder and(Predicate predicate);
 
+    @JavaDocClear
     PredicateBuilder or(Predicate predicate);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/QueryConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/QueryConstants.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.query;
 
+import com.hazelcast.internal.JavaDocClear;
+
 /**
  * Contains constants for Query.
  */
@@ -37,6 +39,7 @@ public enum QueryConstants {
         this.value = value;
     }
 
+    @JavaDocClear
     public String value() {
         return value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
@@ -16,11 +16,12 @@
 
 package com.hazelcast.version;
 
+import com.hazelcast.internal.JavaDocClear;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.internal.util.StringUtil;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -111,7 +112,7 @@ public final class MemberVersion
 
     @Override
     public int hashCode() {
-        int result = (int) major;
+        int result = major;
         result = 31 * result + (int) minor;
         result = 31 * result + (int) patch;
         return result;
@@ -137,6 +138,7 @@ public final class MemberVersion
         this.patch = in.readByte();
     }
 
+    @JavaDocClear
     public static MemberVersion of(int major, int minor, int patch) {
         if (major == 0 && minor == 0 && patch == 0) {
             return MemberVersion.UNKNOWN;
@@ -145,6 +147,7 @@ public final class MemberVersion
         }
     }
 
+    @JavaDocClear
     public static MemberVersion of(String version) {
         if (version == null || version.startsWith(UNKNOWN_VERSION_STRING)) {
             return MemberVersion.UNKNOWN;


### PR DESCRIPTION
With the recent update of checkstyle our coverage for catching missing
javadocs on types is lost due to the changes done in checkstyle. We need
to add the newly introduced `MissingJavaDocType` and `MissingJavaDocMethod`
modules. Adding the former comes with only a few violations, but lots of
public methods lack javadocs. This PR intends to provide solutions for
both. Adding javadocs to all methods in a single PR would be too
time-consuming, while enabling method level javadoc checks has the
benefit of guarding against further debts introduced. Hence, this PR
exhibits a middle-ground solution that accepts the current debts while
guarding against introducing more. This is done by allowing no javadocs
on getters/setters, constructors and a couple of other common-sense
methods, such as create and build. Besides this `JavaDocClear` and
`JavaDocDefine` annotations are introduced with the following meanings:
- `JavaDocClear`: the annotated method is straightforward and adding
javadoc has no real benefit.
- `JavaDocDefine`: allow not having javadoc here, but please define later.

Note that this PR is intended to trigger thoughts instead of getting
merged as is.