### PR TITLE
Add Kerberos helper options

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -5005,6 +5005,7 @@
     <xs:complexType name="kerberos-authentication">
         <xs:all>
             <xs:element name="relax-flags-check" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="use-name-without-realm" type="xs:boolean" minOccurs="0"/>
             <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
             <xs:element name="ldap" type="ldap-authentication" minOccurs="0"/>
         </xs:all>
@@ -5042,6 +5043,7 @@
             <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
             <xs:element name="service-name-prefix" type="xs:string" minOccurs="0"/>
             <xs:element name="spn" type="xs:string" minOccurs="0"/>
+            <xs:element name="use-canonical-hostname" type="xs:boolean" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="realm-reference">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -605,11 +605,13 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         KerberosAuthenticationConfig kerbAuthentication = kerberosRealm.getKerberosAuthenticationConfig();
         assertNotNull(kerbAuthentication);
         assertEquals(TRUE, kerbAuthentication.getRelaxFlagsCheck());
+        assertEquals(TRUE, kerbAuthentication.getUseNameWithoutRealm());
         assertEquals("krb5Acceptor", kerbAuthentication.getSecurityRealm());
         assertNotNull(kerbAuthentication.getLdapAuthenticationConfig());
         KerberosIdentityConfig kerbIdentity = kerberosRealm.getKerberosIdentityConfig();
         assertNotNull(kerbIdentity);
         assertEquals("HAZELCAST.COM", kerbIdentity.getRealm());
+        assertEquals(TRUE, kerbIdentity.getUseCanonicalHostname());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -665,6 +665,7 @@
                         <hz:authentication>
                             <hz:kerberos>
                                 <hz:relax-flags-check>true</hz:relax-flags-check>
+                                <hz:use-name-without-realm>true</hz:use-name-without-realm>
                                 <hz:security-realm>krb5Acceptor</hz:security-realm>
                                 <hz:ldap>
                                     <hz:url>ldap://127.0.0.1/</hz:url>
@@ -681,6 +682,7 @@
                                 <hz:realm>HAZELCAST.COM</hz:realm>
                                 <hz:security-realm>krb5Initiator</hz:security-realm>
                                 <hz:service-name-prefix>hz/</hz:service-name-prefix>
+                                <hz:use-canonical-hostname>true</hz:use-canonical-hostname>
                                 <hz:spn>hz/127.0.0.1@HAZELCAST.COM</hz:spn>
                             </hz:kerberos>
                         </hz:identity>

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -257,6 +257,7 @@ public final class ClientConfigXmlGenerator {
             .nodeIfContents("realm", c.getRealm())
             .nodeIfContents("security-realm", c.getSecurityRealm())
             .nodeIfContents("service-name-prefix", c.getServiceNamePrefix())
+            .nodeIfContents("use-canonical-hostname", c.getUseCanonicalHostname())
             .nodeIfContents("spn", c.getSpn())
             .close();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -657,6 +657,8 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
                 kerbIdentity.setServiceNamePrefix(getTextContent(child));
             } else if ("spn".equals(nodeName)) {
                 kerbIdentity.setSpn(getTextContent(child));
+            } else if ("use-canonical-hostname".equals(nodeName)) {
+                kerbIdentity.setUseCanonicalHostname(getBooleanValue(getTextContent(child)));
             }
         }
         clientSecurityConfig.setKerberosIdentityConfig(kerbIdentity);

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -361,6 +361,7 @@ public class ConfigXmlGenerator {
         XmlGenerator kerberosGen = gen.open("kerberos");
         addClusterLoginElements(kerberosGen, c)
             .nodeIfContents("relax-flags-check", c.getRelaxFlagsCheck())
+            .nodeIfContents("use-name-without-realm", c.getUseNameWithoutRealm())
             .nodeIfContents("security-realm", c.getSecurityRealm());
         ldapAuthenticationGenerator(kerberosGen, c.getLdapAuthenticationConfig());
         kerberosGen.close();
@@ -375,6 +376,7 @@ public class ConfigXmlGenerator {
             .nodeIfContents("security-realm", c.getSecurityRealm())
             .nodeIfContents("service-name-prefix", c.getServiceNamePrefix())
             .nodeIfContents("spn", c.getSpn())
+            .nodeIfContents("use-canonical-hostname", c.getUseCanonicalHostname())
             .close();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<KerberosAuthenticationConfig> {
 
     private Boolean relaxFlagsCheck;
+    private Boolean useNameWithoutRealm;
     private String securityRealm;
     private LdapAuthenticationConfig ldapAuthenticationConfig;
 
@@ -39,6 +40,15 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
 
     public String getSecurityRealm() {
         return securityRealm;
+    }
+
+    public KerberosAuthenticationConfig setUseNameWithoutRealm(Boolean useNameWithoutRealm) {
+        this.useNameWithoutRealm = useNameWithoutRealm;
+        return this;
+    }
+
+    public Boolean getUseNameWithoutRealm() {
+        return useNameWithoutRealm;
     }
 
     public KerberosAuthenticationConfig setSecurityRealm(String securityRealm) {
@@ -59,6 +69,7 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
     protected Properties initLoginModuleProperties() {
         Properties props = super.initLoginModuleProperties();
         setIfConfigured(props, "relaxFlagsCheck", relaxFlagsCheck);
+        setIfConfigured(props, "useNameWithoutRealm", useNameWithoutRealm);
         setIfConfigured(props, "securityRealm", securityRealm);
         return props;
     }
@@ -85,7 +96,7 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + Objects.hash(ldapAuthenticationConfig, relaxFlagsCheck, securityRealm);
+        result = prime * result + Objects.hash(ldapAuthenticationConfig, relaxFlagsCheck, useNameWithoutRealm, securityRealm);
         return result;
     }
 
@@ -102,12 +113,15 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         }
         KerberosAuthenticationConfig other = (KerberosAuthenticationConfig) obj;
         return Objects.equals(ldapAuthenticationConfig, other.ldapAuthenticationConfig)
-                && Objects.equals(relaxFlagsCheck, other.relaxFlagsCheck) && Objects.equals(securityRealm, other.securityRealm);
+                && Objects.equals(relaxFlagsCheck, other.relaxFlagsCheck)
+                && Objects.equals(useNameWithoutRealm, other.useNameWithoutRealm)
+                && Objects.equals(securityRealm, other.securityRealm);
     }
 
     @Override
     public String toString() {
         return "KerberosAuthenticationConfig [relaxFlagsCheck=" + relaxFlagsCheck + ", securityRealm=" + securityRealm
+                + ", useNameWithoutRealm=" + useNameWithoutRealm
                 + ", ldapAuthenticationConfig=" + ldapAuthenticationConfig
                 + ", getSkipIdentity()=" + getSkipIdentity() + ", getSkipEndpoint()=" + getSkipEndpoint() + ", getSkipRole()="
                 + getSkipRole() + "]";

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
@@ -17,9 +17,12 @@
 package com.hazelcast.config.security;
 
 import java.util.Objects;
+import java.util.Properties;
 
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.security.ICredentialsFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class KerberosIdentityConfig implements IdentityConfig {
 
@@ -62,6 +65,22 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return this;
     }
 
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "Proper support in the config XML generator.")
+    public Boolean getUseCanonicalHostname() {
+        String strVal = factoryConfig.getProperties().getProperty("useCanonicalHostname");
+        return strVal != null ? Boolean.parseBoolean(strVal) : null;
+    }
+
+    public KerberosIdentityConfig setUseCanonicalHostname(Boolean useCanonicalHostname) {
+        Properties props = factoryConfig.getProperties();
+        if (useCanonicalHostname != null) {
+            props.setProperty("useCanonicalHostname", useCanonicalHostname.toString());
+        } else {
+            props.remove("useCanonicalHostname");
+        }
+        return this;
+    }
+
     @Override
     public ICredentialsFactory asCredentialsFactory(ClassLoader cl) {
         return factoryConfig.asCredentialsFactory(cl);
@@ -96,7 +115,10 @@ public class KerberosIdentityConfig implements IdentityConfig {
     @Override
     public String toString() {
         return "KerberosIdentityConfig [spn=" + getSpn() + ", serviceNamePrefix=" + getServiceNamePrefix()
-                + ", realm()=" + getRealm() + ", securityRealm=" + getSecurityRealm() + "]";
+                + ", realm=" + getRealm()
+                + ", securityRealm=" + getSecurityRealm()
+                + ", useCanonicalHostname=" + getUseCanonicalHostname()
+                + "]";
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2985,6 +2985,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 kerbIdentity.setServiceNamePrefix(getTextContent(child));
             } else if ("spn".equals(nodeName)) {
                 kerbIdentity.setSpn(getTextContent(child));
+            } else if ("use-canonical-hostname".equals(nodeName)) {
+                kerbIdentity.setUseCanonicalHostname(getBooleanValue(getTextContent(child)));
             }
         }
         realmConfig.setKerberosIdentityConfig(kerbIdentity);
@@ -3058,6 +3060,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             String nodeName = cleanNodeName(child);
             if ("relax-flags-check".equals(nodeName)) {
                 krbCfg.setRelaxFlagsCheck(getBooleanValue(getTextContent(child)));
+            } else if ("use-name-without-realm".contentEquals(nodeName)) {
+                krbCfg.setUseNameWithoutRealm(getBooleanValue(getTextContent(child)));
             } else if ("security-realm".contentEquals(nodeName)) {
                 krbCfg.setSecurityRealm(getTextContent(child));
             } else if ("ldap".contentEquals(nodeName)) {

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -882,6 +882,7 @@
             <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
             <xs:element name="service-name-prefix" type="xs:string" minOccurs="0"/>
             <xs:element name="spn" type="xs:string" minOccurs="0"/>
+            <xs:element name="use-canonical-hostname" type="xs:boolean" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -396,6 +396,7 @@
             <realm>HAZELCAST.COM</realm>
             <security-realm>krb5Initiator</security-realm>
             <service-name-prefix>hz/</service-name-prefix>
+            <use-canonical-hostname>true</use-canonical-hostname>
             <spn>hz/127.0.0.1@HAZELCAST.COM</spn>
         </kerberos>
          -->

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -4898,6 +4898,7 @@
             <xs:extension base="basic-authentication">
                 <xs:choice maxOccurs="unbounded">
                     <xs:element name="relax-flags-check" type="xs:boolean" minOccurs="0"/>
+                    <xs:element name="use-name-without-realm" type="xs:boolean" minOccurs="0"/>
                     <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
                     <xs:element name="ldap" type="ldap-authentication" minOccurs="0"/>
                 </xs:choice>
@@ -4918,6 +4919,7 @@
             <xs:element name="security-realm" type="xs:string" minOccurs="0"/>
             <xs:element name="service-name-prefix" type="xs:string" minOccurs="0"/>
             <xs:element name="spn" type="xs:string" minOccurs="0"/>
+            <xs:element name="use-canonical-hostname" type="xs:boolean" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="username-password">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2254,6 +2254,7 @@
                     <kerberos>
                         <skip-role>true</skip-role>
                         <relax-flags-check>true</relax-flags-check>
+                        <use-name-without-realm>true</use-name-without-realm>
                         <security-realm>krb5Acceptor</security-realm>
                         <ldap>
                             <url>ldap://127.0.0.1/</url>
@@ -2270,6 +2271,7 @@
                         <realm>HAZELCAST.COM</realm>
                         <security-realm>krb5Initiator</security-realm>
                         <service-name-prefix>hz/</service-name-prefix>
+                        <use-canonical-hostname>true</use-canonical-hostname>
                         <spn>hz/127.0.0.1@HAZELCAST.COM</spn>
                     </kerberos>
                 </identity>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2216,6 +2216,7 @@ hazelcast:
           kerberos:
             skip-role: true
             relax-flags-check: true
+            use-name-without-realm: true
             security-realm: krb5Acceptor
             ldap:
               url: ldap://127.0.0.1/
@@ -2229,6 +2230,7 @@ hazelcast:
             realm: HAZELCAST.COM
             security-realm: krb5Initiator
             service-name-prefix: hz/
+            use-canonical-hostname: true
             spn: hz/127.0.0.1@HAZELCAST.COM
       - name: krb5Acceptor
         authentication:

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -388,6 +388,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
                 + "        <realm>HAZELCAST.COM</realm>"
                 + "        <security-realm>krb5Initiator</security-realm>"
                 + "        <service-name-prefix>hz/</service-name-prefix>"
+                + "        <use-canonical-hostname>true</use-canonical-hostname>"
                 + "        <spn>hz/127.0.0.1@HAZELCAST.COM</spn>"
                 + "    </kerberos>"
                 + "</security>"
@@ -398,6 +399,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         assertEquals("HAZELCAST.COM", identityConfig.getRealm());
         assertEquals("krb5Initiator", identityConfig.getSecurityRealm());
         assertEquals("hz/", identityConfig.getServiceNamePrefix());
+        assertTrue(identityConfig.getUseCanonicalHostname());
         assertEquals("hz/127.0.0.1@HAZELCAST.COM", identityConfig.getSpn());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -394,6 +394,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
                 + "      realm: HAZELCAST.COM\n"
                 + "      security-realm: krb5Initiator\n"
                 + "      service-name-prefix: hz/\n"
+                + "      use-canonical-hostname: true\n"
                 + "      spn: hz/127.0.0.1@HAZELCAST.COM\n";
 
         ClientConfig config = buildConfig(yaml);
@@ -402,6 +403,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         assertEquals("HAZELCAST.COM", identityConfig.getRealm());
         assertEquals("krb5Initiator", identityConfig.getSecurityRealm());
         assertEquals("hz/", identityConfig.getServiceNamePrefix());
+        assertTrue(identityConfig.getUseCanonicalHostname());
         assertEquals("hz/127.0.0.1@HAZELCAST.COM", identityConfig.getSpn());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -585,6 +585,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                 .setSkipEndpoint(FALSE)
                 .setSkipRole(TRUE)
                 .setRelaxFlagsCheck(TRUE)
+                .setUseNameWithoutRealm(TRUE)
                 .setSecurityRealm("jaasRealm")
                 .setLdapAuthenticationConfig(new LdapAuthenticationConfig()
                         .setUrl("url")))
@@ -592,6 +593,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                 .setRealm("HAZELCAST.COM")
                 .setSecurityRealm("krb5Init")
                 .setServiceNamePrefix("hz/")
+                .setUseCanonicalHostname(TRUE)
                 .setSpn("spn@HAZELCAST.COM"));
         SecurityConfig expectedConfig = new SecurityConfig().setMemberRealmConfig("kerberosRealm", realmConfig);
         cfg.setSecurityConfig(expectedConfig);

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -224,6 +224,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "        <kerberos>"
                 + "          <skip-role>false</skip-role>"
                 + "          <relax-flags-check>true</relax-flags-check>"
+                + "          <use-name-without-realm>true</use-name-without-realm>"
                 + "          <security-realm>krb5Acceptor</security-realm>"
                 + "          <ldap>"
                 + "            <url>ldap://127.0.0.1</url>"
@@ -234,6 +235,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "        <kerberos>"
                 + "          <realm>HAZELCAST.COM</realm>"
                 + "          <security-realm>krb5Initializer</security-realm>"
+                + "          <use-canonical-hostname>true</use-canonical-hostname>"
                 + "        </kerberos>"
                 + "      </identity>"
                 + "    </realm>"
@@ -302,6 +304,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertNotNull(kerbIdentity);
         assertEquals("HAZELCAST.COM", kerbIdentity.getRealm());
         assertEquals("krb5Initializer", kerbIdentity.getSecurityRealm());
+        assertTrue(kerbIdentity.getUseCanonicalHostname());
 
         KerberosAuthenticationConfig kerbAuthentication = kerberosRealm.getKerberosAuthenticationConfig();
         assertNotNull(kerbAuthentication);
@@ -309,6 +312,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(Boolean.FALSE, kerbAuthentication.getSkipRole());
         assertNull(kerbAuthentication.getSkipIdentity());
         assertEquals("krb5Acceptor", kerbAuthentication.getSecurityRealm());
+        assertTrue(kerbAuthentication.getUseNameWithoutRealm());
 
         LdapAuthenticationConfig kerbLdapAuthentication = kerbAuthentication.getLdapAuthenticationConfig();
         assertNotNull(kerbLdapAuthentication);

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -204,6 +204,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          kerberos:\n"
                 + "            skip-role: false\n"
                 + "            relax-flags-check: true\n"
+                + "            use-name-without-realm: true\n"
                 + "            security-realm: krb5Acceptor\n"
                 + "            ldap:\n"
                 + "              url: ldap://127.0.0.1\n"
@@ -211,6 +212,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          kerberos:\n"
                 + "            realm: HAZELCAST.COM\n"
                 + "            security-realm: krb5Initializer\n"
+                + "            use-canonical-hostname: true\n"
                 + "    client-permission-policy:\n"
                 + "      class-name: MyPermissionPolicy\n"
                 + "      properties:\n"
@@ -270,6 +272,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertNotNull(kerbIdentity);
         assertEquals("HAZELCAST.COM", kerbIdentity.getRealm());
         assertEquals("krb5Initializer", kerbIdentity.getSecurityRealm());
+        assertTrue(kerbIdentity.getUseCanonicalHostname());
 
         KerberosAuthenticationConfig kerbAuthentication = kerberosRealm.getKerberosAuthenticationConfig();
         assertNotNull(kerbAuthentication);
@@ -277,6 +280,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(Boolean.FALSE, kerbAuthentication.getSkipRole());
         assertNull(kerbAuthentication.getSkipIdentity());
         assertEquals("krb5Acceptor", kerbAuthentication.getSecurityRealm());
+        assertTrue(kerbAuthentication.getUseNameWithoutRealm());
 
         LdapAuthenticationConfig kerbLdapAuthentication = kerbAuthentication.getLdapAuthenticationConfig();
         assertNotNull(kerbLdapAuthentication);

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -687,6 +687,7 @@
                     <kerberos>
                         <skip-role>true</skip-role>
                         <relax-flags-check>true</relax-flags-check>
+                        <use-name-without-realm>true</use-name-without-realm>
                         <security-realm>krb5Acceptor</security-realm>
                         <ldap>
                             <url>ldap://127.0.0.1/</url>
@@ -703,6 +704,7 @@
                         <realm>HAZELCAST.COM</realm>
                         <security-realm>krb5Initiator</security-realm>
                         <service-name-prefix>hz/</service-name-prefix>
+                        <use-canonical-hostname>true</use-canonical-hostname>
                         <spn>hz/127.0.0.1@HAZELCAST.COM</spn>
                     </kerberos>
                 </identity>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -657,6 +657,7 @@ hazelcast:
           kerberos:
             skip-role: true
             relax-flags-check: true
+            use-name-without-realm: true
             security-realm: krb5Acceptor
             ldap:
               url: ldap://127.0.0.1/
@@ -670,6 +671,7 @@ hazelcast:
             realm: HAZELCAST.COM
             security-realm: krb5Initiator
             service-name-prefix: hz/
+            use-canonical-hostname: true
             spn: hz/127.0.0.1@HAZELCAST.COM
       - name: krb5Acceptor
         authentication:


### PR DESCRIPTION
This PR simplifies Kerberos authentication in Active Directory environments. 

It introduces new options/flags:
* `use-name-without-realm` (authentication) - allows cutting off the Kerberos realm name (e.g. `jduke@HAZELCAST.COM` becomes `jduke`)
* `use-canonical-hostname` (identity) - service ticket is requested for canonical hostname instead of IP address from the member list (e.g. `hz/192.168.1.1@ACME.COM` can become `hz/member1.acme.com@ACME.COM`)

Both new flags are `false` by default.