### PR TITLE
Auditlog - configuration and events

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -24,6 +24,7 @@ import com.hazelcast.collection.ISet;
 import com.hazelcast.collection.QueueStore;
 import com.hazelcast.collection.QueueStoreFactory;
 import com.hazelcast.config.AttributeConfig;
+import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.AzureConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
@@ -1426,6 +1427,15 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(lockConfig2);
         assertEquals(1, lockConfig1.getLockAcquireLimit());
         assertEquals(2, lockConfig2.getLockAcquireLimit());
+    }
+
+    @Test
+    public void testAuditlogConfig() {
+        AuditlogConfig auditlogConfig = config.getAuditlogConfig();
+        assertFalse(auditlogConfig.isEnabled());
+        assertEquals("com.acme.AuditlogToSyslogFactory", auditlogConfig.getFactoryClassName());
+        assertEquals("syslogserver.acme.com", auditlogConfig.getProperty("host"));
+        assertEquals("514", auditlogConfig.getProperty("port"));
     }
 
     @Test

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -977,6 +977,13 @@
                 <hz:operation-pool-size>20</hz:operation-pool-size>
                 <hz:query-timeout-millis>30</hz:query-timeout-millis>
             </hz:sql>
+
+            <hz:auditlog enabled="false" factory-class-name="com.acme.AuditlogToSyslogFactory">
+                <hz:properties>
+                    <hz:property name="host">syslogserver.acme.com</hz:property>
+                    <hz:property name="port">514</hz:property>
+                </hz:properties>
+            </hz:auditlog>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -19,6 +19,7 @@ package com.hazelcast.spring;
 import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.AttributeConfig;
+import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -339,6 +340,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleInstanceTracking(node);
                     } else if ("sql".equals(nodeName)) {
                         handleSql(node);
+                    } else if ("auditlog".equals(nodeName)) {
+                        handleAuditlog(node);
                     }
                 }
             }
@@ -2124,6 +2127,18 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
 
             configBuilder.addPropertyValue("sqlConfig", sqlConfigBuilder.getBeanDefinition());
+        }
+
+        private void handleAuditlog(Node node) {
+            BeanDefinitionBuilder builder = createBeanBuilder(AuditlogConfig.class);
+            fillValues(node, builder);
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("properties".equals(nodeName)) {
+                    handleProperties(child, builder);
+                }
+            }
+            configBuilder.addPropertyValue("auditlogConfig", builder.getBeanDefinition());
         }
     }
 }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -1360,6 +1360,7 @@
                         <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="sql" type="sql" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="auditlog" type="auditlog" minOccurs="0" maxOccurs="1"/>
                     </xs:choice>
                 </xs:extension>
             </xs:complexContent>
@@ -5180,4 +5181,11 @@
         <xs:attributeGroup ref="class-or-bean-name"/>
     </xs:complexType>
 
+    <xs:complexType name="auditlog">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" default="false" type="xs:string"/>
+        <xs:attribute name="factory-class-name" type="xs:string" use="optional"/>
+    </xs:complexType>
 </xs:schema>

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/AuditableEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/AuditableEvent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.auditlog;
+package com.hazelcast.auditlog;
 
 import java.util.Map;
 
@@ -29,11 +29,20 @@ public interface AuditableEvent {
     String typeId();
 
     /**
+     * Return a text description of the event.
+     * <p>
+     * <strong>Warning:</strong> Hazelcast doesn't guarantee content of the message. The value can change between versions.
+     *
      * @return Event message
      */
     String message();
 
     /**
+     * Return Map of parameters for given event.
+     * <p>
+     * <strong>Warning:</strong> Hazelcast doesn't guarantee content of the parameters Map (parameters, names, values
+     * or types used). The value can change between versions.
+     *
      * @return Event parameters. Must not be {@code null}.
      */
     Map<String, Object> parameters();

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/AuditlogService.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/AuditlogService.java
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.auditlog;
+package com.hazelcast.auditlog;
 
 /**
- * Service for logging {@link AuditableEvent AuditableEvents}.
+ * Service for logging {@link AuditableEvent AuditableEvents}. Standard events have their type identifiers defined as constants
+ * in the {@link AuditlogTypeIds} class.
+ * <p>
+ * The invocations on this interface may be done in performance sensitive places so the implementation should not do anything
+ * too heavy.
  */
 public interface AuditlogService {
 
@@ -48,10 +52,11 @@ public interface AuditlogService {
 
     /**
      * Returns an instance of the {@link EventBuilder} interface. It can be performance optimized (e.g. when Event Audit logging
-     * is disabled).
+     * is disabled). The {@link EventBuilder} allows creating {@link AuditableEvent auditable events} by using simple fluent
+     * API.
      *
-     * @param typeId
-     * @return
+     * @param typeId Unique identifier for given type of auditable event.
+     * @return {@link EventBuilder} instance
      */
     EventBuilder<?> eventBuilder(String typeId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/AuditlogServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/AuditlogServiceFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.auditlog;
+
+import java.util.Properties;
+
+import javax.security.auth.callback.CallbackHandler;
+
+/**
+ * Interface implemented by {@link AuditlogService} factory classes.
+ */
+public interface AuditlogServiceFactory {
+
+    /**
+     * Initializes this class with given properties. The callbackCandler can provide access to member internals.
+     *
+     * @param callbackHandler callback handler which provides access to member internals
+     * @param properties properties from the config
+     */
+    void init(CallbackHandler callbackHandler, Properties properties) throws Exception;
+
+    /**
+     * Creates the configured {@link AuditlogService} instance.
+     */
+    AuditlogService createAuditlog() throws Exception;
+}

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/AuditlogTypeIds.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/AuditlogTypeIds.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.auditlog;
+
+/**
+ * Auditable event type identifiers.
+ *
+ * @see AuditableEvent#typeId()
+ */
+public final class AuditlogTypeIds {
+
+    // Network Events
+    /**
+     * Event type ID: Connection accepted.
+     */
+    public static final String NETWORK_CONNECT = "HZ-0101";
+    /**
+     * Event type ID: Connection closed.
+     */
+    public static final String NETWORK_DISCONNECT = "HZ-0102";
+    /**
+     * Event type ID: Protocol selected.
+     */
+    public static final String NETWORK_SELECT_PROTOCOL = "HZ-0103";
+
+    // WAN
+    /**
+     * Event type ID: WAN sync.
+     */
+    public static final String WAN_SYNC = "HZ-0201";
+    /**
+     * Event type ID: WAN add config.
+     */
+    public static final String WAN_ADD_CONFIG = "HZ-0202";
+
+    // Authentication
+    /**
+     * Event type ID: Client authentication.
+     */
+    public static final String AUTHENTICATION_CLIENT = "HZ-0501";
+    /**
+     * Event type ID: Member authentication.
+     */
+    public static final String AUTHENTICATION_MEMBER = "HZ-0502";
+    /**
+     * Event type ID: REST authentication.
+     */
+    public static final String AUTHENTICATION_REST = "HZ-0503";
+
+    // Cluster events
+    /**
+     * Event type ID: Member joined.
+     */
+    public static final String CLUSTER_MEMBER_ADDED = "HZ-0601";
+    /**
+     * Event type ID: Member removed from the cluster.
+     */
+    public static final String CLUSTER_MEMBER_REMOVED = "HZ-0602";
+    /**
+     * Event type ID: Lite member promoted.
+     */
+    public static final String CLUSTER_PROMOTE_MEMBER = "HZ-0603";
+    /**
+     * Event type ID: Cluster shutdown.
+     */
+    public static final String CLUSTER_SHUTDOWN = "HZ-0604";
+    /**
+     * Event type ID: Cluster member suspected.
+     */
+    public static final String CLUSTER_MEMBER_SUSPECTED = "HZ-0605";
+    /**
+     * Event type ID: Clusters merged.
+     */
+    public static final String CLUSTER_MERGE = "HZ-0606";
+
+    private AuditlogTypeIds() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/EventBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/EventBuilder.java
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.auditlog;
+package com.hazelcast.auditlog;
 
 import java.util.Map;
 
 /**
  * Builder interface for {@link AuditableEvent} instances. The mandatory typeId is expected to be initiated by constructing the
  * builder.
+ * <p>
+ * <strong>Warning:</strong> The {@link #message(String) text message} and {@link #addParameter(String, Object) object
+ * parameters} may provide more details about the event, but Hazelcast doesn't guarantee their content (e.g. exact text value of
+ * the message, parameter names, object types used in parameters). They can change between versions.
  *
  * @see AuditlogService#eventBuilder(String)
  * @param <T> builder type

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/Level.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/Level.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.auditlog;
+
+/**
+ * Event importance levels.
+ */
+public enum Level {
+
+    /**
+     * Debug level.
+     */
+    DEBUG,
+
+    /**
+     * Info level.
+     */
+    INFO,
+
+    /**
+     * Warning level.
+     */
+    WARN,
+
+    /**
+     * Error level.
+     */
+    ERROR;
+}

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/impl/NoOpAuditlogService.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/impl/NoOpAuditlogService.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.auditlog.impl;
+package com.hazelcast.auditlog.impl;
 
 import java.util.Collections;
 import java.util.Map;
 
-import com.hazelcast.internal.auditlog.AuditableEvent;
-import com.hazelcast.internal.auditlog.EventBuilder;
-import com.hazelcast.internal.auditlog.AuditlogService;
-import com.hazelcast.internal.auditlog.Level;
+import com.hazelcast.auditlog.AuditableEvent;
+import com.hazelcast.auditlog.AuditlogService;
+import com.hazelcast.auditlog.EventBuilder;
+import com.hazelcast.auditlog.Level;
 
 public final class NoOpAuditlogService implements AuditlogService {
 

--- a/hazelcast/src/main/java/com/hazelcast/auditlog/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/auditlog/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains interfaces and classes related to auditable events.
+ */
+package com.hazelcast.auditlog;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -43,6 +43,7 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.RingbufferStoreConf
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.config.AdvancedNetworkConfig;
+import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
@@ -1013,6 +1014,16 @@ public class ClientDynamicClusterConfig extends Config {
     @Override
     @Nonnull
     public Config setSqlConfig(@Nonnull SqlConfig sqlConfig) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public AuditlogConfig getAuditlogConfig() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setAuditlogConfig(AuditlogConfig auditlogConfig) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractFactoryWithPropertiesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractFactoryWithPropertiesConfig.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static com.hazelcast.internal.util.Preconditions.checkHasText;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Configuration base for config types with a factory class and its properties.
+ *
+ * @param <T> final child type
+ */
+public abstract class AbstractFactoryWithPropertiesConfig<T extends AbstractFactoryWithPropertiesConfig<T>> {
+
+    protected boolean enabled;
+    protected String factoryClassName;
+    protected Properties properties = new Properties();
+
+    /**
+     * Returns the factory class name.
+     */
+    public String getFactoryClassName() {
+        return factoryClassName;
+    }
+
+    /**
+     * Sets the factory class name.
+     */
+    public T setFactoryClassName(@Nonnull String factoryClassName) {
+        this.factoryClassName =  checkHasText(factoryClassName, "The factoryClassName cannot be null!");
+        return self();
+    }
+
+    /**
+     * Returns if this configuration is enabled.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables and disables this configuration.
+     *
+     * @param enabled {@code true} to enable, {@code false} to disable
+     */
+    public T setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return self();
+    }
+
+    /**
+     * Sets a single property.
+     *
+     * @param name  the name of the property to set
+     * @param value the value of the property to set
+     * @return the updated config object (self)
+     * @throws NullPointerException if name or value is {@code null}
+     */
+    public T setProperty(String name, String value) {
+        properties.put(name, value);
+        return self();
+    }
+
+    /**
+     * Gets a property.
+     *
+     * @param name the name of the property to get
+     * @return the value of the property, null if not found
+     * @throws NullPointerException if name is {@code null}
+     */
+    public String getProperty(String name) {
+        return properties.getProperty(name);
+    }
+
+    /**
+     * Gets all properties.
+     *
+     * @return the properties
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    /**
+     * Sets the properties.
+     *
+     * @param properties the properties to set
+     * @return the updated config object (self)
+     * @throws IllegalArgumentException if properties is {@code null}
+     */
+    public T setProperties(@Nonnull Properties properties) {
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+        this.properties = properties;
+        return self();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{"
+                + "factoryClassName='" + factoryClassName + '\''
+                + ", enabled=" + enabled
+                + ", properties=" + properties
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractFactoryWithPropertiesConfig<?> otherConfig = (AbstractFactoryWithPropertiesConfig<?>) o;
+
+        return Objects.equals(enabled, otherConfig.enabled)
+            && Objects.equals(properties, otherConfig.properties)
+            && Objects.equals(factoryClassName, otherConfig.factoryClassName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, factoryClassName, properties);
+    }
+
+    protected abstract T self();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AuditlogConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AuditlogConfig.java
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.auditlog.impl;
+package com.hazelcast.config;
 
-public final class AuditlogTypeIds {
+/**
+ * Auditlog configuration.
+ */
+public final class AuditlogConfig extends AbstractFactoryWithPropertiesConfig<AuditlogConfig> {
 
-    public static final String CONNECTION_ASKS_PROTOCOL = "HZ-1001";
-
-    private AuditlogTypeIds() {
+    @Override
+    protected AuditlogConfig self() {
+        return this;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -178,6 +178,8 @@ public class Config {
 
     private SqlConfig sqlConfig = new SqlConfig();
 
+    private AuditlogConfig auditlogConfig = new AuditlogConfig();
+
     private MetricsConfig metricsConfig = new MetricsConfig();
 
     private InstanceTrackingConfig instanceTrackingConfig = new InstanceTrackingConfig();
@@ -2633,6 +2635,17 @@ public class Config {
         return this;
     }
 
+    @Nonnull
+    public AuditlogConfig getAuditlogConfig() {
+        return auditlogConfig;
+    }
+
+    @Nonnull
+    public Config setAuditlogConfig(@Nonnull AuditlogConfig auditlogConfig) {
+        this.auditlogConfig = checkNotNull(auditlogConfig, "auditlogConfig");
+        return this;
+    }
+
     /**
      * @return Return SQL config.
      */
@@ -2727,6 +2740,7 @@ public class Config {
                 + ", cpSubsystemConfig=" + cpSubsystemConfig
                 + ", sqlConfig=" + sqlConfig
                 + ", metricsConfig=" + metricsConfig
+                + ", auditlogConfig=" + auditlogConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
@@ -20,40 +20,25 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 import java.util.Properties;
 
-import static com.hazelcast.internal.util.Preconditions.checkHasText;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * SSL configuration.
  */
-public final class SSLConfig {
+public final class SSLConfig extends AbstractFactoryWithPropertiesConfig<SSLConfig> {
 
-    private boolean enabled;
-    private String factoryClassName;
     private Object factoryImplementation;
-    private Properties properties = new Properties();
 
     public SSLConfig() {
     }
 
     public SSLConfig(SSLConfig sslConfig) {
-        enabled = sslConfig.enabled;
-        factoryClassName = sslConfig.factoryClassName;
         factoryImplementation = sslConfig.factoryImplementation;
-        properties = new Properties();
-        properties.putAll(sslConfig.properties);
-    }
-
-    /**
-     * Returns the name of the implementation class.
-     * <p>
-     * Class can either be an {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@code com.hazelcast.nio.ssl.SSLEngineFactory}
-     * (Enterprise edition).
-     *
-     * @return the name implementation class
-     */
-    public String getFactoryClassName() {
-        return factoryClassName;
+        setEnabled(sslConfig.isEnabled());
+        factoryClassName = sslConfig.getFactoryClassName();
+        Properties properties = new Properties();
+        properties.putAll(sslConfig.getProperties());
+        setProperties(properties);
     }
 
     /**
@@ -65,27 +50,8 @@ public final class SSLConfig {
      * @param factoryClassName the name implementation class
      */
     public SSLConfig setFactoryClassName(@Nonnull String factoryClassName) {
-        this.factoryClassName = checkHasText(factoryClassName, "SSL context factory class name cannot be null!");
+        super.setFactoryClassName(factoryClassName);
         this.factoryImplementation = null;
-        return this;
-    }
-
-    /**
-     * Returns if this configuration is enabled.
-     *
-     * @return {@code true} if enabled, {@code false} otherwise
-     */
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    /**
-     * Enables and disables this configuration.
-     *
-     * @param enabled {@code true} to enable, {@code false} to disable
-     */
-    public SSLConfig setEnabled(boolean enabled) {
-        this.enabled = enabled;
         return this;
     }
 
@@ -100,7 +66,7 @@ public final class SSLConfig {
      */
     public SSLConfig setFactoryImplementation(@Nonnull Object factoryImplementation) {
         this.factoryImplementation = checkNotNull(factoryImplementation, "SSL context factory cannot be null!");
-        this.factoryClassName = null;
+        factoryClassName = null;
         return this;
     }
 
@@ -116,83 +82,38 @@ public final class SSLConfig {
         return factoryImplementation;
     }
 
-    /**
-     * Sets a property.
-     *
-     * @param name  the name of the property to set
-     * @param value the value of the property to set
-     * @return the updated SSLConfig
-     * @throws NullPointerException if name or value is {@code null}
-     */
-    public SSLConfig setProperty(String name, String value) {
-        properties.put(name, value);
-        return this;
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(factoryImplementation);
+        return result;
     }
 
-    /**
-     * Gets a property.
-     *
-     * @param name the name of the property to get
-     * @return the value of the property, null if not found
-     * @throws NullPointerException if name is {@code null}
-     */
-    public String getProperty(String name) {
-        return properties.getProperty(name);
-    }
-
-    /**
-     * Gets all properties.
-     *
-     * @return the properties
-     */
-    public Properties getProperties() {
-        return properties;
-    }
-
-    /**
-     * Sets the properties.
-     *
-     * @param properties the properties to set
-     * @return the updated SSLConfig
-     * @throws IllegalArgumentException if properties is {@code null}
-     */
-    public SSLConfig setProperties(Properties properties) {
-        if (properties == null) {
-            throw new IllegalArgumentException("properties can't be null");
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
         }
-        this.properties = properties;
-        return this;
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SSLConfig other = (SSLConfig) obj;
+        return Objects.equals(factoryImplementation, other.factoryImplementation);
     }
 
     @Override
     public String toString() {
-        return "SSLConfig{"
-                + "className='" + factoryClassName + '\''
-                + ", enabled=" + enabled
-                + ", implementation=" + factoryImplementation
-                + ", properties=" + properties
-                + '}';
+        return "SSLConfig [factoryImplementation=" + factoryImplementation + ", getFactoryClassName()=" + getFactoryClassName()
+                + ", isEnabled()=" + isEnabled() + ", getProperties()=" + getProperties() + "]";
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        SSLConfig sslConfig = (SSLConfig) o;
-
-        return Objects.equals(enabled, sslConfig.enabled)
-            && Objects.equals(properties, sslConfig.properties)
-            && Objects.equals(factoryImplementation, sslConfig.factoryImplementation)
-            && Objects.equals(factoryClassName, sslConfig.factoryClassName);
+    protected SSLConfig self() {
+        return this;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(enabled, factoryImplementation, factoryClassName, properties);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.instance.impl;
 
+import com.hazelcast.auditlog.AuditlogService;
+import com.hazelcast.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.impl.ClusterViewListenerService;
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.InstanceTrackingConfig;
@@ -39,8 +42,6 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.TextCommandServiceImpl;
-import com.hazelcast.internal.auditlog.AuditlogService;
-import com.hazelcast.internal.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.internal.cluster.ClusterStateListener;
 import com.hazelcast.internal.cluster.ClusterVersionListener;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
@@ -174,6 +175,12 @@ public class DefaultNodeExtension implements NodeExtension {
         if (symmetricEncryptionConfig != null && symmetricEncryptionConfig.isEnabled()) {
             if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
                 throw new IllegalStateException("Symmetric Encryption requires Hazelcast Enterprise Edition");
+            }
+        }
+        AuditlogConfig auditlogConfig = node.getConfig().getAuditlogConfig();
+        if (auditlogConfig != null && auditlogConfig.isEnabled()) {
+            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
+                throw new IllegalStateException("Auditlog requires Hazelcast Enterprise Edition");
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.instance.impl;
 
+import com.hazelcast.auditlog.AuditlogService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cp.internal.persistence.CPPersistenceService;
 import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.ascii.TextCommandService;
-import com.hazelcast.internal.auditlog.AuditlogService;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.internal.diagnostics.Diagnostics;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.auditlog.AuditlogTypeIds;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
@@ -373,14 +374,25 @@ public class ClusterJoinManager {
                 throw new SecurityException("Expecting security credentials, but credentials could not be found in join request");
             }
             String endpoint = joinRequest.getAddress().getHost();
+            Boolean passed = Boolean.FALSE;
             try {
                 String remoteClusterName = joinRequest.getConfigCheck().getClusterName();
                 LoginContext loginContext = node.securityContext.createMemberLoginContext(remoteClusterName, credentials,
                         connection);
                 loginContext.login();
+                passed = Boolean.TRUE;
             } catch (LoginException e) {
                 throw new SecurityException(format("Authentication has failed for %s @%s, cause: %s",
                         String.valueOf(credentials), endpoint, e.getMessage()));
+            } finally {
+                nodeEngine.getNode().getNodeExtension().getAuditlogService()
+                    .eventBuilder(AuditlogTypeIds.AUTHENTICATION_MEMBER)
+                    .message("Member connection authentication.")
+                    .addParameter("credentials", credentials)
+                    .addParameter("connection", connection)
+                    .addParameter("endpoint", endpoint)
+                    .addParameter("passed", passed)
+                    .log();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
@@ -20,6 +20,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.auditlog.AuditlogTypeIds;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -57,7 +58,11 @@ public class MergeClustersOp extends AbstractClusterOperation {
 
         logger.warning(node.getThisAddress() + " is merging to " + newTargetAddress
                 + ", because: instructed by master " + masterAddress);
-
+        node.getNodeExtension().getAuditlogService().eventBuilder(AuditlogTypeIds.CLUSTER_MERGE)
+            .message("Merging this cluster into another one")
+            .addParameter("masterAddress", masterAddress)
+            .addParameter("targetAddress", newTargetAddress)
+            .log();
         nodeEngine.getExecutionService().execute(SPLIT_BRAIN_HANDLER_EXECUTOR_NAME, () -> clusterService.merge(newTargetAddress));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.config;
 
+import com.hazelcast.config.AbstractFactoryWithPropertiesConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.InstanceTrackingConfig;
@@ -227,21 +228,24 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
     }
 
     protected SSLConfig parseSslConfig(Node node) {
-        SSLConfig sslConfig = new SSLConfig();
+        return fillFactoryWithPropertiesConfig(node, new SSLConfig());
+    }
+
+    protected <T extends AbstractFactoryWithPropertiesConfig<?>> T fillFactoryWithPropertiesConfig(Node node, T factoryConfig) {
         NamedNodeMap atts = node.getAttributes();
         Node enabledNode = atts.getNamedItem("enabled");
         boolean enabled = enabledNode != null && getBooleanValue(getTextContent(enabledNode));
-        sslConfig.setEnabled(enabled);
+        factoryConfig.setEnabled(enabled);
 
         for (Node n : childElements(node)) {
             String nodeName = cleanNodeName(n);
             if ("factory-class-name".equals(nodeName)) {
-                sslConfig.setFactoryClassName(getTextContent(n));
+                factoryConfig.setFactoryClassName(getTextContent(n));
             } else if ("properties".equals(nodeName)) {
-                fillProperties(n, sslConfig.getProperties());
+                fillProperties(n, factoryConfig.getProperties());
             }
         }
-        return sslConfig;
+        return factoryConfig;
     }
 
     protected void fillNativeMemoryConfig(Node node, NativeMemoryConfig nativeMemoryConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
@@ -62,6 +62,7 @@ public enum ConfigSections {
     ADVANCED_NETWORK("advanced-network", false),
     CP_SUBSYSTEM("cp-subsystem", false),
     METRICS("metrics", false),
+    AUDITLOG("auditlog", false),
     INSTANCE_TRACKING("instance-tracking", false),
     SQL("sql", false);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.AttributeConfig;
+import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.AutoDetectionConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.CacheDeserializedValues;
@@ -162,6 +163,7 @@ import static com.hazelcast.config.security.LdapRoleMappingMode.getRoleMappingMo
 import static com.hazelcast.config.security.LdapSearchScope.getSearchScope;
 import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.getConfigByTag;
 import static com.hazelcast.internal.config.ConfigSections.ADVANCED_NETWORK;
+import static com.hazelcast.internal.config.ConfigSections.AUDITLOG;
 import static com.hazelcast.internal.config.ConfigSections.CACHE;
 import static com.hazelcast.internal.config.ConfigSections.CARDINALITY_ESTIMATOR;
 import static com.hazelcast.internal.config.ConfigSections.CLUSTER_NAME;
@@ -337,6 +339,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             handleAdvancedNetwork(node);
         } else if (CP_SUBSYSTEM.isEqual(nodeName)) {
             handleCPSubsystem(node);
+        } else if (AUDITLOG.isEqual(nodeName)) {
+            config.setAuditlogConfig(fillFactoryWithPropertiesConfig(node, new AuditlogConfig()));
         } else if (METRICS.isEqual(nodeName)) {
             handleMetrics(node);
         } else if (INSTANCE_TRACKING.isEqual(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.AdvancedNetworkConfig;
+import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
@@ -1087,6 +1088,16 @@ public class DynamicConfigurationAwareConfig extends Config {
     @Nonnull
     @Override
     public Config setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public AuditlogConfig getAuditlogConfig() {
+        return staticConfig.getAuditlogConfig();
+    }
+
+    @Override
+    public Config setAuditlogConfig(AuditlogConfig auditlogConfig) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.server;
 
+import com.hazelcast.auditlog.AuditlogService;
 import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.MemcacheProtocolConfig;
@@ -23,7 +24,6 @@ import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.ascii.TextCommandService;
-import com.hazelcast.internal.auditlog.AuditlogService;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.serialization.InternalSerializationService;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.server.tcp;
 
+import com.hazelcast.auditlog.AuditlogTypeIds;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
@@ -288,7 +289,12 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
             if (logger.isFineEnabled()) {
                 logger.fine("Accepting socket connection from " + channel.socket().getRemoteSocketAddress());
             }
-
+            serverContext.getAuditLogService()
+                .eventBuilder(AuditlogTypeIds.NETWORK_CONNECT)
+                .message("New connection accepted.")
+                .addParameter("qualifier", qualifier)
+                .addParameter("socket", socketChannel.socket())
+                .log();
             if (serverContext.isSocketInterceptorEnabled(qualifier)) {
                 serverContext.executeAsync(() -> newConnection0(connectionManager, channel));
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.server.tcp;
 
+import com.hazelcast.auditlog.AuditlogTypeIds;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.networking.Channel;
@@ -226,6 +227,14 @@ public class TcpServerConnection implements ServerConnection {
 
         this.closeCause = cause;
         this.closeReason = reason;
+
+        serverContext.getAuditLogService()
+            .eventBuilder(AuditlogTypeIds.NETWORK_DISCONNECT)
+            .message("Closing server connection.")
+            .addParameter("reason", reason)
+            .addParameter("cause", cause)
+            .addParameter("remoteAddress", remoteAddress)
+            .log();
 
         logClose();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.server.tcp;
 
+import com.hazelcast.auditlog.AuditlogService;
 import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.AdvancedNetworkConfig;
@@ -31,7 +32,6 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
 import com.hazelcast.internal.ascii.TextCommandService;
-import com.hazelcast.internal.auditlog.AuditlogService;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.networking.InboundHandler;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.internal.server.tcp;
 
+import com.hazelcast.auditlog.AuditlogTypeIds;
+import com.hazelcast.auditlog.Level;
 import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.config.MemcacheProtocolConfig;
 import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.internal.auditlog.Level;
-import com.hazelcast.internal.auditlog.impl.AuditlogTypeIds;
 import com.hazelcast.internal.networking.ChannelOptions;
 import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.networking.InboundHandler;
@@ -91,7 +91,7 @@ public class UnifiedProtocolDecoder
             String protocol = loadProtocol();
 
             serverContext.getAuditLogService()
-                .eventBuilder(AuditlogTypeIds.CONNECTION_ASKS_PROTOCOL)
+                .eventBuilder(AuditlogTypeIds.NETWORK_SELECT_PROTOCOL)
                 .message("Protocol bytes received for a connection")
                 .level(Level.DEBUG)
                 .addParameter("protocol", protocol)

--- a/hazelcast/src/main/java/com/hazelcast/security/LoggingServiceCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/LoggingServiceCallback.java
@@ -14,11 +14,24 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.auditlog;
+package com.hazelcast.security;
+
+import javax.security.auth.callback.Callback;
+
+import com.hazelcast.logging.LoggingService;
 
 /**
- * Event importance levels.
+ * This JAAS {@link Callback} is used to retrieve a {@link LoggingService} from the current member.
  */
-public enum Level {
-    DEBUG, INFO, WARN, ERROR;
+public class LoggingServiceCallback implements Callback {
+
+    private LoggingService loggingService;
+
+    public LoggingService getLoggingService() {
+        return loggingService;
+    }
+
+    public void setLoggingService(LoggingService loggingService) {
+        this.loggingService = loggingService;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1037,8 +1037,6 @@ public final class ClusterProperty {
     public static final HazelcastProperty CLIENT_PROTOCOL_UNVERIFIED_MESSAGE_BYTES =
             new HazelcastProperty("hazelcast.client.protocol.max.message.bytes", 4096);
 
-    public static final HazelcastProperty AUDIT_LOG_ENABLED = new HazelcastProperty("hazelcast.auditlog.enabled", false);
-
     /**
      * The interval at which network stats (bytes sent and received) are re-calculated and published.
      * Used only when Advanced Networking is enabled.

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -70,6 +70,7 @@
                 <xs:element name="pn-counter" type="pn-counter" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="advanced-network" type="advanced-network" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="cp-subsystem" type="cp-subsystem" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="auditlog" type="factory-class-with-properties" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="sql" type="sql" minOccurs="0" maxOccurs="1"/>
@@ -1285,7 +1286,13 @@
             </xs:element>
             <xs:element name="join" type="join" minOccurs="0" maxOccurs="1"/>
             <xs:element name="interfaces" type="interfaces" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ssl" type="factory-class-with-properties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        SSL configuration with com.hazelcast.nio.ssl.SSLContextFactory used as the factory type.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
             <xs:element name="symmetric-encryption" type="symmetric-encryption" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
@@ -2421,12 +2428,12 @@
             </xs:element>
         </xs:all>
     </xs:complexType>
-    <xs:complexType name="ssl">
+    <xs:complexType name="factory-class-with-properties">
         <xs:all>
             <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        The name of the com.hazelcast.nio.ssl.SSLContextFactory implementation class.
+                        Full factory classname.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -2435,26 +2442,7 @@
         <xs:attribute name="enabled" default="false" type="xs:boolean">
             <xs:annotation>
                 <xs:documentation>
-                    True to enable this ssl configuration, false to disable.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <xs:complexType name="mutual-auth">
-        <xs:all>
-            <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        The name of the com.hazelcast.nio.ssl.SSLContextFactory implementation class.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
-        </xs:all>
-        <xs:attribute name="enabled" default="false" type="xs:boolean">
-            <xs:annotation>
-                <xs:documentation>
-                    True to enable this mutual-auth configuration, false to disable.
+                    True to enable this configuration element, false to disable.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -3597,7 +3585,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1">
+            <xs:element name="ssl" type="factory-class-with-properties" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         SSL/TLS configuration for HTTPS connections.
@@ -4214,7 +4202,7 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="interfaces" type="interfaces" minOccurs="0"/>
-            <xs:element name="ssl" type="ssl" minOccurs="0"/>
+            <xs:element name="ssl" type="factory-class-with-properties" minOccurs="0"/>
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0"/>
             <xs:element name="symmetric-encryption" type="symmetric-encryption" minOccurs="0"/>
             <xs:element name="socket-options" type="socket-options" minOccurs="0"/>
@@ -4283,7 +4271,7 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="interfaces" type="interfaces" minOccurs="0"/>
-            <xs:element name="ssl" type="ssl" minOccurs="0"/>
+            <xs:element name="ssl" type="factory-class-with-properties" minOccurs="0"/>
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0"/>
             <xs:element name="symmetric-encryption" type="symmetric-encryption" minOccurs="0"/>
             <xs:element name="socket-options" type="socket-options" minOccurs="0"/>
@@ -4369,7 +4357,7 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="interfaces" type="interfaces" minOccurs="0"/>
-            <xs:element name="ssl" type="ssl" minOccurs="0"/>
+            <xs:element name="ssl" type="factory-class-with-properties" minOccurs="0"/>
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0"/>
             <xs:element name="symmetric-encryption" type="symmetric-encryption" minOccurs="0"/>
             <xs:element name="socket-options" type="socket-options" minOccurs="0"/>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3448,6 +3448,15 @@
         <collection-frequency-seconds>10</collection-frequency-seconds>
     </metrics>
 
+    <auditlog enabled="false">
+        <factory-class-name>com.acme.AuditlogToSyslogFactory</factory-class-name>
+        <properties>
+            <property name="host">syslogserver.acme.com</property>
+            <property name="port">514</property>
+            <property name="type">tcp</property>
+        </properties>
+    </auditlog>
+
     <!--
       ===== HAZELCAST INSTANCE TRACKING CONFIGURATION =====
 

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3337,6 +3337,14 @@ hazelcast:
       enabled: false
     collection-frequency-seconds: 10
 
+  auditlog:
+    enabled: false
+    factory-class-name: com.acme.AuditlogToSyslogFactory
+    properties:
+      host: syslogserver.acme.com
+      port: 514
+      type: tcp
+
   #
   # ===== HAZELCAST INSTANCE TRACKING CONFIGURATION =====
   #

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Properties;
 
 import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
 import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
@@ -34,6 +35,7 @@ import static com.hazelcast.instance.ProtocolType.MEMCACHE;
 import static com.hazelcast.instance.ProtocolType.WAN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -537,6 +539,20 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
 
     public abstract void testMetricsConfigJmxDisabled();
 
+    @Test
+    public void testAuditlogConfig() {
+        Config config = buildAuditlogConfig();
+        AuditlogConfig auditlogConfig = config.getAuditlogConfig();
+        assertNotNull(auditlogConfig);
+        assertTrue(auditlogConfig.isEnabled());
+
+        assertEquals("com.acme.auditlog.AuditlogToSyslogFactory", auditlogConfig.getFactoryClassName());
+        Properties properties = auditlogConfig.getProperties();
+        assertNotNull(properties);
+        assertEquals("syslogserver.acme.com", properties.get("host"));
+        assertEquals("514", properties.get("port"));
+    }
+
     public abstract void testSqlConfig();
 
     protected static void assertAwsConfig(AwsConfig aws) {
@@ -561,4 +577,7 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     }
 
     public abstract void testPersistentMemoryDirectoryConfiguration() throws IOException;
+
+    protected abstract Config buildAuditlogConfig();
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -128,6 +128,8 @@ public class ConfigCompatibilityChecker {
                 singletonMap("", c2.getSecurityConfig()), new SecurityConfigChecker());
         checkCompatibleConfigs("cp subsystem", c1, c2, singletonMap("", c1.getCPSubsystemConfig()),
                 singletonMap("", c2.getCPSubsystemConfig()), new CPSubsystemConfigChecker());
+        checkCompatibleConfigs("auditlog", c1, c2, singletonMap("", c1.getAuditlogConfig()),
+                singletonMap("", c2.getAuditlogConfig()), new AuditlogConfigChecker());
 
         checkCompatibleConfigs("metrics", c1.getMetricsConfig(), c2.getMetricsConfig(), new MetricsConfigChecker());
         checkCompatibleConfigs("sql", c1.getSqlConfig(), c2.getSqlConfig(), new SqlConfigChecker());
@@ -1314,6 +1316,17 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(
                         classNameOrImpl(c1.getFactoryClassName(), c1.getFactoryImplementation()),
                         classNameOrImpl(c2.getFactoryClassName(), c2.getFactoryImplementation()))
+                    && nullSafeEqual(c1.getProperties(), c2.getProperties()));
+        }
+    }
+
+    public static class AuditlogConfigChecker extends ConfigChecker<AuditlogConfig> {
+        @Override
+        boolean check(AuditlogConfig c1, AuditlogConfig c2) {
+            boolean c1Disabled = c1 == null || !c1.isEnabled();
+            boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null
+                    && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
                     && nullSafeEqual(c1.getProperties(), c2.getProperties()));
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -2011,6 +2011,20 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testAuditlogConfig() {
+        Config config = new Config();
+
+        config.getAuditlogConfig()
+              .setEnabled(true)
+              .setFactoryClassName("com.acme.AuditlogToSyslog")
+              .setProperty("host", "syslogserver.acme.com")
+              .setProperty("port", "514");
+        AuditlogConfig generatedConfig = getNewConfigViaXMLGenerator(config).getAuditlogConfig();
+        assertTrue(generatedConfig + " should be compatible with " + config.getAuditlogConfig(),
+                new ConfigCompatibilityChecker.AuditlogConfigChecker().check(config.getAuditlogConfig(), generatedConfig));
+    }
+
+    @Test
     public void testUserCodeDeployment() {
         Config config = new Config();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3497,6 +3497,23 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    protected Config buildAuditlogConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <auditlog enabled='true'>\n"
+                + "        <factory-class-name>\n"
+                + "            com.acme.auditlog.AuditlogToSyslogFactory\n"
+                + "        </factory-class-name>\n"
+                + "        <properties>\n"
+                + "            <property name='host'>syslogserver.acme.com</property>\n"
+                + "            <property name='port'>514</property>\n"
+                + "            <property name='type'>tcp</property>\n"
+                + "        </properties>\n"
+                + "    </auditlog>"
+                + HAZELCAST_END_TAG;
+        return new InMemoryXmlConfig(xml);
+    }
+
+    @Override
     @Test
     public void testSqlConfig() {
         String xml = HAZELCAST_START_TAG

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3518,4 +3518,18 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertTrue(metricsConfig.getManagementCenterConfig().isEnabled());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
     }
+
+    @Override
+    protected Config buildAuditlogConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  auditlog:\n"
+                + "    enabled: true\n"
+                + "    factory-class-name: com.acme.auditlog.AuditlogToSyslogFactory\n"
+                + "    properties:\n"
+                + "      host: syslogserver.acme.com\n"
+                + "      port: 514\n"
+                + "      type: tcp\n";
+        return new InMemoryYamlConfig(yaml);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.instance;
 
+import com.hazelcast.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cp.internal.persistence.NopCPPersistenceService;
 import com.hazelcast.internal.cluster.Joiner;
@@ -79,6 +80,7 @@ public class TestNodeContext implements NodeContext {
         when(nodeExtension.createMemberUuid()).thenReturn(UuidUtil.newUnsecureUUID());
         when(nodeExtension.createDynamicConfigListener()).thenReturn(mock(DynamicConfigListener.class));
         when(nodeExtension.getCPPersistenceService()).thenReturn(new NopCPPersistenceService());
+        when(nodeExtension.getAuditlogService()).thenReturn(NoOpAuditlogService.INSTANCE);
         return nodeExtension;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.impl.Node;
@@ -35,7 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -79,7 +80,8 @@ public class ClusterStateManagerTest {
     public void setup() {
         NodeExtension nodeExtension = mock(NodeExtension.class);
         when(nodeExtension.isStartCompleted()).thenReturn(true);
-        when(nodeExtension.isNodeVersionCompatibleWith(Matchers.any(Version.class))).thenReturn(true);
+        when(nodeExtension.getAuditlogService()).thenReturn(NoOpAuditlogService.INSTANCE);
+        when(nodeExtension.isNodeVersionCompatibleWith(ArgumentMatchers.any(Version.class))).thenReturn(true);
 
         when(node.getPartitionService()).thenReturn(partitionService);
         when(node.getClusterService()).thenReturn(clusterService);

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.server;
 
+import com.hazelcast.auditlog.AuditlogService;
+import com.hazelcast.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.MemcacheProtocolConfig;
@@ -24,8 +26,6 @@ import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.ascii.TextCommandService;
-import com.hazelcast.internal.auditlog.AuditlogService;
-import com.hazelcast.internal.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.Packet;

--- a/hazelcast/src/test/java/com/hazelcast/security/SecurityWithoutEnterpriseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/SecurityWithoutEnterpriseTest.java
@@ -27,17 +27,23 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.Accessors.getSerializationService;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Rule;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SecurityWithoutEnterpriseTest extends HazelcastTestSupport {
 
-    @Test(expected = IllegalStateException.class)
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Test
     public void test() {
         SecurityConfig securityConfig = new SecurityConfig()
                 .setEnabled(true);
@@ -45,15 +51,25 @@ public class SecurityWithoutEnterpriseTest extends HazelcastTestSupport {
         Config config = new Config()
                 .setSecurityConfig(securityConfig);
 
+        expected.expect(IllegalStateException.class);
         createHazelcastInstance(config);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSymmetricEncryption() {
         SymmetricEncryptionConfig symmetricEncryptionConfig = new SymmetricEncryptionConfig()
                 .setEnabled(true);
         Config config = new Config();
         config.getNetworkConfig().setSymmetricEncryptionConfig(symmetricEncryptionConfig);
+        expected.expect(IllegalStateException.class);
+        createHazelcastInstance(config);
+    }
+
+    @Test
+    public void testAuditlog() {
+        Config config = new Config();
+        config.getAuditlogConfig().setEnabled(true);
+        expected.expect(IllegalStateException.class);
         createHazelcastInstance(config);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
@@ -267,7 +267,7 @@ public class HazelcastPropertiesTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getTimeUnit_noTimeUnitProperty() {
-        defaultProperties.getMillis(ClusterProperty.AUDIT_LOG_ENABLED);
+        defaultProperties.getMillis(ClusterProperty.EVENT_THREAD_COUNT);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.test;
 
+import com.hazelcast.auditlog.AuditlogService;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.collection.ISet;
@@ -95,6 +96,10 @@ public class Accessors {
 
     public static MetricsRegistry getMetricsRegistry(HazelcastInstance hz) {
         return getNodeEngineImpl(hz).getMetricsRegistry();
+    }
+
+    public static AuditlogService getAuditlogService(HazelcastInstance hz) {
+        return getNode(hz).getNodeExtension().getAuditlogService();
     }
 
     public static Address getAddress(HazelcastInstance hz) {

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.test.compatibility;
 
+import com.hazelcast.auditlog.AuditlogService;
+import com.hazelcast.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cp.internal.persistence.CPPersistenceService;
 import com.hazelcast.cp.internal.persistence.NopCPPersistenceService;
@@ -24,8 +26,6 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.ascii.TextCommandService;
-import com.hazelcast.internal.auditlog.AuditlogService;
-import com.hazelcast.internal.auditlog.impl.NoOpAuditlogService;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.dynamicconfig.DynamicConfigListener;

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -967,6 +967,15 @@
         </locks>
     </cp-subsystem>
 
+    <auditlog enabled="false">
+        <factory-class-name>com.acme.AuditlogToSyslogFactory</factory-class-name>
+        <properties>
+            <property name="host">syslogserver.acme.com</property>
+            <property name="port">514</property>
+            <property name="type">tcp</property>
+        </properties>
+    </auditlog>
+
     <metrics enabled="false">
         <management-center enabled="false">
             <retention-seconds>42</retention-seconds>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -912,6 +912,14 @@ hazelcast:
       lock2:
         lock-acquire-limit: 2
 
+  auditlog:
+    enabled: false
+    factory-class-name: com.acme.AuditlogToSyslogFactory
+    properties:
+      host: syslogserver.acme.com
+      port: 514
+      type: tcp
+
   metrics:
     enabled: false
     management-center:


### PR DESCRIPTION
This PR adds configuration and basic events for Auditlog.

The Auditlog implementation is part of the Hazelcast EE. The default (OOTB) implementation uses the `ILogger` as the logging facility with category (name) `"hazelcast.auditlog"`. It can be enabled in hazelcast configuration. E.g. (XML version):

```xml
<hazelcast>
    <auditlog enabled="true"/>
</hazelcast>
```
If a custom `AuditLogService` implementation is required, then it can be configured by using factory class:
```xml
<hazelcast>
    <auditlog enabled="true">
        <factory-class-name>
            com.acme.auditlog.AuditlogToSyslogFactory
        </factory-class-name>
        <properties>
            <property name="host">syslogserver.acme.com</property>
            <property name="port">514</property>
            <property name="type">tcp</property>
        </properties>
    </auditlog>
</hazelcast>
```

The message types logged into the auditlog have their ID stored in class `com.hazelcast.auditlog.AuditlogTypeIds`.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3640