### PR TITLE
[BACKPORT] Fixes test failure in event journal test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
@@ -48,10 +48,11 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.journal.EventJournalEventAdapter.EventType.ADDED;
 import static com.hazelcast.journal.EventJournalEventAdapter.EventType.EVICTED;
 import static com.hazelcast.journal.EventJournalEventAdapter.EventType.LOADED;
-import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -482,34 +483,34 @@ public abstract class AbstractEventJournalBasicTest<EJ_TYPE> extends HazelcastTe
         assertEquals(-1, state.getNewestSequence());
         assertEventJournalSize(context.dataAdapter, 0);
 
-        final String key = randomPartitionKey();
         final Integer value = RANDOM.nextInt();
         final CountDownLatch latch = new CountDownLatch(1);
         final int startSequence = 1;
 
         final BiConsumer<ReadResultSet<EJ_TYPE>, Throwable> callback = (response, t) -> {
             if (t == null) {
+                latch.countDown();
                 assertEquals(1, response.size());
                 final EventJournalEventAdapter<String, Integer, EJ_TYPE> journalAdapter = context.eventJournalAdapter;
                 final EJ_TYPE e = response.get(0);
 
                 assertEquals(ADDED, journalAdapter.getType(e));
-                assertEquals(key, journalAdapter.getKey(e));
                 assertEquals(value, journalAdapter.getNewValue(e));
-                assertNotEquals(startSequence + response.readCount(), response.getNextSequenceToReadFrom());
-                assertEquals(1, response.getNextSequenceToReadFrom());
-                latch.countDown();
             } else {
-                t.printStackTrace();
+                rethrow(t);
             }
         };
-        readFromEventJournal(context.dataAdapter, startSequence, 1, partitionId, TRUE_PREDICATE, IDENTITY_FUNCTION)
-                .whenCompleteAsync(callback);
+        CompletionStage<ReadResultSet<EJ_TYPE>> callbackStage =
+                readFromEventJournal(context.dataAdapter, startSequence, 1, partitionId, TRUE_PREDICATE, IDENTITY_FUNCTION)
+                    .whenCompleteAsync(callback);
 
-        context.dataAdapter.put(key, value);
+        assertTrueEventually(() -> {
+            context.dataAdapter.put(randomPartitionKey(), value);
+            assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+        }, 30);
 
-        assertOpenEventually(latch, 30);
-        assertEventJournalSize(context.dataAdapter, 1);
+        // ensure no exception thrown from callback
+        callbackStage.toCompletableFuture().join();
     }
 
     /**


### PR DESCRIPTION
Fixes `allowReadingWithFutureSeq` to account for
potential reordering of invocations.
In the specific test, the request to read
from event journal with a future sequence may be
reordered with put request when a client is not yet
aware of partition owners.
Additionally, in order to unblock the event journal
reader several puts may be required.

Backport of #17095 for `4.0.z` branch