### PR TITLE
Fixes interoperability issues with CompletableFuture

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
@@ -54,14 +54,18 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
     final boolean deserializeResponse;
     private final ClientMessageDecoder clientMessageDecoder;
-    private volatile Object decodedResponse = VOID;
+    private volatile Object decodedResponse;
 
     public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
                                   SerializationService serializationService,
                                   ClientMessageDecoder clientMessageDecoder, V defaultValue, boolean deserializeResponse) {
-        super(serializationService, clientInvocationFuture, defaultValue);
+        super(serializationService, clientInvocationFuture, defaultValue, false);
+        this.decodedResponse = VOID;
         this.clientMessageDecoder = clientMessageDecoder;
         this.deserializeResponse = deserializeResponse;
+        this.future.whenComplete((v, t) -> {
+            completeSuper(v, (Throwable) t);
+        });
     }
 
     public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
@@ -385,7 +389,7 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
     @Override
     public String toString() {
-        return future.toString();
+        return "ClientDelegatingFuture{future=" + future.toString() + "}";
     }
 
     @SuppressWarnings("unchecked")

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
@@ -126,7 +126,7 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
         if (deserializeResponse) {
             decoded = serializationService.toObject(decoded);
         }
-        cacheDeserializedValue(decoded);
+        decoded = cacheDeserializedValue(decoded);
 
         return (V) decoded;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFuture.java
@@ -85,6 +85,7 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
 
     @Override
     protected void onComplete() {
+        super.onComplete();
         callIdSequence.complete();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -650,7 +650,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public V getNow(V valueIfAbsent) {
-        return (state == UNRESOLVED) ? valueIfAbsent : join();
+        return isDone() ? join() : valueIfAbsent;
     }
 
     @Override
@@ -1203,7 +1203,11 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     protected void onComplete() {
-
+        if (state instanceof ExceptionalResult) {
+            super.completeExceptionally(((ExceptionalResult) state).getCause());
+        } else {
+            super.complete((V) state);
+        }
     }
 
     // it can be that this future is already completed, e.g. when an invocation already

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.impl.operationservice.WrappableException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
@@ -48,7 +49,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -127,7 +128,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     // CompletionStage API implementation
     @Override
     public <U> InternalCompletableFuture<U> thenApply(@Nonnull Function<? super V, ? extends U> fn) {
-        return thenApplyAsync(fn, CALLER_RUNS);
+        return thenApplyAsync(fn, defaultExecutor());
     }
 
     @Override
@@ -153,7 +154,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> thenAccept(@Nonnull Consumer<? super V> action) {
-        return thenAcceptAsync(action, CALLER_RUNS);
+        return thenAcceptAsync(action, defaultExecutor());
     }
 
     @Override
@@ -180,7 +181,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> thenRun(@Nonnull Runnable action) {
-        return thenRunAsync(action, CALLER_RUNS);
+        return thenRunAsync(action, defaultExecutor());
     }
 
     @Override
@@ -206,7 +207,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U> InternalCompletableFuture<U> handle(@Nonnull BiFunction<? super V, Throwable, ? extends U> fn) {
-        return handleAsync(fn, CALLER_RUNS);
+        return handleAsync(fn, defaultExecutor());
     }
 
     @Override
@@ -233,7 +234,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<V> whenComplete(@Nonnull BiConsumer<? super V, ? super Throwable> action) {
-        return whenCompleteAsync(action, CALLER_RUNS);
+        return whenCompleteAsync(action, defaultExecutor());
     }
 
     @Override
@@ -260,7 +261,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U> InternalCompletableFuture<U> thenCompose(@Nonnull Function<? super V, ? extends CompletionStage<U>> fn) {
-        return thenComposeAsync(fn, CALLER_RUNS);
+        return thenComposeAsync(fn, defaultExecutor());
     }
 
     @Override
@@ -288,7 +289,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     @Override
     public <U, R> InternalCompletableFuture<R> thenCombine(@Nonnull CompletionStage<? extends U> other,
                                                  @Nonnull BiFunction<? super V, ? super U, ? extends R> fn) {
-        return thenCombineAsync(other, fn, CALLER_RUNS);
+        return thenCombineAsync(other, fn, defaultExecutor());
     }
 
     @Override
@@ -319,7 +320,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     @Override
     public <U> InternalCompletableFuture<Void> thenAcceptBoth(@Nonnull CompletionStage<? extends U> other,
                                                       @Nonnull BiConsumer<? super V, ? super U> action) {
-        return thenAcceptBothAsync(other, action, CALLER_RUNS);
+        return thenAcceptBothAsync(other, action, defaultExecutor());
     }
 
     @Override
@@ -351,7 +352,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> runAfterBoth(@Nonnull CompletionStage<?> other, @Nonnull Runnable action) {
-        return runAfterBothAsync(other, action, CALLER_RUNS);
+        return runAfterBothAsync(other, action, defaultExecutor());
     }
 
     @Override
@@ -384,7 +385,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     @Override
     public <U> InternalCompletableFuture<U> applyToEither(@Nonnull CompletionStage<? extends V> other,
                                                   @Nonnull Function<? super V, U> fn) {
-        return applyToEitherAsync(other, fn, CALLER_RUNS);
+        return applyToEitherAsync(other, fn, defaultExecutor());
     }
 
     @Override
@@ -422,7 +423,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     @Override
     public InternalCompletableFuture<Void> acceptEither(@Nonnull CompletionStage<? extends V> other,
                                                 @Nonnull Consumer<? super V> action) {
-        return acceptEitherAsync(other, action, CALLER_RUNS);
+        return acceptEitherAsync(other, action, defaultExecutor());
     }
 
     @Override
@@ -459,7 +460,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
-        return runAfterEitherAsync(other, action, CALLER_RUNS);
+        return runAfterEitherAsync(other, action, defaultExecutor());
     }
 
     @Override
@@ -1339,11 +1340,11 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     static final class WaitNode {
         final Object waiter;
         volatile Object next;
-        private final Executor executor;
+        private final @Nonnull Executor executor;
 
-        WaitNode(Object waiter, Executor executor) {
+        WaitNode(Object waiter, @Nullable Executor executor) {
             this.waiter = waiter;
-            this.executor = executor;
+            this.executor = executor == null ? DEFAULT_ASYNC_EXECUTOR : executor;
         }
 
         @Override
@@ -1419,7 +1420,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
      * future's resolved value.
      */
     interface UniWaiter extends Waiter {
-        void execute(Executor executor, Object value);
+        void execute(@Nonnull Executor executor, Object value);
     }
 
     /**
@@ -1428,7 +1429,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
      * on the normal or exceptional completion value.
      */
     interface BiWaiter<V, T extends Throwable> extends Waiter {
-        void execute(Executor executor, V value, T throwable);
+        void execute(@Nonnull Executor executor, V value, T throwable);
     }
 
     // a WaitNode for a Function<V, R>
@@ -1442,19 +1443,15 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, Object value) {
+        public void execute(@Nonnull Executor executor, Object value) {
             if (cascadeException(value, future)) {
                 return;
             }
-            if (executor == null) {
-                future.complete(function.apply((V) value));
-            } else {
-                try {
-                    executor.execute(() -> future.complete(function.apply((V) value)));
-                } catch (RejectedExecutionException e) {
-                    future.completeExceptionally(wrapToInstanceNotActiveException(e));
-                    throw e;
-                }
+            try {
+                executor.execute(() -> future.complete(function.apply((V) value)));
+            } catch (RejectedExecutionException e) {
+                future.completeExceptionally(wrapToInstanceNotActiveException(e));
+                throw e;
             }
         }
     }
@@ -1495,10 +1492,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, V value, Throwable throwable) {
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
+        public void execute(@Nonnull Executor executor, V value, Throwable throwable) {
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         future.complete(biFunction.apply(value, throwable));
                     } catch (Throwable t) {
@@ -1523,10 +1519,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, V value, T throwable) {
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
+        public void execute(@Nonnull Executor executor, V value, T throwable) {
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         biConsumer.accept(value, throwable);
                     } catch (Throwable t) {
@@ -1561,13 +1556,12 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, Object value) {
+        public void execute(@Nonnull Executor executor, Object value) {
             if (cascadeException(value, future)) {
                 return;
             }
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         consumer.accept((T) value);
                         future.complete(null);
@@ -1593,13 +1587,12 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, Object resolved) {
+        public void execute(@Nonnull Executor executor, Object resolved) {
             if (cascadeException(resolved, future)) {
                 return;
             }
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         runnable.run();
                         future.complete(null);
@@ -1624,13 +1617,12 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, Object resolved) {
+        public void execute(@Nonnull Executor executor, Object resolved) {
             if (cascadeException(resolved, future)) {
                 return;
             }
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         CompletionStage<U> r = function.apply((T) resolved);
                         r.whenComplete((v, t) -> {
@@ -1666,7 +1658,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
         @Override
         @SuppressWarnings("checkstyle:npathcomplexity")
-        public void execute(Executor executor, Object resolved) {
+        public void execute(@Nonnull Executor executor, Object resolved) {
             if (cascadeException(resolved, result)) {
                 return;
             }
@@ -1699,9 +1691,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
                 return;
             }
             U otherValue = otherFuture.join();
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         R r = process((T) resolved, otherValue);
                         result.complete(r);
@@ -1779,16 +1770,15 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
 
         @Override
-        public void execute(Executor executor, Object resolved) {
+        public void execute(@Nonnull Executor executor, Object resolved) {
             if (!executed.compareAndSet(false, true)) {
                 return;
             }
             if (cascadeException(resolved, result)) {
                 return;
             }
-            Executor e = (executor == null) ? CALLER_RUNS : executor;
             try {
-                e.execute(() -> {
+                executor.execute(() -> {
                     try {
                         R r = process((T) resolved);
                         result.complete(r);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFutureTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
 import static org.junit.Assert.assertEquals;
@@ -290,6 +291,7 @@ public class ClientInvocationFutureTest {
                 (t) -> t);
         invocationFuture.complete(response);
 
+        assertTrueEventually(() -> assertTrue(nextStage.isDone()));
         assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -915,6 +916,14 @@ public class BasicMapTest extends HazelcastTestSupport {
         } catch (ExecutionException e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void testAsyncMethodChaining() {
+        IMap<Integer, Integer> map = getInstance().getMap("testGetPutRemoveAsync");
+        CompletionStage<Integer> setThenGet = map.setAsync(1, 1)
+                                              .thenCompose(v -> map.getAsync(1));
+        assertEquals(1L, (long) setThenGet.toCompletableFuture().join());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFutureTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -26,12 +26,19 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.spi.impl.InternalCompletableFuture.completedExceptionally;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
+import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -110,5 +117,106 @@ public class DelegatingCompletableFutureTest {
     public void test_isDone() {
         Future future = new DelegatingCompletableFuture(null, newCompletedFuture("value"));
         assertTrue(future.isDone());
+    }
+
+    @Test
+    public void test_actionsTrigger_whenAlreadyCompletedFuture() {
+        CountDownLatch latch = new CountDownLatch(1);
+        CompletableFuture<String> future =
+                new DelegatingCompletableFuture(null, newCompletedFuture("value"));
+        future.thenRun(latch::countDown);
+        assertOpenEventually(latch);
+    }
+
+    @Test
+    public void testInteroperability1() {
+        // given f1 (JDK CompletableFuture), is completed asynchronously after 3 seconds
+        //       f2 (DelegatingCompletableFuture wrapping f1) returned from thenCompose
+        // then  f2 is completed eventually
+        CompletableFuture f1 = CompletableFuture.runAsync(() -> sleepSeconds(2));
+        CompletableFuture f2 = CompletableFuture.completedFuture(null).thenCompose(v -> {
+            return new DelegatingCompletableFuture<>(serializationService, f1);
+        });
+
+        assertTrueEventually(() -> assertTrue(f2.isDone() && !f2.isCompletedExceptionally()));
+    }
+
+    @Test
+    public void testInteroperability2() {
+        // given f1 (JDK CompletableFuture), is already completed
+        //       f2 (DelegatingCompletableFuture wrapping f1) returned from thenCompose
+        // then  f2 is completed eventually
+        CompletableFuture f1 = CompletableFuture.completedFuture(null);
+        CompletableFuture f2 = CompletableFuture.completedFuture(null).thenCompose(v ->
+                new DelegatingCompletableFuture<>(serializationService, f1)
+        );
+
+        assertTrueEventually(() -> assertTrue(f2.isDone() && !f2.isCompletedExceptionally()));
+    }
+
+    @Test
+    public void testInteroperability3() {
+        // given f1 (DelegatingCompletableFuture wrapping completed future)
+        //       f2 (JDK CompletableFuture) returned from thenCompose
+        // then  f2 is completed eventually
+        CompletableFuture f1 = new DelegatingCompletableFuture<>(serializationService, completedFuture(null));
+        CompletableFuture f2 = f1.thenCompose(v -> CompletableFuture.runAsync(() -> sleepSeconds(2)));
+
+        assertTrueEventually(() -> assertTrue(f2.isDone() && !f2.isCompletedExceptionally()));
+    }
+
+    @Test
+    public void testInteroperability_withValueDeserializationInFunction() {
+        // given f1 (DelegatingCompletableFuture wrapping completed future with Data as value)
+        //       f2 (JDK CompletableFuture) returned from thenCompose
+        // then  argument in compose function is deserialized
+        //       f2 is completed eventually
+        String value = "test";
+        Data valueData = serializationService.toData(value);
+        CompletableFuture f1 = new DelegatingCompletableFuture<>(serializationService, completedFuture(valueData));
+        CompletableFuture f2 = f1.thenCompose(v -> {
+            assertEquals(value, v);
+            return CompletableFuture.runAsync(() -> sleepSeconds(2));
+        });
+
+        assertTrueEventually(() -> assertTrue(f2.isDone() && !f2.isCompletedExceptionally()));
+        assertEquals(value, f1.join());
+    }
+
+    @Test
+    public void testInteroperability_withValueDeserializationInCompletedReturnedFuture() {
+        // given f1 (DelegatingCompletableFuture wrapping completed future)
+        //       f2 (JDK CompletableFuture) returned from thenCompose
+        // then  f2 is completed eventually
+        //       completion value of f2 is deserialized
+        String value = "test";
+        Data valueData = serializationService.toData(value);
+        CompletableFuture f1 = completedFuture(null);
+        CompletableFuture<String> f2 = f1.thenCompose(v ->
+            new DelegatingCompletableFuture<String>(serializationService, completedFuture(valueData))
+        );
+
+        assertTrueEventually(() -> assertTrue(f2.isDone() && !f2.isCompletedExceptionally()));
+        assertEquals(value, f2.join());
+    }
+
+    @Test
+    public void testInteroperability_withValueDeserializationInReturnedFuture() {
+        // given f1 (DelegatingCompletableFuture wrapping completed future)
+        //       f2 (JDK CompletableFuture) returned from thenCompose
+        // then  f2 is completed eventually
+        //       completion value of f2 is deserialized
+        String value = "test";
+        Data valueData = serializationService.toData(value);
+        CompletableFuture f1 = completedFuture(null);
+        CompletableFuture<String> f2 = f1.thenCompose(v ->
+            new DelegatingCompletableFuture<String>(serializationService, supplyAsync(() -> {
+                sleepSeconds(2);
+                return valueData;
+            }))
+        );
+
+        assertTrueEventually(() -> assertTrue(f2.isDone() && !f2.isCompletedExceptionally()));
+        assertEquals(value, f2.join());
     }
 }


### PR DESCRIPTION
`CompletableFuture` subclasses `DelegatingCompletableFuture` and
`AbstractInvocationFuture` manage their own completion
value state separately from their superclass.
However `CompletableFuture` 's
methods make use of private `CompletableFuture` state
resulting in broken interoperability. This PR ensures that when
`AbstractInvocationFuture`/`DelegatingCompletableFuture` are
completed, the `CompletableFuture` superclass internal state is
also updated to allow for `CompletableFuture` methods which use
its internals to work properly.

Second commit in this PR fixes a leftover from #16154: dependent
actions registered with default sync methods (like `thenCompose`,
`whenComplete` etc) should use the
`ConcurrencyUtil#DEFAULT_ASYNC_EXECUTOR`. See #16154
description for reasoning.

Fixes #17019 