### PR TITLE
Allow operations while node is shutting down

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeState.java
@@ -19,7 +19,6 @@ package com.hazelcast.instance.impl;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
-import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 
 /**
  * Possible states of a {@link Node} during its lifecycle.
@@ -54,12 +53,6 @@ public enum NodeState {
      * {@link Cluster#changeClusterState(ClusterState)}
      * </li>
      * </ul>
-     * <p>
-     * In {@code PASSIVE} state, all operations will be rejected except operations marked as
-     * {@link ReadonlyOperation}, join operations of some members that are explained in
-     * {@link ClusterState}, replication / migration operations and heartbeat operations.
-     * Operations those are to be allowed during {@code PASSIVE} state should be marked as
-     * {@link AllowedDuringPassiveState}.
      */
     PASSIVE,
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
@@ -16,16 +16,12 @@
 
 package com.hazelcast.spi.impl;
 
-import com.hazelcast.instance.impl.Node;
-import com.hazelcast.instance.impl.NodeState;
-
 /**
  * Marker interface for operations those are allowed to be executed or invoked during
- * {@link Node}'s {@link NodeState#PASSIVE} state.
+ * when cluster is in {@link com.hazelcast.cluster.ClusterState#PASSIVE} state.
  * <p>
- * By default, only join, replication and cluster heartbeat operations are allowed during shutdown.
+ * By default, only join, replication, cluster heartbeat operations and readonly operation are allowed.
  *
- * @see NodeState
  * @since 3.6
  */
 public interface AllowedDuringPassiveState {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.client.impl.ClientBackupAwareResponse;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
@@ -507,10 +508,15 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
             return true;
         }
 
-        boolean allowed = state == NodeState.PASSIVE && (op instanceof AllowedDuringPassiveState);
-        if (!allowed) {
+        boolean allowed = true;
+        if (state == NodeState.SHUT_DOWN) {
             notifyError(new HazelcastInstanceNotActiveException("State: " + state + " Operation: " + op.getClass()));
-            remote = false;
+            allowed = false;
+        } else if (!(op instanceof AllowedDuringPassiveState)
+                && context.clusterService.getClusterState() == ClusterState.PASSIVE) {
+            // Similar to OperationRunnerImpl.checkNodeState(op)
+            notifyError(new IllegalStateException("Cluster is in " + ClusterState.PASSIVE + " state! Operation: " + op));
+            allowed = false;
         }
         return allowed;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -32,11 +32,11 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.StaticMetricsProvider;
 import com.hazelcast.internal.nio.Packet;
-import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.PartitionReplica;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.impl.SerializationServiceV1;
+import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.logging.ILogger;
@@ -46,7 +46,6 @@ import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -278,16 +277,6 @@ class OperationRunnerImpl extends OperationRunner implements StaticMetricsProvid
         if (nodeEngine.getClusterService().getClusterState() == ClusterState.PASSIVE) {
             throw new IllegalStateException("Cluster is in " + ClusterState.PASSIVE + " state! Operation: " + op);
         }
-
-        // Operation has no partition ID, so it's sent to this node in purpose.
-        // Operation will fail since node is shutting down or cluster is passive.
-        if (op.getPartitionId() < 0) {
-            throw new HazelcastInstanceNotActiveException("Member " + localAddress + " is currently passive! Operation: " + op);
-        }
-
-        // Custer is not passive but this node is shutting down.
-        // Since operation has a partition ID, it must be retried on another node.
-        throw new RetryableHazelcastException("Member " + localAddress + " is currently shutting down! Operation: " + op);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -17,12 +17,10 @@
 package com.hazelcast.client.cluster;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
@@ -107,12 +105,11 @@ public class ClientClusterStateTest {
         factory.newHazelcastClient();
     }
 
-    @Test(expected = OperationTimeoutException.class)
+    @Test(expected = IllegalStateException.class)
     public void testClient_canNotExecuteWriteOperations_whenClusterState_passive() {
         warmUpPartitions(instances);
 
-        ClientConfig clientConfig = new ClientConfig().setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
-        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        HazelcastInstance client = factory.newHazelcastClient();
         IMap<Object, Object> map = client.getMap(randomMapName());
         changeClusterStateEventually(instance, ClusterState.PASSIVE);
         map.put(1, 1);

--- a/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -475,6 +476,7 @@ public abstract class AbstractEventJournalBasicTest<EJ_TYPE> extends HazelcastTe
     }
 
     @Test
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/16964")
     public void allowReadingWithFutureSeq() throws Exception {
         final EventJournalTestContext<String, Integer, EJ_TYPE> context = createContext();
 


### PR DESCRIPTION
Currently, we are rejecting all operations, except the ones marked as
`AllowedDuringPassiveState`, while node is shutting down (`nodeState == PASSIVE`).
But this constraint does not provide any additional safety guarantees.

There are four major tasks are executed during node shutdown:
- Partition replicas owned by shutting down member are migrated to other members.
- Latest un-replicated CRDT state is replicated to other members.
- If the member is CP and persistence is not enabled, it removes itself from CP groups.
- CP sessions are closed.

All of these have their own mechanisms to provide safety.

With this change, we will allow submitting & executing operations
while a node is shutting down. This is especially important when node holds
large data (hundreds of GBs). Because graceful shutdown process more than
a few minutes, rejecting/blocking operations on & from that node
during that period reduces availability of the cluster.

Fixes #16932