### PR TITLE
[BACKPORT] Add ConfigRecognizer API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigRecognizer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.client.config.impl.ClientXmlConfigRootTagRecognizer;
+import com.hazelcast.client.config.impl.ClientYamlConfigRootTagRecognizer;
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.internal.config.AbstractConfigRecognizer;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+/**
+ * {@link ConfigRecognizer} implementation that recognizes Hazelcast
+ * client declarative configurations based on an extensible set of
+ * built-in {@link ConfigRecognizer} implementations.
+ */
+public class ClientConfigRecognizer extends AbstractConfigRecognizer {
+
+    /**
+     * Constructs an instance with the built-in set of
+     * {@link ConfigRecognizer} implementations only.
+     *
+     * @throws Exception If there is an unexpected error occur during
+     *                   instantiation.
+     */
+    public ClientConfigRecognizer() throws Exception {
+        super(builtInRecognizers());
+    }
+
+    /**
+     * Constructs an instance with the built-in set of
+     * {@link ConfigRecognizer} implementations extended with ones
+     * provided in {@code customRecognizers}.
+     *
+     * @param customRecognizers The custom config recognizers to use
+     *                          besides the built-in ones.
+     * @throws Exception If there is an unexpected error occur during
+     *                   instantiation.
+     */
+    public ClientConfigRecognizer(ConfigRecognizer... customRecognizers) throws Exception {
+        super(recognizers(customRecognizers));
+    }
+
+    private static List<ConfigRecognizer> recognizers(ConfigRecognizer... customRecognizers) throws Exception {
+        List<ConfigRecognizer> configRecognizers = new LinkedList<>(builtInRecognizers());
+        configRecognizers.addAll(asList(customRecognizers));
+        return configRecognizers;
+    }
+
+    private static List<ConfigRecognizer> builtInRecognizers() throws Exception {
+        return asList(
+                new ClientXmlConfigRootTagRecognizer(),
+                new ClientYamlConfigRootTagRecognizer());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientFailoverConfigRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientFailoverConfigRecognizer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.client.config.impl.ClientFailoverXmlConfigRootTagRecognizer;
+import com.hazelcast.client.config.impl.ClientFailoverYamlConfigRootTagRecognizer;
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.internal.config.AbstractConfigRecognizer;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+/**
+ * {@link ConfigRecognizer} implementation that recognizes Hazelcast
+ * client failover declarative configurations based on an extensible set
+ * of built-in {@link ConfigRecognizer} implementations.
+ */
+public class ClientFailoverConfigRecognizer extends AbstractConfigRecognizer {
+
+    /**
+     * Constructs an instance with the built-in set of
+     * {@link ConfigRecognizer} implementations only.
+     *
+     * @throws Exception If there is an unexpected error occur during
+     *                   instantiation.
+     */
+    public ClientFailoverConfigRecognizer() throws Exception {
+        super(builtInRecognizers());
+    }
+
+    /**
+     * Constructs an instance with the built-in set of
+     * {@link ConfigRecognizer} implementations extended with ones
+     * provided in {@code customRecognizers}.
+     *
+     * @param customRecognizers The custom config recognizers to use
+     *                          besides the built-in ones.
+     * @throws Exception If there is an unexpected error occur during
+     *                   instantiation.
+     */
+    public ClientFailoverConfigRecognizer(ConfigRecognizer... customRecognizers) throws Exception {
+        super(recognizers(customRecognizers));
+    }
+
+    private static List<ConfigRecognizer> recognizers(ConfigRecognizer... customRecognizers) throws Exception {
+        List<ConfigRecognizer> configRecognizers = new LinkedList<>(builtInRecognizers());
+        configRecognizers.addAll(asList(customRecognizers));
+        return configRecognizers;
+    }
+
+    private static List<ConfigRecognizer> builtInRecognizers() throws Exception {
+        return asList(
+                new ClientFailoverXmlConfigRootTagRecognizer(),
+                new ClientFailoverYamlConfigRootTagRecognizer());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientFailoverXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientFailoverXmlConfigRootTagRecognizer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config.impl;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.internal.config.AbstractXmlConfigRootTagRecognizer;
+
+/**
+ * This {@link ConfigRecognizer} implementation recognizes Hazelcast
+ * failover client XML configuration by checking if the defined root tag
+ * is "hazelcast-client-failover" or not. For the implementation details
+ * please refer to the {@link AbstractXmlConfigRootTagRecognizer}
+ * documentation.
+ */
+public class ClientFailoverXmlConfigRootTagRecognizer extends AbstractXmlConfigRootTagRecognizer {
+    public ClientFailoverXmlConfigRootTagRecognizer() throws Exception {
+        super(ClientFailoverConfigSections.CLIENT_FAILOVER.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientFailoverYamlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientFailoverYamlConfigRootTagRecognizer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config.impl;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.internal.config.AbstractYamlConfigRootTagRecognizer;
+
+/**
+ * This {@link ConfigRecognizer} implementation recognizes Hazelcast
+ * failover client YAML configuration by checking if the defined root tag
+ * is "hazelcast-client-failover" or not. For the implementation details
+ * please refer to the {@link AbstractYamlConfigRootTagRecognizer}
+ * documentation.
+ */
+public class ClientFailoverYamlConfigRootTagRecognizer extends AbstractYamlConfigRootTagRecognizer {
+    public ClientFailoverYamlConfigRootTagRecognizer() {
+        super(ClientFailoverConfigSections.CLIENT_FAILOVER.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientXmlConfigRootTagRecognizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config.impl;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.internal.config.AbstractXmlConfigRootTagRecognizer;
+
+/**
+ * This {@link ConfigRecognizer} implementation recognizes Hazelcast
+ * client XML configuration by checking if the defined root tag is
+ * "hazelcast-client" or not. For the implementation details please refer
+ * to the {@link AbstractXmlConfigRootTagRecognizer} documentation.
+ */
+public class ClientXmlConfigRootTagRecognizer extends AbstractXmlConfigRootTagRecognizer {
+    public ClientXmlConfigRootTagRecognizer() throws Exception {
+        super(ClientConfigSections.HAZELCAST_CLIENT.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientYamlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientYamlConfigRootTagRecognizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config.impl;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.internal.config.AbstractYamlConfigRootTagRecognizer;
+
+/**
+ * This {@link ConfigRecognizer} implementation recognizes Hazelcast
+ * client YAML configuration by checking if the defined root tag is
+ * "hazelcast-client" or not. For the implementation details please refer
+ * to the {@link AbstractYamlConfigRootTagRecognizer} documentation.
+ */
+public class ClientYamlConfigRootTagRecognizer extends AbstractYamlConfigRootTagRecognizer {
+    public ClientYamlConfigRootTagRecognizer() {
+        super(ClientConfigSections.HAZELCAST_CLIENT.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -69,7 +69,7 @@ public abstract class AbstractXmlConfigHelper {
     }
 
     protected void schemaValidation(Document doc) throws Exception {
-        ArrayList<StreamSource> schemas = new ArrayList<StreamSource>();
+        ArrayList<StreamSource> schemas = new ArrayList<>();
         InputStream inputStream = null;
         String schemaLocation = doc.getDocumentElement().getAttribute("xsi:schemaLocation");
         schemaLocation = schemaLocation.replaceAll("^ +| +$| (?= )", "");

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigRecognizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Interface for recognizing a declarative Hazelcast configuration
+ * based on the rules defined in the actual implementation.
+ * The main use case for this interface is recognizing whether a given
+ * declarative configuration is a member or a client configuration.
+ */
+public interface ConfigRecognizer {
+    /**
+     * Recognizes the configuration given in the {@code configStream}
+     * argument.
+     *
+     * @param configStream The stream with the declarative configuration
+     * @return {@code true} if the configuration is recognized, {@code false}
+     * otherwise
+     * @throws Exception If any error occurs during the recognition
+     */
+    boolean isRecognized(ConfigStream configStream) throws Exception;
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigStream.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.nio.IOUtil;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Stream wrapping or copying a generic {@link InputStream} for the
+ * {@link ConfigRecognizer} API. The purpose of this class is to make
+ * the provided {@link InputStream} resetable so that multiple
+ * {@link ConfigRecognizer} implementations can iterate over the stream.
+ * There are even basic {@link InputStream} implementations that don't
+ * support {@link InputStream#reset()} such as {@link BufferedInputStream}.
+ * If calling {@code reset()} on the provided implementation fails with
+ * an exception, this class reads the stream into a {@code byte[]} and
+ * delegates all {@link InputStream} method calls to a
+ * {@link ByteArrayInputStream} created with this {@code byte[]}. To
+ * prevent OOM issues, the size of this {@code byte[]} is limited to 4096
+ * bytes. This limit can be configured in the constructor.
+ *
+ * @see ConfigRecognizer
+ */
+public class ConfigStream extends InputStream {
+    static final int DEFAULT_READ_LIMIT_4K = 4096;
+
+    private final InputStream delegateStream;
+
+    public ConfigStream(InputStream configStream) throws IOException {
+        this(configStream, DEFAULT_READ_LIMIT_4K);
+    }
+
+    public ConfigStream(InputStream configStream, int readLimit) throws IOException {
+        this.delegateStream = useOrCopyConfigStream(configStream, readLimit);
+    }
+
+    private static InputStream useOrCopyConfigStream(InputStream configStream, int readLimit) throws IOException {
+        if (!configStream.markSupported()) {
+            return copyInputStream(configStream, readLimit);
+        }
+
+        try {
+            configStream.reset();
+            return configStream;
+        } catch (Exception ex) {
+            return copyInputStream(configStream, readLimit);
+        }
+    }
+
+    private static InputStream copyInputStream(InputStream configStream, int readLimit) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            IOUtil.drainToLimited(configStream, baos, readLimit);
+            return new ByteArrayInputStream(baos.toByteArray());
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        return delegateStream.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return delegateStream.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return delegateStream.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return delegateStream.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return delegateStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegateStream.close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        delegateStream.mark(readlimit);
+    }
+
+    @Override
+    public void reset() throws IOException {
+        delegateStream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return delegateStream.markSupported();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberConfigRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberConfigRecognizer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.config.AbstractConfigRecognizer;
+import com.hazelcast.internal.config.MemberXmlConfigRootTagRecognizer;
+import com.hazelcast.internal.config.MemberYamlConfigRootTagRecognizer;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+/**
+ * {@link ConfigRecognizer} implementation that recognizes Hazelcast
+ * member declarative configurations based on an extensible set of
+ * built-in {@link ConfigRecognizer} implementations.
+ */
+public class MemberConfigRecognizer extends AbstractConfigRecognizer {
+
+    /**
+     * Constructs an instance with the built-in set of
+     * {@link ConfigRecognizer} implementations only.
+     *
+     * @throws Exception If there is an unexpected error occur during
+     *                   instantiation.
+     */
+    public MemberConfigRecognizer() throws Exception {
+        super(builtInRecognizers());
+    }
+
+    /**
+     * Constructs an instance with the built-in set of
+     * {@link ConfigRecognizer} implementations extended with ones
+     * provided in {@code customRecognizers}.
+     *
+     * @param customRecognizers The custom config recognizers to use
+     *                          besides the built-in ones.
+     * @throws Exception If there is an unexpected error occur during
+     *                   instantiation.
+     */
+    public MemberConfigRecognizer(ConfigRecognizer... customRecognizers) throws Exception {
+        super(recognizers(customRecognizers));
+    }
+
+    private static List<ConfigRecognizer> recognizers(ConfigRecognizer... customRecognizers) throws Exception {
+        List<ConfigRecognizer> configRecognizers = new LinkedList<>(builtInRecognizers());
+        configRecognizers.addAll(asList(customRecognizers));
+        return configRecognizers;
+    }
+
+    private static List<ConfigRecognizer> builtInRecognizers() throws Exception {
+        return asList(
+                new MemberXmlConfigRootTagRecognizer(),
+                new MemberYamlConfigRootTagRecognizer());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigRecognizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.config.ConfigStream;
+
+import java.util.Collection;
+
+/**
+ * Abstract composite {@link ConfigRecognizer} implementation that uses
+ * multiple recognizers under the hood.
+ */
+public class AbstractConfigRecognizer implements ConfigRecognizer {
+    protected final Collection<ConfigRecognizer> recognizers;
+
+    public AbstractConfigRecognizer(Collection<ConfigRecognizer> recognizers) {
+        this.recognizers = recognizers;
+    }
+
+    @Override
+    public boolean isRecognized(ConfigStream configStream) throws Exception {
+        boolean recognized = false;
+        for (ConfigRecognizer recognizer : recognizers) {
+            configStream.reset();
+            recognized = recognized || recognizer.isRecognized(configStream);
+        }
+
+        return recognized;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.config.ConfigStream;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Abstract {@link ConfigRecognizer} implementation that recognizes
+ * Hazelcast XML configurations. The recognition is done by looking into
+ * the provided configuration to check if the root node is the expected
+ * one.
+ * <p/>
+ * This implementation uses a SAX parser. The parsing is aborted once the
+ * root tag is processed.
+ * <p/>
+ * If the provided configuration is not a valid XML document, no exception
+ * is thrown. Instead, the configuration is simply not recognized by this
+ * implementation.
+ * </p>
+ * Note that this {@link ConfigRecognizer} doesn't validate the
+ * configuration and doesn't look further into the provided configuration.
+ */
+public class AbstractXmlConfigRootTagRecognizer implements ConfigRecognizer {
+    private final SAXParser saxParser;
+    private final String expectedRootNode;
+    private final ILogger logger = Logger.getLogger(AbstractXmlConfigRootTagRecognizer.class);
+
+    public AbstractXmlConfigRootTagRecognizer(String expectedRootNode) throws Exception {
+        this.expectedRootNode = expectedRootNode;
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        saxParser = factory.newSAXParser();
+    }
+
+    @Override
+    public boolean isRecognized(ConfigStream configStream) throws Exception {
+        MemberHandler memberHandler = new MemberHandler(expectedRootNode);
+        try {
+            saxParser.parse(configStream, memberHandler);
+        } catch (TerminateParseException ex) {
+            // expected, always
+        } catch (SAXParseException ex) {
+            // thrown if the provided XML is not a valid XML
+            handleParseException(ex);
+            return false;
+        } catch (Exception ex) {
+            // thrown if any unexpected exception is encountered
+            handleUnexpectedException(ex);
+            throw ex;
+        }
+        return memberHandler.isMemberXml;
+    }
+
+    private void handleParseException(SAXParseException ex) {
+        if (logger.isFineEnabled()) {
+            logger.fine("An exception is encountered while processing the provided XML configuration", ex);
+        }
+    }
+
+    private void handleUnexpectedException(Exception ex) {
+        if (logger.isFineEnabled()) {
+            logger.fine("An unexpected exception is encountered while processing the provided XML configuration", ex);
+        }
+    }
+
+    private static final class MemberHandler extends DefaultHandler {
+        private final String expectedRootNode;
+        private boolean isMemberXml;
+
+        private MemberHandler(String expectedRootNode) {
+            this.expectedRootNode = requireNonNull(expectedRootNode);
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+            if (expectedRootNode.equalsIgnoreCase(qName)) {
+                isMemberXml = true;
+            }
+            throw new TerminateParseException();
+        }
+    }
+
+    private static final class TerminateParseException extends SAXException {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractYamlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractYamlConfigRootTagRecognizer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ConfigRecognizer;
+import com.hazelcast.config.ConfigStream;
+import com.hazelcast.internal.yaml.YamlException;
+import com.hazelcast.internal.yaml.YamlLoader;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.snakeyaml.engine.v1.api.ConstructNode;
+import org.snakeyaml.engine.v1.api.LoadSettingsBuilder;
+
+import java.util.Optional;
+
+/**
+ * Abstract {@link ConfigRecognizer} implementation that recognizes
+ * Hazelcast YAML configurations. The recognition is done by looking into
+ * the provided configuration to check if the root node is the expected
+ * one.
+ * <p/>
+ * This implementation loads the entire YAML document and builds the
+ * document's internal Hazelcast YAML representation graph. This can be
+ * prevented by creating and using custom {@link ConstructNode}
+ * implementations for the tag types.
+ * See {@link LoadSettingsBuilder#setRootConstructNode(Optional)}.
+ * <p/>
+ * If the provided configuration is not a valid YAML document, no exception
+ * is thrown. Instead, the configuration is simply not recognized by this
+ * implementation.
+ * </p>
+ * Note that this {@link ConfigRecognizer} doesn't validate the
+ * configuration and doesn't look further into the provided configuration.
+ */
+public abstract class AbstractYamlConfigRootTagRecognizer implements ConfigRecognizer {
+    private final String expectedRootNode;
+    private final ILogger logger = Logger.getLogger(AbstractYamlConfigRootTagRecognizer.class);
+
+    public AbstractYamlConfigRootTagRecognizer(String expectedRootNode) {
+        this.expectedRootNode = expectedRootNode;
+    }
+
+    @Override
+    public boolean isRecognized(ConfigStream configStream) {
+        try {
+            YamlLoader.load(configStream, expectedRootNode);
+            return true;
+        } catch (YamlException ex) {
+            handleParseException(ex);
+
+            return false;
+        } catch (Exception ex) {
+            handleUnexpectedException(ex);
+            throw ex;
+        }
+    }
+
+    private void handleParseException(YamlException ex) {
+        if (logger.isFineEnabled()) {
+            logger.fine("An exception is encountered while processing the provided YAML configuration", ex);
+        }
+    }
+
+    private void handleUnexpectedException(Exception ex) {
+        if (logger.isFineEnabled()) {
+            logger.fine("An unexpected exception is encountered while processing the provided YAML configuration", ex);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberXmlConfigRootTagRecognizer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ConfigRecognizer;
+
+/**
+ * This {@link ConfigRecognizer} implementation recognizes Hazelcast
+ * member XML configuration by checking if the defined root tag is
+ * "hazelcast" or not. For the implementation details please refer to
+ * the {@link AbstractXmlConfigRootTagRecognizer} documentation.
+ */
+public class MemberXmlConfigRootTagRecognizer extends AbstractXmlConfigRootTagRecognizer {
+    public MemberXmlConfigRootTagRecognizer() throws Exception {
+        super(ConfigSections.HAZELCAST.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberYamlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberYamlConfigRootTagRecognizer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ConfigRecognizer;
+
+/**
+ * This {@link ConfigRecognizer} implementation recognizes Hazelcast
+ * member YAML configuration by checking if the defined root node is
+ * "hazelcast" or not. For the implementation details please refer to
+ * the {@link AbstractYamlConfigRootTagRecognizer} documentation.
+ */
+public class MemberYamlConfigRootTagRecognizer extends AbstractYamlConfigRootTagRecognizer {
+    public MemberYamlConfigRootTagRecognizer() {
+        super(ConfigSections.HAZELCAST.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -20,11 +20,11 @@ import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelOptions;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.ClassNameFilter;
-import com.hazelcast.internal.serialization.Data;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
@@ -706,6 +706,28 @@ public final class IOUtil {
             if (n == -1) {
                 throw new IOException("Not enough bytes in the input stream");
             }
+            output.write(buffer, 0, n);
+            remaining -= n;
+        }
+    }
+
+    /**
+     * Writes maximum {@code limit} bytes from the given input stream to the given output stream.
+     *
+     * @param input  the input stream
+     * @param output the output stream
+     * @param limit  the maximum number of bytes to write
+     * @throws IOException if there is any other IO error.
+     */
+    public static void drainToLimited(InputStream input, OutputStream output, int limit) throws IOException {
+        byte[] buffer = new byte[1024];
+        int remaining = limit;
+        while (remaining > 0) {
+            int n = input.read(buffer, 0, Math.min(buffer.length, remaining));
+            if (n < 1) {
+                return;
+            }
+
             output.write(buffer, 0, n);
             remaining -= n;
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigRecognizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigRecognizerTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.client.config.ClientConfigRecognizer;
+import com.hazelcast.client.config.ClientFailoverConfigRecognizer;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.util.Scanner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ConfigRecognizerTest {
+    static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";
+    static final String HAZELCAST_END_TAG = "</hazelcast>\n";
+    static final String HAZELCAST_CLIENT_START_TAG =
+            "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
+    static final String HAZELCAST_CLIENT_END_TAG = "</hazelcast-client>";
+    static final String HAZELCAST_CLIENT_FAILOVER_START_TAG =
+            "<hazelcast-client-failover xmlns=\"http://www.hazelcast.com/schema/client-failover-config\">\n";
+    static final String HAZELCAST_CLIENT_FAILOVER_END_TAG = "</hazelcast-client-failover>";
+
+    @Test
+    public void testRecognizeMemberFullBlownXml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!--\n"
+                + "BANNER\n"
+                + "-->\n"
+                + "\n"
+                + HAZELCAST_START_TAG
+                + "  <cluster-name>foobar</cluster-name>\n"
+                + HAZELCAST_END_TAG;
+        byte[] bytes = xml.getBytes();
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(bytes), bytes.length));
+
+        assertTrue(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeMemberFullBlownXmlPartialStreamRead() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!--\n"
+                + "BANNER\n"
+                + "-->\n"
+                + "\n"
+                + HAZELCAST_START_TAG  // end of read limit:116 bytes
+                + "  <cluster-name>foobar</cluster-name>"; // incomplete config, this line is not consumed by the recognizer
+        byte[] bytes = xml.getBytes();
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(bytes), bytes.length), 116);
+
+        assertTrue(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeMemberXml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = HAZELCAST_START_TAG
+                + "  <cluster-name>foobar</cluster-name>\n"
+                + HAZELCAST_END_TAG;
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(xml.getBytes()));
+
+        assertTrue(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeClientXml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "  <cluster-name>foobar</cluster-name>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(xml.getBytes()));
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertTrue(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeClientXmlPartialStreamRead() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = HAZELCAST_CLIENT_START_TAG // end of read limit:72 bytes
+                + "  <cluster-name>foobar</cluster-name>\n"; // incomplete config, this line is not consumed by the recognizers
+        byte[] bytes = xml.getBytes();
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(bytes), bytes.length), 72);
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertTrue(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeFailoverClientXml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = HAZELCAST_CLIENT_FAILOVER_START_TAG
+                + "  <cluster-name>foobar</cluster-name>\n"
+                + HAZELCAST_CLIENT_FAILOVER_END_TAG;
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(xml.getBytes()));
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertTrue(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeFailoverClientXmlPartialStreamRead() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = HAZELCAST_CLIENT_FAILOVER_START_TAG // end of read limit:90 bytes
+                + "  <cluster-name>foobar</cluster-name>\n"; // incomplete config, this line is not consumed by the recognizers
+        byte[] bytes = xml.getBytes();
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(bytes), bytes.length), 90);
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertTrue(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testInvalidXmlIsNotRecognized() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String xml = "invalid-xml";
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(xml.getBytes()));
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeMemberYaml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  cluster-name: foobar";
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(yaml.getBytes()));
+
+        assertTrue(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeMemberYamlPartialStreamRead() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  c"; // ...luster-name: foobar"; "c" is needed to make the YAML document valid
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(yaml.getBytes())), 14);
+
+        assertTrue(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeClientYaml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  cluster-name: foobar";
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(yaml.getBytes()));
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertTrue(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeClientYamlPartialStreamRead() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  c"; // ...luster-name: foobar"; "c" is needed to make the YAML document valid
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(yaml.getBytes())), 21);
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertTrue(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeFailoverClientYaml() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = ""
+                + "hazelcast-client-failover:\n"
+                + "  cluster-name: foobar";
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(yaml.getBytes()));
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertTrue(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeFailoverClientYamlPartialStreamRead() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = ""
+                + "hazelcast-client-failover:\n"
+                + "  c"; // ...luster-name: foobar"; "c" is needed to make the YAML document valid
+        ConfigStream bis = new ConfigStream(new BufferedInputStream(new ByteArrayInputStream(yaml.getBytes())), 30);
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertTrue(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testInvalidYamlIsNotRecognized() throws Exception {
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer();
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer();
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer();
+
+        String yaml = "invalid-yaml";
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(yaml.getBytes()));
+
+        assertFalse(memberRecognizer.isRecognized(bis));
+        assertFalse(clientRecognizer.isRecognized(bis));
+        assertFalse(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    @Test
+    public void testRecognizeWithCustomConfigRecognizer() throws Exception {
+        ConfigRecognizer customRecognizer = new TestConfigRecognizer();
+        ConfigRecognizer memberRecognizer = new MemberConfigRecognizer(customRecognizer);
+        ConfigRecognizer clientRecognizer = new ClientConfigRecognizer(customRecognizer);
+        ConfigRecognizer clientFailoverRecognizer = new ClientFailoverConfigRecognizer(customRecognizer);
+
+        String config = "test-hazelcast-config";
+        ConfigStream bis = new ConfigStream(new ByteArrayInputStream(config.getBytes()));
+
+        assertTrue(memberRecognizer.isRecognized(bis));
+        assertTrue(clientRecognizer.isRecognized(bis));
+        assertTrue(clientFailoverRecognizer.isRecognized(bis));
+    }
+
+    private class TestConfigRecognizer implements ConfigRecognizer {
+
+        @Override
+        public boolean isRecognized(ConfigStream configStream) throws Exception {
+            String firstLine;
+            try (Scanner scanner = new Scanner(configStream)) {
+                firstLine = scanner.nextLine();
+            }
+
+            return "test-hazelcast-config".equalsIgnoreCase(firstLine);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigStreamTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import static java.lang.Math.min;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ConfigStreamTest {
+    private static final byte[] TEST_BYTES = "test-bytes".getBytes();
+
+    @Parameters(name = "readLimit={0}, expectedRead={1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {TEST_BYTES.length, "test-bytes"},
+                {ConfigStream.DEFAULT_READ_LIMIT_4K, "test-bytes"},
+                {4, "test"}
+        });
+    }
+
+    @Parameter(0)
+    public int readLimit;
+    @Parameter(1)
+    public String expectedRead;
+
+    @Test
+    public void resetableIsReused() throws IOException {
+        InputStream mockIs = givenMockedInputStream();
+
+        ConfigStream configStream = new ConfigStream(mockIs);
+        verify(mockIs).reset();
+
+        reset(mockIs);
+        stubReadByteArr(mockIs);
+
+        byte[] actualBytes = new byte[expectedRead.getBytes().length];
+        configStream.read(actualBytes);
+        verify(mockIs).read(any(byte[].class));
+        assertArrayEquals(expectedRead.getBytes(), actualBytes);
+    }
+
+    @Test
+    public void nonResetableIsCopied() throws IOException {
+        InputStream mockIs = givenMockedInputStream();
+        doThrow(IOException.class).when(mockIs).reset();
+
+        ConfigStream configStream = new ConfigStream(mockIs);
+        verify(mockIs).reset();
+
+        reset(mockIs);
+
+        byte[] actualBytes = new byte[expectedRead.getBytes().length];
+        configStream.read(actualBytes);
+        verifyZeroInteractions(mockIs);
+        assertArrayEquals(expectedRead.getBytes(), actualBytes);
+    }
+
+    @Test
+    public void markableIsReused() throws IOException {
+        InputStream mockIs = givenMarkableMockedInputStream();
+
+        ConfigStream configStream = new ConfigStream(mockIs);
+        verify(mockIs).markSupported();
+
+        reset(mockIs);
+        stubReadByteArr(mockIs);
+
+        byte[] actualBytes = new byte[expectedRead.getBytes().length];
+        configStream.read(actualBytes);
+        verify(mockIs).read(any(byte[].class));
+        assertArrayEquals(expectedRead.getBytes(), actualBytes);
+    }
+
+    @Test
+    public void nonMarkableIsCopied() throws IOException {
+        InputStream mockIs = givenNonMarkableMockedInputStream();
+
+        ConfigStream configStream = new ConfigStream(mockIs);
+        verify(mockIs).markSupported();
+
+        reset(mockIs);
+
+        byte[] actualBytes = new byte[expectedRead.getBytes().length];
+        configStream.read(actualBytes);
+        verifyZeroInteractions(mockIs);
+        assertArrayEquals(expectedRead.getBytes(), actualBytes);
+    }
+
+    private InputStream givenMockedInputStream() throws IOException {
+        return givenMockedInputStream(true);
+    }
+
+    private InputStream givenMarkableMockedInputStream() throws IOException {
+        return givenMockedInputStream(true);
+    }
+
+    private InputStream givenNonMarkableMockedInputStream() throws IOException {
+        return givenMockedInputStream(false);
+    }
+
+    private InputStream givenMockedInputStream(boolean markable) throws IOException {
+        InputStream mockIs = mock(InputStream.class);
+        when(mockIs.markSupported()).thenReturn(markable);
+        stubReadByteArr(mockIs);
+        return mockIs;
+    }
+
+    private void stubReadByteArr(InputStream mockIs) throws IOException {
+        // copy the TEST_BYTES to the byte[] argument
+        when(mockIs.read(any(byte[].class))).thenAnswer(invocation -> {
+            byte[] targetArr = invocation.getArgument(0);
+            System.arraycopy(TEST_BYTES, 0, targetArr, 0, targetArr.length);
+            return targetArr.length;
+        });
+        // copy the TEST_BYTES to the byte[] argument with the limits taken into account
+        when(mockIs.read(any(byte[].class), anyInt(), anyInt())).thenAnswer(invocation -> {
+            byte[] targetArr = invocation.getArgument(0);
+            int src = invocation.getArgument(1);
+            int len = invocation.getArgument(2);
+            System.arraycopy(TEST_BYTES, src, targetArr, src, min(len, TEST_BYTES.length - src));
+            return targetArr.length;
+        });
+    }
+
+}


### PR DESCRIPTION
Almost 1:1 backport of https://github.com/hazelcast/hazelcast/pull/16958
The only resolved conflict is in `IOUtil` in an import.

This commit introduces the `ConfigRecognition` API that is meant to
recognize if a provided declarative configuration is recognized by the
rules defined in a given implementation. The main use case for this
implementation is to recognize member, client and failover client XML
and YAML configurations just by looking into the content of the
configuration, without building any actual configuration.

Along with the API the following three implementations are added:
- `MemberConfigRecognizer` for recognizing member XML and YAML
configurations
- `ClientConfigRecognizer` for recognizing client XML and YAML
configurations
- `ClientFailoverConfigRecognizer` for recognizing failover client XML and
YAML configurations

All the three are extensible with custom recognizers so that even those
configurations can be recognized that would otherwise remain
unrecognized with the built-in set of recognizers that recognizes XML
and YAML configurations by checking the root node in the provided
configuration.

The API recognizes configuration provided in InputStreams only, while
the ConfigBuilder implementations can be built from files defined by
their location and URLs too. The reason for lacking the support for
these two options is that both are easy to convert to InputStreams and
that handling errors caused by non-existing resources, missing
privileges etc should be handled outside of this API with potentially
having more contextual information.

The built-in implementations honor parse errors with unrecognized
configuration. The reason is that the provided InputStream can be tested
both for XML and YAML configuration and at least one is expected to
lead to parse errors.

Implements #16866