### PR TITLE
Allow longer metric words, fail-fast if exceeded (backport of #16869)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongWordException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.core.HazelcastException;
+
+public class LongWordException extends HazelcastException {
+    public LongWordException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
When metric dictionary word was longer than 127 characters, incorrect
compressed stream was produced. This PR pushes the limit to 255
characters and gracefully ignores the metric that violates the limit.

Also removes unnused `String[] dictionary` from `MetricsDictionary`.

Backport of: https://github.com/hazelcast/hazelcast/pull/16869

Related to hazelcast/hazelcast-jet#2155