### PR TITLE
[4.0.2-migration] Fine-tuning cluster properties for EE WAN throttling (#17092)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1108,6 +1108,63 @@ public final class ClusterProperty {
     @Deprecated
     public static final HazelcastProperty MC_TRUSTED_INTERFACES = new HazelcastProperty("hazelcast.mc.trusted.interfaces");
 
+    /**
+     * Defines the pending invocation threshold for the Enterprise WAN
+     * replication implementation. Exceeding this threshold on a WAN
+     * consumer member makes the member delaying the WAN acknowledgment,
+     * thus slowing down the WAN publishers on the source side that send
+     * WAN events to the given WAN consumer. Setting this value to
+     * negative turns off the acknowledgement delaying feature.
+     *
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_INIT_MS
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_MAX_MS
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_MULTIPLIER
+     */
+    public static final HazelcastProperty WAN_CONSUMER_INVOCATION_THRESHOLD
+            = new HazelcastProperty("hazelcast.wan.consumer.invocation.threshold", 50000);
+
+    /**
+     * Defines the initial backoff delay for the Enterprise WAN
+     * implementation's consumer. It is used if the acknowledgment
+     * delaying feature is enabled by setting
+     * {@link #WAN_CONSUMER_INVOCATION_THRESHOLD} to a non-negative value
+     * and that the threshold is exceeded.
+     *
+     * @see #WAN_CONSUMER_INVOCATION_THRESHOLD
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_MAX_MS
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_MULTIPLIER
+     */
+    public static final HazelcastProperty WAN_CONSUMER_ACK_DELAY_BACKOFF_INIT_MS
+            = new HazelcastProperty("hazelcast.wan.consumer.ack.delay.backoff.init", 1);
+
+    /**
+     * Defines the maximum backoff delay for the Enterprise WAN
+     * implementation's consumer. It is used if the acknowledgment
+     * delaying feature is enabled by setting
+     * {@link #WAN_CONSUMER_INVOCATION_THRESHOLD} to a non-negative value
+     * and that the threshold is exceeded.
+     *
+     * @see #WAN_CONSUMER_INVOCATION_THRESHOLD
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_INIT_MS
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_MULTIPLIER
+     */
+    public static final HazelcastProperty WAN_CONSUMER_ACK_DELAY_BACKOFF_MAX_MS
+            = new HazelcastProperty("hazelcast.wan.consumer.ack.delay.backoff.max", 100);
+
+    /**
+     * Defines the multiplier (the speed of the function) for the backoff
+     * delay for the Enterprise WAN implementation's consumer. It is used
+     * if the acknowledgment delaying feature is enabled by setting
+     * {@link #WAN_CONSUMER_INVOCATION_THRESHOLD} to a non-negative value
+     * and that the threshold is exceeded.
+     *
+     * @see #WAN_CONSUMER_INVOCATION_THRESHOLD
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_INIT_MS
+     * @see #WAN_CONSUMER_ACK_DELAY_BACKOFF_MAX_MS
+     */
+    public static final HazelcastProperty WAN_CONSUMER_ACK_DELAY_BACKOFF_MULTIPLIER
+            = new HazelcastProperty("hazelcast.wan.consumer.ack.delay.backoff.multiplier", "1.5");
+
     private ClusterProperty() {
     }
 }


### PR DESCRIPTION
Adding the fine-tuning group properties for the EE WAN throttling
feature.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3637
Clean port of: https://github.com/hazelcast/hazelcast/pull/17092