### PR TITLE
Simplified the  SwCounter.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
@@ -89,7 +89,6 @@ public abstract class SwCounter implements Counter {
             OFFSET = MEM.objectFieldOffset(field);
         }
 
-        private long localValue;
         private volatile long value;
 
         UnsafeSwCounter(long initialValue) {
@@ -99,7 +98,7 @@ public abstract class SwCounter implements Counter {
         @Override
         @SuppressWarnings("checkstyle:innerassignment")
         public long inc() {
-            long newLocalValue = localValue += 1;
+            final long newLocalValue = value + 1;
             MEM.putOrderedLong(this, OFFSET, newLocalValue);
             return newLocalValue;
         }
@@ -107,7 +106,7 @@ public abstract class SwCounter implements Counter {
         @Override
         @SuppressWarnings("checkstyle:innerassignment")
         public long inc(long amount) {
-            long newLocalValue = localValue += amount;
+            final long newLocalValue = value + amount;
             MEM.putOrderedLong(this, OFFSET, newLocalValue);
             return newLocalValue;
         }
@@ -119,7 +118,6 @@ public abstract class SwCounter implements Counter {
 
         @Override
         public void set(long newValue) {
-            localValue = newValue;
             MEM.putOrderedLong(this, OFFSET, newValue);
         }
 


### PR DESCRIPTION
It had a non volatile field that reads the value and then increments it
and then does a putOrdered. The reason behind this is was the believe
that a volatile read is expensive.

On the X86 a volatile read needs an loadAcquire and this is provided by
TSO since it guarantees [LoadLoad][StoreStore][LoadStore] and a
loadAcquire just needs [LoadLoad][LoadStore].

Apart from preventing compiler optimizations, a volatile read is
equally expensive as a non volatile read. So there is no point in trying
to prevent a volatile read.

```
package com;

import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;

import java.util.concurrent.TimeUnit;
import java.util.concurrent.atomic.AtomicLongFieldUpdater;

@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(value = 1)
@Measurement(iterations = 2)
@Warmup(iterations = 1)
@State(Scope.Thread)
public class SkippedVolatileReadBenchmark {

    private volatile long value;
    private long nonVolatileValue;
    private AtomicLongFieldUpdater<SkippedVolatileReadBenchmark> VALUE = AtomicLongFieldUpdater.newUpdater(SkippedVolatileReadBenchmark.class,"value");

    @Benchmark
    public long skippedVolatile(){
        long tmp = nonVolatileValue;
        tmp++;
        nonVolatileValue=tmp;
        VALUE.lazySet(this, tmp);
        return tmp;
    }

    @Benchmark
    public long nonSkippedVolatile(){
        long tmp = value;
        tmp++;
        VALUE.lazySet(this, tmp);
        return tmp;
    }
}
```

```
Benchmark                                        Mode  Cnt  Score   Error  Units
SkippedVolatileReadBenchmark.nonSkippedVolatile  avgt    2  5.143          ns/op
SkippedVolatileReadBenchmark.skippedVolatile     avgt    2  5.184          ns/op
```