### PR TITLE
Make client not wait for next connection attempt on shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -321,8 +321,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         if (!isAlive.compareAndSet(true, false)) {
             return;
         }
-
-        ClientExecutionServiceImpl.shutdownExecutor("cluster", executor, logger);
+        executor.shutdownNow();
+        ClientExecutionServiceImpl.awaitExecutorTermination("cluster", executor, logger);
         for (Connection connection : activeConnections.values()) {
             connection.close("Hazelcast client is shutting down", null);
         }
@@ -453,7 +453,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         return true;
                     }
                 }
-
                 // If the address providers load no addresses (which seems to be possible), then the above loop is not entered
                 // and the lifecycle check is missing, hence we need to repeat the same check at this point.
                 checkClientActive();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientExecutionServiceImpl.java
@@ -56,10 +56,10 @@ public final class ClientExecutionServiceImpl implements TaskScheduler, StaticMe
         logger = loggingService.getLogger(TaskScheduler.class);
         internalExecutor = new LoggingScheduledExecutor(logger, internalPoolSize,
                 new PoolExecutorThreadFactory(name + ".internal-", classLoader), (r, executor) -> {
-                    String message = "Internal executor rejected task: " + r + ", because client is shutting down...";
-                    logger.finest(message);
-                    throw new RejectedExecutionException(message);
-                });
+            String message = "Internal executor rejected task: " + r + ", because client is shutting down...";
+            logger.finest(message);
+            throw new RejectedExecutionException(message);
+        });
     }
 
     @Override
@@ -83,11 +83,11 @@ public final class ClientExecutionServiceImpl implements TaskScheduler, StaticMe
     }
 
     public void shutdown() {
-        shutdownExecutor("internal", internalExecutor, logger);
+        internalExecutor.shutdown();
+        awaitExecutorTermination("internal", internalExecutor, logger);
     }
 
-    public static void shutdownExecutor(String name, ExecutorService executor, ILogger logger) {
-        executor.shutdown();
+    public static void awaitExecutorTermination(String name, ExecutorService executor, ILogger logger) {
         try {
             boolean success = executor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!success) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
@@ -238,7 +238,8 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
 
     public void shutdown() {
         eventExecutor.shutdown();
-        ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger);
+        registrationExecutor.shutdown();
+        ClientExecutionServiceImpl.awaitExecutorTermination("registrationExecutor", registrationExecutor, logger);
     }
 
     public void start() {


### PR DESCRIPTION
TcpClientConnectionManager was waiting for all executor tasks to
complete without interrupting them.

shutdownExecutor is refactored as awaitExecutorTermination so that
callers of this method can decide to interrupt or not
(shutdown vs shutdownNow)

Leaving awaitExecutorTermination on TcpClientConnectionManager
so that ones that can not be interrupted will be caught and fixed.

(cherry picked from commit 40185c38e61c1d9b3d0051078dee8c23f0b57419)
backport of https://github.com/hazelcast/hazelcast/pull/17097