### PR TITLE
Change compatibility matching rule

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -162,8 +162,12 @@ public final class Packet extends HeapData implements OutboundFrame {
     }
 
     public Type getPacketType() {
-        boolean is4x = isFlagRaised(FLAG_4_0);
-        return Type.fromFlags(flags, is4x);
+        // the packet was sent from 4.0 if the 3_12 flag is missing
+        // 3.12.0-3.12.7 members do not set this flag
+        // so this member should not be a part of a cluster
+        // with those members
+        boolean isCompatibility = !isFlagRaised(FLAG_3_12);
+        return Type.fromFlags(flags, isCompatibility);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpEndpointManager.java
@@ -182,7 +182,11 @@ public class TcpIpEndpointManager
 
     @Override
     public synchronized void accept(Packet packet) {
-        boolean isCompatibility = packet.isFlagRaised(Packet.FLAG_4_0);
+        // the packet was sent from 4.0 if the 3_12 flag is missing
+        // 3.12.0-3.12.7 members do not set this flag
+        // so this member should not be a part of a cluster
+        // with those members
+        boolean isCompatibility = !packet.isFlagRaised(Packet.FLAG_3_12);
         if (isCompatibility) {
             compatibilityBindHandler.process(packet);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -395,9 +395,11 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         Connection connection = packet.getConn();
         Address caller = connection.getEndPoint();
         try {
-            // deserialize with compatibility serialization service
-            // if sent from 4.x member
-            boolean isCompatibility = packet.isFlagRaised(Packet.FLAG_4_0);
+            // the packet was sent from 4.0 if the 3_12 flag is missing
+            // 3.12.0-3.12.7 members do not set this flag
+            // so this member should not be a part of a cluster
+            // with those members
+            boolean isCompatibility = !packet.isFlagRaised(Packet.FLAG_3_12);
             InternalSerializationService serializationService = isCompatibility
                     ? nodeEngine.getNode().getCompatibilitySerializationService()
                     : nodeEngine.getNode().getSerializationService();


### PR DESCRIPTION
**Note to reviewers**: this PR is to align the behaviour with https://github.com/hazelcast/hazelcast/pull/17025 but I'm unsure if we need to have the same behaviour, maybe we can leave the 3.12 code as-is and only rely that the user will use 4.0.2 with 4.0.2-migration, where we can rely only on one flag instead of two - FLAG_4_0.

We change the rule which determines if a packet was sent by a member of
another major version. Previously, we were looking for the existence of
a flag on the Packet which meant the sender needed to be at least 3.12.8
or 4.0.2. This places a restriction on the source cluster when migrating
from 4.0 to 3.12 which means users need to upgrade all source cluster
members to 4.0.2 before migrating data.

Instead, we change the rule to determine that a packet was sent if
another flag is missing. This removes the restriction on the source
cluster but places another restriction on the target cluster.
Regardless, this is much simpler for actual migration scenarios - now
users probably don't need to do any kind of restart of the source
cluster and may only set up the target cluster appropriately after which
they can add the WAN configuration between the two clusters dynamically.

This also means that now the migration members must not be members of
the same cluster with members not setting the FLAG_3_12, which means they
cannot coexist in the same cluster with 3.12.0-3.12.7 members. This is
also ok because "migration" members may easily be started alongside
3.12.7 members.

Unfortunately we cannot make a compatibility test for this scenario as
it requires a wide range of versions running inside a single JVM, namely
3.12.8, 3.12.8-migration and 4.0.1 while the compatibility guardian
framework assumes it will need to translate only between two versions -
the current codebase version and another version. The migration scenario
was tested manually:
- started two 4.0.1 members
- started two 3.12.8 members
- started a lite 3.12.8-migration member
- added dynamic WAN configuration between 4.0.1 and 3.12.8-migration
- added data in 4.0.1 cluster
- asserted data is in 3.12.8 members, shutdown 4.0.1 and 3.12.8-migration