### PR TITLE
SQL: Optimization rules for Project/Filter (#17045)

### DIFF
--- a/docs/design/sql/01-type-system.md
+++ b/docs/design/sql/01-type-system.md
@@ -127,7 +127,7 @@ converted to the target type.
 
 *Table 4: Type conversions (I - implicit, E - explicit)*
 
-| From/To | VARCHAR | BOOLEAN | TINYINT | SMALLINT | INT | BINGINT | DECIMAL | REAL | DOUBLE | DATE | TIME | TIMESTAMP | TIMESTAMP W/ TZ | OBJECT |
+| From/To | VARCHAR | BOOLEAN | TINYINT | SMALLINT | INT | BIGINT | DECIMAL | REAL | DOUBLE | DATE | TIME | TIMESTAMP | TIMESTAMP W/ TZ | OBJECT |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | **VARCHAR** | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` | `I` |
 | **BOOLEAN** | `E` | `I` |  |  |  |  |  |  |  |  |  |  |  | `I` |

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractMapScanRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractMapScanRel.java
@@ -49,7 +49,8 @@ public abstract class AbstractMapScanRel extends AbstractScanRel {
         return computeSelfCost(
             planner,
             table0.getTotalRowCount(),
-            CostUtils.TABLE_SCAN_CPU_MULTIPLIER, table0.getFilter() != null,
+            CostUtils.TABLE_SCAN_CPU_MULTIPLIER,
+            table0.getFilter() != null,
             table.getRowCount(),
             table0.getProjects().size()
         );
@@ -69,7 +70,7 @@ public abstract class AbstractMapScanRel extends AbstractScanRel {
         // 2. Get cost of the filter, if any.
         double filterCpu = hasFilter ? CostUtils.adjustCpuForConstrainedScan(scanCpu) : 0;
 
-        // 3. Get cost of the project taking in count filter and number of expressions. Project never produces IO.
+        // 3. Get cost of the project taking into account the filter and number of expressions. Project never produces IO.
         double projectCpu = CostUtils.adjustCpuForConstrainedScan(CostUtils.getProjectCpu(filterRowCount, projectCount));
 
         // 4. Finally, return sum of both scan and project.

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractMapScanRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractMapScanRel.java
@@ -17,43 +17,25 @@
 package com.hazelcast.sql.impl.calcite.opt;
 
 import com.hazelcast.sql.impl.calcite.opt.cost.CostUtils;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import com.hazelcast.sql.impl.schema.map.AbstractMapTable;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rex.RexNode;
-
-import java.util.List;
 
 /**
  * Base class for map scans.
  */
 public abstract class AbstractMapScanRel extends AbstractScanRel {
-    /** Filter. */
-    protected final RexNode filter;
-
     public AbstractMapScanRel(
         RelOptCluster cluster,
         RelTraitSet traitSet,
-        RelOptTable table,
-        List<Integer> projects,
-        RexNode filter
+        RelOptTable table
     ) {
-        super(cluster, traitSet, table, projects);
-
-        this.filter = filter;
-    }
-
-    public List<Integer> getProjects() {
-        return projects != null ? projects : identity();
-    }
-
-    public RexNode getFilter() {
-        return filter;
+        super(cluster, traitSet, table);
     }
 
     public AbstractMapTable getMap() {
@@ -61,66 +43,40 @@ public abstract class AbstractMapScanRel extends AbstractScanRel {
     }
 
     @Override
-    public RelWriter explainTerms(RelWriter pw) {
-        return super.explainTerms(pw).itemIf("filter", filter, filter != null);
-    }
-
-    @Override
-    public final double estimateRowCount(RelMetadataQuery mq) {
-        double rowCount = super.estimateRowCount(mq);
-
-        if (filter != null) {
-            double selectivity = mq.getSelectivity(this, filter);
-
-            rowCount = rowCount * selectivity;
-        }
-
-        return rowCount;
-    }
-
-    @Override
     public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        HazelcastTable table0 = getTableUnwrapped();
+
         return computeSelfCost(
             planner,
-            mq,
+            table0.getTotalRowCount(),
+            CostUtils.TABLE_SCAN_CPU_MULTIPLIER, table0.getFilter() != null,
             table.getRowCount(),
-            filter,
-            getProjects().size(),
-            CostUtils.TABLE_SCAN_CPU_MULTIPLIER
+            table0.getProjects().size()
         );
     }
 
     protected RelOptCost computeSelfCost(
         RelOptPlanner planner,
-        RelMetadataQuery mq,
         double scanRowCount,
-        RexNode filter,
-        int projectCount,
-        double costMultiplier
+        double scanCostMultiplier,
+        boolean hasFilter,
+        double filterRowCount,
+        int projectCount
     ) {
-        // 1. Get cost of the scan itself. For replicated map cost is multiplied by the number of nodes.
-        double scanCpu = scanRowCount;
+            // 1. Get cost of the scan itself.
+            double scanCpu = scanRowCount * scanCostMultiplier;
 
-        // 2. Get cost of the filter, if any.
-        double filterRowCount;
-        double filterCpu;
+            // 2. Get cost of the filter, if any.
+            double filterCpu = hasFilter ? CostUtils.adjustCpuForConstrainedScan(scanCpu) : 0;
 
-        if (filter != null) {
-            filterRowCount = CostUtils.adjustFilteredRowCount(scanRowCount, mq.getSelectivity(this, filter));
-            filterCpu = CostUtils.adjustCpuForConstrainedScan(scanCpu);
-        } else {
-            filterRowCount = scanRowCount;
-            filterCpu = 0;
+            // 3. Get cost of the project taking in count filter and number of expressions. Project never produces IO.
+            double projectCpu = CostUtils.adjustCpuForConstrainedScan(CostUtils.getProjectCpu(filterRowCount, projectCount));
+
+            // 4. Finally, return sum of both scan and project.
+            return planner.getCostFactory().makeCost(
+                filterRowCount,
+                scanCpu + filterCpu + projectCpu,
+                0
+            );
         }
-
-        // 3. Get cost of the project taking in count filter and number of expressions. Project never produces IO.
-        double projectCpu = CostUtils.adjustCpuForConstrainedScan(CostUtils.getProjectCpu(filterRowCount, projectCount));
-
-        // 4. Finally, return sum of both scan and project.
-        return planner.getCostFactory().makeCost(
-            filterRowCount,
-            (scanCpu + filterCpu + projectCpu) * costMultiplier,
-            0
-        );
-    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractMapScanRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractMapScanRel.java
@@ -63,20 +63,20 @@ public abstract class AbstractMapScanRel extends AbstractScanRel {
         double filterRowCount,
         int projectCount
     ) {
-            // 1. Get cost of the scan itself.
-            double scanCpu = scanRowCount * scanCostMultiplier;
+        // 1. Get cost of the scan itself.
+        double scanCpu = scanRowCount * scanCostMultiplier;
 
-            // 2. Get cost of the filter, if any.
-            double filterCpu = hasFilter ? CostUtils.adjustCpuForConstrainedScan(scanCpu) : 0;
+        // 2. Get cost of the filter, if any.
+        double filterCpu = hasFilter ? CostUtils.adjustCpuForConstrainedScan(scanCpu) : 0;
 
-            // 3. Get cost of the project taking in count filter and number of expressions. Project never produces IO.
-            double projectCpu = CostUtils.adjustCpuForConstrainedScan(CostUtils.getProjectCpu(filterRowCount, projectCount));
+        // 3. Get cost of the project taking in count filter and number of expressions. Project never produces IO.
+        double projectCpu = CostUtils.adjustCpuForConstrainedScan(CostUtils.getProjectCpu(filterRowCount, projectCount));
 
-            // 4. Finally, return sum of both scan and project.
-            return planner.getCostFactory().makeCost(
-                filterRowCount,
-                scanCpu + filterCpu + projectCpu,
-                0
-            );
-        }
+        // 4. Finally, return sum of both scan and project.
+        return planner.getCostFactory().makeCost(
+            filterRowCount,
+            scanCpu + filterCpu + projectCpu,
+            0
+        );
+    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractProjectRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractProjectRel.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.opt;
 
+import com.google.common.collect.ImmutableList;
 import com.hazelcast.sql.impl.calcite.opt.cost.CostUtils;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
@@ -41,7 +42,7 @@ public abstract class AbstractProjectRel extends Project implements HazelcastRel
         List<? extends RexNode> projects,
         RelDataType rowType
     ) {
-        super(cluster, traits, input, projects, rowType);
+        super(cluster, traits, ImmutableList.of(), input, projects, rowType);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractScanRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/AbstractScanRel.java
@@ -20,50 +20,19 @@ import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeField;
 
 import java.util.Collections;
-import java.util.List;
 
 /**
  * Base class for scans.
  */
 public abstract class AbstractScanRel extends TableScan implements HazelcastRelNode {
-    /** Projection. */
-    protected final List<Integer> projects;
-
-    protected AbstractScanRel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table, List<Integer> projects) {
+    protected AbstractScanRel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table) {
         super(cluster, traitSet, Collections.emptyList(), table);
-
-        this.projects = projects;
-    }
-
-    public List<Integer> getProjects() {
-        return projects != null ? projects : identity();
     }
 
     public HazelcastTable getTableUnwrapped() {
         return table.unwrap(HazelcastTable.class);
-    }
-
-    @Override
-    public final RelDataType deriveRowType() {
-        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
-        List<RelDataTypeField> fieldList = table.getRowType().getFieldList();
-
-        for (int project : getProjects()) {
-            builder.add(fieldList.get(project));
-        }
-
-        return builder.build();
-    }
-
-    @Override
-    public RelWriter explainTerms(RelWriter pw) {
-        return super.explainTerms(pw).item("projects", getProjects());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/OptUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/OptUtils.java
@@ -163,7 +163,7 @@ public final class OptUtils {
 
     /**
      * @param rel Node.
-     * @return {@code True} if the given node is physical node.
+     * @return {@code true} if the given node is physical node.
      */
     public static boolean isPhysical(RelNode rel) {
         return rel.getTraitSet().getTrait(ConventionTraitDef.INSTANCE).equals(HazelcastConventions.PHYSICAL);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/OptUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/OptUtils.java
@@ -18,6 +18,8 @@ package com.hazelcast.sql.impl.calcite.opt;
 
 import com.hazelcast.sql.impl.calcite.opt.distribution.DistributionTrait;
 import com.hazelcast.sql.impl.calcite.opt.distribution.DistributionTraitDef;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastRelOptTable;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.HazelcastRelOptCluster;
@@ -26,7 +28,11 @@ import org.apache.calcite.plan.RelOptRuleOperand;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.prepare.RelOptTableImpl;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -193,6 +199,20 @@ public final class OptUtils {
         }
     }
 
+    public static boolean isHazelcastTable(TableScan scan) {
+        HazelcastTable table = scan.getTable().unwrap(HazelcastTable.class);
+
+        return table != null;
+    }
+
+    public static HazelcastTable getHazelcastTable(TableScan scan) {
+        HazelcastTable table = scan.getTable().unwrap(HazelcastTable.class);
+
+        assert table != null;
+
+        return table;
+    }
+
     public static HazelcastRelOptCluster getCluster(RelNode rel) {
         assert rel.getCluster() instanceof HazelcastRelOptCluster;
 
@@ -205,5 +225,40 @@ public final class OptUtils {
 
     public static DistributionTrait getDistribution(RelNode rel) {
         return rel.getTraitSet().getTrait(getDistributionDef(rel));
+    }
+
+    public static HazelcastRelOptTable createRelTable(
+        HazelcastRelOptTable originalRelTable,
+        HazelcastTable newHazelcastTable,
+        RelDataTypeFactory typeFactory
+    ) {
+        RelOptTableImpl newTable = RelOptTableImpl.create(
+            originalRelTable.getRelOptSchema(),
+            newHazelcastTable.getRowType(typeFactory),
+            originalRelTable.getDelegate().getQualifiedName(),
+            newHazelcastTable,
+            null
+        );
+
+        return new HazelcastRelOptTable(newTable);
+    }
+
+    public static LogicalTableScan createLogicalScanWithNewTable(
+        TableScan originalScan,
+        HazelcastTable newHazelcastTable
+    ) {
+        HazelcastRelOptTable originalRelTable = (HazelcastRelOptTable) originalScan.getTable();
+
+        HazelcastRelOptTable newTable = createRelTable(
+            originalRelTable,
+            newHazelcastTable,
+            originalScan.getCluster().getTypeFactory()
+        );
+
+        return LogicalTableScan.create(
+            originalScan.getCluster(),
+            newTable,
+            originalScan.getHints()
+        );
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/FilterIntoScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/FilterIntoScanLogicalRule.java
@@ -93,22 +93,22 @@ public final class FilterIntoScanLogicalRule extends RelOptRule {
     /**
      * Remaps the column indexes referenced in the {@code Filter} to match the original indexed used by {@code TableScan}.
      * <p>
-     * Consider the following query: "SELECT f2, f1 FROM t WHERE f1>?" for the table {@code t[f1, f2]}
+     * Consider the following query: "SELECT f1, f0 FROM t WHERE f0 > ?" for the table {@code t[f0, f1]}
      * <p>
      * The original tree before optimization:
      * <pre>
-     * LogicalFilter[$1>?]                                  // f1 is referenced as $1
-     *   LogicalProject[$1, $0]                             // f2, f1
-     *     LogicalScan[table=t[projects=[0, 1]]]            // f1, f2
+     * LogicalFilter[$1>?]                                  // f0 is referenced as $1
+     *   LogicalProject[$1, $0]                             // f1, f0
+     *     LogicalScan[table=t[projects=[0, 1]]]            // f0, f1
      * </pre>
      * After project pushdown:
      * <pre>
-     * LogicalFilter[$1>?]                                  // f1 is referenced as $1
-     *   LogicalScan[table=t[projects=[1, 0]]]              // f2, f1
+     * LogicalFilter[$1>?]                                  // f0 is referenced as $1
+     *   LogicalScan[table=t[projects=[1, 0]]]              // f1, f0
      * </pre>
      * After filter pushdown:
      * <pre>
-     * LogicalScan[table=t[projects=[1, 0], filter=[$0>?]]] // f1 is referenced as $0
+     * LogicalScan[table=t[projects=[1, 0], filter=[$0>?]]] // f0 is referenced as $0
      * </pre>
      *
      * @param originalHazelcastTable The original table from the {@code TableScan} before the pushdown

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/FilterIntoScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/FilterIntoScanLogicalRule.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Logical rules that pushes down a {@link Filter} into a {@link TableScan} to allow for constrained scans.
+ * Logical rule that pushes down a {@link Filter} into a {@link TableScan} to allow for constrained scans.
  * See {@link HazelcastTable} for more information about constrained scans.
  * <p>
  * Before:
@@ -113,7 +113,7 @@ public final class FilterIntoScanLogicalRule extends RelOptRule {
      *
      * @param originalHazelcastTable The original table from the {@code TableScan} before the pushdown
      * @param originalFilterCondition The original condition from the {@code Filter}.
-     * @return New condition that is going to be pushe down to a {@code TableScan}.
+     * @return New condition that is going to be pushed down to a {@code TableScan}.
      */
     private static RexNode remapCondition(HazelcastTable originalHazelcastTable, RexNode originalFilterCondition) {
         List<Integer> projects = originalHazelcastTable.getProjects();

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/FilterIntoScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/FilterIntoScanLogicalRule.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.logical;
+
+import com.hazelcast.sql.impl.calcite.opt.OptUtils;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Logical rules that pushes down a {@link Filter} into a {@link TableScan} to allow for constrained scans.
+ * See {@link HazelcastTable} for more information about constrained scans.
+ * <p>
+ * Before:
+ * <pre>
+ * LogicalFilter[filter=exp1]
+ *     LogicalScan[table[filter=exp2]]
+ * </pre>
+ * After:
+ * <pre>
+ * LogicalScan[table[filter=exp1 AND exp2]]
+ * </pre>
+ */
+public final class FilterIntoScanLogicalRule extends RelOptRule {
+
+    public static final FilterIntoScanLogicalRule INSTANCE = new FilterIntoScanLogicalRule();
+
+    private FilterIntoScanLogicalRule() {
+        super(
+            operand(LogicalFilter.class,
+                operandJ(LogicalTableScan.class, null, OptUtils::isHazelcastTable, none())),
+            RelFactories.LOGICAL_BUILDER,
+            FilterIntoScanLogicalRule.class.getSimpleName()
+        );
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        Filter filter = call.rel(0);
+        TableScan scan = call.rel(1);
+
+        HazelcastTable originalTable = OptUtils.getHazelcastTable(scan);
+
+        // Remap the condition to the original TableScan columns.
+        RexNode newCondition = remapCondition(originalTable, filter.getCondition());
+
+        // Compose the conjunction with the old filter if needed.
+        RexNode originalCondition = originalTable.getFilter();
+
+        if (originalCondition != null) {
+            List<RexNode> nodes = new ArrayList<>(2);
+            nodes.add(originalCondition);
+            nodes.add(newCondition);
+
+            newCondition = RexUtil.composeConjunction(scan.getCluster().getRexBuilder(), nodes, true);
+        }
+
+        // Create a scan with a new filter.
+        LogicalTableScan newScan = OptUtils.createLogicalScanWithNewTable(
+            scan,
+            originalTable.withFilter(newCondition)
+        );
+
+        call.transformTo(newScan);
+    }
+
+    /**
+     * Remaps the column indexes referenced in the {@code Filter} to match the original indexed used by {@code TableScan}.
+     * <p>
+     * Consider the following query: "SELECT f2, f1 FROM t WHERE f1>?" for the table {@code t[f1, f2]}
+     * <p>
+     * The original tree before optimization:
+     * <pre>
+     * LogicalFilter[$1>?]                                  // f1 is referenced as $1
+     *   LogicalProject[$1, $0]                             // f2, f1
+     *     LogicalScan[table=t[projects=[0, 1]]]            // f1, f2
+     * </pre>
+     * After project pushdown:
+     * <pre>
+     * LogicalFilter[$1>?]                                  // f1 is referenced as $1
+     *   LogicalScan[table=t[projects=[1, 0]]]              // f2, f1
+     * </pre>
+     * After filter pushdown:
+     * <pre>
+     * LogicalScan[table=t[projects=[1, 0], filter=[$0>?]]] // f1 is referenced as $0
+     * </pre>
+     *
+     * @param originalHazelcastTable The original table from the {@code TableScan} before the pushdown
+     * @param originalFilterCondition The original condition from the {@code Filter}.
+     * @return New condition that is going to be pushe down to a {@code TableScan}.
+     */
+    private static RexNode remapCondition(HazelcastTable originalHazelcastTable, RexNode originalFilterCondition) {
+        List<Integer> projects = originalHazelcastTable.getProjects();
+
+        Mapping mapping = Mappings.source(projects, originalHazelcastTable.getOriginalFieldCount());
+
+        return RexUtil.apply(mapping, originalFilterCondition);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalRules.java
@@ -16,6 +16,12 @@
 
 package com.hazelcast.sql.impl.calcite.opt.logical;
 
+import org.apache.calcite.rel.rules.FilterMergeRule;
+import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
+import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
+import org.apache.calcite.rel.rules.ProjectJoinTransposeRule;
+import org.apache.calcite.rel.rules.ProjectMergeRule;
+import org.apache.calcite.rel.rules.ProjectRemoveRule;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
 
@@ -29,7 +35,19 @@ public final class LogicalRules {
 
     public static RuleSet getRuleSet() {
         return RuleSets.ofList(
-            // Convert Calcite node into Hazelcast nodes.
+            // Filter rules.
+            FilterMergeRule.INSTANCE,
+            FilterProjectTransposeRule.INSTANCE,
+            FilterIntoScanLogicalRule.INSTANCE,
+
+            // Project rules.
+            ProjectMergeRule.INSTANCE,
+            ProjectRemoveRule.INSTANCE,
+            ProjectFilterTransposeRule.INSTANCE,
+            ProjectJoinTransposeRule.INSTANCE,
+            ProjectIntoScanLogicalRule.INSTANCE,
+
+            // Converter rules
             MapScanLogicalRule.INSTANCE,
             FilterLogicalRule.INSTANCE,
             ProjectLogicalRule.INSTANCE

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/MapScanLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/MapScanLogicalRel.java
@@ -21,7 +21,6 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
 
@@ -32,15 +31,13 @@ public class MapScanLogicalRel extends AbstractMapScanRel implements LogicalRel 
     public MapScanLogicalRel(
         RelOptCluster cluster,
         RelTraitSet traitSet,
-        RelOptTable table,
-        List<Integer> projects,
-        RexNode filter
+        RelOptTable table
     ) {
-        super(cluster, traitSet, table, projects, filter);
+        super(cluster, traitSet, table);
     }
 
     @Override
     public final RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new MapScanLogicalRel(getCluster(), traitSet, table, projects, filter);
+        return new MapScanLogicalRel(getCluster(), traitSet, table);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/MapScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/MapScanLogicalRule.java
@@ -41,9 +41,7 @@ public final class MapScanLogicalRule extends ConverterRule {
         return new MapScanLogicalRel(
             scan.getCluster(),
             OptUtils.toLogicalConvention(scan.getTraitSet()),
-            scan.getTable(),
-            null,
-            null
+            scan.getTable()
         );
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ProjectIntoScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ProjectIntoScanLogicalRule.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.logical;
+
+import com.hazelcast.sql.impl.calcite.opt.OptUtils;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Logical rule that pushes down a column references from a {@link Project} into a {@link TableScan} to allow for constrained
+ * scans. See {@link HazelcastTable} for more information about constrained scans.
+ * <p>
+ * <b>Case 1: </b>projects that have only column expressions are eliminated completely, unused columns returned from the
+ * {@code TableScan} are trimmed.
+ * <p>
+ * Before:
+ * <pre>
+ * LogicalProject[projects=[$2, $1]]]
+ *   LogicalTableScan[table[projects=[0, 1, 2]]]
+ * </pre>
+ * After:
+ * <pre>
+ * LogicalTableScan[table[projects=[2, 1]]]
+ * </pre>
+ * <b>Case 2: </b>projects with non-column expressions trim the unused columns only.
+ * <p>
+ * Before:
+ * <pre>
+ * LogicalProject[projects=[+$2, $0]]]
+ *   LogicalTableScan[table[projects=[0, 1, 2]]]
+ * </pre>
+ * After:
+ * <pre>
+ * LogicalProject[projects=[+$0, $1]]]
+ *   LogicalTableScan[table[projects=[2, 0]]]
+ * </pre>
+ */
+public final class ProjectIntoScanLogicalRule extends RelOptRule {
+
+    public static final ProjectIntoScanLogicalRule INSTANCE = new ProjectIntoScanLogicalRule();
+
+    private ProjectIntoScanLogicalRule() {
+        super(
+            operand(LogicalProject.class,
+                operandJ(LogicalTableScan.class, null, OptUtils::isHazelcastTable, none())),
+            RelFactories.LOGICAL_BUILDER,
+            ProjectIntoScanLogicalRule.class.getSimpleName()
+        );
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        Project project = call.rel(0);
+        TableScan scan = call.rel(1);
+
+        Mappings.TargetMapping mapping = project.getMapping();
+
+        if (mapping != null) {
+            processSimple(call, mapping, scan);
+        } else {
+            processComplex(call, project, scan);
+        }
+    }
+
+    /**
+     * Process simple case when all project expressions are direct field access. The {@code Project} is eliminated completely.
+     *
+     * @param mapping Projects mapping.
+     * @param scan Scan.
+     */
+    private static void processSimple(RelOptRuleCall call, Mappings.TargetMapping mapping, TableScan scan) {
+        // Get columns defined in the original TableScan.
+        HazelcastTable originalTable = OptUtils.getHazelcastTable(scan);
+
+        List<Integer> originalProjects = originalTable.getProjects();
+
+        // Remap columns from the Project. The result is the projects that will be pushed down to the new TableScan.
+        // E.g. consider the table "t[f0, f1, f2]" and the SQL query "SELECT f2, f0":
+        //   Original projects: [0(f0), 1(f1), 2(f2)]
+        //   New projects:      [2(f2), 0(f0)]
+        List<Integer> newProjects = Mappings.apply((Mapping) mapping, originalProjects);
+
+        // Construct the new TableScan with adjusted columns.
+        LogicalTableScan newScan = OptUtils.createLogicalScanWithNewTable(
+            scan,
+            originalTable.withProject(newProjects)
+        );
+
+        call.transformTo(newScan);
+    }
+
+    /**
+     * Process the complex project with expressions. The {@code Project} operator will remain, but the number and the order of
+     * columns returned from the {@code TableScan} is adjusted.
+     *
+     * @param project Project.
+     * @param scan Scan.
+     */
+    private void processComplex(RelOptRuleCall call, Project project, TableScan scan) {
+        HazelcastTable originalTable = OptUtils.getHazelcastTable(scan);
+
+        // Map projected field references to real scan fields.
+        ProjectFieldVisitor projectFieldVisitor = new ProjectFieldVisitor(originalTable.getProjects());
+
+        for (RexNode projectExp : project.getProjects()) {
+            projectExp.accept(projectFieldVisitor);
+        }
+
+        // Get new scan fields. These are the only fields that are accessed by the project operator.
+        List<Integer> newScanProjects = projectFieldVisitor.createNewScanProjects();
+
+        if (newScanProjects.isEmpty()) {
+            // No TableScan columns are referenced from within a project, i.e. the Project doesn't depend on column values
+            // of the TableScan. E.g. "SELECT CURRENT_TIME() FROM t". In future we will introduce a special optimizer operator
+            // for that case that will not do a real scan. It is not trivial, because we should take in count whether the
+            // Project expressions are deterministic or not. Therefore, we simply ignore that case for now.
+            return;
+        }
+
+        if (newScanProjects.size() == originalTable.getProjects().size()) {
+            // The Project operator already references all the fields from the TableScan. No trimming is possible, so further
+            // optimization makes no sense.
+            // E.g. "SELECT f3, f2, f1 FROM t" where t=[f1, f2, f3]
+            return;
+        }
+
+        // Create the new TableScan that do not return unused columns.
+        LogicalTableScan newScan = OptUtils.createLogicalScanWithNewTable(
+            scan,
+            originalTable.withProject(newScanProjects)
+        );
+
+        // Create new Projectwith adjusted columns references that point to new TableScan fields.
+        ProjectConverter projectConverter = projectFieldVisitor.createProjectConverter();
+
+        List<RexNode> newProjects = new ArrayList<>();
+
+        for (RexNode projectExp : project.getProjects()) {
+            RexNode newProjectExp = projectExp.accept(projectConverter);
+
+            newProjects.add(newProjectExp);
+        }
+
+        LogicalProject newProject = LogicalProject.create(
+            newScan,
+            project.getHints(),
+            newProjects,
+            project.getRowType()
+        );
+
+        call.transformTo(newProject);
+    }
+
+    /**
+     * Visitor which collects fields from project expressions and map them to respective scan fields.
+     */
+    private static final class ProjectFieldVisitor extends RexVisitorImpl<Void> {
+        /** Fields from the original TableScan operator. */
+        private final List<Integer> originalScanFields;
+
+        /** Map from original scan fields to input expressions that must be remapped during the pushdown. */
+        private final Map<Integer, List<RexInputRef>> scanFieldIndexToProjectInputs = new LinkedHashMap<>();
+
+        private ProjectFieldVisitor(List<Integer> originalScanFields) {
+            super(true);
+
+            this.originalScanFields = originalScanFields;
+        }
+
+        @Override
+        public Void visitInputRef(RexInputRef projectInput) {
+            // Get the scan field referenced by the given column expression (RexInputRef).
+            // E.g., for the table t[t1, t2, t3] and the constrained TableScan[table=[t, project[2, 0]]], the input
+            // reference [$0] (i.e. t3) is mapped to the scan field [2].
+            Integer scanField = originalScanFields.get(projectInput.getIndex());
+
+            assert scanField != null;
+
+            // Track all column expressions from the Project operator that refer to the same TableScan field.
+            List<RexInputRef> projectInputs = scanFieldIndexToProjectInputs.computeIfAbsent(scanField, (k) -> new ArrayList<>(1));
+
+            projectInputs.add(projectInput);
+
+            return null;
+        }
+
+        @Override
+        public Void visitCall(RexCall call) {
+            for (RexNode operand : call.operands) {
+                operand.accept(this);
+            }
+
+            return null;
+        }
+
+        /**
+         * @return The list of {@code TableScan} columns referenced by expressions of the {@code Project} operator.
+         */
+        private List<Integer> createNewScanProjects() {
+            return new ArrayList<>(scanFieldIndexToProjectInputs.keySet());
+        }
+
+        /**
+         * @return The converter that will adjust column references ({@code RexInputRef}) of the new {@code Project} operator.
+         */
+        private ProjectConverter createProjectConverter() {
+            Map<RexNode, Integer> projectExpToScanFieldMap = new HashMap<>();
+
+            int index = 0;
+
+            for (List<RexInputRef> projectInputs : scanFieldIndexToProjectInputs.values()) {
+                for (RexNode projectInput : projectInputs) {
+                    projectExpToScanFieldMap.put(projectInput, index);
+                }
+
+                index++;
+            }
+
+            return new ProjectConverter(projectExpToScanFieldMap);
+        }
+    }
+
+    /**
+     * Visitor which converts old column expressions (before pushdown) to new column expressions (after pushdown).
+     */
+    public static final class ProjectConverter extends RexShuttle {
+        /** Map from old project expression to relevant field in the new scan operator. */
+        private final Map<RexNode, Integer> projectExpToScanFieldMap;
+
+        private ProjectConverter(Map<RexNode, Integer> projectExpToScanFieldMap) {
+            this.projectExpToScanFieldMap = projectExpToScanFieldMap;
+        }
+
+        @Override
+        public RexNode visitInputRef(RexInputRef inputRef) {
+            Integer index = projectExpToScanFieldMap.get(inputRef);
+
+            assert index != null;
+
+            return new RexInputRef(index, inputRef.getType());
+        }
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ProjectIntoScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ProjectIntoScanLogicalRule.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Logical rule that pushes down a column references from a {@link Project} into a {@link TableScan} to allow for constrained
+ * Logical rule that pushes down column references from a {@link Project} into a {@link TableScan} to allow for constrained
  * scans. See {@link HazelcastTable} for more information about constrained scans.
  * <p>
  * <b>Case 1: </b>projects that have only column expressions are eliminated completely, unused columns returned from the
@@ -145,7 +145,7 @@ public final class ProjectIntoScanLogicalRule extends RelOptRule {
         if (newScanProjects.isEmpty()) {
             // No TableScan columns are referenced from within a project, i.e. the Project doesn't depend on column values
             // of the TableScan. E.g. "SELECT CURRENT_TIME() FROM t". In future we will introduce a special optimizer operator
-            // for that case that will not do a real scan. It is not trivial, because we should take in count whether the
+            // for that case that will not do a real scan. It is not trivial, because we should take into account whether the
             // Project expressions are deterministic or not. Therefore, we simply ignore that case for now.
             return;
         }
@@ -163,7 +163,7 @@ public final class ProjectIntoScanLogicalRule extends RelOptRule {
             originalTable.withProject(newScanProjects)
         );
 
-        // Create new Projectwith adjusted columns references that point to new TableScan fields.
+        // Create new Project with adjusted column references that point to new TableScan fields.
         ProjectConverter projectConverter = projectFieldVisitor.createProjectConverter();
 
         List<RexNode> newProjects = new ArrayList<>();

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ProjectIntoScanLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ProjectIntoScanLogicalRule.java
@@ -142,14 +142,6 @@ public final class ProjectIntoScanLogicalRule extends RelOptRule {
         // Get new scan fields. These are the only fields that are accessed by the project operator.
         List<Integer> newScanProjects = projectFieldVisitor.createNewScanProjects();
 
-        if (newScanProjects.isEmpty()) {
-            // No TableScan columns are referenced from within a project, i.e. the Project doesn't depend on column values
-            // of the TableScan. E.g. "SELECT CURRENT_TIME() FROM t". In future we will introduce a special optimizer operator
-            // for that case that will not do a real scan. It is not trivial, because we should take into account whether the
-            // Project expressions are deterministic or not. Therefore, we simply ignore that case for now.
-            return;
-        }
-
         if (newScanProjects.size() == originalTable.getProjects().size()) {
             // The Project operator already references all the fields from the TableScan. No trimming is possible, so further
             // optimization makes no sense.

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/AbstractMapScanPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/AbstractMapScanPhysicalRel.java
@@ -20,9 +20,6 @@ import com.hazelcast.sql.impl.calcite.opt.AbstractMapScanRel;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rex.RexNode;
-
-import java.util.List;
 
 /**
  * Base class for physical map scans.
@@ -31,10 +28,8 @@ public abstract class AbstractMapScanPhysicalRel extends AbstractMapScanRel impl
     public AbstractMapScanPhysicalRel(
         RelOptCluster cluster,
         RelTraitSet traitSet,
-        RelOptTable table,
-        List<Integer> projects,
-        RexNode filter
+        RelOptTable table
     ) {
-        super(cluster, traitSet, table, projects, filter);
+        super(cluster, traitSet, table);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/MapScanPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/MapScanPhysicalRel.java
@@ -21,7 +21,6 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
 
@@ -38,16 +37,14 @@ public class MapScanPhysicalRel extends AbstractMapScanPhysicalRel {
     public MapScanPhysicalRel(
         RelOptCluster cluster,
         RelTraitSet traitSet,
-        RelOptTable table,
-        List<Integer> projects,
-        RexNode filter
+        RelOptTable table
     ) {
-        super(cluster, traitSet, table, projects, filter);
+        super(cluster, traitSet, table);
     }
 
     @Override
     public final RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new MapScanPhysicalRel(getCluster(), traitSet, getTable(), projects, filter);
+        return new MapScanPhysicalRel(getCluster(), traitSet, getTable());
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/MapScanPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/MapScanPhysicalRule.java
@@ -45,9 +45,7 @@ public final class MapScanPhysicalRule extends RelOptRule {
         call.transformTo(new MapScanPhysicalRel(
             scan.getCluster(),
             OptUtils.toPhysicalConvention(scan.getTraitSet(), distribution),
-            scan.getTable(),
-            scan.getProjects(),
-            scan.getFilter()
+            scan.getTable()
         ));
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PlanCreateVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PlanCreateVisitor.java
@@ -24,6 +24,7 @@ import com.hazelcast.sql.impl.calcite.opt.physical.ProjectPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.RootPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.exchange.AbstractExchangePhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.exchange.RootExchangePhysicalRel;
+import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.plan.Plan;
@@ -163,6 +164,7 @@ public class PlanCreateVisitor implements PhysicalRelVisitor {
 
     @Override
     public void onMapScan(MapScanPhysicalRel rel) {
+        HazelcastTable hazelcastTable = rel.getTableUnwrapped();
         AbstractMapTable table = rel.getMap();
 
         PlanNodeSchema schemaBefore = getScanSchemaBeforeProject(table);
@@ -174,8 +176,8 @@ public class PlanCreateVisitor implements PhysicalRelVisitor {
             table.getValueDescriptor(),
             getScanFieldPaths(table),
             schemaBefore.getTypes(),
-            rel.getProjects(),
-            convertFilter(schemaBefore, rel.getFilter())
+            hazelcastTable.getProjects(),
+            convertFilter(schemaBefore, hazelcastTable.getFilter())
         );
 
         pushUpstream(scanNode);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
@@ -55,6 +55,9 @@ public final class UnsupportedOperationVisitor implements SqlVisitor<Void> {
         // of Apache Calcite.
         SUPPORTED_KINDS = new HashSet<>();
 
+        // Arithmetics
+        SUPPORTED_KINDS.add(SqlKind.PLUS);
+
         // "IS" predicates
         SUPPORTED_KINDS.add(SqlKind.IS_NULL);
 
@@ -118,6 +121,7 @@ public final class UnsupportedOperationVisitor implements SqlVisitor<Void> {
         SqlTypeName typeName = literal.getTypeName();
 
         switch (typeName) {
+            case BOOLEAN:
             case TINYINT:
             case SMALLINT:
             case INTEGER:

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastCalciteCatalogReader.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastCalciteCatalogReader.java
@@ -19,13 +19,14 @@ package com.hazelcast.sql.impl.calcite.schema;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
 
 import java.util.List;
 
 /**
- * Catalog reader that allows for setting predefined schema paths.
+ * Custom catalog reader that allows for setting predefined schema paths and wrapping of returned tables.
  */
 public class HazelcastCalciteCatalogReader extends CalciteCatalogReader {
     public HazelcastCalciteCatalogReader(
@@ -42,5 +43,22 @@ public class HazelcastCalciteCatalogReader extends CalciteCatalogReader {
             typeFactory,
             config
         );
+    }
+
+    /**
+     * Hook into the Apache Calcite table creation process and wrap the Calcite table into our own implementation
+     * that resolves signatures of tables with pushed-down projects and filters properly.
+     */
+    @Override
+    public Prepare.PreparingTable getTable(List<String> names) {
+        // Resolve the original table as usual.
+        Prepare.PreparingTable table = super.getTable(names);
+
+        if (table == null) {
+            return null;
+        }
+
+        // Wrap it into our own table.
+        return new HazelcastRelOptTable(table);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastRelOptTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastRelOptTable.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.schema;
+
+import com.hazelcast.sql.impl.calcite.opt.logical.FilterIntoScanLogicalRule;
+import com.hazelcast.sql.impl.calcite.opt.logical.ProjectIntoScanLogicalRule;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.sql.SqlAccessType;
+import org.apache.calcite.sql.validate.SqlModality;
+import org.apache.calcite.sql.validate.SqlMonotonicity;
+import org.apache.calcite.sql2rel.InitializerContext;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom implementation of Apache Calcite table.
+ * <p>
+ * Tables are used inside {@link TableScan} operators. During logical planning we attempt to flatten the relational tree by
+ * pushing down projects and filters into the table, see {@link ProjectIntoScanLogicalRule} and {@link FilterIntoScanLogicalRule}.
+ * <p>
+ * It is important do distinguish {@code TableScan} operators with and without pushdown. Otherwise scans that produce different
+ * results will be merged into a single equivalence group, leading to incorrect query results.
+ * <p>
+ * To mitigate this we provide our own table implementation that overrides {@link #getQualifiedName()} method, used for scan
+ * signature calculation (see {@link TableScan#explainTerms(RelWriter)}). The overridden version adds information about
+ * pushed down project and scans to the table name, thus avoiding the problem.
+ * <p>
+ * For example, table scan over table {@code p} without pushdowns may have a signature
+ * <pre>
+ * ...table=[[hazelcast, p]]....
+ * </pre>
+ * <p>
+ * Scan over the same table with project and filter will have a signature
+ * <pre>
+ * ...table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]...
+ * </pre>
+ */
+public class HazelcastRelOptTable implements Prepare.PreparingTable {
+
+    private final Prepare.PreparingTable delegate;
+
+    public HazelcastRelOptTable(Prepare.PreparingTable delegate) {
+        this.delegate = delegate;
+    }
+
+    public Prepare.PreparingTable getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public List<String> getQualifiedName() {
+        // Get original names.
+        List<String> names = delegate.getQualifiedName();
+
+        assert names != null && !names.isEmpty();
+
+        // Extend table name with project/filter information.
+        List<String> res = new ArrayList<>(names.size());
+
+        for (int i = 0; i < names.size(); i++) {
+            String currentPart = names.get(i);
+
+            if (i != names.size() - 1) {
+                // Not a table name, just add it as is.
+                res.add(currentPart);
+            } else {
+                // Table name. Extend it with project/filter.
+                res.add(currentPart + getTableSignature());
+            }
+        }
+
+        return res;
+    }
+
+    private String getTableSignature() {
+        HazelcastTable table = delegate.unwrap(HazelcastTable.class);
+
+        assert table != null;
+
+        return table.getSignature();
+    }
+
+    @Override
+    public double getRowCount() {
+        return delegate.getRowCount();
+    }
+
+    @Override
+    public RelDataType getRowType() {
+        return delegate.getRowType();
+    }
+
+    @Override
+    public RelOptSchema getRelOptSchema() {
+        return delegate.getRelOptSchema();
+    }
+
+    @Override
+    public RelNode toRel(ToRelContext context) {
+        // Override this method to pass this table to the LogicalTableScan.
+        // Otherwise the delegate would be used, which is incorrect.
+        return LogicalTableScan.create(context.getCluster(), this, context.getTableHints());
+    }
+
+    @Override
+    public List<RelCollation> getCollationList() {
+        return delegate.getCollationList();
+    }
+
+    @Override
+    public RelDistribution getDistribution() {
+        return delegate.getDistribution();
+    }
+
+    @Override
+    public boolean isKey(ImmutableBitSet columns) {
+        return delegate.isKey(columns);
+    }
+
+    @Override
+    public List<ImmutableBitSet> getKeys() {
+        return delegate.getKeys();
+    }
+
+    @Override
+    public List<RelReferentialConstraint> getReferentialConstraints() {
+        return delegate.getReferentialConstraints();
+    }
+
+    @Override
+    public Expression getExpression(Class clazz) {
+        return delegate.getExpression(clazz);
+    }
+
+    @Override
+    public RelOptTable extend(List<RelDataTypeField> extendedFields) {
+        return delegate.extend(extendedFields);
+    }
+
+    @Override
+    public List<ColumnStrategy> getColumnStrategies() {
+        return delegate.getColumnStrategies();
+    }
+
+    @Override
+    public SqlMonotonicity getMonotonicity(String columnName) {
+        return delegate.getMonotonicity(columnName);
+    }
+
+    @Override
+    public SqlAccessType getAllowedAccess() {
+        return delegate.getAllowedAccess();
+    }
+
+    @Override
+    public boolean supportsModality(SqlModality modality) {
+        return delegate.supportsModality(modality);
+    }
+
+    @Override
+    public boolean isTemporal() {
+        return delegate.isTemporal();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean columnHasDefaultValue(RelDataType rowType, int ordinal, InitializerContext initializerContext) {
+        return delegate.columnHasDefaultValue(rowType, ordinal, initializerContext);
+    }
+
+    @Override
+    public <C> C unwrap(Class<C> aClass) {
+        return delegate.unwrap(aClass);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastRelOptTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastRelOptTable.java
@@ -52,7 +52,7 @@ import java.util.List;
  * <p>
  * To mitigate this we provide our own table implementation that overrides {@link #getQualifiedName()} method, used for scan
  * signature calculation (see {@link TableScan#explainTerms(RelWriter)}). The overridden version adds information about
- * pushed-down projects and scans to the table name, thus avoiding the problem.
+ * pushed-down projections and scans to the table name, thus avoiding the problem.
  * <p>
  * For example, a table scan over table {@code p} without pushdowns may have a signature:
  * <pre>
@@ -83,20 +83,10 @@ public class HazelcastRelOptTable implements Prepare.PreparingTable {
 
         assert names != null && !names.isEmpty();
 
-        // Extend table name with project/filter information.
-        List<String> res = new ArrayList<>(names.size());
-
-        for (int i = 0; i < names.size(); i++) {
-            String currentPart = names.get(i);
-
-            if (i != names.size() - 1) {
-                // Not a table name, just add it as is.
-                res.add(currentPart);
-            } else {
-                // Table name. Extend it with project/filter.
-                res.add(currentPart + getTableSignature());
-            }
-        }
+        List<String> res = new ArrayList<>(names);
+        // Extend the table name (the last element) with project/filter signature.
+        int lastElement = res.size() - 1;
+        res.set(lastElement, res.get(lastElement) + getTableSignature());
 
         return res;
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastRelOptTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastRelOptTable.java
@@ -47,19 +47,19 @@ import java.util.List;
  * Tables are used inside {@link TableScan} operators. During logical planning we attempt to flatten the relational tree by
  * pushing down projects and filters into the table, see {@link ProjectIntoScanLogicalRule} and {@link FilterIntoScanLogicalRule}.
  * <p>
- * It is important do distinguish {@code TableScan} operators with and without pushdown. Otherwise scans that produce different
+ * It is important to distinguish {@code TableScan} operators with and without pushdown. Otherwise scans that produce different
  * results will be merged into a single equivalence group, leading to incorrect query results.
  * <p>
  * To mitigate this we provide our own table implementation that overrides {@link #getQualifiedName()} method, used for scan
  * signature calculation (see {@link TableScan#explainTerms(RelWriter)}). The overridden version adds information about
- * pushed down project and scans to the table name, thus avoiding the problem.
+ * pushed-down projects and scans to the table name, thus avoiding the problem.
  * <p>
- * For example, table scan over table {@code p} without pushdowns may have a signature
+ * For example, a table scan over table {@code p} without pushdowns may have a signature:
  * <pre>
  * ...table=[[hazelcast, p]]....
  * </pre>
  * <p>
- * Scan over the same table with project and filter will have a signature
+ * A scan over the same table with project and filter will have a signature:
  * <pre>
  * ...table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]...
  * </pre>

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -40,6 +40,7 @@ import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -111,6 +112,7 @@ public class HazelcastTable extends AbstractTable {
         return new HazelcastTable(target, statistic, projects, filter);
     }
 
+    @Nonnull
     public List<Integer> getProjects() {
         if (projects == null) {
             int fieldCount = target.getFieldCount();
@@ -213,6 +215,7 @@ public class HazelcastTable extends AbstractTable {
      */
     public String getSignature() {
         StringJoiner res = new StringJoiner(", ", "[", "]");
+
         res.setEmptyValue("");
 
         res.add("projects=" + getProjects().stream().map(Objects::toString).collect(joining(", ", "[", "]")));

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -50,22 +50,22 @@ import java.util.Set;
  * <ul>
  *     <li>Maps field types defined in the {@code core} module to Calcite types</li>
  *     <li>Provides access to the underlying table and statistics</li>
- *     <li>Encapsulates projects and filter to allow for constained scans</li>
+ *     <li>Encapsulates projects and filter to allow for constrained scans</li>
  * </ul>
  * <p>
  * <h2>Constrained scans</h2>
- * For a sequence of logical project/filter/scan operators, we would like to ensure that the resulting relational tree is as
- * flat as possible because this minimizes processing overhead and memory usage. To achieve this we try to push projects and
- * filters into the table using {@link ProjectIntoScanLogicalRule} and {@link FilterIntoScanLogicalRule} rules. These rules
- * reduce the amount of data returned from the table during scanning. Pushed down projection ensures that only columns required
- * by parent operators are returned, thus implementing field trimming. Pushed down filter reduces the number of returned rows.
+ * For a sequence of logical project/filter/scan operators we would like to ensure that the resulting relational tree is as
+ * flat as possible because this minimizes the processing overhead and memory usage. To achieve this we try to push projects and
+ * filters into the table using {@link ProjectIntoScanLogicalRule} and {@link FilterIntoScanLogicalRule}. These rules
+ * reduce the amount of data returned from the table during scanning. Pushed-down projection ensures that only columns required
+ * by parent operators are returned, thus implementing field trimming. Pushed-down filter reduces the number of returned rows.
  * <p>
  * Projects are indexes of table fields that are returned. Initial projection (i.e. before optimization) returns all the columns.
  * After project pushdown the number and order of columns may change. For example, for the table {@code t[f1, f2, f3]} the
  * initial projection is {@code [0, 1, 2]}. After pushdown of a {@code "SELECT f3, f1"} the projection becomes {@code [2, 0]}
  * which means that the columns {@code [f3, f1]} are returned in that order.
  * <p>
- * Filter is a conjunctive expression that references table fields via their original indexes. That is, {@code [f3]} is
+ * Filter is a conjunctive expression that references table fields via their original indexes. That is, {@code [f2]} is
  * referenced as {@code [2]} even if it is projected as the first field in the example above. This is needed to allow for
  * projections and filters on disjoint sets of attributes.
  * <p>
@@ -73,7 +73,7 @@ import java.util.Set;
  * <pre>
  * SELECT f3, f1 FROM t WHERE f2 > ?
  * </pre>
- * In this case {@code projects=[2, 0]}, {@code filter=[>$1,?]}.
+ * In this case {@code projects=[2, 0]}, {@code filter=[>$1, ?]}.
  * <p>
  * We do not pushdown the project expressions other than columns because in this case it will be difficult to pushdown
  * filters, as it will require non-trivial rewrite of the filter expression to match to original scan columns.

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -80,8 +80,8 @@ import static java.util.stream.Collectors.joining;
  * </pre>
  * In this case {@code projects=[2, 0]}, {@code filter=[>$1, ?]}.
  * <p>
- * We do not pushdown the project expressions other than columns because in this case it will be difficult to pushdown
- * filters, as it will require non-trivial rewrite of the filter expression to match to original scan columns.
+ * We do not pushdown the project expressions other than columns, because expressions inside the scan may change its physical
+ * properties, thus making further optimization more complex.
  */
 public class HazelcastTable extends AbstractTable {
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -218,8 +218,8 @@ public class HazelcastTable extends AbstractTable {
         res.setEmptyValue("");
 
         if (projects != null) {
-            res.add("projects=" +
-                    projects.stream()
+            res.add("projects="
+                    + projects.stream()
                             .map(Objects::toString)
                             .collect(joining(", ", "[", "]")));
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -65,9 +65,9 @@ import static java.util.stream.Collectors.joining;
  * by parent operators are returned, thus implementing field trimming. Pushed-down filter reduces the number of returned rows.
  * <p>
  * Projects are indexes of table fields that are returned. Initial projection (i.e. before optimization) returns all the columns.
- * After project pushdown the number and order of columns may change. For example, for the table {@code t[f1, f2, f3]} the
- * initial projection is {@code [0, 1, 2]}. After pushdown of a {@code "SELECT f3, f1"} the projection becomes {@code [2, 0]}
- * which means that the columns {@code [f3, f1]} are returned in that order.
+ * After project pushdown the number and order of columns may change. For example, for the table {@code t[f0, f1, f2]} the
+ * initial projection is {@code [0, 1, 2]}. After pushdown of a {@code "SELECT f2, f0"} the projection becomes {@code [2, 0]}
+ * which means that the columns {@code [f2, f0]} are returned, in that order.
  * <p>
  * Filter is a conjunctive expression that references table fields via their original indexes. That is, {@code [f2]} is
  * referenced as {@code [2]} even if it is projected as the first field in the example above. This is needed to allow for
@@ -75,7 +75,7 @@ import static java.util.stream.Collectors.joining;
  * <p>
  * Consider the following SQL statement:
  * <pre>
- * SELECT f3, f1 FROM t WHERE f2 > ?
+ * SELECT f2, f0 FROM t WHERE f1 > ?
  * </pre>
  * In this case {@code projects=[2, 0]}, {@code filter=[>$1, ?]}.
  * <p>

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -43,7 +43,11 @@ import org.apache.calcite.util.ImmutableBitSet;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Base class for all tables in the Calcite integration:
@@ -210,35 +214,19 @@ public class HazelcastTable extends AbstractTable {
      * @return Signature.
      */
     public String getSignature() {
-        if (projects == null && filter == null) {
-            return "";
-        }
-
-        StringBuilder res = new StringBuilder("[");
+        StringJoiner res = new StringJoiner(", ", "[", "]");
+        res.setEmptyValue("");
 
         if (projects != null) {
-            res.append("projects=[");
-
-            for (int i = 0; i < projects.size(); i++) {
-                if (i != 0) {
-                    res.append(", ");
-                }
-
-                res.append(projects.get(i));
-            }
-
-            res.append("]");
+            res.add("projects=" +
+                    projects.stream()
+                            .map(Objects::toString)
+                            .collect(joining(", ", "[", "]")));
         }
 
         if (filter != null) {
-            if (projects != null) {
-                res.append(", ");
-            }
-
-            res.append("filter=").append(filter);
+            res.add("filter=" + filter);
         }
-
-        res.append("]");
 
         return res.toString();
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -17,19 +17,28 @@
 package com.hazelcast.sql.impl.calcite.schema;
 
 import com.hazelcast.sql.impl.calcite.SqlToQueryType;
+import com.hazelcast.sql.impl.calcite.opt.cost.CostUtils;
+import com.hazelcast.sql.impl.calcite.opt.logical.FilterIntoScanLogicalRule;
+import com.hazelcast.sql.impl.calcite.opt.logical.ProjectIntoScanLogicalRule;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rel.type.StructKind;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,19 +50,83 @@ import java.util.Set;
  * <ul>
  *     <li>Maps field types defined in the {@code core} module to Calcite types</li>
  *     <li>Provides access to the underlying table and statistics</li>
+ *     <li>Encapsulates projects and filter to allow for constained scans</li>
  * </ul>
+ * <p>
+ * <h2>Constrained scans</h2>
+ * For a sequence of logical project/filter/scan operators, we would like to ensure that the resulting relational tree is as
+ * flat as possible because this minimizes processing overhead and memory usage. To achieve this we try to push projects and
+ * filters into the table using {@link ProjectIntoScanLogicalRule} and {@link FilterIntoScanLogicalRule} rules. These rules
+ * reduce the amount of data returned from the table during scanning. Pushed down projection ensures that only columns required
+ * by parent operators are returned, thus implementing field trimming. Pushed down filter reduces the number of returned rows.
+ * <p>
+ * Projects are indexes of table fields that are returned. Initial projection (i.e. before optimization) returns all the columns.
+ * After project pushdown the number and order of columns may change. For example, for the table {@code t[f1, f2, f3]} the
+ * initial projection is {@code [0, 1, 2]}. After pushdown of a {@code "SELECT f3, f1"} the projection becomes {@code [2, 0]}
+ * which means that the columns {@code [f3, f1]} are returned in that order.
+ * <p>
+ * Filter is a conjunctive expression that references table fields via their original indexes. That is, {@code [f3]} is
+ * referenced as {@code [2]} even if it is projected as the first field in the example above. This is needed to allow for
+ * projections and filters on disjoint sets of attributes.
+ * <p>
+ * Consider the following SQL statement:
+ * <pre>
+ * SELECT f3, f1 FROM t WHERE f2 > ?
+ * </pre>
+ * In this case {@code projects=[2, 0]}, {@code filter=[>$1,?]}.
+ * <p>
+ * We do not pushdown the project expressions other than columns because in this case it will be difficult to pushdown
+ * filters, as it will require non-trivial rewrite of the filter expression to match to original scan columns.
  */
 public class HazelcastTable extends AbstractTable {
 
     private final Table target;
     private final Statistic statistic;
+    private final List<Integer> projects;
+    private final RexNode filter;
 
     private RelDataType rowType;
     private Set<String> hiddenFieldNames;
 
     public HazelcastTable(Table target, Statistic statistic) {
+        this(target, statistic, null, null);
+    }
+
+    private HazelcastTable(Table target, Statistic statistic, List<Integer> projects, RexNode filter) {
         this.target = target;
         this.statistic = statistic;
+        this.projects = projects;
+        this.filter = filter;
+    }
+
+    public HazelcastTable withProject(List<Integer> projects) {
+        return new HazelcastTable(target, statistic, projects, filter);
+    }
+
+    public HazelcastTable withFilter(RexNode filter) {
+        return new HazelcastTable(target, statistic, projects, filter);
+    }
+
+    public List<Integer> getProjects() {
+        assert projects == null || !projects.isEmpty();
+
+        if (projects == null) {
+            int fieldCount = target.getFieldCount();
+
+            List<Integer> res = new ArrayList<>(fieldCount);
+
+            for (int i = 0; i < fieldCount; i++) {
+                res.add(i);
+            }
+
+            return res;
+        }
+
+        return projects;
+    }
+
+    public RexNode getFilter() {
+        return filter;
     }
 
     @SuppressWarnings("unchecked")
@@ -69,10 +142,12 @@ public class HazelcastTable extends AbstractTable {
 
         hiddenFieldNames = new HashSet<>();
 
-        List<RelDataTypeField> convertedFields = new ArrayList<>(target.getFieldCount());
+        List<Integer> projects = getProjects();
 
-        for (int i = 0; i < target.getFieldCount(); i++) {
-            TableField field = target.getField(i);
+        List<RelDataTypeField> convertedFields = new ArrayList<>(projects.size());
+
+        for (Integer project : projects) {
+            TableField field = target.getField(project);
 
             String fieldName = field.getName();
             QueryDataType fieldType = field.getType();
@@ -102,12 +177,111 @@ public class HazelcastTable extends AbstractTable {
 
     @Override
     public Statistic getStatistic() {
-        return statistic;
+        if (filter == null) {
+            return statistic;
+        } else {
+            Double selectivity = RelMdUtil.guessSelectivity(filter);
+
+            double rowCount = CostUtils.adjustFilteredRowCount(statistic.getRowCount(), selectivity);
+
+            return new AdjustedStatistic(rowCount);
+        }
+    }
+
+    public double getTotalRowCount() {
+        return statistic.getRowCount();
     }
 
     public boolean isHidden(String fieldName) {
         assert hiddenFieldNames != null;
 
         return hiddenFieldNames.contains(fieldName);
+    }
+
+    public int getOriginalFieldCount() {
+        return target.getFieldCount();
+    }
+
+    /**
+     * Constructs a signature for the table.
+     * <p>
+     * See {@link HazelcastRelOptTable} for more information.
+     *
+     * @return Signature.
+     */
+    public String getSignature() {
+        if (projects == null && filter == null) {
+            return "";
+        }
+
+        StringBuilder res = new StringBuilder("[");
+
+        if (projects != null) {
+            res.append("projects=[");
+
+            for (int i = 0; i < projects.size(); i++) {
+                if (i != 0) {
+                    res.append(", ");
+                }
+
+                res.append(projects.get(i));
+            }
+
+            res.append("]");
+        }
+
+        if (filter != null) {
+            if (projects != null) {
+                res.append(", ");
+            }
+
+            res.append("filter=").append(filter);
+        }
+
+        res.append("]");
+
+        return res.toString();
+    }
+
+    /**
+     * Statistics that takes in count the row count after the filter is applied.
+     */
+    private final class AdjustedStatistic implements Statistic {
+
+        private final double rowCount;
+
+        private AdjustedStatistic(double rowCount) {
+            this.rowCount = rowCount;
+        }
+
+        @Override
+        public Double getRowCount() {
+            return rowCount;
+        }
+
+        @Override
+        public boolean isKey(ImmutableBitSet columns) {
+            return statistic.isKey(columns);
+        }
+
+        @Override
+        public List<ImmutableBitSet> getKeys() {
+            return statistic.getKeys();
+        }
+
+        @Override
+        public List<RelReferentialConstraint> getReferentialConstraints() {
+            return statistic.getReferentialConstraints();
+        }
+
+        @Override
+        public List<RelCollation> getCollations() {
+            return statistic.getCollations();
+        }
+
+        @Override
+        public RelDistribution getDistribution() {
+            return statistic.getDistribution();
+        }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/schema/HazelcastTable.java
@@ -112,8 +112,6 @@ public class HazelcastTable extends AbstractTable {
     }
 
     public List<Integer> getProjects() {
-        assert projects == null || !projects.isEmpty();
-
         if (projects == null) {
             int fieldCount = target.getFieldCount();
 
@@ -217,12 +215,7 @@ public class HazelcastTable extends AbstractTable {
         StringJoiner res = new StringJoiner(", ", "[", "]");
         res.setEmptyValue("");
 
-        if (projects != null) {
-            res.add("projects="
-                    + projects.stream()
-                            .map(Objects::toString)
-                            .collect(joining(", ", "[", "]")));
-        }
+        res.add("projects=" + getProjects().stream().map(Objects::toString).collect(joining(", ", "[", "]")));
 
         if (filter != null) {
             res.add("filter=" + filter);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlValidator.java
@@ -45,7 +45,7 @@ public class HazelcastSqlValidator extends SqlValidatorImpl {
         RelDataTypeFactory typeFactory,
         SqlConformance conformance
     ) {
-        super(opTab, catalogReader, typeFactory, conformance);
+        super(opTab, catalogReader, typeFactory, Config.DEFAULT.withSqlConformance(conformance));
     }
 
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
@@ -216,7 +216,7 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
         int expectedRowCount = expected.getRowCount();
         int actualRowCount = actual.getRowCount();
 
-        assertEquals(planErrorMessage("Plan are different", expected, actual), expectedRowCount, actualRowCount);
+        assertEquals(planErrorMessage("Plans are different", expected, actual), expectedRowCount, actualRowCount);
 
         for (int i = 0; i < expectedRowCount; i++) {
             PlanRow expectedRow = expected.getRow(i);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
@@ -147,7 +147,7 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
     }
 
     /**
-     * Creates the default test schema. Override that method if you would like to have anoher schema.
+     * Creates the default test schema. Override this method if you would like to have another schema.
      *
      * @return Default schema.
      */
@@ -156,7 +156,7 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
 
         tableMap.put("p", partitionedTable(
             "p",
-            fields("f1", INT, "f2", INT, "f3", INT, "f4", INT, "f5", INT),
+            fields("f0", INT, "f1", INT, "f2", INT, "f3", INT, "f4", INT),
             100
         ));
 
@@ -248,7 +248,7 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
     }
 
     public static Cost cost(double rows, double cpu, double network) {
-        return (Cost) CostFactory.INSTANCE.makeCost(rows, cpu, network);
+        return CostFactory.INSTANCE.makeCost(rows, cpu, network);
     }
 
     private static String planErrorMessage(String message, PlanRows expected, PlanRows actual) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
@@ -37,6 +37,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.SqlExplainLevel;
@@ -44,7 +45,9 @@ import org.apache.calcite.sql.SqlNode;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -250,6 +253,16 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
 
     private static String planErrorMessage(String message, PlanRows expected, PlanRows actual) {
         return message + "\n\n>>> EXPECTED PLAN:\n" + expected + "\n>>> ACTUAL PLAN:\n" + actual;
+    }
+
+    public static void dump(RelNode node) {
+        VolcanoPlanner planner = (VolcanoPlanner) node.getCluster().getPlanner();
+
+        StringWriter sw = new StringWriter();
+
+        planner.dump(new PrintWriter(sw));
+
+        System.out.println(sw);
     }
 
     /**

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
@@ -36,7 +36,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
             optimizeLogical("SELECT f0, f1, f2, f3, f4 FROM p"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2, 3, 4]]]]", 100d)
             )
         );
     }
@@ -47,7 +47,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
             optimizeLogical("SELECT f0, f1, f2, f3, f4 FROM (SELECT f0, f1, f2, f3, f4 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2, 3, 4]]]]", 100d)
             )
         );
     }
@@ -58,7 +58,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
             optimizeLogical("SELECT * FROM p"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2, 3, 4]]]]", 100d)
             )
         );
     }
@@ -69,7 +69,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
             optimizeLogical("SELECT * FROM (SELECT * FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2, 3, 4]]]]", 100d)
             )
         );
     }
@@ -96,7 +96,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[true]", 100d),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[]]]]", 100d)
             )
         );
     }
@@ -406,11 +406,11 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testFilterCompoundExpression() {
         assertPlan(
-                optimizeLogical("SELECT f2 FROM (SELECT f0 + f1 d1, f2 FROM p) WHERE d1 + f2 > 2"),
-                plan(
-                        planRow(0, RootLogicalRel.class, "", 50d),
-                        planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[2], filter=>(+(+($0, $1), $2), 2)]]]", 50d)
-                )
+            optimizeLogical("SELECT f2 FROM (SELECT f0 + f1 d1, f2 FROM p) WHERE d1 + f2 > 2"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[2], filter=>(+(+($0, $1), $2), 2)]]]", 50d)
+            )
         );
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
@@ -31,83 +31,374 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
-    public void test_project() {
+    public void testTrivialProject() {
+        assertPlan(
+            optimizeLogical("SELECT f1, f2, f3, f4, f5 FROM p"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    @Test
+    public void testTrivialProjectProject() {
+        assertPlan(
+            optimizeLogical("SELECT f1, f2, f3, f4, f5 FROM (SELECT f1, f2, f3, f4, f5 FROM p)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    @Test
+    public void testTrivialStartProject() {
+        assertPlan(
+            optimizeLogical("SELECT * FROM p"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    @Test
+    public void testTrivialStartProjectProject() {
+        assertPlan(
+            optimizeLogical("SELECT * FROM (SELECT * FROM p)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project <- Scan
+     * After : Scan(Project)
+     */
+    @Test
+    public void testProjectIntoScan() {
         assertPlan(
             optimizeLogical("SELECT f1, f2 FROM p"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, ProjectLogicalRel.class, "f1=[$0], f2=[$1]", 100d),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1]]]]", 100d)
             )
         );
     }
 
     @Test
-    public void test_projectFilter() {
+    public void testProjectWithoutInputReferences() {
         assertPlan(
-            optimizeLogical("SELECT f1, f2 FROM p WHERE f3 IS NULL"),
+            optimizeLogical("SELECT TRUE FROM p"),
             plan(
-                planRow(0, RootLogicalRel.class, "", 25d),
-                planRow(1, ProjectLogicalRel.class, "f1=[$0], f2=[$1]", 25d),
-                planRow(2, FilterLogicalRel.class, "condition=[IS NULL($2)]", 25d),
-                planRow(3, ProjectLogicalRel.class, "f1=[$0], f2=[$1], f3=[$2]", 100d),
-                planRow(4, MapScanLogicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[true]", 100d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
             )
         );
     }
 
+    /**
+     * Before: Project(exp) <- Scan
+     * After : Project(exp) <- Scan(Project)
+     */
     @Test
-    public void test_project_project() {
+    public void testProjectExpressionIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 + f2, f3 FROM p"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project <- Filter <- Scan
+     * After : Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1, f2 FROM p WHERE f3 > 1"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project(exp) <- Filter <- Scan
+     * After : Project(exp) <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectExpressionFilterScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 + f2, f3 FROM p WHERE f4 > 1"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Project1 <- Scan
+     * After : Scan(Project2)
+     */
+    @Test
+    public void testProjectProjectIntoScan() {
         assertPlan(
             optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, ProjectLogicalRel.class, "f1=[$0]", 100d),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0]]]]", 100d)
             )
         );
     }
 
+    /**
+     * Before: Project2 <- Project1(expression) <- Scan
+     * After : Scan(Project2)
+     */
     @Test
-    public void test_project_projectFilter() {
+    public void testProjectProjectExpressionIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 IS NULL)"),
+            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 100d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1 <- Scan
+     * After : Project2 <- Scan(Project2)
+     */
+    @Test
+    public void testProjectExpressionProjectIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 + f2, f3 FROM (SELECT f1, f2, f3, f4 FROM p)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1(expression) <- Scan
+     * After : Scan(Project2)
+     */
+    @Test
+    public void testProjectExpressionProjectExpressionIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 100d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 100d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Project1 <- Filter <- Scan
+     * After : Scan(Project2, Filter)
+     */
+    @Test
+    public void testProjectProjectFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 > 1)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Project1(expression) <- Filter <- Scan
+     * After : Project <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectProjectExpressionFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($4, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1 <- Filter <- Scan
+     * After : Project <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectExpressionProjectFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f3 > 1)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1(expression) <- Filter <- Scan
+     * After : Project <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectExpressionProjectExpressionFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($4, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Filter <- Project1 <- Scan
+     * After : Scan(Project2, Filter)
+     */
+    @Test
+    public void testProjectFilterProjectIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p) WHERE f2 > 1"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0], filter=>($1, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Filter <- Project1(expression) <- Scan
+     * After : Project <- Project <- Scan(Project2, Filter)
+     *
+     */
+    @Test
+    public void testProjectFilterProjectExpressionIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Filter <- Project1 <- Scan
+     * After : Project <-  Scan(Project, Filter)
+     *
+     */
+    @Test
+    public void testProjectExpressionFilterProjectIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p) WHERE f3 > 1"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Filter <- Project1(expression) <- Scan
+     * After : Project <- Project <- Scan(Project, Filter)
+     *
+     */
+    @Test
+    public void testProjectExpressionFilterProjectExpressionIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 50d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 50d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project1 <- Filter1 <- Project2 <- Filter2 <- Scan
+     * After : Scan(Project1, Filter1 and Filter2)
+     */
+    @Test
+    public void testProjectFilterProjectFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p WHERE f4 > 1) WHERE f2 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 25d),
-                planRow(1, ProjectLogicalRel.class, "f1=[$0]", 25d),
-                planRow(2, FilterLogicalRel.class, "condition=[IS NULL($1)]", 25d),
-                planRow(3, ProjectLogicalRel.class, "f1=[$0], f3=[$2]", 100d),
-                planRow(4, MapScanLogicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0], filter=AND(>($3, 1), >($1, 1))]]]", 25d)
             )
         );
     }
 
+    /**
+     * Before: Project1 <- Filter1 <- Project2(expression) <- Filter2 <- Scan
+     * After : Project1 <- Project2 <- Scan(Project, Filter1 and Filter2)
+     */
     @Test
-    public void test_projectFilter_project() {
+    public void testProjectFilterProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p) WHERE f2 IS NULL"),
+            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 25d),
-                planRow(1, ProjectLogicalRel.class, "f1=[$0]", 25d),
-                planRow(2, FilterLogicalRel.class, "condition=[IS NULL($1)]", 25d),
-                planRow(3, ProjectLogicalRel.class, "f1=[$0], f2=[$1]", 100d),
-                planRow(4, MapScanLogicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 25d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=AND(>($3, 1), >($2, 2))]]]", 25d)
             )
         );
     }
 
+    /**
+     * Before: Project1(expression) <- Filter1 <- Project2 <- Filter2 <- Scan
+     * After : Project <- Scan(Project, Filter1 and Filter2)
+     */
     @Test
-    public void test_projectFilter_projectFilter() {
+    public void testProjectExpressionFilterProjectFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 IS NULL) WHERE f2 IS NULL"),
+            optimizeLogical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f4 > 1) WHERE f3 > 1"),
             plan(
-                planRow(0, RootLogicalRel.class, "", 6.2d),
-                planRow(1, ProjectLogicalRel.class, "f1=[$0]", 6.2d),
-                planRow(2, FilterLogicalRel.class, "condition=[IS NULL($1)]", 6.2d),
-                planRow(3, ProjectLogicalRel.class, "f1=[$0], f2=[$1]", 25d),
-                planRow(4, FilterLogicalRel.class, "condition=[IS NULL($2)]", 25d),
-                planRow(5, ProjectLogicalRel.class, "f1=[$0], f2=[$1], f3=[$2]", 100d),
-                planRow(6, MapScanLogicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(0, RootLogicalRel.class, "", 25d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)]", 25d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=AND(>($3, 1), >($2, 1))]]]", 25d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project1(expression) <- Filter1 <- Project2(expression) <- Filter2 <- Scan
+     * After : Project1 <- Project2 <- Scan(Project, Filter1 and Filter2)
+     */
+    @Test
+    public void testProjectExpressionFilterProjectExpressionFilterIntoScan() {
+        assertPlan(
+            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2"),
+            plan(
+                planRow(0, RootLogicalRel.class, "", 25d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 25d),
+                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=AND(>($3, 1), >($2, 2))]]]", 25d)
             )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
@@ -402,4 +402,15 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
             )
         );
     }
+
+    @Test
+    public void testFilterCompoundExpression() {
+        assertPlan(
+                optimizeLogical("SELECT f3 FROM (SELECT f1 + f2 d1, f3 FROM p) WHERE d1 + f3 > 2"),
+                plan(
+                        planRow(0, RootLogicalRel.class, "", 50d),
+                        planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[2], filter=>(+(+($0, $1), $2), 2)]]]", 50d)
+                )
+        );
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
@@ -33,7 +33,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testTrivialProject() {
         assertPlan(
-            optimizeLogical("SELECT f1, f2, f3, f4, f5 FROM p"),
+            optimizeLogical("SELECT f0, f1, f2, f3, f4 FROM p"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
@@ -44,7 +44,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testTrivialProjectProject() {
         assertPlan(
-            optimizeLogical("SELECT f1, f2, f3, f4, f5 FROM (SELECT f1, f2, f3, f4, f5 FROM p)"),
+            optimizeLogical("SELECT f0, f1, f2, f3, f4 FROM (SELECT f0, f1, f2, f3, f4 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p]]", 100d)
@@ -81,7 +81,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1, f2 FROM p"),
+            optimizeLogical("SELECT f0, f1 FROM p"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1]]]]", 100d)
@@ -108,10 +108,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 + f2, f3 FROM p"),
+            optimizeLogical("SELECT f0 + f1, f2 FROM p"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f2=[$2]", 100d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
             )
         );
@@ -124,7 +124,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1, f2 FROM p WHERE f3 > 1"),
+            optimizeLogical("SELECT f0, f1 FROM p WHERE f2 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
@@ -139,10 +139,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 + f2, f3 FROM p WHERE f4 > 1"),
+            optimizeLogical("SELECT f0 + f1, f2 FROM p WHERE f3 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
-                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 50d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f2=[$2]", 50d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
             )
         );
@@ -155,7 +155,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p)"),
+            optimizeLogical("SELECT f0 FROM (SELECT f0, f1 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0]]]]", 100d)
@@ -170,10 +170,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectExpressionIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)"),
+            optimizeLogical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 100d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f2=[$2]", 100d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
             )
         );
@@ -186,10 +186,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 + f2, f3 FROM (SELECT f1, f2, f3, f4 FROM p)"),
+            optimizeLogical("SELECT f0 + f1, f2 FROM (SELECT f0, f1, f2, f3 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
-                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)], f2=[$2]", 100d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
             )
         );
@@ -202,7 +202,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectExpressionIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)"),
+            optimizeLogical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 100d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 100d),
@@ -218,7 +218,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 > 1)"),
+            optimizeLogical("SELECT f0 FROM (SELECT f0, f1 FROM p WHERE f2 > 1)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0], filter=>($2, 1)]]]", 50d)
@@ -233,10 +233,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)"),
+            optimizeLogical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p WHERE f4 > 1)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
-                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f2=[$2]", 50d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($4, 1)]]]", 50d)
             )
         );
@@ -249,7 +249,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f3 > 1)"),
+            optimizeLogical("SELECT f0 + f1 FROM (SELECT f0, f1, f2, f3 FROM p WHERE f2 > 1)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)]", 50d),
@@ -265,7 +265,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)"),
+            optimizeLogical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p WHERE f4 > 1)"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 50d),
@@ -281,7 +281,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p) WHERE f2 > 1"),
+            optimizeLogical("SELECT f0 FROM (SELECT f0, f1, f2 FROM p) WHERE f1 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0], filter=>($1, 1)]]]", 50d)
@@ -297,10 +297,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectExpressionIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1"),
+            optimizeLogical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p) WHERE f3 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
-                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f2=[$2]", 50d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
             )
         );
@@ -314,7 +314,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p) WHERE f3 > 1"),
+            optimizeLogical("SELECT f0 + f1 FROM (SELECT f0, f1, f2, f3 FROM p) WHERE f2 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)]", 50d),
@@ -331,7 +331,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectExpressionIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1"),
+            optimizeLogical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p) WHERE f3 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 50d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 50d),
@@ -347,7 +347,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p WHERE f4 > 1) WHERE f2 > 1"),
+            optimizeLogical("SELECT f0 FROM (SELECT f0, f1, f2 FROM p WHERE f3 > 1) WHERE f1 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 25d),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0], filter=AND(>($3, 1), >($1, 1))]]]", 25d)
@@ -362,10 +362,10 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2"),
+            optimizeLogical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p WHERE f3 > 1) WHERE f2 > 2"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 25d),
-                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f3=[$2]", 25d),
+                planRow(1, ProjectLogicalRel.class, "d1=[+($0, $1)], f2=[$2]", 25d),
                 planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=AND(>($3, 1), >($2, 2))]]]", 25d)
             )
         );
@@ -378,7 +378,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f4 > 1) WHERE f3 > 1"),
+            optimizeLogical("SELECT f0 + f1 FROM (SELECT f0, f1, f2, f3 FROM p WHERE f3 > 1) WHERE f2 > 1"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 25d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+($0, $1)]", 25d),
@@ -394,7 +394,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizeLogical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2"),
+            optimizeLogical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p WHERE f3 > 1) WHERE f2 > 2"),
             plan(
                 planRow(0, RootLogicalRel.class, "", 25d),
                 planRow(1, ProjectLogicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 25d),
@@ -406,7 +406,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testFilterCompoundExpression() {
         assertPlan(
-                optimizeLogical("SELECT f3 FROM (SELECT f1 + f2 d1, f3 FROM p) WHERE d1 + f3 > 2"),
+                optimizeLogical("SELECT f2 FROM (SELECT f0 + f1 d1, f2 FROM p) WHERE d1 + f2 > 2"),
                 plan(
                         planRow(0, RootLogicalRel.class, "", 50d),
                         planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, p[projects=[2], filter=>(+(+($0, $1), $2), 2)]]]", 50d)

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalProjectFilterTest.java
@@ -53,7 +53,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     }
 
     @Test
-    public void testTrivialStartProject() {
+    public void testTrivialStarProject() {
         assertPlan(
             optimizeLogical("SELECT * FROM p"),
             plan(
@@ -64,7 +64,7 @@ public class LogicalProjectFilterTest extends OptimizerTestSupport {
     }
 
     @Test
-    public void testTrivialStartProjectProject() {
+    public void testTrivialStarProjectProject() {
         assertPlan(
             optimizeLogical("SELECT * FROM (SELECT * FROM p)"),
             plan(

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalSelectStarTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalSelectStarTest.java
@@ -44,8 +44,8 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
         tableMap.put("r", OptimizerTestSupport.partitionedTable(
             "r",
             Arrays.asList(
-                TestMapTable.field("r_f1", false),
-                TestMapTable.field("r_f2", true)
+                TestMapTable.field("r_f0", false),
+                TestMapTable.field("r_f1", true)
             ),
             100
         ));
@@ -72,7 +72,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
         );
 
         assertPlan(
-            optimizeLogical("SELECT *, r.r_f2 FROM r"),
+            optimizeLogical("SELECT *, r.r_f1 FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r]]")
@@ -80,7 +80,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
         );
 
         assertPlan(
-            optimizeLogical("SELECT r.*, r.r_f2 FROM r"),
+            optimizeLogical("SELECT r.*, r.r_f1 FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r]]")
@@ -88,7 +88,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
         );
 
         assertPlan(
-            optimizeLogical("SELECT r.r_f2, r.* FROM r"),
+            optimizeLogical("SELECT r.r_f1, r.* FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
                 planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r[projects=[1, 0]]]]")

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalSelectStarTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalSelectStarTest.java
@@ -50,15 +50,6 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             100
         ));
 
-        tableMap.put("s", OptimizerTestSupport.partitionedTable(
-            "s",
-            Arrays.asList(
-                TestMapTable.field("s_f1", false),
-                TestMapTable.field("s_f2", true)
-            ),
-            100
-        ));
-
         return new HazelcastSchema(tableMap);
     }
 
@@ -68,8 +59,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT * FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, ProjectLogicalRel.class, "r_f1=[$0]"),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, r]], projects=[[0, 1]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r[projects=[0]]]]")
             )
         );
 
@@ -77,8 +67,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT r.* FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, ProjectLogicalRel.class, "r_f1=[$0]"),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, r]], projects=[[0, 1]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r[projects=[0]]]]")
             )
         );
 
@@ -86,8 +75,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT *, r.r_f2 FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, ProjectLogicalRel.class, "r_f1=[$0], r_f2=[$1]"),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, r]], projects=[[0, 1]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r]]")
             )
         );
 
@@ -95,8 +83,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT r.*, r.r_f2 FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, ProjectLogicalRel.class, "r_f1=[$0], r_f2=[$1]"),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, r]], projects=[[0, 1]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r]]")
             )
         );
 
@@ -104,8 +91,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT r.r_f2, r.* FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, ProjectLogicalRel.class, "r_f2=[$1], r_f1=[$0]"),
-                planRow(2, MapScanLogicalRel.class, "table=[[hazelcast, r]], projects=[[0, 1]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r[projects=[1, 0]]]]")
             )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalSelectStarTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalSelectStarTest.java
@@ -75,7 +75,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT *, r.r_f1 FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r[projects=[0, 1]]]]")
             )
         );
 
@@ -83,7 +83,7 @@ public class LogicalSelectStarTest extends OptimizerTestSupport {
             optimizeLogical("SELECT r.*, r.r_f1 FROM r"),
             plan(
                 planRow(0, RootLogicalRel.class, ""),
-                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r]]")
+                planRow(1, MapScanLogicalRel.class, "table=[[hazelcast, r[projects=[0, 1]]]]")
             )
         );
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalProjectFilterTest.java
@@ -34,7 +34,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testTrivialProject() {
         assertPlan(
-            optimizePhysical("SELECT f1, f2, f3, f4, f5 FROM p", 2),
+            optimizePhysical("SELECT f0, f1, f2, f3, f4 FROM p", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
@@ -46,7 +46,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testTrivialProjectProject() {
         assertPlan(
-            optimizePhysical("SELECT f1, f2, f3, f4, f5 FROM (SELECT f1, f2, f3, f4, f5 FROM p)", 2),
+            optimizePhysical("SELECT f0, f1, f2, f3, f4 FROM (SELECT f0, f1, f2, f3, f4 FROM p)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
@@ -86,7 +86,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1, f2 FROM p", 2),
+            optimizePhysical("SELECT f0, f1 FROM p", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
@@ -115,11 +115,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 + f2, f3 FROM p", 2),
+            optimizePhysical("SELECT f0 + f1, f2 FROM p", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
-                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f2=[$2]", 100d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
             )
         );
@@ -132,7 +132,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1, f2 FROM p WHERE f3 > 1", 2),
+            optimizePhysical("SELECT f0, f1 FROM p WHERE f2 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -148,11 +148,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 + f2, f3 FROM p WHERE f4 > 1", 2),
+            optimizePhysical("SELECT f0 + f1, f2 FROM p WHERE f3 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
-                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 50d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f2=[$2]", 50d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
             )
         );
@@ -165,7 +165,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p)", 2),
+            optimizePhysical("SELECT f0 FROM (SELECT f0, f1 FROM p)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
@@ -181,11 +181,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectExpressionIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)", 2),
+            optimizePhysical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
-                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 100d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f2=[$2]", 100d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
             )
         );
@@ -198,11 +198,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 + f2, f3 FROM (SELECT f1, f2, f3, f4 FROM p)", 2),
+            optimizePhysical("SELECT f0 + f1, f2 FROM (SELECT f0, f1, f2, f3 FROM p)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
-                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f2=[$2]", 100d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
             )
         );
@@ -215,7 +215,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectExpressionIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)", 2),
+            optimizePhysical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
@@ -232,7 +232,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 > 1)", 2),
+            optimizePhysical("SELECT f0 FROM (SELECT f0, f1 FROM p WHERE f2 > 1)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -248,11 +248,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)", 2),
+            optimizePhysical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p WHERE f4 > 1)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
-                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f2=[$2]", 50d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($4, 1)]]]", 50d)
             )
         );
@@ -265,7 +265,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f3 > 1)", 2),
+            optimizePhysical("SELECT f0 + f1 FROM (SELECT f0, f1, f2, f3 FROM p WHERE f2 > 1)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -282,7 +282,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)", 2),
+            optimizePhysical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3 FROM p WHERE f4 > 1)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -299,7 +299,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p) WHERE f2 > 1", 2),
+            optimizePhysical("SELECT f0 FROM (SELECT f0, f1, f2 FROM p) WHERE f1 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -316,11 +316,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectExpressionIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1", 2),
+            optimizePhysical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p) WHERE f3 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
-                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f2=[$2]", 50d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
             )
         );
@@ -334,7 +334,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p) WHERE f3 > 1", 2),
+            optimizePhysical("SELECT f0 + f1 FROM (SELECT f0, f1, f2, f3 FROM p) WHERE f2 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -352,7 +352,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectExpressionIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1", 2),
+            optimizePhysical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p) WHERE f3 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 50d),
                 planRow(1, RootExchangePhysicalRel.class, "", 50d),
@@ -369,7 +369,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p WHERE f4 > 1) WHERE f2 > 1", 2),
+            optimizePhysical("SELECT f0 FROM (SELECT f0, f1, f2 FROM p WHERE f3 > 1) WHERE f1 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 25d),
                 planRow(1, RootExchangePhysicalRel.class, "", 25d),
@@ -385,11 +385,11 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectFilterProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2", 2),
+            optimizePhysical("SELECT d1, f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p WHERE f3 > 1) WHERE f2 > 2", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 25d),
                 planRow(1, RootExchangePhysicalRel.class, "", 25d),
-                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 25d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f2=[$2]", 25d),
                 planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=AND(>($3, 1), >($2, 2))]]]", 25d)
             )
         );
@@ -402,7 +402,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f4 > 1) WHERE f3 > 1", 2),
+            optimizePhysical("SELECT f0 + f1 FROM (SELECT f0, f1, f2, f3 FROM p WHERE f3 > 1) WHERE f2 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 25d),
                 planRow(1, RootExchangePhysicalRel.class, "", 25d),
@@ -419,7 +419,7 @@ public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
     public void testProjectExpressionFilterProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2", 2),
+            optimizePhysical("SELECT d1 + f2 FROM (SELECT f0 + f1 d1, f2, f3, f4 FROM p WHERE f3 > 1) WHERE f2 > 2", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 25d),
                 planRow(1, RootExchangePhysicalRel.class, "", 25d),

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalProjectFilterTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalProjectFilterTest.java
@@ -32,89 +32,399 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PhysicalProjectFilterTest extends OptimizerTestSupport {
     @Test
-    public void test_project() {
+    public void testTrivialProject() {
+        assertPlan(
+            optimizePhysical("SELECT f1, f2, f3, f4, f5 FROM p", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    @Test
+    public void testTrivialProjectProject() {
+        assertPlan(
+            optimizePhysical("SELECT f1, f2, f3, f4, f5 FROM (SELECT f1, f2, f3, f4, f5 FROM p)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    @Test
+    public void testTrivialStartProject() {
+        assertPlan(
+            optimizePhysical("SELECT * FROM p", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    @Test
+    public void testTrivialStartProjectProject() {
+        assertPlan(
+            optimizePhysical("SELECT * FROM (SELECT * FROM p)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project <- Scan
+     * After : Scan(Project)
+     */
+    @Test
+    public void testProjectIntoScan() {
         assertPlan(
             optimizePhysical("SELECT f1, f2 FROM p", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0], f2=[$1]", 100d),
-                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1]]]]", 100d)
             )
         );
     }
 
     @Test
-    public void test_projectFilter() {
+    public void testProjectWithoutInputReferences() {
         assertPlan(
-            optimizePhysical("SELECT f1, f2 FROM p WHERE f3 IS NULL", 2),
+            optimizePhysical("SELECT TRUE FROM p", 2),
             plan(
-                planRow(0, RootPhysicalRel.class, "", 25d),
-                planRow(1, RootExchangePhysicalRel.class, "", 25d),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0], f2=[$1]", 25d),
-                planRow(3, FilterPhysicalRel.class, "condition=[IS NULL($2)]", 25d),
-                planRow(4, ProjectPhysicalRel.class, "f1=[$0], f2=[$1], f3=[$2]", 100d),
-                planRow(5, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[true]", 100d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d)
             )
         );
     }
 
+    /**
+     * Before: Project(exp) <- Scan
+     * After : Project(exp) <- Scan(Project)
+     */
     @Test
-    public void test_project_project() {
+    public void testProjectExpressionIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 + f2, f3 FROM p", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project <- Filter <- Scan
+     * After : Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1, f2 FROM p WHERE f3 > 1", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project(exp) <- Filter <- Scan
+     * After : Project(exp) <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectExpressionFilterScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 + f2, f3 FROM p WHERE f4 > 1", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Project1 <- Scan
+     * After : Scan(Project2)
+     */
+    @Test
+    public void testProjectProjectIntoScan() {
         assertPlan(
             optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p)", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0]", 100d),
-                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0]]]]", 100d)
             )
         );
     }
 
+    /**
+     * Before: Project2 <- Project1(expression) <- Scan
+     * After : Scan(Project2)
+     */
     @Test
-    public void test_project_projectFilter() {
+    public void testProjectProjectExpressionIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 IS NULL)", 2),
+            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 100d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1 <- Scan
+     * After : Project2 <- Scan(Project2)
+     */
+    @Test
+    public void testProjectExpressionProjectIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 + f2, f3 FROM (SELECT f1, f2, f3, f4 FROM p)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)], f3=[$2]", 100d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1(expression) <- Scan
+     * After : Scan(Project2)
+     */
+    @Test
+    public void testProjectExpressionProjectExpressionIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 100d),
+                planRow(1, RootExchangePhysicalRel.class, "", 100d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 100d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2]]]]", 100d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Project1 <- Filter <- Scan
+     * After : Scan(Project2, Filter)
+     */
+    @Test
+    public void testProjectProjectFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 > 1)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Project1(expression) <- Filter <- Scan
+     * After : Project <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectProjectExpressionFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($4, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1 <- Filter <- Scan
+     * After : Project <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectExpressionProjectFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f3 > 1)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Project1(expression) <- Filter <- Scan
+     * After : Project <- Scan(Project, Filter)
+     */
+    @Test
+    public void testProjectExpressionProjectExpressionFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4 FROM p WHERE f5 > 1)", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($4, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Filter <- Project1 <- Scan
+     * After : Scan(Project2, Filter)
+     */
+    @Test
+    public void testProjectFilterProjectIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p) WHERE f2 > 1", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0], filter=>($1, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2 <- Filter <- Project1(expression) <- Scan
+     * After : Project <- Project <- Scan(Project2, Filter)
+     *
+     */
+    @Test
+    public void testProjectFilterProjectExpressionIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Filter <- Project1 <- Scan
+     * After : Project <-  Scan(Project, Filter)
+     *
+     */
+    @Test
+    public void testProjectExpressionFilterProjectIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p) WHERE f3 > 1", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=>($2, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project2(expression) <- Filter <- Project1(expression) <- Scan
+     * After : Project <- Project <- Scan(Project, Filter)
+     *
+     */
+    @Test
+    public void testProjectExpressionFilterProjectExpressionIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p) WHERE f4 > 1", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 50d),
+                planRow(1, RootExchangePhysicalRel.class, "", 50d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 50d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=>($3, 1)]]]", 50d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project1 <- Filter1 <- Project2 <- Filter2 <- Scan
+     * After : Scan(Project1, Filter1 and Filter2)
+     */
+    @Test
+    public void testProjectFilterProjectFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT f1 FROM (SELECT f1, f2, f3 FROM p WHERE f4 > 1) WHERE f2 > 1", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 25d),
                 planRow(1, RootExchangePhysicalRel.class, "", 25d),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0]", 25d),
-                planRow(3, FilterPhysicalRel.class, "condition=[IS NULL($1)]", 25d),
-                planRow(4, ProjectPhysicalRel.class, "f1=[$0], f3=[$2]", 100d),
-                planRow(5, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0], filter=AND(>($3, 1), >($1, 1))]]]", 25d)
             )
         );
     }
 
+    /**
+     * Before: Project1 <- Filter1 <- Project2(expression) <- Filter2 <- Scan
+     * After : Project1 <- Project2 <- Scan(Project, Filter1 and Filter2)
+     */
     @Test
-    public void test_projectFilter_project() {
+    public void testProjectFilterProjectExpressionFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p) WHERE f2 IS NULL", 2),
+            optimizePhysical("SELECT d1, f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2", 2),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 25d),
                 planRow(1, RootExchangePhysicalRel.class, "", 25d),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0]", 25d),
-                planRow(3, FilterPhysicalRel.class, "condition=[IS NULL($1)]", 25d),
-                planRow(4, ProjectPhysicalRel.class, "f1=[$0], f2=[$1]", 100d),
-                planRow(5, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(2, ProjectPhysicalRel.class, "d1=[+($0, $1)], f3=[$2]", 25d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=AND(>($3, 1), >($2, 2))]]]", 25d)
             )
         );
     }
 
+    /**
+     * Before: Project1(expression) <- Filter1 <- Project2 <- Filter2 <- Scan
+     * After : Project <- Scan(Project, Filter1 and Filter2)
+     */
     @Test
-    public void test_projectFilter_projectFilter() {
+    public void testProjectExpressionFilterProjectFilterIntoScan() {
         assertPlan(
-            optimizePhysical("SELECT f1 FROM (SELECT f1, f2 FROM p WHERE f3 IS NULL) WHERE f2 IS NULL", 2),
+            optimizePhysical("SELECT f1 + f2 FROM (SELECT f1, f2, f3, f4 FROM p WHERE f4 > 1) WHERE f3 > 1", 2),
             plan(
-                planRow(0, RootPhysicalRel.class, "", 6.2d),
-                planRow(1, RootExchangePhysicalRel.class, "", 6.2d),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0]", 6.2d),
-                planRow(3, FilterPhysicalRel.class, "condition=[IS NULL($1)]", 6.2d),
-                planRow(4, ProjectPhysicalRel.class, "f1=[$0], f2=[$1]", 25d),
-                planRow(5, FilterPhysicalRel.class, "condition=[IS NULL($2)]", 25d),
-                planRow(6, ProjectPhysicalRel.class, "f1=[$0], f2=[$1], f3=[$2]", 100d),
-                planRow(7, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d)
+                planRow(0, RootPhysicalRel.class, "", 25d),
+                planRow(1, RootExchangePhysicalRel.class, "", 25d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+($0, $1)]", 25d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1], filter=AND(>($3, 1), >($2, 1))]]]", 25d)
+            )
+        );
+    }
+
+    /**
+     * Before: Project1(expression) <- Filter1 <- Project2(expression) <- Filter2 <- Scan
+     * After : Project1 <- Project2 <- Scan(Project, Filter1 and Filter2)
+     */
+    @Test
+    public void testProjectExpressionFilterProjectExpressionFilterIntoScan() {
+        assertPlan(
+            optimizePhysical("SELECT d1 + f3 FROM (SELECT f1 + f2 d1, f3, f4, f5 FROM p WHERE f4 > 1) WHERE f3 > 2", 2),
+            plan(
+                planRow(0, RootPhysicalRel.class, "", 25d),
+                planRow(1, RootExchangePhysicalRel.class, "", 25d),
+                planRow(2, ProjectPhysicalRel.class, "EXPR$0=[+(+($0, $1), $2)]", 25d),
+                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2], filter=AND(>($3, 1), >($2, 2))]]]", 25d)
             )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRootTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRootTest.java
@@ -73,15 +73,13 @@ public class PhysicalRootTest extends OptimizerTestSupport {
     @Test
     public void test_singleNode_nonEmpty() {
         Cost scanCost = cost(100d, 500d, 0d);
-        Cost projectCost = cost(100d, 500d, 0d).plus(scanCost);
-        Cost rootCost = cost(100d, 100d, 0d).plus(projectCost);
+        Cost rootCost = cost(100d, 100d, 0d).plus(scanCost);
 
         assertPlan(
             optimizePhysical("SELECT * FROM p"),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d, rootCost),
-                planRow(1, ProjectPhysicalRel.class, "f1=[$0], f2=[$1], f3=[$2], f4=[$3], f5=[$4]", 100d, projectCost),
-                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d, scanCost)
+                planRow(1, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d, scanCost)
             )
         );
     }
@@ -89,15 +87,13 @@ public class PhysicalRootTest extends OptimizerTestSupport {
     @Test
     public void test_singleNode_empty() {
         Cost scanCost = cost(0d, 0d, 0d);
-        Cost projectCost = cost(1d, 5d, 0d).plus(scanCost);
-        Cost rootCost = cost(1d, 1d, 0d).plus(projectCost);
+        Cost rootCost = cost(1d, 1d, 0d).plus(scanCost);
 
         assertPlan(
             optimizePhysical("SELECT * FROM e"),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 1d, rootCost),
-                planRow(1, ProjectPhysicalRel.class, "f1=[$0], f2=[$1], f3=[$2], f4=[$3], f5=[$4]", 1d, projectCost),
-                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, e]], projects=[[0, 1, 2, 3, 4]]", 1d, scanCost)
+                planRow(1, MapScanPhysicalRel.class, "table=[[hazelcast, e]]", 1d, scanCost)
             )
         );
     }
@@ -105,8 +101,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
     @Test
     public void test_multipleNodes_nonEmpty() {
         Cost scanCost = cost(100d, 500d, 0d);
-        Cost projectCost = cost(100d, 500d, 0d).plus(scanCost);
-        Cost rootExchangeCost = cost(100d, 100d, 2000d).plus(projectCost);
+        Cost rootExchangeCost = cost(100d, 100d, 2000d).plus(scanCost);
         Cost rootCost = cost(100d, 100d, 0d).plus(rootExchangeCost);
 
         assertPlan(
@@ -114,8 +109,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d, rootCost),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d, rootExchangeCost),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0], f2=[$1], f3=[$2], f4=[$3], f5=[$4]", 100d, projectCost),
-                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, p]], projects=[[0, 1, 2, 3, 4]]", 100d, scanCost)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d, scanCost)
             )
         );
     }
@@ -123,8 +117,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
     @Test
     public void test_multipleNodes_empty() {
         Cost scanCost = cost(0d, 0d, 0d);
-        Cost projectCost = cost(1d, 5d, 0d).plus(scanCost);
-        Cost rootExchangeCost = cost(1d, 1d, 20d).plus(projectCost);
+        Cost rootExchangeCost = cost(1d, 1d, 20d).plus(scanCost);
         Cost rootCost = cost(1d, 1d, 0d).plus(rootExchangeCost);
 
         assertPlan(
@@ -132,8 +125,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
             plan(
                 planRow(0, RootPhysicalRel.class, "", 1d, rootCost),
                 planRow(1, RootExchangePhysicalRel.class, "", 1d, rootExchangeCost),
-                planRow(2, ProjectPhysicalRel.class, "f1=[$0], f2=[$1], f3=[$2], f4=[$3], f5=[$4]", 1d, projectCost),
-                planRow(3, MapScanPhysicalRel.class, "table=[[hazelcast, e]], projects=[[0, 1, 2, 3, 4]]", 1d, scanCost)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, e]]", 1d, scanCost)
             )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRootTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRootTest.java
@@ -46,11 +46,11 @@ public class PhysicalRootTest extends OptimizerTestSupport {
         tableMap.put("p", OptimizerTestSupport.partitionedTable(
             "p",
             Arrays.asList(
+                TestMapTable.field("f0"),
                 TestMapTable.field("f1"),
                 TestMapTable.field("f2"),
                 TestMapTable.field("f3"),
-                TestMapTable.field("f4"),
-                TestMapTable.field("f5")
+                TestMapTable.field("f4")
             ),
             100
         ));
@@ -58,11 +58,11 @@ public class PhysicalRootTest extends OptimizerTestSupport {
         tableMap.put("e", OptimizerTestSupport.partitionedTable(
             "e",
             Arrays.asList(
+                TestMapTable.field("f0"),
                 TestMapTable.field("f1"),
                 TestMapTable.field("f2"),
                 TestMapTable.field("f3"),
-                TestMapTable.field("f4"),
-                TestMapTable.field("f5")
+                TestMapTable.field("f4")
             ),
             0
         ));

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRootTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRootTest.java
@@ -79,7 +79,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
             optimizePhysical("SELECT * FROM p"),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d, rootCost),
-                planRow(1, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d, scanCost)
+                planRow(1, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2, 3, 4]]]]", 100d, scanCost)
             )
         );
     }
@@ -93,7 +93,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
             optimizePhysical("SELECT * FROM e"),
             plan(
                 planRow(0, RootPhysicalRel.class, "", 1d, rootCost),
-                planRow(1, MapScanPhysicalRel.class, "table=[[hazelcast, e]]", 1d, scanCost)
+                planRow(1, MapScanPhysicalRel.class, "table=[[hazelcast, e[projects=[0, 1, 2, 3, 4]]]]", 1d, scanCost)
             )
         );
     }
@@ -109,7 +109,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
             plan(
                 planRow(0, RootPhysicalRel.class, "", 100d, rootCost),
                 planRow(1, RootExchangePhysicalRel.class, "", 100d, rootExchangeCost),
-                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p]]", 100d, scanCost)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, p[projects=[0, 1, 2, 3, 4]]]]", 100d, scanCost)
             )
         );
     }
@@ -125,7 +125,7 @@ public class PhysicalRootTest extends OptimizerTestSupport {
             plan(
                 planRow(0, RootPhysicalRel.class, "", 1d, rootCost),
                 planRow(1, RootExchangePhysicalRel.class, "", 1d, rootExchangeCost),
-                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, e]]", 1d, scanCost)
+                planRow(2, MapScanPhysicalRel.class, "table=[[hazelcast, e[projects=[0, 1, 2, 3, 4]]]]", 1d, scanCost)
             )
         );
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
@@ -39,6 +39,7 @@ import com.hazelcast.sql.impl.plan.node.MapScanPlanNode;
 import com.hazelcast.sql.impl.plan.node.RootPlanNode;
 import com.hazelcast.sql.impl.plan.node.io.ReceivePlanNode;
 import com.hazelcast.sql.impl.plan.node.io.RootSendPlanNode;
+import com.hazelcast.sql.impl.row.EmptyRow;
 import com.hazelcast.sql.impl.row.EmptyRowBatch;
 import com.hazelcast.sql.impl.row.HeapRow;
 import com.hazelcast.sql.impl.row.JoinRow;
@@ -61,30 +62,31 @@ public class SqlDataSerializerHook implements DataSerializerHook {
 
     public static final int ROW_HEAP = 2;
     public static final int ROW_JOIN = 3;
-    public static final int ROW_BATCH_LIST = 4;
-    public static final int ROW_BATCH_EMPTY = 5;
+    public static final int ROW_EMPTY = 4;
+    public static final int ROW_BATCH_LIST = 5;
+    public static final int ROW_BATCH_EMPTY = 6;
 
-    public static final int OPERATION_EXECUTE = 6;
-    public static final int OPERATION_EXECUTE_FRAGMENT = 7;
-    public static final int OPERATION_BATCH = 8;
-    public static final int OPERATION_FLOW_CONTROL = 9;
-    public static final int OPERATION_CANCEL = 10;
-    public static final int OPERATION_CHECK = 11;
-    public static final int OPERATION_CHECK_RESPONSE = 12;
+    public static final int OPERATION_EXECUTE = 7;
+    public static final int OPERATION_EXECUTE_FRAGMENT = 8;
+    public static final int OPERATION_BATCH = 9;
+    public static final int OPERATION_FLOW_CONTROL = 10;
+    public static final int OPERATION_CANCEL = 11;
+    public static final int OPERATION_CHECK = 12;
+    public static final int OPERATION_CHECK_RESPONSE = 13;
 
-    public static final int NODE_ROOT = 13;
-    public static final int NODE_ROOT_SEND = 14;
-    public static final int NODE_RECEIVE = 15;
-    public static final int NODE_PROJECT = 16;
-    public static final int NODE_FILTER = 17;
-    public static final int NODE_MAP_SCAN = 18;
+    public static final int NODE_ROOT = 14;
+    public static final int NODE_ROOT_SEND = 15;
+    public static final int NODE_RECEIVE = 16;
+    public static final int NODE_PROJECT = 17;
+    public static final int NODE_FILTER = 18;
+    public static final int NODE_MAP_SCAN = 19;
 
-    public static final int EXPRESSION_COLUMN = 19;
-    public static final int EXPRESSION_IS_NULL = 20;
+    public static final int EXPRESSION_COLUMN = 20;
+    public static final int EXPRESSION_IS_NULL = 21;
 
-    public static final int TARGET_DESCRIPTOR_GENERIC = 21;
+    public static final int TARGET_DESCRIPTOR_GENERIC = 22;
 
-    public static final int QUERY_PATH = 22;
+    public static final int QUERY_PATH = 23;
 
     public static final int LEN = QUERY_PATH + 1;
 
@@ -104,6 +106,7 @@ public class SqlDataSerializerHook implements DataSerializerHook {
 
         constructors[ROW_HEAP] = arg -> new HeapRow();
         constructors[ROW_JOIN] = arg -> new JoinRow();
+        constructors[ROW_EMPTY] = arg -> EmptyRow.INSTANCE;
         constructors[ROW_BATCH_LIST] = arg -> new ListRowBatch();
         constructors[ROW_BATCH_EMPTY] = arg -> EmptyRowBatch.INSTANCE;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -19,12 +19,14 @@ package com.hazelcast.sql.impl.exec.scan;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.sql.impl.exec.AbstractExec;
+import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.extract.QueryTargetDescriptor;
-import com.hazelcast.sql.impl.worker.QueryFragmentContext;
-import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.row.EmptyRow;
 import com.hazelcast.sql.impl.row.HeapRow;
+import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.worker.QueryFragmentContext;
 
 import java.util.List;
 
@@ -93,7 +95,7 @@ public abstract class AbstractMapScanExec extends AbstractExec {
      * @param rawValue Value (data or object)
      * @return Row that is ready for processing by parent operators or {@code null} if the row hasn't passed the filter.
      */
-    protected HeapRow prepareRow(Object rawkey, Object rawValue) {
+    protected Row prepareRow(Object rawkey, Object rawValue) {
         row.setKeyValue(rawkey, rawValue);
 
         // Filter.
@@ -102,6 +104,10 @@ public abstract class AbstractMapScanExec extends AbstractExec {
         }
 
         // Project.
+        if (projects.size() == 0) {
+            return EmptyRow.INSTANCE;
+        }
+
         HeapRow row = new HeapRow(projects.size());
 
         for (int j = 0; j < projects.size(); j++) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExec.java
@@ -26,7 +26,6 @@ import com.hazelcast.sql.impl.exec.IterationResult;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.extract.QueryTargetDescriptor;
-import com.hazelcast.sql.impl.row.HeapRow;
 import com.hazelcast.sql.impl.row.ListRowBatch;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.row.RowBatch;
@@ -80,7 +79,7 @@ public class MapScanExec extends AbstractMapScanExec {
         currentRows = null;
 
         while (recordIterator.tryAdvance()) {
-            HeapRow row = prepareRow(recordIterator.getKey(), recordIterator.getValue());
+            Row row = prepareRow(recordIterator.getKey(), recordIterator.getValue());
 
             if (row != null) {
                 if (currentRows == null) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/row/EmptyRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/row/EmptyRow.java
@@ -21,24 +21,32 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 
+import java.io.IOException;
+
 /**
- * Empty row batch.
+ * Row with no columns. It may appear when the downstream operator doesn't need any columns from
+ * the upstream, and only the number of returned rows is important.
+ * <p>
+ * Example:
+ * <pre>
+ * SELECT GET_DATE() FROM person
+ * </pre>
  */
-public final class EmptyRowBatch implements RowBatch, IdentifiedDataSerializable {
+public class EmptyRow implements Row, IdentifiedDataSerializable {
 
-    public static final EmptyRowBatch INSTANCE = new EmptyRowBatch();
+    public static final EmptyRow INSTANCE = new EmptyRow();
 
-    private EmptyRowBatch() {
+    public EmptyRow() {
         // No-op.
     }
 
     @Override
-    public Row getRow(int idx) {
+    public <T> T get(int index) {
         throw new UnsupportedOperationException("Should not be called.");
     }
 
     @Override
-    public int getRowCount() {
+    public int getColumnCount() {
         return 0;
     }
 
@@ -49,16 +57,31 @@ public final class EmptyRowBatch implements RowBatch, IdentifiedDataSerializable
 
     @Override
     public int getClassId() {
-        return SqlDataSerializerHook.ROW_BATCH_EMPTY;
+        return SqlDataSerializerHook.ROW_EMPTY;
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) {
+    public void writeData(ObjectDataOutput out) throws IOException {
         // No-op.
     }
 
     @Override
-    public void readData(ObjectDataInput in) {
+    public void readData(ObjectDataInput in) throws IOException {
         // No-op.
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof EmptyRow;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "{}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/row/EmptyRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/row/EmptyRow.java
@@ -42,7 +42,7 @@ public class EmptyRow implements Row, IdentifiedDataSerializable {
 
     @Override
     public <T> T get(int index) {
-        throw new UnsupportedOperationException("Should not be called.");
+        throw new IndexOutOfBoundsException(getClass().getName() + " has no columns");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/row/EmptyRowBatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/row/EmptyRowBatch.java
@@ -34,7 +34,7 @@ public final class EmptyRowBatch implements RowBatch, IdentifiedDataSerializable
 
     @Override
     public Row getRow(int idx) {
-        throw new UnsupportedOperationException("Should not be called.");
+        throw new IndexOutOfBoundsException(getClass().getName() + " has no rows");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
@@ -40,6 +40,7 @@ import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.extract.GenericQueryTargetDescriptor;
 import com.hazelcast.sql.impl.extract.QueryPath;
+import com.hazelcast.sql.impl.row.EmptyRow;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.row.RowBatch;
 import com.hazelcast.sql.impl.type.QueryDataType;
@@ -109,6 +110,77 @@ public class MapScanExecTest extends SqlTestSupport {
     @Test
     public void testNormal_Binary() {
         checkNormal(instance1.getMap(MAP_BINARY));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void testEmptyRow() {
+        MapProxyImpl<TestKey, TestValue> map = (MapProxyImpl) instance1.getMap(MAP_OBJECT);
+
+        // Get local partition
+        int partitionId = 0;
+
+        for (Partition partition : instance1.getPartitionService().getPartitions()) {
+            if (instance1.getLocalEndpoint().getUuid().equals(partition.getOwner().getUuid())) {
+                partitionId = partition.getPartitionId();
+
+                break;
+            }
+        }
+
+        PartitionIdSet parts = new PartitionIdSet(PARTITION_COUNT);
+        parts.add(partitionId);
+
+        // Put local data
+        map.clear();
+
+        int currentIndex = 0;
+        int currentKey = 0;
+
+        while (true) {
+            TestKey key = new TestKey(currentKey);
+
+            if (instance1.getPartitionService().getPartition(key).getPartitionId() == partitionId) {
+                map.put(key, new TestValue(currentKey, currentIndex == 0));
+
+                if (++currentIndex == 2) {
+                    break;
+                }
+            }
+
+            currentKey++;
+        }
+
+        // Execute
+        List<QueryPath> fieldPaths = Arrays.asList(keyPath("val1"), valuePath("val2"), valuePath("val3"));
+        List<QueryDataType> fieldTypes = Arrays.asList(QueryDataType.INT, QueryDataType.BIGINT, QueryDataType.BOOLEAN);
+
+        int id = 1;
+        MapContainer mapContainer = map.getService().getMapServiceContext().getMapContainer(map.getName());
+        InternalSerializationService serializationService =
+            (InternalSerializationService) map.getNodeEngine().getSerializationService();
+
+        MapScanExec exec = new MapScanExec(
+            id,
+            mapContainer,
+            parts,
+            GenericQueryTargetDescriptor.INSTANCE,
+            GenericQueryTargetDescriptor.INSTANCE,
+            fieldPaths,
+            fieldTypes,
+            Collections.emptyList(),
+            new TestFilter(2),
+            serializationService
+        );
+
+        exec.setup(emptyFragmentContext());
+
+        IterationResult res = exec.advance();
+        assertEquals(IterationResult.FETCHED_DONE, res);
+
+        RowBatch batch = exec.currentBatch();
+        assertEquals(1, batch.getRowCount());
+        assertEquals(EmptyRow.INSTANCE, batch.getRow(0));
     }
 
     private void checkNormal(IMap<TestKey, TestValue> map) {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/row/EmptyRowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/row/EmptyRowTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.row;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class EmptyRowTest extends SqlTestSupport {
+    @Test
+    public void testEmptyRow() {
+        EmptyRow row = EmptyRow.INSTANCE;
+
+        assertEquals(0, row.getColumnCount());
+    }
+
+    @Test
+    public void testSerialization() {
+        EmptyRow original = EmptyRow.INSTANCE;
+        Object restored = serializeAndCheck(original, SqlDataSerializerHook.ROW_EMPTY);
+
+        assertSame(EmptyRow.class, restored.getClass());
+    }
+}


### PR DESCRIPTION
This PR introduces optimization rules for `Project` and `Filter` operators:
1. Apache Calcite rules: eliminate and merge `LogicalProject` and `LogicalFilter` when possible
1. Custom rules: a) push the `LogicalFilter` into the `LogicalTableScan`, b) trim unused `LogicalTableScan` columns based on the content of the parent `LogicalProject`

Closes #17045 