### PR TITLE
Allow operations while node is shutting down

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeState.java
@@ -19,7 +19,6 @@ package com.hazelcast.instance.impl;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
-import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 
 /**
  * Possible states of a {@link Node} during its lifecycle.
@@ -54,12 +53,6 @@ public enum NodeState {
      * {@link Cluster#changeClusterState(ClusterState)}
      * </li>
      * </ul>
-     * <p>
-     * In {@code PASSIVE} state, all operations will be rejected except operations marked as
-     * {@link ReadonlyOperation}, join operations of some members that are explained in
-     * {@link ClusterState}, replication / migration operations and heartbeat operations.
-     * Operations those are to be allowed during {@code PASSIVE} state should be marked as
-     * {@link AllowedDuringPassiveState}.
      */
     PASSIVE,
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
@@ -16,16 +16,12 @@
 
 package com.hazelcast.spi.impl;
 
-import com.hazelcast.instance.impl.Node;
-import com.hazelcast.instance.impl.NodeState;
-
 /**
  * Marker interface for operations those are allowed to be executed or invoked during
- * {@link Node}'s {@link NodeState#PASSIVE} state.
+ * when cluster is in {@link com.hazelcast.cluster.ClusterState#PASSIVE} state.
  * <p>
- * By default, only join, replication and cluster heartbeat operations are allowed during shutdown.
+ * By default, only join, replication, cluster heartbeat operations and readonly operation are allowed.
  *
- * @see NodeState
  * @since 3.6
  */
 public interface AllowedDuringPassiveState {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -46,7 +46,6 @@ import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -278,16 +277,6 @@ class OperationRunnerImpl extends OperationRunner implements StaticMetricsProvid
         if (nodeEngine.getClusterService().getClusterState() == ClusterState.PASSIVE) {
             throw new IllegalStateException("Cluster is in " + ClusterState.PASSIVE + " state! Operation: " + op);
         }
-
-        // Operation has no partition ID, so it's sent to this node in purpose.
-        // Operation will fail since node is shutting down or cluster is passive.
-        if (op.getPartitionId() < 0) {
-            throw new HazelcastInstanceNotActiveException("Member " + localAddress + " is currently passive! Operation: " + op);
-        }
-
-        // Custer is not passive but this node is shutting down.
-        // Since operation has a partition ID, it must be retried on another node.
-        throw new RetryableHazelcastException("Member " + localAddress + " is currently shutting down! Operation: " + op);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -17,12 +17,10 @@
 package com.hazelcast.client.cluster;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
@@ -107,12 +105,11 @@ public class ClientClusterStateTest {
         factory.newHazelcastClient();
     }
 
-    @Test(expected = OperationTimeoutException.class)
+    @Test(expected = IllegalStateException.class)
     public void testClient_canNotExecuteWriteOperations_whenClusterState_passive() {
         warmUpPartitions(instances);
 
-        ClientConfig clientConfig = new ClientConfig().setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
-        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        HazelcastInstance client = factory.newHazelcastClient();
         IMap<Object, Object> map = client.getMap(randomMapName());
         changeClusterStateEventually(instance, ClusterState.PASSIVE);
         map.put(1, 1);

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeStateTest.java
@@ -18,16 +18,15 @@ package com.hazelcast.instance.impl;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.ExceptionUtil;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -107,91 +106,79 @@ public class NodeStateTest extends HazelcastTestSupport {
 
     @Test
     public void shouldReject_NormalOperationInvocation_whilePassive() throws Exception {
-        InvocationTask task = new InvocationTask() {
-            @Override
-            public void invoke(NodeEngine nodeEngine) throws Exception {
-                Future<Object> future = nodeEngine.getOperationService()
-                        .invokeOnPartition(null, new DummyOperation(), 1);
-                try {
-                    future.get();
-                    fail("Invocation should fail while node is passive!");
-                } catch (ExecutionException e) {
-                    Throwable cause = e.getCause();
-                    assertTrue("Cause: " + cause, cause instanceof HazelcastInstanceNotActiveException);
-                }
+        InvocationTask task = nodeEngine -> {
+            Future<Object> future = nodeEngine.getOperationService()
+                    .invokeOnPartition(null, new DummyOperation(), 1);
+            try {
+                future.get();
+                fail("Invocation should fail while node is passive!");
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                assertTrue("Cause: " + cause, cause instanceof IllegalStateException);
             }
         };
 
-        testInvocation_whilePassive(task);
+        testInvocation_whileClusterPassive(task);
     }
 
     @Test
     public void shouldReject_NormalOperationExecution_whilePassive() throws Exception {
-        InvocationTask task = new InvocationTask() {
-            @Override
-            public void invoke(NodeEngine nodeEngine) throws Exception {
-                final CountDownLatch latch = new CountDownLatch(1);
-                Operation op = new DummyOperation() {
-                    @Override
-                    public void onExecutionFailure(Throwable e) {
-                        latch.countDown();
-                    }
+        InvocationTask task = nodeEngine -> {
+            final CountDownLatch latch = new CountDownLatch(1);
+            Operation op = new DummyOperation() {
+                @Override
+                public void onExecutionFailure(Throwable e) {
+                    latch.countDown();
+                }
 
-                    @Override
-                    public boolean returnsResponse() {
-                        return false;
-                    }
-                };
+                @Override
+                public boolean returnsResponse() {
+                    return false;
+                }
+            };
 
-                nodeEngine.getOperationService().run(op);
-                assertOpenEventually(latch);
-            }
+            nodeEngine.getOperationService().run(op);
+            assertOpenEventually(latch);
         };
 
-        testInvocation_whilePassive(task);
+        testInvocation_whileClusterPassive(task);
     }
 
     @Test
     public void shouldAllow_AllowedOperationInvocation_whilePassive() throws Exception {
-        InvocationTask task = new InvocationTask() {
-            @Override
-            public void invoke(NodeEngine nodeEngine) throws Exception {
-                Future<Object> future = nodeEngine.getOperationService()
-                        .invokeOnTarget(null, new DummyAllowedDuringPassiveStateOperation(), nodeEngine.getThisAddress());
-                future.get(1, TimeUnit.MINUTES);
-            }
+        InvocationTask task = nodeEngine -> {
+            Future<Object> future = nodeEngine.getOperationService()
+                    .invokeOnTarget(null, new DummyAllowedDuringPassiveStateOperation(), nodeEngine.getThisAddress());
+            future.get(1, TimeUnit.MINUTES);
         };
 
-        testInvocation_whilePassive(task);
+        testInvocation_whileClusterPassive(task);
     }
 
     @Test
     public void shouldAllow_AllowedOperationExecution_whilePassive() throws Exception {
-        InvocationTask task = new InvocationTask() {
-            @Override
-            public void invoke(NodeEngine nodeEngine) throws Exception {
-                final CountDownLatch latch = new CountDownLatch(1);
-                Operation op = new DummyAllowedDuringPassiveStateOperation() {
-                    @Override
-                    public void afterRun() throws Exception {
-                        latch.countDown();
-                    }
+        InvocationTask task = nodeEngine -> {
+            final CountDownLatch latch = new CountDownLatch(1);
+            Operation op = new DummyAllowedDuringPassiveStateOperation() {
+                @Override
+                public void afterRun() throws Exception {
+                    latch.countDown();
+                }
 
-                    @Override
-                    public boolean returnsResponse() {
-                        return false;
-                    }
-                };
+                @Override
+                public boolean returnsResponse() {
+                    return false;
+                }
+            };
 
-                nodeEngine.getOperationService().run(op);
-                assertOpenEventually(latch);
-            }
+            nodeEngine.getOperationService().run(op);
+            assertOpenEventually(latch);
         };
 
-        testInvocation_whilePassive(task);
+        testInvocation_whileClusterPassive(task);
     }
 
-    private void testInvocation_whilePassive(InvocationTask invocationTask) throws Exception {
+    private void testInvocation_whileClusterPassive(InvocationTask invocationTask) throws Exception {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         final HazelcastInstance hz = factory.newHazelcastInstance();
         final Node node = getNode(hz);


### PR DESCRIPTION
Currently, we are rejecting all operations, except the ones marked as
`AllowedDuringPassiveState`, while node is shutting down (`nodeState == PASSIVE`).
But this constraint does not provide any additional safety guarantees.

There are four major tasks are executed during node shutdown:
- Partition replicas owned by shutting down member are migrated to other members.
- Latest un-replicated CRDT state is replicated to other members.
- If the member is CP and persistence is not enabled, it removes itself from CP groups.
- CP sessions are closed.

All of these have their own mechanisms to provide safety.

With this change, we will allow submitting & executing operations
while a node is shutting down. This is especially important when node holds
large data (hundreds of GBs). Because graceful shutdown process more than
a few minutes, rejecting/blocking operations on & from that node
during that period reduces availability of the cluster.

Fixes #16932
Backport of https://github.com/hazelcast/hazelcast/pull/17028