### PR TITLE
Checks for existing static config when adding config from client

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/clientside/ClientDynamicConfigSmokeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/clientside/ClientDynamicConfigSmokeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigSmokeTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientDynamicConfigSmokeTest extends DynamicConfigSmokeTest {
+
+    @Override
+    protected HazelcastInstance[] members(int count, Config config) {
+        factory = new TestHazelcastFactory(count);
+        if (config == null) {
+            config = smallInstanceConfig();
+        }
+        HazelcastInstance[] members = new HazelcastInstance[count];
+        for (int i = 0; i < count; i++) {
+            members[i] = factory.newHazelcastInstance(config);
+        }
+        return members;
+    }
+
+    @Override
+    protected HazelcastInstance driver() {
+        return ((TestHazelcastFactory) factory).newHazelcastClient();
+    }
+
+    @Override
+    @Ignore("Only makes sense to be executed on the member side")
+    public void mapConfig_withLiteMemberJoiningLater_isImmediatelyAvailable() {
+        super.mapConfig_withLiteMemberJoiningLater_isImmediatelyAvailable();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -40,6 +40,7 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddLockConfigMessag
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMerkleTreeConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMultiMapConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddPNCounterConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddQueueConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableTopicConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReplicatedMapConfigMessageTask;
@@ -695,7 +696,7 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         };
         factories[com.hazelcast.client.impl.protocol.codec.SemaphoreIncreasePermitsCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
-                return new com.hazelcast.client.impl.protocol.task.semaphore.SemaphoreIncreasePermitsMessageTask(clientMessage,node, connection);
+                return new com.hazelcast.client.impl.protocol.task.semaphore.SemaphoreIncreasePermitsMessageTask(clientMessage, node, connection);
             }
         };
         factories[com.hazelcast.client.impl.protocol.codec.SemaphoreTryAcquireCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
@@ -2155,6 +2156,11 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 return new AddFlakeIdGeneratorConfigMessageTask(clientMessage, node, connection);
             }
         };
+        factories[com.hazelcast.client.impl.protocol.codec.DynamicConfigAddPNCounterConfigCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new AddPNCounterConfigMessageTask(clientMessage, node, connection);
+            }
+        };
 //endregion
 // region ----------- REGISTRATION FOR flake id generator
         factories[com.hazelcast.client.impl.protocol.codec.FlakeIdGeneratorNewIdBatchCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
@@ -2185,8 +2191,6 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
             }
         };
 //endregion
-
-
 
 
         factories[com.hazelcast.client.impl.protocol.codec.CPGroupCreateCPGroupCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AbstractAddConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AbstractAddConfigMessageTask.java
@@ -70,8 +70,12 @@ public abstract class AbstractAddConfigMessageTask<P> extends AbstractMessageTas
     public final void processMessage() {
         IdentifiedDataSerializable config = getConfig();
         ClusterWideConfigurationService service = getService(ClusterWideConfigurationService.SERVICE_NAME);
-        ICompletableFuture<Object> future = service.broadcastConfigAsync(config);
-        future.andThen(this);
+        if (checkStaticConfigDoesNotExist(config)) {
+            ICompletableFuture<Object> future = service.broadcastConfigAsync(config);
+            future.andThen(this);
+        } else {
+            sendResponse(null);
+        }
     }
 
     @Override
@@ -106,4 +110,6 @@ public abstract class AbstractAddConfigMessageTask<P> extends AbstractMessageTas
     }
 
     protected abstract IdentifiedDataSerializable getConfig();
+
+    protected abstract boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.util.ArrayList;
@@ -90,5 +91,13 @@ public class AddCacheConfigMessageTask
     @Override
     public String getMethodName() {
         return "addCacheConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        CacheSimpleConfig cacheConfig = (CacheSimpleConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getCacheConfigs(),
+                cacheConfig.getName(), cacheConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCardinalityEstimatorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCardinalityEstimatorConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddCardinalityEstim
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -57,5 +58,13 @@ public class AddCardinalityEstimatorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addCardinalityEstimatorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        CardinalityEstimatorConfig cardinalityEstimatorConfig = (CardinalityEstimatorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getCardinalityEstimatorConfigs(),
+                cardinalityEstimatorConfig.getName(), cardinalityEstimatorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddDurableExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddDurableExecutorConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddDurableExecutorConfigCodec;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -50,5 +51,13 @@ public class AddDurableExecutorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addDurableExecutorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        DurableExecutorConfig durableExecutorConfig = (DurableExecutorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getDurableExecutorConfigs(),
+                durableExecutorConfig.getName(), durableExecutorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddEventJournalConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddEventJournalConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddEventJournalConfigCodec;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.StringUtil;
@@ -57,6 +58,18 @@ public class AddEventJournalConfigMessageTask
         config.setTimeToLiveSeconds(parameters.timeToLiveSeconds);
         config.setCapacity(parameters.capacity);
         return config;
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        EventJournalConfig eventJournalConfig = (EventJournalConfig) config;
+        String name = eventJournalConfig.getMapName();
+        if (name == null) {
+            name = eventJournalConfig.getCacheName();
+        }
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getCacheEventJournalConfigs(),
+                name, eventJournalConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddExecutorConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddExecutorConfigCodec;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -51,5 +52,13 @@ public class AddExecutorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addExecutorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ExecutorConfig executorConfig = (ExecutorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getExecutorConfigs(),
+                executorConfig.getName(), executorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddFlakeIdGeneratorConfigCodec;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -54,5 +55,13 @@ public class AddFlakeIdGeneratorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addFlakeIdGeneratorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        FlakeIdGeneratorConfig flakeIdGeneratorConfig = (FlakeIdGeneratorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getFlakeIdGeneratorConfigs(),
+                flakeIdGeneratorConfig.getName(), flakeIdGeneratorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddListConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddListConfigMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -65,5 +66,13 @@ public class AddListConfigMessageTask
     @Override
     public String getMethodName() {
         return "addListConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ListConfig listConfig = (ListConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getListConfigs(),
+                listConfig.getName(), listConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddLockConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddLockConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddLockConfigCodec;
 import com.hazelcast.config.LockConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -45,6 +46,14 @@ public class AddLockConfigMessageTask
         LockConfig config = new LockConfig(parameters.name);
         config.setQuorumName(parameters.quorumName);
         return config;
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        LockConfig lockConfig = (LockConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getLockConfigs(),
+                lockConfig.getName(), lockConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -31,6 +31,7 @@ import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.map.eviction.MapEvictionPolicy;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -127,5 +128,14 @@ public class AddMapConfigMessageTask
     @Override
     public String getMethodName() {
         return "addMapConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        MapConfig mapConfig = (MapConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(
+                nodeConfig.getStaticConfig().getMapConfigs(),
+                mapConfig.getName(), mapConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMerkleTreeConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMerkleTreeConfigMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMerkleTreeConfigCodec;
 import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.Preconditions;
@@ -51,6 +52,14 @@ public class AddMerkleTreeConfigMessageTask
                 .setMapName(parameters.mapName)
                 .setEnabled(parameters.enabled)
                 .setDepth(parameters.depth);
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        MerkleTreeConfig merkleTreeConfig = (MerkleTreeConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getMapMerkleTreeConfigs(),
+                merkleTreeConfig.getMapName(), merkleTreeConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMultiMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMultiMapConfigMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -66,5 +67,13 @@ public class AddMultiMapConfigMessageTask extends
     @Override
     public String getMethodName() {
         return "addMultiMapConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        MultiMapConfig multiMapConfig = (MultiMapConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getMultiMapConfigs(),
+                multiMapConfig.getName(), multiMapConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddPNCounterConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddPNCounterConfigMessageTask.java
@@ -17,56 +17,49 @@
 package com.hazelcast.client.impl.protocol.task.dynamicconfig;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddTopicConfigCodec;
-import com.hazelcast.config.ListenerConfig;
-import com.hazelcast.config.TopicConfig;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddPNCounterConfigCodec;
+import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-import java.util.List;
+public class AddPNCounterConfigMessageTask
+        extends AbstractAddConfigMessageTask<DynamicConfigAddPNCounterConfigCodec.RequestParameters> {
 
-public class AddTopicConfigMessageTask
-        extends AbstractAddConfigMessageTask<DynamicConfigAddTopicConfigCodec.RequestParameters> {
-
-    public AddTopicConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    public AddPNCounterConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected DynamicConfigAddTopicConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return DynamicConfigAddTopicConfigCodec.decodeRequest(clientMessage);
+    protected DynamicConfigAddPNCounterConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return DynamicConfigAddPNCounterConfigCodec.decodeRequest(clientMessage);
     }
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return DynamicConfigAddTopicConfigCodec.encodeResponse();
+        return DynamicConfigAddPNCounterConfigCodec.encodeResponse();
     }
 
     @Override
     protected IdentifiedDataSerializable getConfig() {
-        TopicConfig config = new TopicConfig(parameters.name);
-        config.setGlobalOrderingEnabled(parameters.globalOrderingEnabled);
-        config.setMultiThreadingEnabled(parameters.multiThreadingEnabled);
+        PNCounterConfig config = new PNCounterConfig(parameters.name);
+        config.setReplicaCount(parameters.replicaCount);
         config.setStatisticsEnabled(parameters.statisticsEnabled);
-        if (parameters.listenerConfigs != null && !parameters.listenerConfigs.isEmpty()) {
-            config.setMessageListenerConfigs(
-                    (List<ListenerConfig>) adaptListenerConfigs(parameters.listenerConfigs));
-        }
+        config.setQuorumName(parameters.quorumName);
         return config;
     }
 
     @Override
     public String getMethodName() {
-        return "addTopicConfig";
+        return "addPNCounterConfig";
     }
 
     @Override
     protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
         DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
-        TopicConfig topicConfig = (TopicConfig) config;
-        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getTopicConfigs(),
-                topicConfig.getName(), topicConfig);
+        PNCounterConfig pnCounterConfig = (PNCounterConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getPNCounterConfigs(),
+                pnCounterConfig.getName(), pnCounterConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddQueueConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddQueueConfigMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -72,5 +73,13 @@ public class AddQueueConfigMessageTask
     @Override
     public String getMethodName() {
         return "addQueueConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        QueueConfig queueConfig = (QueueConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getQueueConfigs(),
+                queueConfig.getName(), queueConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableTopicConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableTopicConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableTopicCon
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.topic.TopicOverloadPolicy;
@@ -63,5 +64,13 @@ public class AddReliableTopicConfigMessageTask
     @Override
     public String getMethodName() {
         return "addReliableTopicConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ReliableTopicConfig reliableTopicConfig = (ReliableTopicConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getReliableTopicConfigs(),
+                reliableTopicConfig.getName(), reliableTopicConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -70,5 +71,13 @@ public class AddReplicatedMapConfigMessageTask
     @Override
     public String getMethodName() {
         return "addReplicatedMapConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ReplicatedMapConfig replicatedMapConfig = (ReplicatedMapConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getReplicatedMapConfigs(),
+                replicatedMapConfig.getName(), replicatedMapConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddRingbufferConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddRingbufferConfigMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.RingbufferStoreConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -64,5 +65,13 @@ public class AddRingbufferConfigMessageTask
     @Override
     public String getMethodName() {
         return "addRingbufferConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        RingbufferConfig ringbufferConfig = (RingbufferConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getRingbufferConfigs(),
+                ringbufferConfig.getName(), ringbufferConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddScheduledExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddScheduledExecutorConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddScheduledExecuto
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -57,5 +58,13 @@ public class AddScheduledExecutorConfigMessageTask
     @Override
     public String getMethodName() {
         return "addScheduledExecutorConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        ScheduledExecutorConfig scheduledExecutorConfig = (ScheduledExecutorConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getScheduledExecutorConfigs(),
+                scheduledExecutorConfig.getName(), scheduledExecutorConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSemaphoreConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSemaphoreConfigMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddSemaphoreConfigC
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddSetConfigCodec;
 import com.hazelcast.config.SemaphoreConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -49,6 +50,14 @@ public class AddSemaphoreConfigMessageTask
         config.setAsyncBackupCount(parameters.asyncBackupCount);
         config.setInitialPermits(parameters.initialPermits);
         return config;
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        SemaphoreConfig semaphoreConfig = (SemaphoreConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getSemaphoreConfigsAsMap(),
+                semaphoreConfig.getName(), semaphoreConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSetConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSetConfigMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.SetConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -65,5 +66,13 @@ public class AddSetConfigMessageTask
     @Override
     public String getMethodName() {
         return "addSetConfig";
+    }
+
+    @Override
+    protected boolean checkStaticConfigDoesNotExist(IdentifiedDataSerializable config) {
+        DynamicConfigurationAwareConfig nodeConfig = (DynamicConfigurationAwareConfig) nodeEngine.getConfig();
+        SetConfig setConfig = (SetConfig) config;
+        return nodeConfig.checkStaticConfigDoesNotExist(nodeConfig.getStaticConfig().getSetConfigs(),
+                setConfig.getName(), setConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -124,7 +124,9 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
         this.cacheLoaderFactory = cacheSimpleConfig.cacheLoaderFactory;
         this.cacheWriterFactory = cacheSimpleConfig.cacheWriterFactory;
         this.expiryPolicyFactoryConfig = cacheSimpleConfig.expiryPolicyFactoryConfig;
-        this.cacheEntryListeners = cacheSimpleConfig.cacheEntryListeners;
+        this.cacheEntryListeners = cacheSimpleConfig.cacheEntryListeners == null
+                ? null
+                : new ArrayList<CacheSimpleEntryListenerConfig>(cacheSimpleConfig.cacheEntryListeners);
         this.asyncBackupCount = cacheSimpleConfig.asyncBackupCount;
         this.backupCount = cacheSimpleConfig.backupCount;
         this.inMemoryFormat = cacheSimpleConfig.inMemoryFormat;
@@ -133,10 +135,11 @@ public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, Identifie
             this.evictionConfig = cacheSimpleConfig.evictionConfig;
         }
         this.wanReplicationRef = cacheSimpleConfig.wanReplicationRef;
-        this.partitionLostListenerConfigs =
-                new ArrayList<CachePartitionLostListenerConfig>(cacheSimpleConfig.getPartitionLostListenerConfigs());
         this.quorumName = cacheSimpleConfig.quorumName;
         this.mergePolicy = cacheSimpleConfig.mergePolicy;
+        this.partitionLostListenerConfigs = cacheSimpleConfig.partitionLostListenerConfigs == null
+                ? null
+                : new ArrayList<CachePartitionLostListenerConfig>(cacheSimpleConfig.partitionLostListenerConfigs);
         this.hotRestartConfig = new HotRestartConfig(cacheSimpleConfig.hotRestartConfig);
         this.disablePerEntryInvalidationEvents = cacheSimpleConfig.disablePerEntryInvalidationEvents;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -305,13 +305,17 @@ public class DynamicConfigurationAwareConfig extends Config {
         return this;
     }
 
-    private <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
+    public <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
         if (existingConfiguration != null && !existingConfiguration.equals(newConfig)) {
             throw new ConfigurationException("Cannot add a new dynamic configuration " + newConfig
                 + " as static configuration already contains " + existingConfiguration);
         }
         return existingConfiguration == null;
+    }
+
+    public Config getStaticConfig() {
+        return staticConfig;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.TopicConfig;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -29,9 +30,19 @@ import com.hazelcast.test.TestConfigUtils;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryListenerException;
+import java.io.Serializable;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,13 +52,42 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
 
     private static final int DEFAULT_INITIAL_CLUSTER_SIZE = 3;
 
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    protected TestHazelcastInstanceFactory factory;
+    private HazelcastInstance[] members;
+
+    @After
+    public void tearDown() {
+        if (factory != null) {
+            factory.terminateAll();
+        }
+    }
+
+    protected HazelcastInstance[] members(int count) {
+        return members(count, null);
+    }
+
+    protected HazelcastInstance[] members(int count, Config config) {
+        if (config == null) {
+            config = smallInstanceConfig();
+        }
+        factory = createHazelcastInstanceFactory(count);
+        members = factory.newInstances(config);
+        return members;
+    }
+
+    protected HazelcastInstance driver() {
+        return members[0];
+    }
+
     @Test
     public void multimap_initialSubmitTest() {
         String mapName = randomMapName();
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance i1 = driver();
 
         MultiMapConfig multiMapConfig = new MultiMapConfig(mapName);
         multiMapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
@@ -60,15 +100,13 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         }
     }
 
-    @Test(expected = HazelcastException.class)
+    @Test
     public void map_testConflictingDynamicConfig() {
         String mapName = randomMapName();
         int initialClusterSize = 2;
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(initialClusterSize);
-
-        HazelcastInstance i1 = factory.newHazelcastInstance();
-        HazelcastInstance i2 = factory.newHazelcastInstance();
+        members(initialClusterSize);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig1 = new MapConfig(mapName);
         mapConfig1.setBackupCount(0);
@@ -76,17 +114,16 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         MapConfig mapConfig2 = new MapConfig(mapName);
         mapConfig2.setBackupCount(1);
 
-        i1.getConfig().addMapConfig(mapConfig1);
-        i1.getConfig().addMapConfig(mapConfig2);
+        driver.getConfig().addMapConfig(mapConfig1);
+        expected.expect(ConfigurationException.class);
+        driver.getConfig().addMapConfig(mapConfig2);
     }
 
     @Test
     public void map_testNonConflictingDynamicConfigWithTheSameName() {
         String mapName = randomMapName();
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-
-        HazelcastInstance i1 = factory.newHazelcastInstance();
-        HazelcastInstance i2 = factory.newHazelcastInstance();
+        members(2);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig1 = new MapConfig(mapName);
         mapConfig1.setBackupCount(0);
@@ -94,8 +131,8 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         MapConfig mapConfig2 = new MapConfig(mapName);
         mapConfig2.setBackupCount(0);
 
-        i1.getConfig().addMapConfig(mapConfig1);
-        i1.getConfig().addMapConfig(mapConfig2);
+        driver.getConfig().addMapConfig(mapConfig1);
+        driver.getConfig().addMapConfig(mapConfig2);
     }
 
     @Test
@@ -122,13 +159,12 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
     public void map_initialSubmitTest() {
         String mapName = randomMapName();
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig = new MapConfig(mapName);
         mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
-        Config config = i1.getConfig();
+        Config config = driver.getConfig();
         config.addMapConfig(mapConfig);
 
         for (HazelcastInstance instance : instances) {
@@ -141,13 +177,12 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
     public void map_initialSubmitTest_withWildcards() {
         String prefixWithWildcard = randomMapName() + "*";
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance driver = driver();
 
         MapConfig mapConfig = new MapConfig(prefixWithWildcard);
         mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
-        Config config = i1.getConfig();
+        Config config = driver.getConfig();
         config.addMapConfig(mapConfig);
 
         for (HazelcastInstance instance : instances) {
@@ -162,13 +197,12 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         String topicName = randomName();
         String listenerClassName = randomName();
 
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(DEFAULT_INITIAL_CLUSTER_SIZE);
-        HazelcastInstance[] instances = factory.newInstances();
-        HazelcastInstance i1 = instances[0];
+        HazelcastInstance[] instances = members(DEFAULT_INITIAL_CLUSTER_SIZE);
+        HazelcastInstance driver = driver();
 
         TopicConfig topicConfig = new TopicConfig(topicName);
         topicConfig.addMessageListenerConfig(new ListenerConfig(listenerClassName));
-        i1.getConfig().addTopicConfig(topicConfig);
+        driver.getConfig().addTopicConfig(topicConfig);
 
         for (HazelcastInstance instance : instances) {
             topicConfig = instance.getConfig().getTopicConfig(topicName);
@@ -204,23 +238,72 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         Config config = new Config();
         config.addMapConfig(getMapConfigWithTTL(mapName, 20));
 
-        HazelcastInstance hz = createHazelcastInstance(config);
-        hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
+        members(1, config);
+        HazelcastInstance driver = driver();
+        driver.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
     }
 
-    @Test(expected = HazelcastException.class)
+    @Test
     public void map_testConflictingStaticConfig() {
         String mapName = "test_map";
         Config config = new Config();
         config.addMapConfig(getMapConfigWithTTL(mapName, 20));
 
-        HazelcastInstance hz = createHazelcastInstance(config);
+        members(1, config);
+        HazelcastInstance hz = driver();
+        expected.expect(ConfigurationException.class);
         hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 50));
+    }
+
+    @Test
+    public void cacheConfig_whenListenerIsRegistered() {
+        String cacheName = randomMapName();
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
+                .setName(cacheName)
+                .setKeyType(String.class.getName())
+                .setValueType((new String[0]).getClass().getName())
+                .setStatisticsEnabled(false)
+                .setManagementEnabled(false);
+
+        members(2);
+        HazelcastInstance driver = driver();
+
+        driver.getConfig().addCacheConfig(cacheSimpleConfig);
+        Cache cache = driver.getCacheManager().getCache(cacheName);
+        cache.registerCacheEntryListener(new CacheEntryListenerConfig(
+                new MyFactory(),
+                null,
+                true,
+                true));
+        driver.getConfig().addCacheConfig(cacheSimpleConfig);
     }
 
     private MapConfig getMapConfigWithTTL(String mapName, int ttl) {
         MapConfig mapConfig = new MapConfig(mapName);
         mapConfig.setTimeToLiveSeconds(ttl);
         return mapConfig;
+    }
+
+    public static class MyFactory implements Factory<CacheEntryCreatedListener>, Serializable {
+
+        @Override
+        public CacheEntryCreatedListener create() {
+            return new MyCacheEntryCreatedListener();
+        }
+    }
+
+    public static class MyCacheEntryCreatedListener implements CacheEntryCreatedListener, Serializable {
+
+        @Override
+        public void onCreated(Iterable iterable) throws CacheEntryListenerException {
+            System.out.println(iterable);
+        }
+    }
+
+    public static class CacheEntryListenerConfig extends MutableCacheEntryListenerConfiguration implements Serializable {
+        public CacheEntryListenerConfig(Factory listenerFactory, Factory filterFactory, boolean isOldValueRequired,
+                                        boolean isSynchronous) {
+            super(listenerFactory, filterFactory, isOldValueRequired, isSynchronous);
+        }
     }
 }


### PR DESCRIPTION
When adding dynamic data structure config from client, a check
for existing conflicting static config has to be made before
broadcasting the config to all members.

Other included fixes:
- an issue with CacheSimpleConfig copies not being
equal to their original which resulted in inability to add
the same cache config twice.
- adds dynamic PNCounterConfig support for client side
- an issue with event journal config being ignored
from client-side dynamic cache configuration.

backport of https://github.com/hazelcast/hazelcast/pull/16170
fixes https://github.com/hazelcast/hazelcast/issues/16927

(cherry picked from commit 4d0caf4a0ca4ae0e6ddfa00d1141b489cd7c15eb)