### PR TITLE
CP Client message tasks should not deserialize responses

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AddAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AddAndGetMessageTask.java
@@ -19,9 +19,7 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongAddAndGetCodec;
 import com.hazelcast.cp.CPGroupId;
-import com.hazelcast.cp.internal.RaftInvocationManager;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.AddAndGetOp;
@@ -29,7 +27,6 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.AtomicLongPermission;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.security.Permission;
 
@@ -46,14 +43,15 @@ public class AddAndGetMessageTask extends AbstractCPMessageTask<AtomicLongAddAnd
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        RaftInvocationManager invocationManager = service.getInvocationManager();
         CPGroupId groupId = parameters.groupId;
         long delta = parameters.delta;
         RaftOp op = new AddAndGetOp(parameters.name, delta);
-        InternalCompletableFuture<Long> future = (delta == 0)
-                ? invocationManager.query(groupId, op, LINEARIZABLE) : invocationManager.invoke(groupId, op);
-        future.whenCompleteAsync(this);
+
+        if (delta == 0) {
+            query(groupId, op, LINEARIZABLE);
+        } else {
+            invoke(groupId, op);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AlterMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongAlterCodec;
 import com.hazelcast.core.IFunction;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.AlterOp;
@@ -44,10 +43,7 @@ public class AlterMessageTask extends AbstractCPMessageTask<AtomicLongAlterCodec
     protected void processMessage() {
         IFunction<Long, Long> function = serializationService.toObject(parameters.function);
         AlterResultType resultType = AlterResultType.fromValue(parameters.returnValueType);
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new AlterOp(parameters.name, function, resultType))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new AlterOp(parameters.name, function, resultType));
     }
 
     @Override
@@ -88,6 +84,6 @@ public class AlterMessageTask extends AbstractCPMessageTask<AtomicLongAlterCodec
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.function};
+        return new Object[] {parameters.function};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/ApplyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/ApplyMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongApplyCodec;
 import com.hazelcast.core.IFunction;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.ApplyOp;
@@ -44,10 +43,7 @@ public class ApplyMessageTask extends AbstractCPMessageTask<AtomicLongApplyCodec
     @Override
     protected void processMessage() {
         IFunction<Long, Object> function = serializationService.toObject(parameters.function);
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .query(parameters.groupId, new ApplyOp<>(parameters.name, function), LINEARIZABLE)
-               .whenCompleteAsync(this);
+        query(parameters.groupId, new ApplyOp<>(parameters.name, function), LINEARIZABLE);
     }
 
     @Override
@@ -82,6 +78,6 @@ public class ApplyMessageTask extends AbstractCPMessageTask<AtomicLongApplyCodec
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.function};
+        return new Object[] {parameters.function};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/CompareAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/CompareAndSetMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongCompareAndSetCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.CompareAndSetOp;
@@ -40,10 +39,7 @@ public class CompareAndSetMessageTask extends AbstractCPMessageTask<AtomicLongCo
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new CompareAndSetOp(parameters.name, parameters.expected, parameters.updated))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new CompareAndSetOp(parameters.name, parameters.expected, parameters.updated));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndSetMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongGetAndSetCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.GetAndSetOp;
@@ -40,10 +39,7 @@ public class GetAndSetMessageTask extends AbstractCPMessageTask<AtomicLongGetAnd
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new GetAndSetOp(parameters.name, parameters.newValue))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new GetAndSetOp(parameters.name, parameters.newValue));
     }
 
     @Override
@@ -78,6 +74,6 @@ public class GetAndSetMessageTask extends AbstractCPMessageTask<AtomicLongGetAnd
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.newValue};
+        return new Object[] {parameters.newValue};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongGetCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.GetAndAddOp;
@@ -42,10 +41,7 @@ public class GetMessageTask extends AbstractCPMessageTask<AtomicLongGetCodec.Req
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>query(parameters.groupId, new GetAndAddOp(parameters.name, 0), LINEARIZABLE)
-               .whenCompleteAsync(this);
+       query(parameters.groupId, new GetAndAddOp(parameters.name, 0), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/CompareAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/CompareAndSetMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicRefCompareAndSetCodec;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.CompareAndSetOp;
@@ -41,9 +40,8 @@ public class CompareAndSetMessageTask extends AbstractCPMessageTask<AtomicRefCom
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new CompareAndSetOp(parameters.name, parameters.oldValue, parameters.newValue);
-        service.getInvocationManager().<Boolean>invoke(parameters.groupId, op).whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/ContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/ContainsMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicRefContainsCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.ContainsOp;
@@ -42,10 +41,7 @@ public class ContainsMessageTask extends AbstractCPMessageTask<AtomicRefContains
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>query(parameters.groupId, new ContainsOp(parameters.name, parameters.value), LINEARIZABLE)
-               .whenCompleteAsync(this);
+        query(parameters.groupId, new ContainsOp(parameters.name, parameters.value), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/GetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/GetMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicRefGetCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.GetOp;
@@ -42,10 +41,7 @@ public class GetMessageTask extends AbstractCPMessageTask<AtomicRefGetCodec.Requ
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .query(parameters.groupId, new GetOp(parameters.name), LINEARIZABLE)
-               .whenCompleteAsync(this);
+        query(parameters.groupId, new GetOp(parameters.name), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/SetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/SetMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicRefSetCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.SetOp;
@@ -40,10 +39,7 @@ public class SetMessageTask extends AbstractCPMessageTask<AtomicRefSetCodec.Requ
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new SetOp(parameters.name, parameters.newValue, parameters.returnOldValue))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new SetOp(parameters.name, parameters.newValue, parameters.returnOldValue));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/AwaitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/AwaitMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchAwaitCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.AwaitOp;
@@ -41,10 +40,7 @@ public class AwaitMessageTask extends AbstractCPMessageTask<CountDownLatchAwaitC
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new AwaitOp(parameters.name, parameters.invocationUid, parameters.timeoutMs))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new AwaitOp(parameters.name, parameters.invocationUid, parameters.timeoutMs));
     }
 
     @Override
@@ -79,6 +75,6 @@ public class AwaitMessageTask extends AbstractCPMessageTask<CountDownLatchAwaitC
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.timeoutMs, TimeUnit.MILLISECONDS};
+        return new Object[] {parameters.timeoutMs, TimeUnit.MILLISECONDS};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/CountDownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/CountDownMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchCountDownCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.CountDownOp;
@@ -40,10 +39,7 @@ public class CountDownMessageTask extends AbstractCPMessageTask<CountDownLatchCo
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new CountDownOp(parameters.name, parameters.invocationUid, parameters.expectedRound))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new CountDownOp(parameters.name, parameters.invocationUid, parameters.expectedRound));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetCountMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchGetRoundCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.GetCountOp;
@@ -42,10 +41,7 @@ public class GetCountMessageTask extends AbstractCPMessageTask<CountDownLatchGet
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Integer>query(parameters.groupId, new GetCountOp(parameters.name), LINEARIZABLE)
-               .whenCompleteAsync(this);
+        query(parameters.groupId, new GetCountOp(parameters.name), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetRoundMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetRoundMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchGetRoundCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.GetRoundOp;
@@ -42,10 +41,7 @@ public class GetRoundMessageTask extends AbstractCPMessageTask<CountDownLatchGet
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-                .<Integer>query(parameters.groupId, new GetRoundOp(parameters.name), LINEARIZABLE)
-                .whenCompleteAsync(this);
+        query(parameters.groupId, new GetRoundOp(parameters.name), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/TrySetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/TrySetCountMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchTrySetCountCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.TrySetCountOp;
@@ -40,10 +39,7 @@ public class TrySetCountMessageTask extends AbstractCPMessageTask<CountDownLatch
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-                .<Boolean>invoke(parameters.groupId, new TrySetCountOp(parameters.name, parameters.count))
-                .whenCompleteAsync(this);
+        invoke(parameters.groupId, new TrySetCountOp(parameters.name, parameters.count));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/GetLockOwnershipStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/GetLockOwnershipStateMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.lock.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.FencedLockGetLockOwnershipCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.lock.LockOwnershipState;
 import com.hazelcast.cp.internal.datastructures.lock.LockService;
@@ -43,10 +42,7 @@ public class GetLockOwnershipStateMessageTask extends AbstractCPMessageTask<Fenc
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<LockOwnershipState>query(parameters.groupId, new GetLockOwnershipStateOp(parameters.name), LINEARIZABLE)
-               .whenCompleteAsync(this);
+        query(parameters.groupId, new GetLockOwnershipStateOp(parameters.name), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/LockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/LockMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.lock.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.FencedLockLockCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.lock.LockService;
 import com.hazelcast.cp.internal.datastructures.lock.operation.LockOp;
@@ -40,11 +39,8 @@ public class LockMessageTask extends AbstractCPMessageTask<FencedLockLockCodec.R
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new LockOp(parameters.name, parameters.sessionId, parameters.threadId,
-                       parameters.invocationUid))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId,
+                new LockOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/TryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/TryLockMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.lock.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.FencedLockTryLockCodec;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.lock.LockService;
 import com.hazelcast.cp.internal.datastructures.lock.operation.TryLockOp;
@@ -42,10 +41,9 @@ public class TryLockMessageTask extends AbstractCPMessageTask<FencedLockTryLockC
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new TryLockOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid,
                 parameters.timeoutMs);
-        service.getInvocationManager().<Long>invoke(parameters.groupId, op).whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/UnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/UnlockMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.lock.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.FencedLockUnlockCodec;
-import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.lock.LockService;
 import com.hazelcast.cp.internal.datastructures.lock.operation.UnlockOp;
 import com.hazelcast.instance.impl.Node;
@@ -41,9 +40,8 @@ public class UnlockMessageTask extends AbstractCPMessageTask<FencedLockUnlockCod
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new UnlockOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid);
-        service.getInvocationManager().<Boolean>invoke(parameters.groupId, op).whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AcquirePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AcquirePermitsMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreAcquireCodec;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.AcquirePermitsOp;
@@ -42,10 +41,9 @@ public class AcquirePermitsMessageTask extends AbstractCPMessageTask<SemaphoreAc
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new AcquirePermitsOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid,
                 parameters.permits, parameters.timeoutMs);
-        service.getInvocationManager().<Boolean>invoke(parameters.groupId, op).whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AvailablePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AvailablePermitsMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreAvailablePermitsCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.AvailablePermitsOp;
@@ -42,10 +41,7 @@ public class AvailablePermitsMessageTask extends AbstractCPMessageTask<Semaphore
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Integer>query(parameters.groupId, new AvailablePermitsOp(parameters.name), LINEARIZABLE)
-               .whenCompleteAsync(this);
+        query(parameters.groupId, new AvailablePermitsOp(parameters.name), LINEARIZABLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/ChangePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/ChangePermitsMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreChangeCodec;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.ChangePermitsOp;
@@ -43,10 +42,9 @@ public class ChangePermitsMessageTask extends AbstractCPMessageTask<SemaphoreCha
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new ChangePermitsOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid,
                 parameters.permits);
-        service.getInvocationManager().<Boolean>invoke(parameters.groupId, op).whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/DrainPermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/DrainPermitsMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreDrainCodec;
-import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.DrainPermitsOp;
 import com.hazelcast.instance.impl.Node;
@@ -41,9 +40,8 @@ public class DrainPermitsMessageTask extends AbstractCPMessageTask<SemaphoreDrai
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new DrainPermitsOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid);
-        service.getInvocationManager().<Integer>invoke(parameters.groupId, op).whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/InitSemaphoreMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/InitSemaphoreMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreInitCodec;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.InitSemaphoreOp;
@@ -40,10 +39,7 @@ public class InitSemaphoreMessageTask extends AbstractCPMessageTask<SemaphoreIni
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new InitSemaphoreOp(parameters.name, parameters.permits))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new InitSemaphoreOp(parameters.name, parameters.permits));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/ReleasePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/ReleasePermitsMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreReleaseCodec;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.ReleasePermitsOp;
@@ -41,12 +40,9 @@ public class ReleasePermitsMessageTask extends AbstractCPMessageTask<SemaphoreRe
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new ReleasePermitsOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid,
                 parameters.permits);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, op)
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/DestroyRaftObjectMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/DestroyRaftObjectMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.cp.internal.datastructures.spi.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPGroupDestroyCPObjectCodec;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
-import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.datastructures.spi.operation.DestroyRaftObjectOp;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
@@ -37,10 +36,7 @@ public class DestroyRaftObjectMessageTask extends AbstractCPMessageTask<CPGroupD
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new DestroyRaftObjectOp(parameters.serviceName, parameters.objectName))
-               .whenCompleteAsync(this);
+        invoke(parameters.groupId, new DestroyRaftObjectOp(parameters.serviceName, parameters.objectName));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/AbstractSessionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/AbstractSessionMessageTask.java
@@ -23,7 +23,6 @@ import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.security.Permission;
 
@@ -35,12 +34,9 @@ abstract class AbstractSessionMessageTask<P, R> extends AbstractCPMessageTask<P>
 
     @Override
     protected final void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         CPGroupId groupId = getGroupId();
         RaftOp raftOp = getRaftOp();
-
-        InternalCompletableFuture<R> future = service.getInvocationManager().invoke(groupId, raftOp);
-        future.whenCompleteAsync(this);
+        invoke(groupId, raftOp);
     }
 
     abstract CPGroupId getGroupId();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocation.java
@@ -51,7 +51,13 @@ public class RaftInvocation extends Invocation<CPMember> {
 
     public RaftInvocation(Context context, RaftInvocationContext raftInvocationContext, CPGroupId groupId, Operation op,
                           int retryCount, long retryPauseMillis, long callTimeoutMillis) {
-        super(context, op, null, retryCount, retryPauseMillis, callTimeoutMillis, DEFAULT_DESERIALIZE_RESULT, null);
+        this(context, raftInvocationContext, groupId, op, retryCount, retryPauseMillis, callTimeoutMillis,
+                DEFAULT_DESERIALIZE_RESULT);
+    }
+
+    public RaftInvocation(Context context, RaftInvocationContext raftInvocationContext, CPGroupId groupId, Operation op,
+            int retryCount, long retryPauseMillis, long callTimeoutMillis, boolean deserializeResponse) {
+        super(context, op, null, retryCount, retryPauseMillis, callTimeoutMillis, deserializeResponse, null);
         this.raftInvocationContext = raftInvocationContext;
         this.groupId = groupId;
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefIsolatedServersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefIsolatedServersTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cp.internal.datastructures.atomicref;
+
+import classloading.domain.Person;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.IAtomicReference;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.internal.util.FilteringClassLoader;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test for issue: https://github.com/hazelcast/hazelcast/issues/17050
+ * <p>
+ * {@code classloading.domain.Person} class is not on classpath of servers.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class AtomicRefIsolatedServersTest extends HazelcastRaftTestSupport {
+
+    @Override
+    protected TestHazelcastInstanceFactory createTestFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Test
+    public void testCpMode() throws Exception {
+        int groupSize = 3;
+        Config config = createConfig(groupSize, groupSize);
+        startServers(groupSize, config);
+
+        testSetAndGet();
+    }
+
+    @Test
+    public void testUnsafeMode() throws Exception {
+        Config config = new Config();
+        startServers(2, config);
+
+        testSetAndGet();
+    }
+
+    private void testSetAndGet() throws Exception {
+        HazelcastInstance client = ((TestHazelcastFactory) factory).newHazelcastClient();
+        IAtomicReference<Object> ref = client.getCPSubsystem().getAtomicReference("test");
+
+        ref.set(new Person());
+        Object result = ref.getAsync().toCompletableFuture().get(1, TimeUnit.MINUTES);
+        assertNotNull(result);
+    }
+
+    private void startServers(int count, Config config) {
+        spawn(() -> {
+            FilteringClassLoader cl = new FilteringClassLoader(singletonList("classloading"), null);
+            Thread.currentThread().setContextClassLoader(cl);
+
+            config.setClassLoader(cl);
+            factory.newInstances(config, count);
+        });
+    }
+}


### PR DESCRIPTION
- Deserialization is not needed, because it will be sent back to client.
- Response class may not be on server classpath.

Fixes #17050

Backport of https://github.com/hazelcast/hazelcast/pull/17054