### PR TITLE
Fix fragmented message handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -164,6 +164,10 @@ public final class ClientMessage implements OutboundFrame {
         return startFrame;
     }
 
+    public Frame getEndFrame() {
+        return endFrame;
+    }
+
     public ClientMessage add(Frame frame) {
         frame.next = null;
         if (startFrame == null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -164,10 +164,6 @@ public final class ClientMessage implements OutboundFrame {
         return startFrame;
     }
 
-    public Frame getEndFrame() {
-        return endFrame;
-    }
-
     public ClientMessage add(Frame frame) {
         frame.next = null;
         if (startFrame == null) {
@@ -278,10 +274,12 @@ public final class ClientMessage implements OutboundFrame {
     }
 
     public void merge(ClientMessage fragment) {
-        // ignore the first frame of the fragment since first frame marks the fragment
-        Frame fragmentMessageStartFrame = fragment.startFrame.next;
-        endFrame.next = fragmentMessageStartFrame;
+        endFrame.next = fragment.startFrame;
         endFrame = fragment.endFrame;
+    }
+
+    public void dropFragmentationFrame() {
+        startFrame = startFrame.next;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -90,13 +90,14 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
                     throw new IllegalStateException(
                             "Fragmented client messages are not allowed before the client is authenticated.");
                 } else {
-                    ClientMessage.ForwardFrameIterator frameIterator = activeReader.getClientMessage().frameIterator();
+                    ClientMessage message = activeReader.getClientMessage();
+                    ClientMessage.ForwardFrameIterator frameIterator = message.frameIterator();
                     //ignore the fragmentationFrame
                     frameIterator.next();
                     ClientMessage.Frame startFrame = frameIterator.next();
                     long fragmentationId = Bits.readLongL(firstFrame.content, FRAGMENTATION_ID_OFFSET);
                     if (ClientMessage.isFlagSet(flags, BEGIN_FRAGMENT_FLAG)) {
-                        builderBySessionIdMap.put(fragmentationId, ClientMessage.createForDecode(startFrame));
+                        builderBySessionIdMap.put(fragmentationId, new ClientMessage(startFrame, message.getEndFrame()));
                     } else if (ClientMessage.isFlagSet(flags, END_FRAGMENT_FLAG)) {
                         ClientMessage clientMessage = mergeIntoExistingClientMessage(fragmentationId);
                         handleMessage(clientMessage);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -91,13 +91,10 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
                             "Fragmented client messages are not allowed before the client is authenticated.");
                 } else {
                     ClientMessage message = activeReader.getClientMessage();
-                    ClientMessage.ForwardFrameIterator frameIterator = message.frameIterator();
-                    //ignore the fragmentationFrame
-                    frameIterator.next();
-                    ClientMessage.Frame startFrame = frameIterator.next();
+                    message.dropFragmentationFrame();
                     long fragmentationId = Bits.readLongL(firstFrame.content, FRAGMENTATION_ID_OFFSET);
                     if (ClientMessage.isFlagSet(flags, BEGIN_FRAGMENT_FLAG)) {
-                        builderBySessionIdMap.put(fragmentationId, new ClientMessage(startFrame, message.getEndFrame()));
+                        builderBySessionIdMap.put(fragmentationId, message);
                     } else if (ClientMessage.isFlagSet(flags, END_FRAGMENT_FLAG)) {
                         ClientMessage clientMessage = mergeIntoExistingClientMessage(fragmentationId);
                         handleMessage(clientMessage);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
@@ -41,13 +41,16 @@ import javax.annotation.Nullable;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
+import static com.hazelcast.client.impl.protocol.util.ClientMessageSplitter.getFragments;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -133,8 +136,6 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         Collection<String> labels = new LinkedList<>();
         labels.add("Label");
         UUID uuid = UUID.randomUUID();
-        UUID ownerUuid = UUID.randomUUID();
-        UUID clusterId = UUID.randomUUID();
         ClientMessage message = ClientAuthenticationCodec.encodeRequest("cluster", "user", "pass",
                 uuid, "JAVA", (byte) 1,
                 "1.0", "name", labels);
@@ -187,7 +188,6 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         Address address2 = new Address("127.0.0.1", 5703);
         members.add(new MemberImpl(address2, MemberVersion.of("3.12"), false, UUID.randomUUID()));
         UUID uuid = UUID.randomUUID();
-        UUID ownerUuid = UUID.randomUUID();
         UUID clusterId = UUID.randomUUID();
 
         ClientMessage message = ClientAuthenticationCodec.encodeResponse((byte) 2, new Address("127.0.0.1", 5701),
@@ -293,6 +293,64 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         assertEquals(1, eventHandler.eventType);
         assertEquals(uuid, eventHandler.uuid);
         assertEquals(1, eventHandler.numberOfAffectedEntries);
+    }
+
+    @Test
+    public void testFragmentedMessageHandling() {
+        ClientMessage message = createMessage(10, 9);
+        List<ClientMessage> fragments = getFragments(48, message);
+
+        assertEquals(3, fragments.size());
+
+        AtomicReference<Iterator<ClientMessage>> reference = new AtomicReference<>(fragments.iterator());
+
+        ClientMessageEncoder encoder = new ClientMessageEncoder();
+        encoder.src(() -> {
+            Iterator<ClientMessage> iterator = reference.get();
+            if (iterator.hasNext()) {
+                return iterator.next();
+            }
+            return null;
+        });
+
+        ByteBuffer buffer = ByteBuffer.allocate(200);
+        buffer.flip();
+        encoder.dst(buffer);
+
+        HandlerStatus result = encoder.onWrite();
+
+        assertEquals(CLEAN, result);
+
+        AtomicReference<ClientMessage> resultingMessageRef = new AtomicReference<>();
+        ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessageRef::set, null);
+        decoder.setNormalPacketsRead(SwCounter.newSwCounter());
+
+        buffer.position(buffer.limit());
+
+        decoder.src(buffer);
+        decoder.onRead();
+
+        ClientMessage resultingMessage = resultingMessageRef.get();
+
+        assertEquals(message.getFrameLength(), resultingMessage.getFrameLength());
+
+        ClientMessage.ForwardFrameIterator expectedIterator = message.frameIterator();
+        ClientMessage.ForwardFrameIterator resultingIterator = resultingMessage.frameIterator();
+        while (expectedIterator.hasNext()) {
+            assertArrayEquals(expectedIterator.next().content, resultingIterator.next().content);
+        }
+    }
+
+    private ClientMessage createMessage(int frameLength, int frameCount) {
+        ClientMessage message = ClientMessage.createForEncode();
+
+        Random random = new Random();
+        for (int i = 0; i < frameCount; i++) {
+            byte[] content = new byte[frameLength];
+            random.nextBytes(content);
+            message.add(new Frame(content));
+        }
+        return message;
     }
 
     private HeapData randomData() {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitterTest.java
@@ -51,7 +51,6 @@ public class ClientMessageSplitterTest extends HazelcastTestSupport {
         String clientType = generateRandomString(1000);
         String clientSerializationVersion = generateRandomString(1000);
         String clusterName = generateRandomString(1000);
-        UUID clusterId = UUID.randomUUID();
         LinkedList<String> labels = new LinkedList<>();
         for (int i = 0; i < 10; i++) {
             labels.add(generateRandomString(1000));


### PR DESCRIPTION
By definition, fragmented messages may have arbitrary number of frames.
However, ClientMessageDecoder was using ClientMessage#createForDecode
which expects a single frame that has no next frame. As the added test
shows, that assumption generally does not hold. Start frame of the
fragmented message may have next frames. The fix correctly creates
a client message using the start and end frames of the fragmented
message.