### PR TITLE
CP Client message tasks should not deserialize responses

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefIsolatedServersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefIsolatedServersTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cp.internal.datastructures.atomicref;
+
+import classloading.domain.Person;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicReference;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.FilteringClassLoader;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test for issue: https://github.com/hazelcast/hazelcast/issues/17050
+ * <p>
+ * {@code classloading.domain.Person} class is not on classpath of servers.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AtomicRefIsolatedServersTest extends HazelcastRaftTestSupport {
+
+    @Override
+    protected TestHazelcastInstanceFactory createTestFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Test
+    public void test() throws Exception {
+        final int groupSize = 3;
+        Config config = createConfig(groupSize, groupSize);
+        startServers(groupSize, config);
+
+        HazelcastInstance client = ((TestHazelcastFactory) factory).newHazelcastClient();
+        IAtomicReference<Object> ref = client.getCPSubsystem().getAtomicReference("test");
+
+        ref.set(new Person());
+        Object result = ref.getAsync().get(1, TimeUnit.MINUTES);
+        assertNotNull(result);
+    }
+
+    private void startServers(final int count, final Config config) {
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                FilteringClassLoader cl = new FilteringClassLoader(singletonList("classloading"), null);
+                Thread.currentThread().setContextClassLoader(cl);
+
+                config.setClassLoader(cl);
+                factory.newInstances(config, count);
+            }
+        });
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
@@ -35,6 +35,7 @@ import com.hazelcast.internal.util.SimpleCompletableFuture;
 import com.hazelcast.internal.util.SimpleCompletedFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -183,24 +184,35 @@ public class RaftInvocationManager {
     }
 
     public <T> InternalCompletableFuture<T> invoke(CPGroupId groupId, RaftOp raftOp) {
+        return invoke(groupId, raftOp, InvocationBuilder.DEFAULT_DESERIALIZE_RESULT);
+    }
+
+    public <T> InternalCompletableFuture<T> invoke(CPGroupId groupId, RaftOp raftOp, boolean deserializeResponse) {
         InternalCompletableFuture<T> completedFuture = completeExceptionallyIfCPSubsystemNotAvailable();
         if (completedFuture != null) {
             return completedFuture;
         }
         Operation operation = new DefaultRaftReplicateOp(groupId, raftOp);
-        Invocation invocation = new RaftInvocation(operationService.getInvocationContext(), raftInvocationContext,
-                groupId, operation, invocationMaxRetryCount, invocationRetryPauseMillis, operationCallTimeout);
+        Invocation invocation =
+                new RaftInvocation(operationService.getInvocationContext(), raftInvocationContext, groupId, operation,
+                        invocationMaxRetryCount, invocationRetryPauseMillis, operationCallTimeout, deserializeResponse);
         return invocation.invoke();
     }
 
     public <T> InternalCompletableFuture<T> query(CPGroupId groupId, RaftOp raftOp, QueryPolicy queryPolicy) {
+        return query(groupId, raftOp, queryPolicy, InvocationBuilder.DEFAULT_DESERIALIZE_RESULT);
+    }
+
+    public <T> InternalCompletableFuture<T> query(CPGroupId groupId, RaftOp raftOp, QueryPolicy queryPolicy,
+            boolean deserializeResponse) {
         InternalCompletableFuture<T> completedFuture = completeExceptionallyIfCPSubsystemNotAvailable();
         if (completedFuture != null) {
             return completedFuture;
         }
         RaftQueryOp operation = new RaftQueryOp(groupId, raftOp, queryPolicy);
-        Invocation invocation = new RaftInvocation(operationService.getInvocationContext(), raftInvocationContext,
-                groupId, operation, invocationMaxRetryCount, invocationRetryPauseMillis, operationCallTimeout);
+        Invocation invocation =
+                new RaftInvocation(operationService.getInvocationContext(), raftInvocationContext, groupId, operation,
+                        invocationMaxRetryCount, invocationRetryPauseMillis, operationCallTimeout, deserializeResponse);
         return invocation.invoke();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/client/AbstractCPMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/client/AbstractCPMessageTask.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.client;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.RaftInvocationManager;
+import com.hazelcast.cp.internal.RaftOp;
+import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.raft.QueryPolicy;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.InternalCompletableFuture;
+
+public abstract class AbstractCPMessageTask<P> extends AbstractMessageTask<P> implements ExecutionCallback<Object> {
+
+    protected AbstractCPMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    protected void query(CPGroupId groupId, RaftOp op, QueryPolicy policy) {
+        RaftInvocationManager invocationManager = getInvocationManager();
+        InternalCompletableFuture<Object> future = invocationManager.query(groupId, op, policy, false);
+        future.andThen(this);
+    }
+
+    protected void invoke(CPGroupId groupId, RaftOp op) {
+        RaftInvocationManager invocationManager = getInvocationManager();
+        InternalCompletableFuture<Object> future = invocationManager.invoke(groupId, op, false);
+        future.andThen(this);
+    }
+
+    private RaftInvocationManager getInvocationManager() {
+        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
+        return service.getInvocationManager();
+    }
+
+    @Override
+    public void onResponse(Object response) {
+        sendResponse(response);
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        handleProcessingFailure(t);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AddAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AddAndGetMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicLongAddAndGetCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicLongAddAndGetCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.AddAndGetOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link AddAndGetOp}
  */
-public class AddAndGetMessageTask extends AbstractMessageTask<CPAtomicLongAddAndGetCodec.RequestParameters>
-        implements ExecutionCallback<Long> {
+public class AddAndGetMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public AddAndGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class AddAndGetMessageTask extends AbstractMessageTask<CPAtomicLongAddAnd
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-                .<Long>invoke(parameters.groupId, new AddAndGetOp(parameters.name, parameters.delta))
-                .andThen(this);
+        invoke(parameters.groupId, new AddAndGetOp(parameters.name, parameters.delta));
     }
 
     @Override
@@ -81,15 +76,5 @@ public class AddAndGetMessageTask extends AbstractMessageTask<CPAtomicLongAddAnd
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CPAtomicLongAddAndGetCodec.encodeResponse((Long) response);
-    }
-
-    @Override
-    public void onResponse(Long response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/AlterMessageTask.java
@@ -18,10 +18,9 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicLongAlterCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicLongAlterCodec.RequestParameters;
 import com.hazelcast.core.IFunction;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.AlterOp;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.AlterOp.AlterResultType;
@@ -35,8 +34,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link AlterOp}
  */
-public class AlterMessageTask extends AbstractMessageTask<CPAtomicLongAlterCodec.RequestParameters>
-        implements ExecutionCallback<Long> {
+public class AlterMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public AlterMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -46,10 +44,7 @@ public class AlterMessageTask extends AbstractMessageTask<CPAtomicLongAlterCodec
     protected void processMessage() {
         IFunction<Long, Long> function = serializationService.toObject(parameters.function);
         AlterResultType resultType = AlterResultType.fromValue(parameters.returnValueType);
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new AlterOp(parameters.name, function, resultType))
-               .andThen(this);
+        invoke(parameters.groupId, new AlterOp(parameters.name, function, resultType));
     }
 
     @Override
@@ -90,16 +85,6 @@ public class AlterMessageTask extends AbstractMessageTask<CPAtomicLongAlterCodec
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.function};
-    }
-
-    @Override
-    public void onResponse(Long response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
+        return new Object[] {parameters.function};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/CompareAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/CompareAndSetMessageTask.java
@@ -18,9 +18,7 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicLongCompareAndSetCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.CompareAndSetOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +31,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link CompareAndSetOp}
  */
-public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicLongCompareAndSetCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class CompareAndSetMessageTask extends AbstractCPMessageTask<CPAtomicLongCompareAndSetCodec.RequestParameters> {
 
     public CompareAndSetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +39,7 @@ public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicLongCo
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new CompareAndSetOp(parameters.name, parameters.expected, parameters.updated))
-               .andThen(this);
+        invoke(parameters.groupId, new CompareAndSetOp(parameters.name, parameters.expected, parameters.updated));
     }
 
     @Override
@@ -70,7 +64,7 @@ public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicLongCo
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.expected, parameters.updated};
+        return new Object[] {parameters.expected, parameters.updated};
     }
 
     @Override
@@ -81,15 +75,5 @@ public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicLongCo
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CPAtomicLongCompareAndSetCodec.encodeResponse((Boolean) response);
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndAddMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicLongGetAndAddCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicLongGetAndAddCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.GetAndAddOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link GetAndAddOp}
  */
-public class GetAndAddMessageTask extends AbstractMessageTask<CPAtomicLongGetAndAddCodec.RequestParameters>
-        implements ExecutionCallback<Long> {
+public class GetAndAddMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public GetAndAddMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class GetAndAddMessageTask extends AbstractMessageTask<CPAtomicLongGetAnd
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new GetAndAddOp(parameters.name, parameters.delta))
-               .andThen(this);
+        invoke(parameters.groupId, new GetAndAddOp(parameters.name, parameters.delta));
     }
 
     @Override
@@ -80,15 +75,5 @@ public class GetAndAddMessageTask extends AbstractMessageTask<CPAtomicLongGetAnd
 
     public Object[] getParameters() {
         return new Object[]{parameters.delta};
-    }
-
-    @Override
-    public void onResponse(Long response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndSetMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.atomiclong.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicLongGetAndSetCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicLongGetAndSetCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.GetAndSetOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link GetAndSetOp}
  */
-public class GetAndSetMessageTask extends AbstractMessageTask<CPAtomicLongGetAndSetCodec.RequestParameters>
-        implements ExecutionCallback<Long> {
+public class GetAndSetMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public GetAndSetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class GetAndSetMessageTask extends AbstractMessageTask<CPAtomicLongGetAnd
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new GetAndSetOp(parameters.name, parameters.newValue))
-               .andThen(this);
+        invoke(parameters.groupId, new GetAndSetOp(parameters.name, parameters.newValue));
     }
 
     @Override
@@ -80,16 +75,6 @@ public class GetAndSetMessageTask extends AbstractMessageTask<CPAtomicLongGetAnd
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.newValue};
-    }
-
-    @Override
-    public void onResponse(Long response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
+        return new Object[] {parameters.newValue};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/CompareAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/CompareAndSetMessageTask.java
@@ -18,10 +18,9 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicRefCompareAndSetCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicRefCompareAndSetCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.RaftAtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.CompareAndSetOp;
 import com.hazelcast.instance.Node;
@@ -34,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link CompareAndSetOp}
  */
-public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicRefCompareAndSetCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class CompareAndSetMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public CompareAndSetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -43,9 +41,8 @@ public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicRefCom
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new CompareAndSetOp(parameters.name, parameters.oldValue, parameters.newValue);
-        service.getInvocationManager().<Boolean>invoke(parameters.groupId, op).andThen(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override
@@ -81,15 +78,5 @@ public class CompareAndSetMessageTask extends AbstractMessageTask<CPAtomicRefCom
     @Override
     public Object[] getParameters() {
         return new Object[]{parameters.oldValue, parameters.newValue};
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/GetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/GetMessageTask.java
@@ -18,11 +18,11 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicRefGetCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicRefGetCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.RaftAtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.GetOp;
+import com.hazelcast.cp.internal.raft.QueryPolicy;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
@@ -33,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link GetOp}
  */
-public class GetMessageTask extends AbstractMessageTask<CPAtomicRefGetCodec.RequestParameters>
-        implements ExecutionCallback<Object> {
+public class GetMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public GetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +41,7 @@ public class GetMessageTask extends AbstractMessageTask<CPAtomicRefGetCodec.Requ
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new GetOp(parameters.name))
-               .andThen(this);
+        query(parameters.groupId, new GetOp(parameters.name), QueryPolicy.LINEARIZABLE);
     }
 
     @Override
@@ -81,15 +77,5 @@ public class GetMessageTask extends AbstractMessageTask<CPAtomicRefGetCodec.Requ
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Object response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/SetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/SetMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.atomicref.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicRefSetCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPAtomicRefSetCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.atomicref.RaftAtomicRefService;
 import com.hazelcast.cp.internal.datastructures.atomicref.operation.SetOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link SetOp}
  */
-public class SetMessageTask extends AbstractMessageTask<CPAtomicRefSetCodec.RequestParameters>
-        implements ExecutionCallback<Object> {
+public class SetMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public SetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class SetMessageTask extends AbstractMessageTask<CPAtomicRefSetCodec.Requ
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new SetOp(parameters.name, parameters.newValue, parameters.returnOldValue))
-               .andThen(this);
+        invoke(parameters.groupId, new SetOp(parameters.name, parameters.newValue, parameters.returnOldValue));
     }
 
     @Override
@@ -80,16 +75,6 @@ public class SetMessageTask extends AbstractMessageTask<CPAtomicRefSetCodec.Requ
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.newValue};
-    }
-
-    @Override
-    public void onResponse(Object response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
+        return new Object[] {parameters.newValue};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/AwaitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/AwaitMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchAwaitCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchAwaitCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.RaftCountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.AwaitOp;
 import com.hazelcast.instance.Node;
@@ -34,8 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Client message task for {@link AwaitOp}
  */
-public class AwaitMessageTask extends AbstractMessageTask<CPCountDownLatchAwaitCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class AwaitMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public AwaitMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -43,10 +41,7 @@ public class AwaitMessageTask extends AbstractMessageTask<CPCountDownLatchAwaitC
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new AwaitOp(parameters.name, parameters.invocationUid, parameters.timeoutMs))
-               .andThen(this);
+        invoke(parameters.groupId, new AwaitOp(parameters.name, parameters.invocationUid, parameters.timeoutMs));
     }
 
     @Override
@@ -81,16 +76,6 @@ public class AwaitMessageTask extends AbstractMessageTask<CPCountDownLatchAwaitC
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.timeoutMs, TimeUnit.MILLISECONDS};
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
+        return new Object[] {parameters.timeoutMs, TimeUnit.MILLISECONDS};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/CountDownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/CountDownMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchCountDownCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchCountDownCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.RaftCountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.CountDownOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link CountDownOp}
  */
-public class CountDownMessageTask extends AbstractMessageTask<CPCountDownLatchCountDownCodec.RequestParameters>
-        implements ExecutionCallback<Object> {
+public class CountDownMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public CountDownMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class CountDownMessageTask extends AbstractMessageTask<CPCountDownLatchCo
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new CountDownOp(parameters.name, parameters.invocationUid, parameters.expectedRound))
-               .andThen(this);
+        invoke(parameters.groupId, new CountDownOp(parameters.name, parameters.invocationUid, parameters.expectedRound));
     }
 
     @Override
@@ -81,15 +76,5 @@ public class CountDownMessageTask extends AbstractMessageTask<CPCountDownLatchCo
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Object response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetCountMessageTask.java
@@ -18,11 +18,11 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchGetRoundCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchGetRoundCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.RaftCountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.GetCountOp;
+import com.hazelcast.cp.internal.raft.QueryPolicy;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
@@ -33,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link GetCountOp}
  */
-public class GetCountMessageTask extends AbstractMessageTask<CPCountDownLatchGetRoundCodec.RequestParameters>
-        implements ExecutionCallback<Integer> {
+public class GetCountMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public GetCountMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +41,7 @@ public class GetCountMessageTask extends AbstractMessageTask<CPCountDownLatchGet
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Integer>invoke(parameters.groupId, new GetCountOp(parameters.name))
-               .andThen(this);
+        query(parameters.groupId, new GetCountOp(parameters.name), QueryPolicy.LINEARIZABLE);
     }
 
     @Override
@@ -81,15 +77,5 @@ public class GetCountMessageTask extends AbstractMessageTask<CPCountDownLatchGet
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Integer response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/TrySetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/TrySetCountMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.countdownlatch.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchTrySetCountCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPCountDownLatchTrySetCountCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.RaftCountDownLatchService;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.operation.TrySetCountOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link TrySetCountOp}
  */
-public class TrySetCountMessageTask extends AbstractMessageTask<CPCountDownLatchTrySetCountCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class TrySetCountMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public TrySetCountMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class TrySetCountMessageTask extends AbstractMessageTask<CPCountDownLatch
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-                .<Boolean>invoke(parameters.groupId, new TrySetCountOp(parameters.name, parameters.count))
-                .andThen(this);
+        invoke(parameters.groupId, new TrySetCountOp(parameters.name, parameters.count));
     }
 
     @Override
@@ -81,15 +76,5 @@ public class TrySetCountMessageTask extends AbstractMessageTask<CPCountDownLatch
     @Override
     public Object[] getParameters() {
         return new Object[]{parameters.count};
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/UnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/UnlockMessageTask.java
@@ -18,10 +18,9 @@ package com.hazelcast.cp.internal.datastructures.lock.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPFencedLockUnlockCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPFencedLockUnlockCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.lock.RaftLockService;
 import com.hazelcast.cp.internal.datastructures.lock.operation.UnlockOp;
 import com.hazelcast.instance.Node;
@@ -34,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link UnlockOp}
  */
-public class UnlockMessageTask extends AbstractMessageTask<CPFencedLockUnlockCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class UnlockMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public UnlockMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -43,9 +41,8 @@ public class UnlockMessageTask extends AbstractMessageTask<CPFencedLockUnlockCod
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new UnlockOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid);
-        service.getInvocationManager().<Boolean>invoke(parameters.groupId, op).andThen(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override
@@ -81,15 +78,5 @@ public class UnlockMessageTask extends AbstractMessageTask<CPFencedLockUnlockCod
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AvailablePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AvailablePermitsMessageTask.java
@@ -18,11 +18,11 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSemaphoreAvailablePermitsCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPSemaphoreAvailablePermitsCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.RaftSemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.AvailablePermitsOp;
+import com.hazelcast.cp.internal.raft.QueryPolicy;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
@@ -33,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link AvailablePermitsOp}
  */
-public class AvailablePermitsMessageTask extends AbstractMessageTask<CPSemaphoreAvailablePermitsCodec.RequestParameters>
-        implements ExecutionCallback<Integer> {
+public class AvailablePermitsMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public AvailablePermitsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +41,7 @@ public class AvailablePermitsMessageTask extends AbstractMessageTask<CPSemaphore
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Integer>invoke(parameters.groupId, new AvailablePermitsOp(parameters.name))
-               .andThen(this);
+        query(parameters.groupId, new AvailablePermitsOp(parameters.name), QueryPolicy.LINEARIZABLE);
     }
 
     @Override
@@ -81,15 +77,5 @@ public class AvailablePermitsMessageTask extends AbstractMessageTask<CPSemaphore
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Integer response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/DrainPermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/DrainPermitsMessageTask.java
@@ -18,10 +18,9 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSemaphoreDrainCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPSemaphoreDrainCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.RaftSemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.DrainPermitsOp;
 import com.hazelcast.instance.Node;
@@ -34,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link DrainPermitsOp}
  */
-public class DrainPermitsMessageTask extends AbstractMessageTask<CPSemaphoreDrainCodec.RequestParameters>
-        implements ExecutionCallback<Integer> {
+public class DrainPermitsMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public DrainPermitsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -43,9 +41,8 @@ public class DrainPermitsMessageTask extends AbstractMessageTask<CPSemaphoreDrai
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new DrainPermitsOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid);
-        service.getInvocationManager().<Integer>invoke(parameters.groupId, op).andThen(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override
@@ -81,15 +78,5 @@ public class DrainPermitsMessageTask extends AbstractMessageTask<CPSemaphoreDrai
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Integer response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/InitSemaphoreMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/InitSemaphoreMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSemaphoreInitCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPSemaphoreInitCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.RaftSemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.InitSemaphoreOp;
 import com.hazelcast.instance.Node;
@@ -33,8 +32,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link InitSemaphoreOp}
  */
-public class InitSemaphoreMessageTask extends AbstractMessageTask<CPSemaphoreInitCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class InitSemaphoreMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public InitSemaphoreMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -42,10 +40,7 @@ public class InitSemaphoreMessageTask extends AbstractMessageTask<CPSemaphoreIni
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new InitSemaphoreOp(parameters.name, parameters.permits))
-               .andThen(this);
+        invoke(parameters.groupId, new InitSemaphoreOp(parameters.name, parameters.permits));
     }
 
     @Override
@@ -81,15 +76,5 @@ public class InitSemaphoreMessageTask extends AbstractMessageTask<CPSemaphoreIni
     @Override
     public Object[] getParameters() {
         return new Object[]{parameters.permits};
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/ReleasePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/ReleasePermitsMessageTask.java
@@ -18,10 +18,9 @@ package com.hazelcast.cp.internal.datastructures.semaphore.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSemaphoreReleaseCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPSemaphoreReleaseCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.RaftSemaphoreService;
 import com.hazelcast.cp.internal.datastructures.semaphore.operation.ReleasePermitsOp;
 import com.hazelcast.instance.Node;
@@ -34,8 +33,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link ReleasePermitsOp}
  */
-public class ReleasePermitsMessageTask extends AbstractMessageTask<CPSemaphoreReleaseCodec.RequestParameters>
-        implements ExecutionCallback<Boolean> {
+public class ReleasePermitsMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public ReleasePermitsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -43,12 +41,9 @@ public class ReleasePermitsMessageTask extends AbstractMessageTask<CPSemaphoreRe
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new ReleasePermitsOp(parameters.name, parameters.sessionId, parameters.threadId, parameters.invocationUid,
                 parameters.permits);
-        service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, op)
-               .andThen(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override
@@ -84,15 +79,5 @@ public class ReleasePermitsMessageTask extends AbstractMessageTask<CPSemaphoreRe
     @Override
     public Object[] getParameters() {
         return new Object[]{parameters.permits};
-    }
-
-    @Override
-    public void onResponse(Boolean response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/DestroyRaftObjectMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/DestroyRaftObjectMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.datastructures.spi.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPGroupDestroyCPObjectCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPGroupDestroyCPObjectCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.spi.operation.DestroyRaftObjectOp;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
@@ -31,8 +30,7 @@ import java.security.Permission;
 /**
  * Client message task for destroying Raft objects
  */
-public class DestroyRaftObjectMessageTask extends AbstractMessageTask<CPGroupDestroyCPObjectCodec.RequestParameters>
-        implements ExecutionCallback<Object> {
+public class DestroyRaftObjectMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public DestroyRaftObjectMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -40,10 +38,7 @@ public class DestroyRaftObjectMessageTask extends AbstractMessageTask<CPGroupDes
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new DestroyRaftObjectOp(parameters.serviceName, parameters.objectName))
-               .andThen(this);
+        invoke(parameters.groupId, new DestroyRaftObjectOp(parameters.serviceName, parameters.objectName));
     }
 
     @Override
@@ -80,16 +75,5 @@ public class DestroyRaftObjectMessageTask extends AbstractMessageTask<CPGroupDes
     public Object[] getParameters() {
         return new Object[] {parameters.serviceName, parameters.objectName};
     }
-
-    @Override
-    public void onResponse(Object response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
-    }
-
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/CloseSessionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/CloseSessionMessageTask.java
@@ -18,9 +18,9 @@ package com.hazelcast.cp.internal.session.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSessionCloseSessionCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPSessionCloseSessionCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.session.operation.CloseSessionOp;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
@@ -30,8 +30,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link CloseSessionOp}
  */
-public class CloseSessionMessageTask extends AbstractMessageTask<CPSessionCloseSessionCodec.RequestParameters>
-        implements ExecutionCallback<Object> {
+public class CloseSessionMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public CloseSessionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -39,10 +38,7 @@ public class CloseSessionMessageTask extends AbstractMessageTask<CPSessionCloseS
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new CloseSessionOp(parameters.sessionId))
-               .andThen(this);
+        invoke(parameters.groupId, new CloseSessionOp(parameters.sessionId));
     }
 
     @Override
@@ -78,15 +74,5 @@ public class CloseSessionMessageTask extends AbstractMessageTask<CPSessionCloseS
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Object response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/CreateSessionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/CreateSessionMessageTask.java
@@ -18,10 +18,10 @@ package com.hazelcast.cp.internal.session.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSessionCreateSessionCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPSessionCreateSessionCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftOp;
 import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.session.SessionResponse;
 import com.hazelcast.cp.internal.session.operation.CreateSessionOp;
 import com.hazelcast.instance.Node;
@@ -34,8 +34,7 @@ import static com.hazelcast.cp.session.CPSession.CPSessionOwnerType.CLIENT;
 /**
  * Client message task for {@link CreateSessionOp}
  */
-public class CreateSessionMessageTask extends AbstractMessageTask<CPSessionCreateSessionCodec.RequestParameters>
-        implements ExecutionCallback<SessionResponse> {
+public class CreateSessionMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public CreateSessionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -43,11 +42,8 @@ public class CreateSessionMessageTask extends AbstractMessageTask<CPSessionCreat
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         RaftOp op = new CreateSessionOp(connection.getEndPoint(), parameters.endpointName, CLIENT);
-        service.getInvocationManager()
-                .<SessionResponse>invoke(parameters.groupId, op)
-                .andThen(this);
+        invoke(parameters.groupId, op);
     }
 
     @Override
@@ -85,15 +81,5 @@ public class CreateSessionMessageTask extends AbstractMessageTask<CPSessionCreat
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(SessionResponse response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/GenerateThreadIdMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/GenerateThreadIdMessageTask.java
@@ -18,9 +18,8 @@ package com.hazelcast.cp.internal.session.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSessionGenerateThreadIdCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.client.impl.protocol.codec.CPSessionGenerateThreadIdCodec.RequestParameters;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.semaphore.RaftSemaphoreService;
 import com.hazelcast.cp.internal.session.operation.GenerateThreadIdOp;
 import com.hazelcast.instance.Node;
@@ -31,8 +30,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link GenerateThreadIdOp}
  */
-public class GenerateThreadIdMessageTask extends AbstractMessageTask<CPSessionGenerateThreadIdCodec.RequestParameters>
-        implements ExecutionCallback<Long> {
+public class GenerateThreadIdMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public GenerateThreadIdMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -40,10 +38,7 @@ public class GenerateThreadIdMessageTask extends AbstractMessageTask<CPSessionGe
 
     @Override
     protected void processMessage() {
-        RaftService raftService = nodeEngine.getService(RaftService.SERVICE_NAME);
-        raftService.getInvocationManager()
-                   .<Long>invoke(parameters.groupId, new GenerateThreadIdOp())
-                   .andThen(this);
+        invoke(parameters.groupId, new GenerateThreadIdOp());
     }
 
     @Override
@@ -54,16 +49,6 @@ public class GenerateThreadIdMessageTask extends AbstractMessageTask<CPSessionGe
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CPSessionGenerateThreadIdCodec.encodeResponse((Long) response);
-    }
-
-    @Override
-    public void onResponse(Long response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/HeartbeatSessionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/client/HeartbeatSessionMessageTask.java
@@ -18,9 +18,9 @@ package com.hazelcast.cp.internal.session.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPSessionHeartbeatSessionCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.client.impl.protocol.codec.CPSessionHeartbeatSessionCodec.RequestParameters;
 import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.session.operation.HeartbeatSessionOp;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
@@ -30,8 +30,7 @@ import java.security.Permission;
 /**
  * Client message task for {@link HeartbeatSessionOp}
  */
-public class HeartbeatSessionMessageTask extends AbstractMessageTask<CPSessionHeartbeatSessionCodec.RequestParameters>
-        implements ExecutionCallback<Object> {
+public class HeartbeatSessionMessageTask extends AbstractCPMessageTask<RequestParameters> {
 
     public HeartbeatSessionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -39,10 +38,7 @@ public class HeartbeatSessionMessageTask extends AbstractMessageTask<CPSessionHe
 
     @Override
     protected void processMessage() {
-        RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .invoke(parameters.groupId, new HeartbeatSessionOp(parameters.sessionId))
-               .andThen(this);
+        invoke(parameters.groupId, new HeartbeatSessionOp(parameters.sessionId));
     }
 
     @Override
@@ -78,15 +74,5 @@ public class HeartbeatSessionMessageTask extends AbstractMessageTask<CPSessionHe
     @Override
     public Object[] getParameters() {
         return new Object[0];
-    }
-
-    @Override
-    public void onResponse(Object response) {
-        sendResponse(response);
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocation.java
@@ -51,7 +51,13 @@ public class RaftInvocation extends Invocation<CPMember> {
 
     public RaftInvocation(Context context, RaftInvocationContext raftInvocationContext, CPGroupId groupId, Operation op,
                           int retryCount, long retryPauseMillis, long callTimeoutMillis) {
-        super(context, op, null, retryCount, retryPauseMillis, callTimeoutMillis, DEFAULT_DESERIALIZE_RESULT, null);
+        this(context, raftInvocationContext, groupId, op, retryCount, retryPauseMillis, callTimeoutMillis,
+                DEFAULT_DESERIALIZE_RESULT);
+    }
+
+    public RaftInvocation(Context context, RaftInvocationContext raftInvocationContext, CPGroupId groupId, Operation op,
+            int retryCount, long retryPauseMillis, long callTimeoutMillis, boolean deserializeResponse) {
+        super(context, op, null, retryCount, retryPauseMillis, callTimeoutMillis, deserializeResponse, null);
         this.raftInvocationContext = raftInvocationContext;
         this.groupId = groupId;
 


### PR DESCRIPTION
- Deserialization is not needed, because it will be sent back to client.
- Response class may not be on server classpath.

Fixes #17050

Backport of https://github.com/hazelcast/hazelcast/pull/17054