### PR TITLE
Remove FLAG_3_12

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/compatibility/nio/tcp/CompatibilityBindRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/compatibility/nio/tcp/CompatibilityBindRequest.java
@@ -69,8 +69,6 @@ public class CompatibilityBindRequest {
         byte[] bytes = ioService.getSerializationService().toBytes(bind);
         Packet packet = new Packet(bytes).setPacketType(Packet.Type.BIND)
                                          .raiseFlags(Packet.FLAG_4_0);
-        // unset 3_12 flag
-        packet.resetFlagsTo(packet.getFlags() & ~Packet.FLAG_3_12);
         connection.write(packet);
         //now you can send anything...
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -103,17 +103,9 @@ public final class Packet extends HeapData implements OutboundFrame {
     /**
      * Reserved for 4.x member compatibility code to mark packets as being sent
      * by a 4.x member. The absence of this flag does not mean the packet was
-     * not sent by a 4.x member, though as it is only set on special
-     * compatibility releases. Instead, check for the presence of the
-     * {@link #FLAG_3_12} which should be set by 3.12.x compatibility releases.
+     * not sent by a 4.x member.
      */
     public static final int FLAG_4_0 = 1 << 7;
-
-    /**
-     * Marks a packet as sent by a 3.12 member
-     */
-    public static final int FLAG_3_12 = 1 << 8;
-
 
     //            END OF HEADER FLAG SECTION
 
@@ -125,7 +117,6 @@ public final class Packet extends HeapData implements OutboundFrame {
     private transient Connection conn;
 
     public Packet() {
-        raiseFlags(FLAG_3_12);
     }
 
     public Packet(byte[] payload) {
@@ -135,7 +126,6 @@ public final class Packet extends HeapData implements OutboundFrame {
     public Packet(byte[] payload, int partitionId) {
         super(payload);
         this.partitionId = partitionId;
-        raiseFlags(FLAG_3_12);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.nio.Packet.FLAG_3_12;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static org.junit.Assert.assertEquals;
@@ -38,23 +37,11 @@ import static org.junit.Assert.assertTrue;
 public class PacketTest {
 
     @Test
-    public void isFlag_3_12Set() {
-        byte[] payload = {};
-        Packet packet = new Packet();
-        Packet packet2 = new Packet(payload);
-        Packet packet3 = new Packet(payload, 1);
-
-        assertTrue(packet.isFlagRaised(FLAG_3_12));
-        assertTrue(packet2.isFlagRaised(FLAG_3_12));
-        assertTrue(packet3.isFlagRaised(FLAG_3_12));
-    }
-
-    @Test
     public void raiseFlags() {
         Packet packet = new Packet();
         packet.raiseFlags(FLAG_URGENT);
 
-        assertEquals(FLAG_URGENT | FLAG_3_12, packet.getFlags());
+        assertEquals(FLAG_URGENT, packet.getFlags());
     }
 
     @Test


### PR DESCRIPTION
The updated compatibility matching logic only needs FLAG_4_0.