### PR TITLE
Add validations to connection retry config and fix sleep time calcula…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.client.config;
 
+import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
+import static com.hazelcast.internal.util.Preconditions.checkTrue;
+
 /**
  * Connection Retry Config is controls the period among the retries and when should a client gave up
  * retrying. Exponential behaviour can be chosen or jitter can be added to wait periods.
@@ -58,6 +61,7 @@ public class ConnectionRetryConfig {
      * @return updated ConnectionRetryConfig
      */
     public ConnectionRetryConfig setInitialBackoffMillis(int initialBackoffMillis) {
+        checkNotNegative(initialBackoffMillis, "Initial backoff must be non-negative!");
         this.initialBackoffMillis = initialBackoffMillis;
         return this;
     }
@@ -78,6 +82,7 @@ public class ConnectionRetryConfig {
      * @return updated ConnectionRetryConfig
      */
     public ConnectionRetryConfig setMaxBackoffMillis(int maxBackoffMillis) {
+        checkNotNegative(maxBackoffMillis, "Max backoff must be non-negative!");
         this.maxBackoffMillis = maxBackoffMillis;
         return this;
     }
@@ -96,6 +101,7 @@ public class ConnectionRetryConfig {
      * @return updated ConnectionRetryConfig
      */
     public ConnectionRetryConfig setMultiplier(double multiplier) {
+        checkTrue(multiplier >= 1.0, "Multiplier must be greater than or equal to 1.0!");
         this.multiplier = multiplier;
         return this;
     }
@@ -117,6 +123,7 @@ public class ConnectionRetryConfig {
      * @return updated ConnectionRetryConfig
      */
     public ConnectionRetryConfig setClusterConnectTimeoutMillis(long clusterConnectTimeoutMillis) {
+        checkNotNegative(clusterConnectTimeoutMillis, "Cluster connect timeout must be non-negative!");
         this.connectTimeoutMillis = clusterConnectTimeoutMillis;
         return this;
     }
@@ -140,6 +147,7 @@ public class ConnectionRetryConfig {
      * @return updated ConnectionRetryConfig
      */
     public ConnectionRetryConfig setJitter(double jitter) {
+        checkTrue(jitter >= 0.0 && jitter <= 1.0, "Jitter must be in range [0.0, 1.0]");
         this.jitter = jitter;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/WaitStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/WaitStrategy.java
@@ -62,8 +62,8 @@ public class WaitStrategy {
 
         //random_between
         // Random(-jitter * current_backoff, jitter * current_backoff)
-        long actualSleepTime = (long) (currentBackoffMillis - (currentBackoffMillis * jitter)
-                + (currentBackoffMillis * jitter * random.nextDouble()));
+        long actualSleepTime = (long) (currentBackoffMillis
+                + currentBackoffMillis * jitter * (2.0 * random.nextDouble() - 1.0));
 
         actualSleepTime = Math.min(actualSleepTime, clusterConnectTimeoutMillis - timePassed);
 


### PR DESCRIPTION
…tion

There were missing validation checks on the ConnectionRetryConfig.
The following checks are added

initialBackoffMillis -> [0, inf)
maxBackoffMillis -> [0, inf)
multiplier -> [1.0, inf)
jitter -> [0.0, 1.0]
clusterConnectionTimeoutMillis -> [0, inf)

Also, `actualSleepTime` calculation was wrong. It was calculating
sleep time in range
[currentBackoffMilis - jitter * currentBackoffMillis, currentBackoffMillis].