### PR TITLE
Change compatibility matching rule

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/compatibility/nio/tcp/CompatibilityBindRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/compatibility/nio/tcp/CompatibilityBindRequest.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.internal.nio.Packet.FLAG_3_12;
 import static com.hazelcast.internal.nio.Packet.FLAG_4_0;
 
 /**
@@ -73,8 +72,7 @@ public class CompatibilityBindRequest {
         CompatibilityExtendedBindMessage bind =
                 new CompatibilityExtendedBindMessage((byte) 1, getConfiguredLocalAddresses(), remoteEndPoint, reply);
         byte[] bytes = ioService.getSerializationService().toBytes(bind);
-        Packet packet = new Packet(bytes).setPacketType(Type.COMPATIBILITY_EXTENDED_BIND)
-                                         .raiseFlags(FLAG_3_12);
+        Packet packet = new Packet(bytes).setPacketType(Type.COMPATIBILITY_EXTENDED_BIND);
         // unset 4_0 flag
         packet.resetFlagsTo(packet.getFlags() & ~FLAG_4_0);
         connection.write(packet);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -103,12 +103,6 @@ public final class Packet extends HeapData implements OutboundFrame {
      */
     public static final int FLAG_4_0 = 1 << 7;
 
-    /**
-     * Marks a packet as sent by a 3.12 member
-     */
-    public static final int FLAG_3_12 = 1 << 8;
-
-
     //            END OF HEADER FLAG SECTION
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -156,7 +156,11 @@ public final class Packet extends HeapData implements OutboundFrame {
     }
 
     public Type getPacketType() {
-        boolean isCompatibility = isFlagRaised(FLAG_3_12);
+        // the packet was sent from 3.12 if the 4_0 flag is missing
+        // 4.0.1 and 4.2 members do not set this flag
+        // so this member should not be a part of a cluster
+        // with those members
+        boolean isCompatibility = !isFlagRaised(FLAG_4_0);
         return Type.fromFlags(flags, isCompatibility);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpEndpointManager.java
@@ -178,7 +178,11 @@ public class TcpIpEndpointManager
 
     @Override
     public synchronized void accept(Packet packet) {
-        boolean isCompatibility = packet.isFlagRaised(Packet.FLAG_3_12);
+        // the packet was sent from 3.12 if the 4_0 flag is missing
+        // 4.0.1 and 4.2 members do not set this flag
+        // so this member should not be a part of a cluster
+        // with those members
+        boolean isCompatibility = !packet.isFlagRaised(Packet.FLAG_4_0);
         if (isCompatibility) {
             compatibilityBindHandler.process(packet);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -416,9 +416,11 @@ class OperationRunnerImpl extends OperationRunner implements StaticMetricsProvid
         Connection connection = packet.getConn();
         Address caller = connection.getEndPoint();
         try {
-            // deserialize with compatibility serialization service
-            // if sent from 3.x member
-            boolean isCompatibility = packet.isFlagRaised(Packet.FLAG_3_12);
+            // the packet was sent from 3.12 if the 4_0 flag is missing
+            // 4.0.1 and 4.2 members do not set this flag
+            // so this member should not be a part of a cluster
+            // with those members
+            boolean isCompatibility = !packet.isFlagRaised(Packet.FLAG_4_0);
             InternalSerializationService serializationService = isCompatibility
                     ? nodeEngine.getNode().getCompatibilitySerializationService()
                     : nodeEngine.getNode().getSerializationService();


### PR DESCRIPTION
We change the rule which determines if a packet was sent by a member of
another major version. Previously, we were looking for the existence of
a flag on the Packet which meant the sender needed to be at least 3.12.8
or 4.0.2. This places a restriction on the source cluster when migrating
from 3.12 to 4.0 which means users need to perform a rolling restart of
all source cluster members to 3.12.8 before migrating data.

Instead, we change the rule to determine that a packet was sent if
another flag is missing. This removes the restriction on the source
cluster but places another restriction on the target cluster.
Regardless, this is much simpler for actual migration scenarios - now
users probably don't need to do any kind of restart of the source
cluster and may only set up the target cluster appropriately after which
they can add the WAN configuration between the two clusters dynamically.

This also means that now the migration members must not be members of
the same cluster with members not setting the FLAG_4_0, which means they
cannot coexist in the same cluster with 4.0.1 and 4.2+ members. This is
also ok because "migration" members may easily be started alongside
4.0.2 members and may simply be shut down before rolling up to 4.2.

Unfortunately we cannot make a compatibility test for this scenario as
it requires a wide range of versions running inside a single JVM, namely
4.0.2, 4.0.2-migration and 3.12.1 while the compatibility guardian
framework assumes it will need to translate only between two versions -
the current codebase version and another version. The migration scenario
was tested manually:
- started two 3.12.1 members
- started two 4.0.2 members
- started a lite 4.0.2-migration member
- added dynamic WAN configuration between 3.12.1 and 4.0.2-migration
- added data in 3.12.1 cluster
- asserted data is in 4.0.2 members, shutdown 3.12.1 and 4.0.2-migration