### PR TITLE
Fixed shade plugin configuration in the SQL module (#16960)

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -97,7 +97,9 @@
                                 <relocation>
                                     <pattern>com.</pattern>
                                     <shadedPattern>${relocation.root}.com.</shadedPattern>
-                                    <excludes>com.hazelcast.**</excludes>
+                                    <excludes>
+                                        <exclude>com.hazelcast.**</exclude>
+                                    </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.</pattern>


### PR DESCRIPTION
This PR fixes an incorrect `<excludes>` tag in the SQL module's "shade" plugin configuration.

Closes #16960 