### PR TITLE
Public API for SQL (#17042)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,3 @@ Thanks for creating your pull request (PR).
 5.	Before you push, run the command `mvn clean package -P checkstyle,spotbugs` in your terminal and fix the CheckStyle and SpotBugs errors (if any). Push your PR once it is free of CheckStyle and SpotBugs errors.
 6.	Please keep your PRs as small as possible, i.e. if you plan to perform a huge change, do not submit a single and large PR for it. For an enhancement or larger feature, you can create a GitHub issue first to discuss.
 7.	If you submit a PR as the solution to a specific issue, please mention the issue number either in the PR description or commit message.
-
-
-[Contributor Agreement Form]:https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast+Contributor+Agreement

--- a/docs/design/sql/03-network-protocol.md
+++ b/docs/design/sql/03-network-protocol.md
@@ -100,7 +100,7 @@ completion futures, timeouts, and retries.
 
 ### 2.4 Discussion
 
-The Hazelcast Mustang engine doesn't use `Operation` and `OperationSerice` abstractions for the following reasons. First, to
+The Hazelcast Mustang engine doesn't use `Operation` and `OperationService` abstractions for the following reasons. First, to
 satisfy the low-latency principle, the engine doesn't use the request-response messaging pattern for query initiation and data
 exchange. Second, due to fail-fast design choice, the engine doesn't need to keep data chunks on the sender side waiting for ack
 from the receiver. The fire-and-forget approach is used instead. Last, since `Operation` and `OperationService` interfaces do

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -2089,7 +2089,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private void handleSql(Node node) {
             BeanDefinitionBuilder sqlConfigBuilder = createBeanBuilder(SqlConfig.class);
 
-            fillValues(node, sqlConfigBuilder, "executorPoolSize", "operationPoolSize", "queryTimeout");
+            fillValues(node, sqlConfigBuilder, "executorPoolSize", "operationPoolSize", "queryTimeoutMillis");
 
             for (Node child : childElements(node)) {
                 String nodeName = cleanNodeName(child);
@@ -2098,8 +2098,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     sqlConfigBuilder.addPropertyValue("executorPoolSize", getIntegerValue("executor-pool-size", value));
                 } else if ("operation-pool-size".equals(nodeName)) {
                     sqlConfigBuilder.addPropertyValue("operationPoolSize", getIntegerValue("operation-pool-size", value));
-                } else if ("query-timeout".equals(nodeName)) {
-                    sqlConfigBuilder.addPropertyValue("queryTimeout", getLongValue("query-timeout", value));
+                } else if ("query-timeout-millis".equals(nodeName)) {
+                    sqlConfigBuilder.addPropertyValue("queryTimeoutMillis", getLongValue("query-timeout-millis", value));
                 }
             }
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -333,6 +334,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleCPSubSystem(node);
                     } else if ("metrics".equals(nodeName)) {
                         handleMetrics(node);
+                    } else if ("sql".equals(nodeName)) {
+                        handleSql(node);
                     }
                 }
             }
@@ -2081,6 +2084,26 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
 
             configBuilder.addPropertyValue("metricsConfig", metricsConfigBuilder.getBeanDefinition());
+        }
+
+        private void handleSql(Node node) {
+            BeanDefinitionBuilder sqlConfigBuilder = createBeanBuilder(SqlConfig.class);
+
+            fillValues(node, sqlConfigBuilder, "executorPoolSize", "operationPoolSize", "queryTimeout");
+
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                String value = getTextContent(child).trim();
+                if ("executor-pool-size".equals(nodeName)) {
+                    sqlConfigBuilder.addPropertyValue("executorPoolSize", getIntegerValue("executor-pool-size", value));
+                } else if ("operation-pool-size".equals(nodeName)) {
+                    sqlConfigBuilder.addPropertyValue("operationPoolSize", getIntegerValue("operation-pool-size", value));
+                } else if ("query-timeout".equals(nodeName)) {
+                    sqlConfigBuilder.addPropertyValue("queryTimeout", getLongValue("query-timeout", value));
+                }
+            }
+
+            configBuilder.addPropertyValue("sqlConfig", sqlConfigBuilder.getBeanDefinition());
         }
     }
 }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -4976,7 +4976,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="query-timeout-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
+            <xs:element name="query-timeout-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the timeout in milliseconds that is applied to queries without an explicit timeout.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -4945,11 +4945,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="executor-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+            <xs:element name="executor-pool-size" type="xs:int" minOccurs="0" maxOccurs="1" default="-1">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the number of threads responsible for query execution.
-                        Normally the value of this parameter should be equal to the number of CPU cores.
+                        The default value -1 sets the pool size equal to the number of CPU cores, and should be good enough
+                        for the most workloads.
                         Setting the value to less than the number of CPU cores will limit the degree of parallelism of the SQL
                         subsystem. This may be beneficial if you would like to prioritize other CPU-intensive workloads on the
                         same machine.
@@ -4958,7 +4959,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="operation-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+            <xs:element name="operation-pool-size" type="xs:int" minOccurs="0" maxOccurs="1" default="-1">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the number of threads responsible for network operations processing.
@@ -4966,14 +4967,16 @@
                         the execution. This includes requests to start or stop query execution, or a request to process a batch
                         of data. These commands are processed in a separate operation thread pool, to avoid frequent interruption
                         of running query fragments.
-                        The default value should be good enough for the most workloads. You may want to increase the default
-                        value if you run very small queries, or the machine has a big number of CPU cores.
+                        The default value -1 sets the pool size equal to the number of CPU cores, and should be good enough
+                        for the most workloads.
+                        Setting the value to less than the number of CPU cores may improve the overall performance on machines
+                        with large CPU count, because it will decrease the number of context switches.
                         It is not recommended to set the value of this parameter greater than the number of CPU cores because it
                         may decrease the system's overall performance due to excessive context switches.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="query-timeout" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
+            <xs:element name="query-timeout-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the timeout in milliseconds that is applied to queries without an explicit timeout.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright 2020 Hazelcast Inc.
-  ~ 
+  ~
   ~ Licensed under the Hazelcast Community License (the "License"); you may not use
   ~ this file except in compliance with the License. You may obtain a copy of the
   ~ License at
-  ~ 
+  ~
   ~ http://hazelcast.com/hazelcast-community-license
-  ~ 
+  ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
@@ -1358,6 +1358,7 @@
                         </xs:element>
                         <xs:element name="cp-subsystem" type="cp-subsystem" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="sql" type="sql" minOccurs="0" maxOccurs="1"/>
                     </xs:choice>
                 </xs:extension>
             </xs:complexContent>
@@ -4935,6 +4936,54 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="sql">
+        <xs:annotation>
+            <xs:documentation>
+                SQL service configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="executor-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the number of threads responsible for query execution.
+                        Normally the value of this parameter should be equal to the number of CPU cores.
+                        Setting the value to less than the number of CPU cores will limit the degree of parallelism of the SQL
+                        subsystem. This may be beneficial if you would like to prioritize other CPU-intensive workloads on the
+                        same machine.
+                        It is not recommended to set the value of this parameter greater than the number of CPU cores because it
+                        may decrease the system's overall performance due to excessive context switches.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="operation-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the number of threads responsible for network operations processing.
+                        When Hazelcast members execute a query, they send commands to each other over the network to coordinate
+                        the execution. This includes requests to start or stop query execution, or a request to process a batch
+                        of data. These commands are processed in a separate operation thread pool, to avoid frequent interruption
+                        of running query fragments.
+                        The default value should be good enough for the most workloads. You may want to increase the default
+                        value if you run very small queries, or the machine has a big number of CPU cores.
+                        It is not recommended to set the value of this parameter greater than the number of CPU cores because it
+                        may decrease the system's overall performance due to excessive context switches.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="query-timeout" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the timeout in milliseconds that is applied to queries without an explicit timeout.
+                        It is possible to set a query timeout through the SqlQuery.setTimeout(long) method. If the query
+                        timeout is not set, then the value of this parameter will be used.
+                        Zero value means no timeout. Negative values are prohibited.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
     </xs:complexType>
 
     <xs:complexType name="realms">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -33,6 +33,7 @@ import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConsistencyCheckStrategy;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.DiscoveryConfig;
@@ -1433,5 +1434,13 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(42, metricsConfig.getManagementCenterConfig().getRetentionSeconds());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
         assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Test
+    public void testSqlConfig() {
+        SqlConfig sqlConfig = config.getSqlConfig();
+        assertEquals(10, sqlConfig.getExecutorPoolSize());
+        assertEquals(20, sqlConfig.getOperationPoolSize());
+        assertEquals(30L, sqlConfig.getQueryTimeout());
     }
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1441,6 +1441,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         SqlConfig sqlConfig = config.getSqlConfig();
         assertEquals(10, sqlConfig.getExecutorPoolSize());
         assertEquals(20, sqlConfig.getOperationPoolSize());
-        assertEquals(30L, sqlConfig.getQueryTimeout());
+        assertEquals(30L, sqlConfig.getQueryTimeoutMillis());
     }
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -968,7 +968,7 @@
             <hz:sql>
                 <hz:executor-pool-size>10</hz:executor-pool-size>
                 <hz:operation-pool-size>20</hz:operation-pool-size>
-                <hz:query-timeout>30</hz:query-timeout>
+                <hz:query-timeout-millis>30</hz:query-timeout-millis>
             </hz:sql>
         </hz:config>
     </hz:hazelcast>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -964,6 +964,12 @@
                 <hz:jmx enabled="false"/>
                 <hz:collection-frequency-seconds>24</hz:collection-frequency-seconds>
             </hz:metrics>
+
+            <hz:sql>
+                <hz:executor-pool-size>10</hz:executor-pool-size>
+                <hz:operation-pool-size>20</hz:operation-pool-size>
+                <hz:query-timeout>30</hz:query-timeout>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/OptimizerContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/OptimizerContext.java
@@ -22,6 +22,7 @@ import com.hazelcast.sql.impl.calcite.opt.cost.CostFactory;
 import com.hazelcast.sql.impl.calcite.opt.distribution.DistributionTraitDef;
 import com.hazelcast.sql.impl.calcite.opt.metadata.HazelcastRelMdRowCount;
 import com.hazelcast.sql.impl.calcite.parse.CasingConfiguration;
+import com.hazelcast.sql.impl.calcite.parse.QueryConvertResult;
 import com.hazelcast.sql.impl.calcite.parse.QueryConverter;
 import com.hazelcast.sql.impl.calcite.parse.QueryParseResult;
 import com.hazelcast.sql.impl.calcite.parse.QueryParser;
@@ -142,7 +143,7 @@ public final class OptimizerContext {
      * @param node SQL tree.
      * @return Relational tree.
      */
-    public RelNode convert(SqlNode node) {
+    public QueryConvertResult convert(SqlNode node) {
         return converter.convert(node);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/SqlToQueryType.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/SqlToQueryType.java
@@ -66,6 +66,9 @@ public final class SqlToQueryType {
         CALCITE_TO_HZ.put(SqlTypeName.DATE, QueryDataType.DATE);
         CALCITE_TO_HZ.put(SqlTypeName.TIMESTAMP, QueryDataType.TIMESTAMP);
         CALCITE_TO_HZ.put(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME);
+
+        HZ_TO_CALCITE.put(QueryDataTypeFamily.OBJECT, SqlTypeName.ANY);
+        CALCITE_TO_HZ.put(SqlTypeName.ANY, QueryDataType.OBJECT);
     }
 
     private SqlToQueryType() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConvertResult.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConvertResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.parse;
+
+import org.apache.calcite.rel.RelNode;
+
+import java.util.List;
+
+/**
+ * Encapsulates result of a query conversion from SQL tree to relational tree.
+ */
+public class QueryConvertResult {
+
+    private final RelNode rel;
+    private final List<String> fieldNames;
+
+    public QueryConvertResult(RelNode rel, List<String> fieldNames) {
+        this.rel = rel;
+        this.fieldNames = fieldNames;
+    }
+
+    public RelNode getRel() {
+        return rel;
+    }
+
+    public List<String> getFieldNames() {
+        return fieldNames;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConverter.java
@@ -29,6 +29,10 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
+import org.apache.calcite.util.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Converts a parse tree into a relational tree.
@@ -69,7 +73,7 @@ public class QueryConverter {
         );
     }
 
-    public RelNode convert(SqlNode node) {
+    public QueryConvertResult convert(SqlNode node) {
         // 1. Perform initial conversion.
         RelRoot root = converter.convertQuery(node, false, true);
 
@@ -85,7 +89,14 @@ public class QueryConverter {
         // primarily in projections. This steps removes unused fields from the tree.
         RelNode relTrimmed = converter.trimUnusedFields(true, relDecorrelated);
 
-        return relTrimmed;
+        // 5. Collect original field names.
+        List<String> fieldNames = new ArrayList<>(root.fields.size());
+
+        for (Pair<Integer, String> field : root.fields) {
+            fieldNames.add(field.right);
+        }
+
+        return new QueryConvertResult(relTrimmed, fieldNames);
     }
 
     /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryConverter.java
@@ -31,9 +31,6 @@ import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.util.Pair;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Converts a parse tree into a relational tree.
  */
@@ -90,13 +87,7 @@ public class QueryConverter {
         RelNode relTrimmed = converter.trimUnusedFields(true, relDecorrelated);
 
         // 5. Collect original field names.
-        List<String> fieldNames = new ArrayList<>(root.fields.size());
-
-        for (Pair<Integer, String> field : root.fields) {
-            fieldNames.add(field.right);
-        }
-
-        return new QueryConvertResult(relTrimmed, fieldNames);
+        return new QueryConvertResult(relTrimmed, Pair.right(root.fields));
     }
 
     /**

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -184,7 +184,7 @@ public class SqlBasicTest extends SqlTestSupport {
 
                 assertEquals(rowMetadata, res.getRowMetadata());
 
-                Long key0 = (Long) row.getObject(rowMetadata.findColumn(adjustFieldName("key")));
+                Long key0 = row.getObject(rowMetadata.findColumn(adjustFieldName("key")));
                 assert key0 != null;
 
                 AbstractPojoKey key = key(key0);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -61,9 +61,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -155,9 +157,13 @@ public class SqlBasicTest extends SqlTestSupport {
         IMap<Object, AbstractPojo> map = instance.getMap(mapName());
 
         // Populate map with values
+        Map<Object, AbstractPojo> data = new HashMap<>();
+
         for (long i = 0; i < dataSetSize; i++) {
-            map.put(key(i), value(i));
+            data.put(key(i), value(i));
         }
+
+        map.putAll(data);
 
         assertEquals(dataSetSize, map.size());
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -71,6 +71,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test that covers basic column read operations through SQL.
@@ -185,7 +186,7 @@ public class SqlBasicTest extends SqlTestSupport {
                 assertEquals(rowMetadata, res.getRowMetadata());
 
                 Long key0 = row.getObject(rowMetadata.findColumn(adjustFieldName("key")));
-                assert key0 != null;
+                assertNotNull(key0);
 
                 AbstractPojoKey key = key(key0);
                 AbstractPojo val = map.get(key);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -295,9 +295,9 @@ public class SqlBasicTest extends SqlTestSupport {
         String sql = sql();
 
         if (cursorBufferSize == SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE) {
-            return instance.getSqlService().query(sql);
+            return instance.getSql().query(sql);
         } else {
-            return instance.getSqlService().query(new SqlQuery(sql).setCursorBufferSize(cursorBufferSize));
+            return instance.getSql().query(new SqlQuery(sql).setCursorBufferSize(cursorBufferSize));
         }
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -148,6 +148,7 @@ public class SqlBasicTest extends SqlTestSupport {
         instance.getMap(MAP_BINARY).clear();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testSelect() {
         // Get proper map
@@ -246,6 +247,8 @@ public class SqlBasicTest extends SqlTestSupport {
 
                 assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(-1));
                 assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(row.getRowMetadata().getColumnCount()));
+                assertThrows(NullPointerException.class, () -> row.getObject(null));
+                assertThrows(IllegalArgumentException.class, () -> row.getObject("unknown_field"));
             }
 
             assertThrows(NoSuchElementException.class, rowIterator::next);
@@ -260,10 +263,12 @@ public class SqlBasicTest extends SqlTestSupport {
         columnName = adjustFieldName(columnName);
 
         int columnIndex = row.getRowMetadata().findColumn(columnName);
+        assertNotEquals(SqlRowMetadata.COLUMN_NOT_FOUND, columnIndex);
+        Object valueByIndex = row.getObject(columnIndex);
+        assertEquals(expectedValue, valueByIndex);
 
-        Object value = row.getObject(columnIndex);
-
-        assertEquals(expectedValue, value);
+        Object valueByName = row.getObject(columnIndex);
+        assertEquals(expectedValue, valueByName);
     }
 
     private void checkRowMetadata(SqlRowMetadata rowMetadata) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -1,0 +1,947 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Test that covers basic column read operations through SQL.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+@SuppressWarnings("checkstyle:RedundantModifier")
+public class SqlBasicTest extends SqlTestSupport {
+
+    private static final int IDS_FACTORY_ID = 1;
+    private static final int IDS_KEY_CLASS_ID = 2;
+    private static final int IDS_VALUE_CLASS_ID = 3;
+    private static final int PORTABLE_FACTORY_ID = 1;
+    private static final int PORTABLE_KEY_CLASS_ID = 2;
+    private static final int PORTABLE_VALUE_CLASS_ID = 3;
+    private static final int PORTABLE_NESTED_CLASS_ID = 4;
+
+    private static final String MAP_OBJECT = "map_object";
+    private static final String MAP_BINARY = "map_binary";
+
+    private static final int[] PAGE_SIZES = { 1, 16, 256, 4096 };
+    private static final int[] DATA_SET_SIZES = { 1, 256, 4096 };
+    private static final TestHazelcastInstanceFactory FACTORY = new TestHazelcastInstanceFactory(2);
+
+    private static HazelcastInstance instance;
+
+    @Parameter
+    public int cursorBufferSize;
+
+    @Parameter(1)
+    public int dataSetSize;
+
+    @Parameter(2)
+    public SerializationMode serializationMode;
+
+    @Parameter(3)
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameters(name = "cursorBufferSize:{0}, dataSetSize:{1}, serializationMode:{2}, inMemoryFormat:{3}")
+    public static Collection<Object[]> parameters() {
+        List<Object[]> res = new ArrayList<>();
+
+        for (int pageSize : PAGE_SIZES) {
+            for (int dataSetSize : DATA_SET_SIZES) {
+                for (SerializationMode serializationMode : SerializationMode.values()) {
+                    for (InMemoryFormat format : new InMemoryFormat[] { InMemoryFormat.OBJECT, InMemoryFormat.BINARY }) {
+                        res.add(new Object[] {
+                            pageSize,
+                            dataSetSize,
+                            serializationMode,
+                            format
+                        });
+                    }
+                }
+            }
+        }
+
+        return res;
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        instance = FACTORY.newHazelcastInstance(config());
+
+        FACTORY.newHazelcastInstance(config());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        FACTORY.shutdownAll();
+    }
+
+    @Before
+    public void before() {
+        instance.getMap(MAP_OBJECT).clear();
+        instance.getMap(MAP_BINARY).clear();
+    }
+
+    @Test
+    public void testSelect() {
+        // Get proper map
+        IMap<Object, AbstractPojo> map = instance.getMap(mapName());
+
+        // Populate map with values
+        for (long i = 0; i < dataSetSize; i++) {
+            map.put(key(i), value(i));
+        }
+
+        assertEquals(dataSetSize, map.size());
+
+        // Execute query
+        boolean portable = serializationMode == SerializationMode.PORTABLE;
+
+        try (SqlResult res = query()) {
+            SqlRowMetadata rowMetadata = res.getRowMetadata();
+
+            checkRowMetadata(rowMetadata);
+
+            Set<Long> uniqueKeys = new HashSet<>();
+
+            Iterator<SqlRow> rowIterator = res.iterator();
+
+            while (rowIterator.hasNext()) {
+                SqlRow row = rowIterator.next();
+
+                assertEquals(rowMetadata, res.getRowMetadata());
+
+                Long key0 = (Long) row.getObject(rowMetadata.findColumn(adjustFieldName("key")));
+                assert key0 != null;
+
+                AbstractPojoKey key = key(key0);
+                AbstractPojo val = map.get(key);
+
+                checkRowValue(key.getKey(), row, "key");
+                checkRowValue(val.isBooleanVal(), row, "booleanVal");
+                checkRowValue(val.getTinyIntVal(), row, "tinyIntVal");
+                checkRowValue(val.getSmallIntVal(), row, "smallIntVal");
+                checkRowValue(val.getIntVal(), row, "intVal");
+                checkRowValue(val.getBigIntVal(), row, "bigIntVal");
+                checkRowValue(val.getRealVal(), row, "realVal");
+                checkRowValue(val.getDoubleVal(), row, "doubleVal");
+
+                if (!portable) {
+                    checkRowValue(new BigDecimal(val.getDecimalBigIntegerVal()), row, "decimalBigIntegerVal");
+                    checkRowValue(val.getDecimalVal(), row, "decimalVal");
+                }
+
+                checkRowValue(Character.toString(val.getCharVal()), row, "charVal");
+                checkRowValue(val.getVarcharVal(), row, "varcharVal");
+
+                if (!portable) {
+                    checkRowValue(val.getDateVal(), row, "dateVal");
+                    checkRowValue(val.getTimeVal(), row, "timeVal");
+                    checkRowValue(val.getTimestampVal(), row, "timestampVal");
+
+                    checkRowValue(
+                        OffsetDateTime.ofInstant(val.getTsTzDateVal().toInstant(), ZoneId.systemDefault()),
+                        row,
+                        "tsTzDateVal"
+                    );
+
+                    checkRowValue(
+                        val.getTsTzCalendarVal().toZonedDateTime().toOffsetDateTime(),
+                        row,
+                        "tsTzCalendarVal"
+                    );
+
+                    checkRowValue(
+                        OffsetDateTime.ofInstant(val.getTsTzInstantVal(), ZoneId.systemDefault()),
+                        row,
+                        "tsTzInstantVal"
+                    );
+
+                    checkRowValue(
+                        val.getTsTzOffsetDateTimeVal(),
+                        row,
+                        "tsTzOffsetDateTimeVal"
+                    );
+
+                    checkRowValue(
+                        val.getTsTzZonedDateTimeVal().toOffsetDateTime(),
+                        row,
+                        "tsTzZonedDateTimeVal"
+                    );
+
+                    checkRowValue(val.getObjectVal(), row, "objectVal");
+                }
+
+                if (portable) {
+                    checkRowValue(((PortablePojo) val).getPortableVal(), row, "portableVal");
+                }
+
+                uniqueKeys.add(key0);
+            }
+
+            assertThrows(NoSuchElementException.class, rowIterator::next);
+
+            assertThrows(IllegalStateException.class, res::iterator);
+
+            assertEquals(dataSetSize, uniqueKeys.size());
+        }
+    }
+
+    private void checkRowValue(Object expectedValue, SqlRow row, String columnName) {
+        columnName = adjustFieldName(columnName);
+
+        int columnIndex = row.getRowMetadata().findColumn(columnName);
+
+        Object value = row.getObject(columnIndex);
+
+        assertEquals(expectedValue, value);
+    }
+
+    private void checkRowMetadata(SqlRowMetadata rowMetadata) {
+        List<String> fields = fields();
+        List<SqlColumnType> fieldTypes = fieldTypes();
+
+        assertEquals(fields.size(), rowMetadata.getColumnCount());
+
+        for (int i = 0; i < fields.size(); i++) {
+            String field = fields.get(i);
+            String adjustedField = adjustFieldName(field);
+            SqlColumnType fieldType = fieldTypes.get(i);
+
+            int fieldIndex = rowMetadata.findColumn(adjustedField);
+
+            assertNotEquals(SqlRowMetadata.COLUMN_NOT_FOUND, fieldIndex);
+
+            SqlColumnMetadata columnMetadata = rowMetadata.getColumn(fieldIndex);
+            assertEquals(adjustedField, columnMetadata.getName());
+            assertEquals(fieldType, columnMetadata.getType());
+        }
+
+        assertThrows(IndexOutOfBoundsException.class, () -> rowMetadata.getColumn(-1));
+
+        assertThrows(IndexOutOfBoundsException.class, () -> rowMetadata.getColumn(fields.size()));
+    }
+
+    private SqlResult query() {
+        String sql = sql();
+
+        if (cursorBufferSize == SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE) {
+            return instance.getSqlService().query(sql);
+        } else {
+            return instance.getSqlService().query(new SqlQuery(sql).setCursorBufferSize(cursorBufferSize));
+        }
+    }
+
+    private List<String> fields() {
+        if (serializationMode == SerializationMode.PORTABLE) {
+            return Arrays.asList(
+                "key",
+                "booleanVal",
+                "tinyIntVal",
+                "smallIntVal",
+                "intVal",
+                "bigIntVal",
+                "realVal",
+                "doubleVal",
+                "charVal",
+                "varcharVal",
+                "portableVal"
+            );
+        } else {
+            return Arrays.asList(
+                "key",
+                "booleanVal",
+                "tinyIntVal",
+                "smallIntVal",
+                "intVal",
+                "bigIntVal",
+                "realVal",
+                "doubleVal",
+                "decimalBigIntegerVal",
+                "decimalVal",
+                "charVal",
+                "varcharVal",
+                "dateVal",
+                "timeVal",
+                "timestampVal",
+                "tsTzDateVal",
+                "tsTzCalendarVal",
+                "tsTzInstantVal",
+                "tsTzOffsetDateTimeVal",
+                "tsTzZonedDateTimeVal",
+                "objectVal"
+            );
+        }
+    }
+
+    private List<SqlColumnType> fieldTypes() {
+        if (serializationMode == SerializationMode.PORTABLE) {
+            return Arrays.asList(
+                SqlColumnType.BIGINT,
+                SqlColumnType.BOOLEAN,
+                SqlColumnType.TINYINT,
+                SqlColumnType.SMALLINT,
+                SqlColumnType.INT,
+                SqlColumnType.BIGINT,
+                SqlColumnType.REAL,
+                SqlColumnType.DOUBLE,
+                SqlColumnType.VARCHAR,
+                SqlColumnType.VARCHAR,
+                SqlColumnType.OBJECT
+            );
+        } else {
+            return Arrays.asList(
+                SqlColumnType.BIGINT,
+                SqlColumnType.BOOLEAN,
+                SqlColumnType.TINYINT,
+                SqlColumnType.SMALLINT,
+                SqlColumnType.INT,
+                SqlColumnType.BIGINT,
+                SqlColumnType.REAL,
+                SqlColumnType.DOUBLE,
+                SqlColumnType.DECIMAL,
+                SqlColumnType.DECIMAL,
+                SqlColumnType.VARCHAR,
+                SqlColumnType.VARCHAR,
+                SqlColumnType.DATE,
+                SqlColumnType.TIME,
+                SqlColumnType.TIMESTAMP,
+                SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                SqlColumnType.OBJECT
+            );
+        }
+
+
+    }
+
+    private String sql() {
+        List<String> fields = fields();
+
+        StringBuilder res = new StringBuilder("SELECT ");
+
+        for (int i = 0; i < fields.size(); i++) {
+            String field = adjustFieldName(fields.get(i));
+
+            if (i != 0) {
+                res.append(", ");
+            }
+
+            res.append(field);
+        }
+
+        res.append(" FROM ").append(mapName());
+
+        return res.toString();
+    }
+
+    private boolean isPortable() {
+        return serializationMode == SerializationMode.PORTABLE;
+    }
+
+    private String mapName() {
+        return inMemoryFormat == InMemoryFormat.OBJECT ? MAP_OBJECT : MAP_BINARY;
+    }
+
+    private AbstractPojoKey key(long i) {
+        switch (serializationMode) {
+            case SERIALIZABLE:
+                return new SerializablePojoKey(i);
+
+            case DATA_SERIALIZABLE:
+                return new DataSerializablePojoKey(i);
+
+            case IDENTIFIED_DATA_SERIALIZABLE:
+                return new IdentifiedDataSerializablePojoKey(i);
+
+            default:
+                return new PortablePojoKey(i);
+        }
+    }
+
+    private AbstractPojo value(long i) {
+        switch (serializationMode) {
+            case SERIALIZABLE:
+                return new SerializablePojo(i);
+
+            case DATA_SERIALIZABLE:
+                return new DataSerializablePojo(i);
+
+            case IDENTIFIED_DATA_SERIALIZABLE:
+                return new IdentifiedDataSerializablePojo(i);
+
+            default:
+                return new PortablePojo(i);
+        }
+    }
+
+    private static Config config() {
+        SerializationConfig serializationConfig = new SerializationConfig();
+
+        serializationConfig.addPortableFactory(PORTABLE_FACTORY_ID, classId -> {
+            if (classId == PORTABLE_KEY_CLASS_ID) {
+                return new PortablePojoKey();
+            } else if (classId == PORTABLE_VALUE_CLASS_ID) {
+                return new PortablePojo();
+            } else if (classId == PORTABLE_NESTED_CLASS_ID) {
+                return new PortablePojoNested();
+            }
+
+            throw new IllegalArgumentException("Unsupported class ID: " + classId);
+        });
+
+        serializationConfig.addDataSerializableFactory(IDS_FACTORY_ID, classId -> {
+            if (classId == IDS_KEY_CLASS_ID) {
+                return new IdentifiedDataSerializablePojoKey();
+            } else if (classId == IDS_VALUE_CLASS_ID) {
+                return new IdentifiedDataSerializablePojo();
+            }
+
+            throw new IllegalArgumentException("Unsupported class ID: " + classId);
+        });
+
+        Config config = new Config().setSerializationConfig(serializationConfig);
+
+        config
+            .addMapConfig(new MapConfig(MAP_OBJECT).setInMemoryFormat(InMemoryFormat.OBJECT))
+            .addMapConfig(new MapConfig(MAP_BINARY).setInMemoryFormat(InMemoryFormat.BINARY));
+
+        return config;
+    }
+
+    private String adjustFieldName(String fieldName) {
+        if (isPortable()) {
+            fieldName = portableFieldName(fieldName);
+        }
+
+        return fieldName;
+    }
+
+    private static String portableFieldName(String fieldName) {
+        return fieldName + "_p";
+    }
+
+    private abstract static class AbstractPojoKey implements Serializable {
+
+        protected long key;
+
+        protected AbstractPojoKey() {
+            // No-op.
+        }
+
+        protected AbstractPojoKey(long key) {
+            this.key = key;
+        }
+
+        public long getKey() {
+            return key;
+        }
+    }
+
+    private abstract static class AbstractPojo implements Serializable {
+
+        protected boolean booleanVal;
+
+        protected byte tinyIntVal;
+        protected short smallIntVal;
+        protected int intVal;
+        protected long bigIntVal;
+        protected float realVal;
+        protected double doubleVal;
+
+        protected BigInteger decimalBigIntegerVal;
+        protected BigDecimal decimalVal;
+
+        protected char charVal;
+        protected String varcharVal;
+
+        protected LocalTime timeVal;
+        protected LocalDate dateVal;
+        protected LocalDateTime timestampVal;
+
+        protected Date tsTzDateVal;
+        protected GregorianCalendar tsTzCalendarVal;
+        protected Instant tsTzInstantVal;
+        protected OffsetDateTime tsTzOffsetDateTimeVal;
+        protected ZonedDateTime tsTzZonedDateTimeVal;
+
+        protected List<Object> objectVal;
+
+        protected AbstractPojo() {
+            // No-op.
+        }
+
+        protected AbstractPojo(long val) {
+            booleanVal = val % 2 == 0;
+
+            tinyIntVal = (byte) val;
+            smallIntVal = (short) val;
+            intVal = (int) val;
+            bigIntVal = val;
+            realVal = (float) val;
+            doubleVal = (double) val;
+
+            decimalBigIntegerVal = BigInteger.valueOf(val);
+            decimalVal = BigDecimal.valueOf(val);
+
+            charVal = 'c';
+            varcharVal = Long.toString(val);
+
+            timestampVal = LocalDateTime.now();
+            dateVal = timestampVal.toLocalDate();
+            timeVal = timestampVal.toLocalTime();
+
+            tsTzDateVal = new Date();
+            tsTzCalendarVal = (GregorianCalendar) GregorianCalendar.getInstance();
+            tsTzInstantVal = Instant.now();
+            tsTzOffsetDateTimeVal = OffsetDateTime.now();
+            tsTzZonedDateTimeVal = ZonedDateTime.now();
+
+            objectVal = new ArrayList<>(1);
+            objectVal.add(val);
+        }
+
+        public boolean isBooleanVal() {
+            return booleanVal;
+        }
+
+        public byte getTinyIntVal() {
+            return tinyIntVal;
+        }
+
+        public short getSmallIntVal() {
+            return smallIntVal;
+        }
+
+        public int getIntVal() {
+            return intVal;
+        }
+
+        public long getBigIntVal() {
+            return bigIntVal;
+        }
+
+        public float getRealVal() {
+            return realVal;
+        }
+
+        public double getDoubleVal() {
+            return doubleVal;
+        }
+
+        public BigInteger getDecimalBigIntegerVal() {
+            return decimalBigIntegerVal;
+        }
+
+        public BigDecimal getDecimalVal() {
+            return decimalVal;
+        }
+
+        public char getCharVal() {
+            return charVal;
+        }
+
+        public String getVarcharVal() {
+            return varcharVal;
+        }
+
+        public LocalTime getTimeVal() {
+            return timeVal;
+        }
+
+        public LocalDate getDateVal() {
+            return dateVal;
+        }
+
+        public LocalDateTime getTimestampVal() {
+            return timestampVal;
+        }
+
+        public Date getTsTzDateVal() {
+            return tsTzDateVal;
+        }
+
+        public GregorianCalendar getTsTzCalendarVal() {
+            return tsTzCalendarVal;
+        }
+
+        public Instant getTsTzInstantVal() {
+            return tsTzInstantVal;
+        }
+
+        public OffsetDateTime getTsTzOffsetDateTimeVal() {
+            return tsTzOffsetDateTimeVal;
+        }
+
+        public ZonedDateTime getTsTzZonedDateTimeVal() {
+            return tsTzZonedDateTimeVal;
+        }
+
+        public List<Object> getObjectVal() {
+            return objectVal;
+        }
+    }
+
+    public static class SerializablePojoKey extends AbstractPojoKey implements Serializable {
+        public SerializablePojoKey(long key) {
+            super(key);
+        }
+    }
+
+    private static class SerializablePojo extends AbstractPojo implements Serializable {
+        public SerializablePojo(long val) {
+            super(val);
+        }
+    }
+
+    private static class DataSerializablePojoKey extends AbstractPojoKey implements DataSerializable {
+        public DataSerializablePojoKey() {
+            // No-op.
+        }
+
+        public DataSerializablePojoKey(long key) {
+            super(key);
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeLong(key);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            key = in.readLong();
+        }
+    }
+
+    private static class DataSerializablePojo extends AbstractPojo implements DataSerializable {
+        public DataSerializablePojo() {
+            // No-op.
+        }
+
+        public DataSerializablePojo(long val) {
+            super(val);
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeBoolean(booleanVal);
+
+            out.writeByte(tinyIntVal);
+            out.writeShort(smallIntVal);
+            out.writeInt(intVal);
+            out.writeLong(bigIntVal);
+            out.writeFloat(realVal);
+            out.writeDouble(doubleVal);
+
+            out.writeObject(decimalBigIntegerVal);
+            out.writeObject(decimalVal);
+
+            out.writeChar(charVal);
+            out.writeUTF(varcharVal);
+
+            out.writeObject(dateVal);
+            out.writeObject(timeVal);
+            out.writeObject(timestampVal);
+
+            out.writeObject(tsTzDateVal);
+            out.writeObject(tsTzCalendarVal);
+            out.writeObject(tsTzInstantVal);
+            out.writeObject(tsTzOffsetDateTimeVal);
+            out.writeObject(tsTzZonedDateTimeVal);
+
+            out.writeObject(objectVal);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            booleanVal = in.readBoolean();
+
+            tinyIntVal = in.readByte();
+            smallIntVal = in.readShort();
+            intVal = in.readInt();
+            bigIntVal = in.readLong();
+            realVal = in.readFloat();
+            doubleVal = in.readDouble();
+
+            decimalBigIntegerVal = in.readObject();
+            decimalVal = in.readObject();
+
+            charVal = in.readChar();
+            varcharVal = in.readUTF();
+
+            dateVal = in.readObject();
+            timeVal = in.readObject();
+            timestampVal = in.readObject();
+
+            tsTzDateVal = in.readObject();
+            tsTzCalendarVal = in.readObject();
+            tsTzInstantVal = in.readObject();
+            tsTzOffsetDateTimeVal = in.readObject();
+            tsTzZonedDateTimeVal = in.readObject();
+
+            objectVal = in.readObject();
+        }
+    }
+
+    private static class IdentifiedDataSerializablePojoKey extends DataSerializablePojoKey implements IdentifiedDataSerializable {
+        public IdentifiedDataSerializablePojoKey() {
+            // No-op.
+        }
+
+        public IdentifiedDataSerializablePojoKey(long key) {
+            super(key);
+        }
+
+        @Override
+        public int getFactoryId() {
+            return IDS_FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return IDS_KEY_CLASS_ID;
+        }
+    }
+
+    private static class IdentifiedDataSerializablePojo extends DataSerializablePojo implements IdentifiedDataSerializable {
+        public IdentifiedDataSerializablePojo() {
+            // No-op.
+        }
+
+        public IdentifiedDataSerializablePojo(long val) {
+            super(val);
+        }
+
+        @Override
+        public int getFactoryId() {
+            return IDS_FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return IDS_VALUE_CLASS_ID;
+        }
+    }
+
+    private static class PortablePojoKey extends AbstractPojoKey implements Portable {
+        public PortablePojoKey() {
+            // No-op.
+        }
+
+        public PortablePojoKey(long key) {
+            super(key);
+        }
+
+        @Override
+        public int getFactoryId() {
+            return PORTABLE_FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return PORTABLE_KEY_CLASS_ID;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeLong(portableFieldName("key"), key);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            key = reader.readLong(portableFieldName("key"));
+        }
+    }
+
+    private static class PortablePojo extends AbstractPojo implements Portable {
+
+        private PortablePojoNested portableVal;
+
+        public PortablePojo() {
+            // No-op.
+        }
+
+        public PortablePojo(long val) {
+            super(val);
+
+            portableVal = new PortablePojoNested((int) val);
+        }
+
+        public PortablePojoNested getPortableVal() {
+            return portableVal;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return PORTABLE_FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return PORTABLE_VALUE_CLASS_ID;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeBoolean(portableFieldName("booleanVal"), booleanVal);
+
+            writer.writeByte(portableFieldName("tinyIntVal"), tinyIntVal);
+            writer.writeShort(portableFieldName("smallIntVal"), smallIntVal);
+            writer.writeInt(portableFieldName("intVal"), intVal);
+            writer.writeLong(portableFieldName("bigIntVal"), bigIntVal);
+            writer.writeFloat(portableFieldName("realVal"), realVal);
+            writer.writeDouble(portableFieldName("doubleVal"), doubleVal);
+
+            writer.writeChar(portableFieldName("charVal"), charVal);
+            writer.writeUTF(portableFieldName("varcharVal"), varcharVal);
+
+            writer.writePortable(portableFieldName("portableVal"), portableVal);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            booleanVal = reader.readBoolean(portableFieldName("booleanVal"));
+
+            tinyIntVal = reader.readByte(portableFieldName("tinyIntVal"));
+            smallIntVal = reader.readShort(portableFieldName("smallIntVal"));
+            intVal = reader.readInt(portableFieldName("intVal"));
+            bigIntVal = reader.readLong(portableFieldName("bigIntVal"));
+            realVal = reader.readFloat(portableFieldName("realVal"));
+            doubleVal = reader.readDouble(portableFieldName("doubleVal"));
+
+            charVal = reader.readChar(portableFieldName("charVal"));
+            varcharVal = reader.readUTF(portableFieldName("varcharVal"));
+
+            portableVal = reader.readPortable(portableFieldName("portableVal"));
+        }
+    }
+
+    private static class PortablePojoNested implements Portable {
+        private int val;
+
+        public PortablePojoNested() {
+            // No-op.
+        }
+
+        public PortablePojoNested(int val) {
+            this.val = val;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return PORTABLE_FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return PORTABLE_NESTED_CLASS_ID;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeInt("val", val);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            val = reader.readInt("val");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            PortablePojoNested that = (PortablePojoNested) o;
+
+            return val == that.val;
+        }
+
+        @Override
+        public int hashCode() {
+            return val;
+        }
+    }
+
+    private enum SerializationMode {
+        SERIALIZABLE,
+        DATA_SERIALIZABLE,
+        IDENTIFIED_DATA_SERIALIZABLE,
+        PORTABLE
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -243,6 +243,9 @@ public class SqlBasicTest extends SqlTestSupport {
                 }
 
                 uniqueKeys.add(key0);
+
+                assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(-1));
+                assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(row.getRowMetadata().getColumnCount()));
             }
 
             assertThrows(NoSuchElementException.class, rowIterator::next);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -246,7 +246,7 @@ public class SqlBasicTest extends SqlTestSupport {
                 uniqueKeys.add(key0);
 
                 assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(-1));
-                assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(row.getRowMetadata().getColumnCount()));
+                assertThrows(IndexOutOfBoundsException.class, () -> row.getObject(row.getMetadata().getColumnCount()));
                 assertThrows(NullPointerException.class, () -> row.getObject(null));
                 assertThrows(IllegalArgumentException.class, () -> row.getObject("unknown_field"));
             }
@@ -262,7 +262,7 @@ public class SqlBasicTest extends SqlTestSupport {
     private void checkRowValue(Object expectedValue, SqlRow row, String columnName) {
         columnName = adjustFieldName(columnName);
 
-        int columnIndex = row.getRowMetadata().findColumn(columnName);
+        int columnIndex = row.getMetadata().findColumn(columnName);
         assertNotEquals(SqlRowMetadata.COLUMN_NOT_FOUND, columnIndex);
         Object valueByIndex = row.getObject(columnIndex);
         assertEquals(expectedValue, valueByIndex);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -320,7 +320,7 @@ public class SqlErrorTest extends SqlTestSupport {
         map.put(1L, 1L);
         map.put(2L, 2L);
 
-        try (SqlResult res = instance.getSqlService().query(query().setCursorBufferSize(1))) {
+        try (SqlResult res = instance.getSql().query(query().setCursorBufferSize(1))) {
             res.close();
 
             try {
@@ -352,7 +352,7 @@ public class SqlErrorTest extends SqlTestSupport {
 
     @SuppressWarnings("UnusedReturnValue")
     private static int execute(HazelcastInstance instance, SqlQuery query) {
-        try (SqlResult res = instance.getSqlService().query(query)) {
+        try (SqlResult res = instance.getSql().query(query)) {
             int count = 0;
 
             for (SqlRow ignore : res) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.exec.BlockingExec;
+import com.hazelcast.sql.impl.exec.FaultyExec;
+import com.hazelcast.sql.impl.exec.scan.MapScanExec;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Nonnull;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+/**
+ * Test for different error conditions.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlErrorTest extends SqlTestSupport {
+
+    private static final String MAP_NAME = "map";
+    private static final int DATA_SET_SIZE = 100;
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(2);
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testTimeout() {
+        // Start two instances and fill them with data
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        HazelcastInstance instance2 = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        // Block batches from instance2 to instance1.
+        BlockingExec.Blocker blocker = new BlockingExec.Blocker();
+
+        setExecHook(instance2, exec -> {
+            if (exec instanceof MapScanExec) {
+                return new BlockingExec(exec, blocker);
+            } else {
+                return exec;
+            }
+        });
+
+        blocker.unblockAfter(5000L);
+
+        // Execute query on the instance1.
+        SqlException error = assertSqlException(instance1, query().setTimeout(100L));
+
+        assertEquals(SqlErrorCode.TIMEOUT, error.getCode());
+        assertEquals(instance1.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());
+    }
+
+    @Test
+    public void testExecutionError_local() {
+        checkExecutionError(true);
+    }
+
+    @Test
+    public void testExecutionError_remote() {
+        checkExecutionError(false);
+    }
+
+    private void checkExecutionError(boolean local) {
+        // Start two instances and fill them with data
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        HazelcastInstance instance2 = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        // Throw an error from local executor
+        String errorMessage = "Test error";
+
+        HazelcastInstance instance = local ? instance1 : instance2;
+
+        setExecHook(instance, exec -> {
+            if (exec instanceof MapScanExec) {
+                return new FaultyExec(exec, new RuntimeException(errorMessage));
+            }
+
+            return exec;
+        });
+
+        // Execute query.
+        SqlException error = assertSqlException(instance1, query());
+
+        assertEquals(SqlErrorCode.GENERIC, error.getCode());
+        assertEquals(instance.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());
+        assertTrue(error.getMessage().contains(errorMessage));
+    }
+
+    @Test
+    public void testMapMigration() {
+        // Start one instance and fill it with data
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        // Block query execution for a while.
+        BlockingExec.Blocker blocker = new BlockingExec.Blocker();
+
+        setExecHook(instance1, exec -> {
+            if (exec instanceof MapScanExec) {
+                return new BlockingExec(exec, blocker);
+            }
+
+            return exec;
+        });
+
+        // Start a thread that will trigger migration as soon as blocking point is reached.
+        new Thread(() -> {
+            try {
+                blocker.awaitReached();
+
+                factory.newHazelcastInstance();
+            } finally {
+                blocker.unblockAfter(2000);
+            }
+        }).start();
+
+        // Start query
+        SqlException error = assertSqlException(instance1, query());
+        assertEquals(SqlErrorCode.PARTITION_MIGRATED, error.getCode());
+    }
+
+    @Test
+    public void testMapDestroy_local() {
+        checkMapDestroy(true);
+    }
+
+    @Test
+    public void testMapDestroy_remote() {
+        checkMapDestroy(false);
+    }
+
+    private void checkMapDestroy(boolean local) {
+        // Start two instances and fill them with data
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        HazelcastInstance instance2 = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        // Block query execution for a while
+        HazelcastInstance instance = local ? instance1 : instance2;
+
+        BlockingExec.Blocker blocker = new BlockingExec.Blocker();
+
+        setExecHook(instance, exec -> {
+            if (exec instanceof MapScanExec) {
+                return new BlockingExec(exec, blocker);
+            }
+
+            return exec;
+        });
+
+        // Destroy map as soon as when the blocking point is reached.
+        new Thread(() -> {
+            try {
+                blocker.awaitReached();
+
+                instance.getMap(MAP_NAME).destroy();
+            } finally {
+                blocker.unblockAfter(2000);
+            }
+        }).start();
+
+        // Start query
+        SqlException error = assertSqlException(instance1, query());
+        assertEquals(SqlErrorCode.MAP_DESTROYED, error.getCode());
+    }
+
+    @Test
+    public void testMemberLeave() {
+        // Start two instances and fill them with data
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        HazelcastInstance instance2 = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        // Block query execution on a remote member
+        BlockingExec.Blocker blocker = new BlockingExec.Blocker();
+
+        setExecHook(instance2, exec -> {
+            if (exec instanceof MapScanExec) {
+                return new BlockingExec(exec, blocker);
+            }
+
+            return exec;
+        });
+
+        // Stop remote member when the blocking point is reached
+        new Thread(() -> {
+            try {
+                blocker.awaitReached();
+
+                instance2.shutdown();
+            } finally {
+                blocker.unblockAfter(2000);
+            }
+        }).start();
+
+        // Start query
+        SqlException error = assertSqlException(instance1, query());
+        assertEquals(SqlErrorCode.MEMBER_LEAVE, error.getCode());
+        assertEquals(instance1.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());
+    }
+
+    @Test
+    public void testDataTypeMismatch() {
+        // Start two instances and fill them with data
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+
+        IMap<Long, Object> map = instance1.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            Object value = i == 0 ? Long.toString(i) : i;
+
+            map.put(i, value);
+        }
+
+        // Execute query.
+        SqlException error = assertSqlException(instance1, query());
+
+        assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
+        assertEquals(
+            "Failed to extract map entry value because of type mismatch "
+                + "[expectedClass=java.lang.Long, actualClass=java.lang.String]",
+            error.getMessage()
+        );
+    }
+
+    @Test
+    public void testLiteMember() {
+        // Start one normal member and one local member.
+        factory.newHazelcastInstance(getConfig());
+        HazelcastInstance liteMember = factory.newHazelcastInstance(getConfig().setLiteMember(true));
+
+        // Insert data
+        IMap<Long, Long> map = liteMember.getMap(MAP_NAME);
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        // Try query from the lite member.
+        SqlException error = assertSqlException(liteMember, query());
+        assertEquals(SqlErrorCode.GENERIC, error.getCode());
+        assertEquals("SQL queries cannot be executed on lite members", error.getMessage());
+    }
+
+    @Test
+    public void testParsingError() {
+        HazelcastInstance instance = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance.getMap(MAP_NAME);
+        map.put(1L, 1L);
+
+        SqlException error = assertSqlException(instance, new SqlQuery("SELECT bad_field FROM " + MAP_NAME));
+        assertEquals(SqlErrorCode.PARSING, error.getCode());
+    }
+
+    @SuppressWarnings("StatementWithEmptyBody")
+    @Test
+    public void testUserCancel() {
+        HazelcastInstance instance = factory.newHazelcastInstance();
+
+        IMap<Long, Long> map = instance.getMap(MAP_NAME);
+        map.put(1L, 1L);
+        map.put(2L, 2L);
+
+        try (SqlResult res = instance.getSqlService().query(query().setCursorBufferSize(1))) {
+            res.close();
+
+            try {
+                for (SqlRow ignore : res) {
+                    // No-op.
+                }
+
+                fail("Exception is not thrown");
+            } catch (SqlException e) {
+                assertEquals(SqlErrorCode.CANCELLED_BY_USER, e.getCode());
+            }
+        }
+    }
+
+    @Nonnull
+    private static SqlException assertSqlException(HazelcastInstance instance, SqlQuery query) {
+        try {
+            execute(instance, query);
+
+            fail("Exception is not thrown.");
+
+            return null;
+        } catch (SqlException e) {
+            System.out.println(">>> Caught expected SQL error: " + e);
+
+            return e;
+        }
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    private static int execute(HazelcastInstance instance, SqlQuery query) {
+        try (SqlResult res = instance.getSqlService().query(query)) {
+            int count = 0;
+
+            for (SqlRow ignore : res) {
+                count++;
+            }
+
+            return count;
+        }
+    }
+
+    private static SqlQuery query() {
+        return new SqlQuery("SELECT __key, this FROM " + MAP_NAME);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -33,6 +33,9 @@ import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
@@ -60,11 +63,7 @@ public class SqlErrorTest extends SqlTestSupport {
         HazelcastInstance instance1 = factory.newHazelcastInstance();
         HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
-
-        for (long i = 0; i < DATA_SET_SIZE; i++) {
-            map.put(i, i);
-        }
+        populate(instance1);
 
         // Block batches from instance2 to instance1.
         BlockingExec.Blocker blocker = new BlockingExec.Blocker();
@@ -101,11 +100,7 @@ public class SqlErrorTest extends SqlTestSupport {
         HazelcastInstance instance1 = factory.newHazelcastInstance();
         HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
-
-        for (long i = 0; i < DATA_SET_SIZE; i++) {
-            map.put(i, i);
-        }
+        populate(instance1);
 
         // Throw an error from local executor
         String errorMessage = "Test error";
@@ -133,11 +128,7 @@ public class SqlErrorTest extends SqlTestSupport {
         // Start one instance and fill it with data
         HazelcastInstance instance1 = factory.newHazelcastInstance();
 
-        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
-
-        for (long i = 0; i < DATA_SET_SIZE; i++) {
-            map.put(i, i);
-        }
+        populate(instance1);
 
         // Block query execution for a while.
         BlockingExec.Blocker blocker = new BlockingExec.Blocker();
@@ -181,11 +172,7 @@ public class SqlErrorTest extends SqlTestSupport {
         HazelcastInstance instance1 = factory.newHazelcastInstance();
         HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
-
-        for (long i = 0; i < DATA_SET_SIZE; i++) {
-            map.put(i, i);
-        }
+        populate(instance1);
 
         // Block query execution for a while
         HazelcastInstance instance = local ? instance1 : instance2;
@@ -222,11 +209,7 @@ public class SqlErrorTest extends SqlTestSupport {
         HazelcastInstance instance1 = factory.newHazelcastInstance();
         HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
-
-        for (long i = 0; i < DATA_SET_SIZE; i++) {
-            map.put(i, i);
-        }
+        populate(instance1);
 
         // Block query execution on a remote member
         BlockingExec.Blocker blocker = new BlockingExec.Blocker();
@@ -288,11 +271,7 @@ public class SqlErrorTest extends SqlTestSupport {
         HazelcastInstance liteMember = factory.newHazelcastInstance(getConfig().setLiteMember(true));
 
         // Insert data
-        IMap<Long, Long> map = liteMember.getMap(MAP_NAME);
-
-        for (long i = 0; i < DATA_SET_SIZE; i++) {
-            map.put(i, i);
-        }
+        populate(liteMember);
 
         // Try query from the lite member.
         SqlException error = assertSqlException(liteMember, query());
@@ -365,5 +344,15 @@ public class SqlErrorTest extends SqlTestSupport {
 
     private static SqlQuery query() {
         return new SqlQuery("SELECT __key, this FROM " + MAP_NAME);
+    }
+
+    private void populate(HazelcastInstance instance) {
+        Map<Long, Long> map = new HashMap<>();
+
+        for (long i = 0; i < DATA_SET_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        instance.getMap(MAP_NAME).putAll(map);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -79,7 +79,7 @@ public class SqlErrorTest extends SqlTestSupport {
         blocker.unblockAfter(5000L);
 
         // Execute query on the instance1.
-        SqlException error = assertSqlException(instance1, query().setTimeout(100L));
+        SqlException error = assertSqlException(instance1, query().setTimeoutMillis(100L));
 
         assertEquals(SqlErrorCode.TIMEOUT, error.getCode());
         assertEquals(instance1.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
@@ -108,7 +108,7 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
      */
     private static Result optimize(String sql, OptimizerContext context, boolean physical) {
         SqlNode node = context.parse(sql).getNode();
-        RelNode convertedRel = context.convert(node);
+        RelNode convertedRel = context.convert(node).getRel();
         LogicalRel logicalRel = optimizeLogicalInternal(context, convertedRel);
         PhysicalRel physicalRel = physical ? optimizePhysicalInternal(context, logicalRel) : null;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -72,6 +72,7 @@ import com.hazelcast.config.RingbufferStoreConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.internal.config.ServicesConfig;
 import com.hazelcast.config.SetConfig;
@@ -990,6 +991,17 @@ public class ClientDynamicClusterConfig extends Config {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
+    @Override
+    @Nonnull
+    public SqlConfig getSqlConfig() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    @Nonnull
+    public Config setSqlConfig(@Nonnull SqlConfig sqlConfig) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
 
     @Override
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -117,6 +117,7 @@ import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
@@ -803,6 +804,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public ConcurrencyDetection getConcurrencyDetection() {
         return concurrencyDetection;
+    }
+
+    @Override
+    public SqlService getSqlService() {
+        throw new UnsupportedOperationException("SQL is not supported on client members yet.");
     }
 
     public void onClusterChange() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -807,7 +807,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public SqlService getSqlService() {
+    public SqlService getSql() {
         throw new UnsupportedOperationException("SQL is not supported on client members yet.");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -806,6 +806,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return concurrencyDetection;
     }
 
+    @Nonnull
     @Override
     public SqlService getSql() {
         throw new UnsupportedOperationException("SQL is not supported on client members yet.");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -313,6 +313,7 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
         return "HazelcastClientInstance {NOT ACTIVE}";
     }
 
+    @Nonnull
     @Override
     public SqlService getSql() {
         return getClient().getSql();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -47,6 +47,7 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
@@ -310,5 +311,10 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
             return hazelcastInstance.toString();
         }
         return "HazelcastClientInstance {NOT ACTIVE}";
+    }
+
+    @Override
+    public SqlService getSqlService() {
+        return getClient().getSqlService();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -314,7 +314,7 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public SqlService getSqlService() {
-        return getClient().getSqlService();
+    public SqlService getSql() {
+        return getClient().getSql();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -176,6 +176,8 @@ public class Config {
 
     private CPSubsystemConfig cpSubsystemConfig = new CPSubsystemConfig();
 
+    private SqlConfig sqlConfig = new SqlConfig();
+
     private MetricsConfig metricsConfig = new MetricsConfig();
 
     public Config() {
@@ -2630,6 +2632,24 @@ public class Config {
     }
 
     /**
+     * @return Return SQL config.
+     */
+    @Nonnull
+    public SqlConfig getSqlConfig() {
+        return sqlConfig;
+    }
+
+    /**
+     * Sets SQL config.
+     */
+    @Nonnull
+    public Config setSqlConfig(@Nonnull SqlConfig sqlConfig) {
+        Preconditions.checkNotNull(sqlConfig, "sqlConfig");
+        this.sqlConfig = sqlConfig;
+        return this;
+    }
+
+    /**
      * Returns the configuration for the user services managed by this
      * hazelcast instance.
      *
@@ -2685,6 +2705,7 @@ public class Config {
                 + ", crdtReplicationConfig=" + crdtReplicationConfig
                 + ", liteMember=" + liteMember
                 + ", cpSubsystemConfig=" + cpSubsystemConfig
+                + ", sqlConfig=" + sqlConfig
                 + ", metricsConfig=" + metricsConfig
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -166,6 +166,7 @@ public class ConfigXmlGenerator {
         splitBrainProtectionXmlGenerator(gen, config);
         cpSubsystemConfig(gen, config);
         metricsConfig(gen, config);
+        sqlConfig(gen, config);
         userCodeDeploymentConfig(gen, config);
 
         xml.append("</hazelcast>");
@@ -1583,6 +1584,15 @@ public class ConfigXmlGenerator {
            .close()
            .node("collection-frequency-seconds", metricsConfig.getCollectionFrequencySeconds())
            .close();
+    }
+
+    private static void sqlConfig(XmlGenerator gen, Config config) {
+        SqlConfig sqlConfig = config.getSqlConfig();
+        gen.open("sql")
+            .node("executor-pool-size", sqlConfig.getExecutorPoolSize())
+            .node("operation-pool-size", sqlConfig.getOperationPoolSize())
+            .node("query-timeout", sqlConfig.getQueryTimeout())
+            .close();
     }
 
     private static void userCodeDeploymentConfig(XmlGenerator gen, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1591,7 +1591,7 @@ public class ConfigXmlGenerator {
         gen.open("sql")
             .node("executor-pool-size", sqlConfig.getExecutorPoolSize())
             .node("operation-pool-size", sqlConfig.getOperationPoolSize())
-            .node("query-timeout", sqlConfig.getQueryTimeout())
+            .node("query-timeout-millis", sqlConfig.getQueryTimeoutMillis())
             .close();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/SqlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SqlConfig.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.sql.SqlQuery;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
+import static com.hazelcast.internal.util.Preconditions.checkPositive;
+
+/**
+ * SQL service configuration.
+ */
+public class SqlConfig {
+    /** Default number of threads responsible for query execution. */
+    public static final int DEFAULT_EXECUTOR_POOL_SIZE = Runtime.getRuntime().availableProcessors();
+
+    /** Default number of threads responsible for network operations processing. */
+    public static final int DEFAULT_OPERATION_POOL_SIZE = Math.min(8, Runtime.getRuntime().availableProcessors());
+
+    /** Default timeout in milliseconds that is applied to queries without explicit timeout. */
+    public static final int DEFAULT_QUERY_TIMEOUT = 0;
+
+    /** Number of threads responsible for query execution. */
+    private int executorPoolSize = DEFAULT_EXECUTOR_POOL_SIZE;
+
+    /** Number of threads responsible for network operations processing. */
+    private int operationPoolSize = DEFAULT_OPERATION_POOL_SIZE;
+
+    /** Timeout in milliseconds that is applied to queries without an explicit timeout. */
+    private long queryTimeout = DEFAULT_QUERY_TIMEOUT;
+
+    /**
+     * Gets the number of threads responsible for query execution.
+     *
+     * @return Number of threads responsible for query execution.
+     */
+    public int getExecutorPoolSize() {
+        return executorPoolSize;
+    }
+
+    /**
+     * Sets the number of threads responsible for query execution.
+     * <p>
+     * Normally the value of this parameter should be equal to the number of CPU cores.
+     * <p>
+     * Setting the value to less than the number of CPU cores will limit the degree of parallelism of the SQL subsystem. This
+     * may be beneficial if you would like to prioritize other CPU-intensive workloads on the same machine.
+     * <p>
+     * It is not recommended to set the value of this parameter greater than the number of CPU cores because it may decrease
+     * the system's overall performance due to excessive context switches.
+     * <p>
+     * Defaults to {@link #DEFAULT_EXECUTOR_POOL_SIZE}.
+     *
+     * @param executorPoolSize Number of threads responsible for query execution.
+     * @return This instance for chaining.
+     */
+    public SqlConfig setExecutorPoolSize(int executorPoolSize) {
+        checkPositive(executorPoolSize, "Executor pool size should be positive");
+
+        this.executorPoolSize = executorPoolSize;
+
+        return this;
+    }
+
+    /**
+     * Gets the number of threads responsible for network operations processing.
+     *
+     * @return Number of threads responsible for network operations processing.
+     */
+    public int getOperationPoolSize() {
+        return operationPoolSize;
+    }
+
+    /**
+     * Sets the number of threads responsible for network operations processing.
+     * <p>
+     * When Hazelcast members execute a query, they send commands to each other over the network to coordinate the execution.
+     * This includes requests to start or stop query execution, or a request to process a batch of data. These commands are
+     * processed in a separate operation thread pool, to avoid frequent interruption of running query fragments.
+     * <p>
+     * The default value should be good enough for the most workloads. You may want to increase the default value if you run
+     * very small queries, or the machine has a big number of CPU cores.
+     * <p>
+     * It is not recommended to set the value of this parameter greater than the number of CPU cores because it may decrease
+     * the system's overall performance due to excessive context switches.
+     *
+     * <p>
+     * Defaults to {@link #DEFAULT_OPERATION_POOL_SIZE}.
+     *
+     * @param operationPoolSize Number of threads responsible for network operations processing.
+     * @return This instance for chaining.
+     */
+    public SqlConfig setOperationPoolSize(int operationPoolSize) {
+        checkPositive(operationPoolSize, "Operation pool size should be positive");
+
+        this.operationPoolSize = operationPoolSize;
+
+        return this;
+    }
+
+    /**
+     * Gets the timeout in milliseconds that is applied to queries without an explicit timeout.
+     *
+     * @return Timeout in milliseconds.
+     */
+    public long getQueryTimeout() {
+        return queryTimeout;
+    }
+
+    /**
+     * Sets the timeout in milliseconds that is applied to queries without an explicit timeout.
+     * <p>
+     * It is possible to set a query timeout through the {@link SqlQuery#setTimeout(long)} method. If the query timeout is
+     * not set, then the value of this parameter will be used.
+     * <p>
+     * Zero value means no timeout. Negative values are prohibited.
+     * <p>
+     * Defaults to {@link #DEFAULT_QUERY_TIMEOUT}.
+     *
+     * @see SqlQuery#setTimeout(long)
+     * @param queryTimeout Timeout in milliseconds.
+     * @return This instance for chaining.
+     */
+    public SqlConfig setQueryTimeout(long queryTimeout) {
+        checkNotNegative(queryTimeout, "Query timeout cannot be negative");
+
+        this.queryTimeout = queryTimeout;
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "SqlConfig{"
+            + "executorPoolSize=" + executorPoolSize
+            + ", operationPoolSize=" + operationPoolSize
+            + ", queryTimeout=" + queryTimeout
+            + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
@@ -61,7 +61,7 @@ public class TcpIpConfig {
      * @param connectionTimeoutSeconds the connection timeout in seconds
      * @return the updated TcpIpConfig
      * @throws IllegalArgumentException if connectionTimeoutSeconds is smaller than 0
-     * @see #getConnectionTimeoutSeconds()
+     * @see #getConnectimeouttionTimeoutSeconds()
      */
     public TcpIpConfig setConnectionTimeoutSeconds(final int connectionTimeoutSeconds) {
         if (connectionTimeoutSeconds < 0) {

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -38,6 +38,7 @@ import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.topic.ITopic;
@@ -460,6 +461,7 @@ public interface HazelcastInstance {
      *
      * @see SqlService
      */
+    @Beta
     @Nonnull SqlService getSql();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -454,9 +454,11 @@ public interface HazelcastInstance {
     @Nonnull CPSubsystem getCPSubsystem();
 
     /**
-     * Returns SQL service.
+     * Returns a service to execute distirbuted SQL queries.
      *
      * @return SQL service.
+     *
+     * @see SqlService
      */
     @Nonnull SqlService getSql();
 

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -456,6 +456,9 @@ public interface HazelcastInstance {
 
     /**
      * Returns a service to execute distributed SQL queries.
+     * <p>
+     * The service is in beta state. Behavior and API might be changed in future releases. Binary compatibility is not
+     * guaranteed between minor and patch releases.
      *
      * @return SQL service
      *

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -458,7 +458,7 @@ public interface HazelcastInstance {
      *
      * @return SQL service.
      */
-    SqlService getSqlService();
+    SqlService getSql();
 
     /**
      * Shuts down this HazelcastInstance. For more information see {@link com.hazelcast.core.LifecycleService#shutdown()}.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -38,6 +38,7 @@ import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.transaction.HazelcastXAResource;
@@ -451,6 +452,13 @@ public interface HazelcastInstance {
      * @return the CP subsystem that offers a set of in-memory linearizable data structures
      */
     @Nonnull CPSubsystem getCPSubsystem();
+
+    /**
+     * Returns SQL service.
+     *
+     * @return SQL service.
+     */
+    SqlService getSqlService();
 
     /**
      * Shuts down this HazelcastInstance. For more information see {@link com.hazelcast.core.LifecycleService#shutdown()}.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -458,7 +458,7 @@ public interface HazelcastInstance {
      *
      * @return SQL service.
      */
-    SqlService getSql();
+    @Nonnull SqlService getSql();
 
     /**
      * Shuts down this HazelcastInstance. For more information see {@link com.hazelcast.core.LifecycleService#shutdown()}.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -454,9 +454,9 @@ public interface HazelcastInstance {
     @Nonnull CPSubsystem getCPSubsystem();
 
     /**
-     * Returns a service to execute distirbuted SQL queries.
+     * Returns a service to execute distributed SQL queries.
      *
-     * @return SQL service.
+     * @return SQL service
      *
      * @see SqlService
      */

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -63,6 +63,7 @@ import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.impl.proxyservice.ProxyService;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.impl.TopicService;
@@ -407,6 +408,11 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     @Override
     public CPSubsystem getCPSubsystem() {
         return cpSubsystem;
+    }
+
+    @Override
+    public SqlService getSqlService() {
+        return node.getNodeEngine().getSqlService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -411,7 +411,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     }
 
     @Override
-    public SqlService getSqlService() {
+    public SqlService getSql() {
         return node.getNodeEngine().getSqlService();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceImpl.java
@@ -410,6 +410,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         return cpSubsystem;
     }
 
+    @Nonnull
     @Override
     public SqlService getSql() {
         return node.getNodeEngine().getSqlService();

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -293,6 +293,7 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().getCPSubsystem();
     }
 
+    @Nonnull
     @Override
     public SqlService getSql() {
         return getOriginal().getSql();

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -294,8 +294,8 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
-    public SqlService getSqlService() {
-        return getOriginal().getSqlService();
+    public SqlService getSql() {
+        return getOriginal().getSql();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -45,6 +45,7 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
@@ -290,6 +291,11 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     @Override
     public CPSubsystem getCPSubsystem() {
         return getOriginal().getCPSubsystem();
+    }
+
+    @Override
+    public SqlService getSqlService() {
+        return getOriginal().getSqlService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
@@ -61,7 +61,8 @@ public enum ConfigSections {
     PN_COUNTER("pn-counter", true),
     ADVANCED_NETWORK("advanced-network", false),
     CP_SUBSYSTEM("cp-subsystem", false),
-    METRICS("metrics", false);
+    METRICS("metrics", false),
+    SQL("sql", false);
 
     final boolean multipleOccurrence;
     private final String name;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2937,8 +2937,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 sqlConfig.setExecutorPoolSize(Integer.parseInt(value));
             } else if ("operation-pool-size".equals(nodeName)) {
                 sqlConfig.setOperationPoolSize(Integer.parseInt(value));
-            } else if ("query-timeout".equals(nodeName)) {
-                sqlConfig.setQueryTimeout(Long.parseLong(value));
+            } else if ("query-timeout-millis".equals(nodeName)) {
+                sqlConfig.setQueryTimeoutMillis(Long.parseLong(value));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -103,6 +103,7 @@ import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.config.SplitBrainProtectionConfigBuilder;
 import com.hazelcast.config.SplitBrainProtectionListenerConfig;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
@@ -194,6 +195,7 @@ import static com.hazelcast.internal.config.ConfigSections.SECURITY;
 import static com.hazelcast.internal.config.ConfigSections.SERIALIZATION;
 import static com.hazelcast.internal.config.ConfigSections.SET;
 import static com.hazelcast.internal.config.ConfigSections.SPLIT_BRAIN_PROTECTION;
+import static com.hazelcast.internal.config.ConfigSections.SQL;
 import static com.hazelcast.internal.config.ConfigSections.TOPIC;
 import static com.hazelcast.internal.config.ConfigSections.USER_CODE_DEPLOYMENT;
 import static com.hazelcast.internal.config.ConfigSections.WAN_REPLICATION;
@@ -335,6 +337,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             handleCPSubsystem(node);
         } else if (METRICS.isEqual(nodeName)) {
             handleMetrics(node);
+        } else if (SQL.isEqual(nodeName)) {
+            handleSql(node);
         } else {
             return true;
         }
@@ -2919,6 +2923,22 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             if ("enabled".equals(att.getNodeName())) {
                 boolean enabled = getBooleanValue(getAttribute(node, "enabled"));
                 jmxConfig.setEnabled(enabled);
+            }
+        }
+    }
+
+    private void handleSql(Node node) {
+        SqlConfig sqlConfig = config.getSqlConfig();
+
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            String value = getTextContent(child).trim();
+            if ("executor-pool-size".equals(nodeName)) {
+                sqlConfig.setExecutorPoolSize(Integer.parseInt(value));
+            } else if ("operation-pool-size".equals(nodeName)) {
+                sqlConfig.setOperationPoolSize(Integer.parseInt(value));
+            } else if ("query-timeout".equals(nodeName)) {
+                sqlConfig.setQueryTimeout(Long.parseLong(value));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -46,6 +46,7 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.internal.config.ServicesConfig;
 import com.hazelcast.config.SetConfig;
@@ -1085,6 +1086,18 @@ public class DynamicConfigurationAwareConfig extends Config {
     @Nonnull
     @Override
     public Config setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Nonnull
+    @Override
+    public SqlConfig getSqlConfig() {
+        return staticConfig.getSqlConfig();
+    }
+
+    @Nonnull
+    @Override
+    public Config setSqlConfig(@Nonnull SqlConfig sqlConfig) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/ExtendedMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/ExtendedMapEntry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface to provide parity with IMap set and put operations. For use in EntryProcessors.
+ *
+ * @see com.hazelcast.map.IMap#set(Object, Object, long, TimeUnit)
+ * @see com.hazelcast.map.IMap#put(Object, Object, long, TimeUnit)
+ *
+ * @param <V> value type
+ */
+public interface ExtendedMapEntry<V> {
+
+    /** Set the value and set the TTL to a non-default value for the IMap */
+    V setValue(V value, long ttl, TimeUnit ttlUnit);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.ExtendedMapEntry;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -26,10 +27,13 @@ import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Metadata;
 import com.hazelcast.query.impl.getters.Extractors;
 
+import static com.hazelcast.map.impl.record.Record.UNSET;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link java.util.Map.Entry Map.Entry} implementation
@@ -56,12 +60,14 @@ import java.util.Objects;
  * @param <V> value
  */
 public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
-        implements Serializable, IdentifiedDataSerializable {
+        implements Serializable, IdentifiedDataSerializable, ExtendedMapEntry<V> {
 
     private static final long serialVersionUID = 0L;
 
     private transient boolean modified;
     private transient Metadata metadata;
+
+    private transient long newTtl = UNSET;
 
     public LazyMapEntry() {
     }
@@ -101,6 +107,12 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
         return oldValue;
     }
 
+    @Override
+    public V setValue(V value, long ttl, TimeUnit ttlUnit) {
+        newTtl = ttlUnit.toMillis(ttl);
+        return setValue(value);
+    }
+
     /**
      * Similar to calling {@link #setValue} with null but doesn't return old-value hence no extra deserialization.
      */
@@ -121,6 +133,10 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
 
     public boolean isModified() {
         return modified;
+    }
+
+    public long getNewTtl() {
+        return newTtl;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -256,9 +256,9 @@ public final class EntryOperator {
         Object newValue = inMemoryFormat == OBJECT
                 ? entry.getValue() : entry.getByPrioritizingDataValue();
         if (backup) {
-            recordStore.putBackup(dataKey, newValue, NOT_WAN);
+            recordStore.putBackup(dataKey, newValue, entry.getNewTtl(), UNSET, NOT_WAN);
         } else {
-            recordStore.setWithUncountedAccess(dataKey, newValue, UNSET, UNSET);
+            recordStore.setWithUncountedAccess(dataKey, newValue, entry.getNewTtl(), UNSET);
             if (mapOperation.isPostProcessing(recordStore)) {
                 Record record = recordStore.getRecord(dataKey);
                 newValue = record == null ? null : record.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -182,8 +182,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Record putBackup(Data key, Object value, CallerProvenance provenance) {
-        return putBackupInternal(key, value, UNSET, UNSET,
+    public Record putBackup(Data key, Object value, long ttl, long maxIdle, CallerProvenance provenance) {
+        return putBackupInternal(key, value, ttl, maxIdle,
                 false, provenance, null);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -80,7 +80,7 @@ public interface RecordStore<R extends Record> {
      * @param provenance origin of call to this method.
      * @return current record after put.
      */
-    R putBackup(Data key, Object value, CallerProvenance provenance);
+    R putBackup(Data key, Object value, long ttl, long maxIdle, CallerProvenance provenance);
 
     /**
      * @return current record after put.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -45,6 +45,7 @@ import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
@@ -281,6 +282,11 @@ class HazelcastOSGiInstanceImpl
     @Override
     public CPSubsystem getCPSubsystem() {
         return delegatedInstance.getCPSubsystem();
+    }
+
+    @Override
+    public SqlService getSqlService() {
+        return delegatedInstance.getSqlService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -285,8 +285,8 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
-    public SqlService getSqlService() {
-        return delegatedInstance.getSqlService();
+    public SqlService getSql() {
+        return delegatedInstance.getSql();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -284,6 +284,7 @@ class HazelcastOSGiInstanceImpl
         return delegatedInstance.getCPSubsystem();
     }
 
+    @Nonnull
     @Override
     public SqlService getSql() {
         return delegatedInstance.getSql();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
@@ -35,6 +35,7 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.sql.impl.SqlServiceImpl;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.wan.impl.WanReplicationService;
@@ -113,6 +114,13 @@ public interface NodeEngine {
      * @return the SplitBrainProtectionService
      */
     SplitBrainProtectionService getSplitBrainProtectionService();
+
+    /**
+     * Gets SQL service.
+     *
+     * @return the SQL service
+     */
+    SqlServiceImpl getSqlService();
 
     /**
      * Gets the TransactionManagerService.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -330,6 +330,7 @@ public class NodeEngineImpl implements NodeEngine {
         return splitBrainProtectionService;
     }
 
+    @Override
     public SqlServiceImpl getSqlService() {
         return sqlService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
@@ -41,7 +41,7 @@ public final class SqlColumnMetadata {
     /**
      * Get column name.
      *
-     * @return Column name.
+     * @return column name
      */
     @Nonnull
     public String getName() {
@@ -51,7 +51,7 @@ public final class SqlColumnMetadata {
     /**
      * Gets column type.
      *
-     * @return Column type.
+     * @return column type
      */
     @Nonnull
     public SqlColumnType getType() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
@@ -17,14 +17,11 @@
 package com.hazelcast.sql;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 
 /**
  * SQL column metadata.
  */
-public class SqlColumnMetadata implements Serializable {
-
-    private static final long serialVersionUID = 1522422443380097801L;
+public class SqlColumnMetadata {
 
     private final String name;
     private final SqlColumnType type;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
@@ -21,12 +21,13 @@ import javax.annotation.Nonnull;
 /**
  * SQL column metadata.
  */
-public class SqlColumnMetadata {
+public final class SqlColumnMetadata {
 
     private final String name;
     private final SqlColumnType type;
 
-    public SqlColumnMetadata(String name, SqlColumnType type) {
+    @SuppressWarnings("ConstantConditions")
+    public SqlColumnMetadata(@Nonnull String name, @Nonnull SqlColumnType type) {
         assert name != null;
         assert type != null;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
@@ -84,6 +84,6 @@ public class SqlColumnMetadata {
 
     @Override
     public String toString() {
-        return '[' + name + ':' + type + ']';
+        return name + ' ' + type;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -26,6 +28,7 @@ public final class SqlColumnMetadata {
     private final String name;
     private final SqlColumnType type;
 
+    @PrivateApi
     @SuppressWarnings("ConstantConditions")
     public SqlColumnMetadata(@Nonnull String name, @Nonnull SqlColumnType type) {
         assert name != null;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnMetadata.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * SQL column metadata.
+ */
+public class SqlColumnMetadata implements Serializable {
+
+    private static final long serialVersionUID = 1522422443380097801L;
+
+    private final String name;
+    private final SqlColumnType type;
+
+    public SqlColumnMetadata(String name, SqlColumnType type) {
+        assert name != null;
+        assert type != null;
+
+        this.name = name;
+        this.type = type;
+    }
+
+    /**
+     * Get column name.
+     *
+     * @return Column name.
+     */
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets column type.
+     *
+     * @return Column type.
+     */
+    @Nonnull
+    public SqlColumnType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SqlColumnMetadata that = (SqlColumnMetadata) o;
+
+        if (!name.equals(that.name)) {
+            return false;
+        }
+
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+
+        result = 31 * result + type.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return '[' + name + ':' + type + ']';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnType.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnType.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql;
 
+import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -65,7 +66,7 @@ public enum SqlColumnType {
     /** TIMESTAMP_WITH_TIME_ZONE type, represented by {@link java.time.OffsetDateTime} */
     TIMESTAMP_WITH_TIME_ZONE(OffsetDateTime.class),
 
-    /** OBJECT type. */
+    /** OBJECT type, could be represented by any Java class. */
     OBJECT(Object.class);
 
     private final Class<?> valueClass;
@@ -79,6 +80,7 @@ public enum SqlColumnType {
      *
      * @return Java class of the value of this SQL type.
      */
+    @Nonnull
     public Class<?> getValueClass() {
         return valueClass;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnType.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnType.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+/**
+ * SQL column type.
+ */
+public enum SqlColumnType {
+    /** VARCHAR type, represented by {@link java.lang.String} */
+    VARCHAR(String.class),
+
+    /** BOOLEAN type, represented by {@link java.lang.Boolean} */
+    BOOLEAN(Boolean.class),
+
+    /** TINYINT type, represented by {@link java.lang.Byte} */
+    TINYINT(Byte.class),
+
+    /** SMALLINT type, represented by {@link java.lang.Short} */
+    SMALLINT(Short.class),
+
+    /** INT type, represented by {@link java.lang.Integer} */
+    INT(Integer.class),
+
+    /** BIGINT type, represented by {@link java.lang.Long} */
+    BIGINT(Long.class),
+
+    /** DECIMAL type, represented by {@link java.math.BigDecimal} */
+    DECIMAL(BigDecimal.class),
+
+    /** REAL type, represented by {@link java.lang.Float} */
+    REAL(Float.class),
+
+    /** DOUBLE type, represented by {@link java.lang.Double} */
+    DOUBLE(Double.class),
+
+    /** DATE type, represented by {@link java.time.LocalDate} */
+    DATE(LocalDate.class),
+
+    /** TIME type, represented by {@link java.time.LocalTime} */
+    TIME(LocalTime.class),
+
+    /** TIMESTAMP type,, represented by {@link java.time.LocalDateTime} */
+    TIMESTAMP(LocalDateTime.class),
+
+    /** TIMESTAMP_WITH_TIME_ZONE type, represented by {@link java.time.OffsetDateTime} */
+    TIMESTAMP_WITH_TIME_ZONE(OffsetDateTime.class),
+
+    /** OBJECT type. */
+    OBJECT(Object.class);
+
+    private final Class<?> valueClass;
+
+    SqlColumnType(Class<?> valueClass) {
+        this.valueClass = valueClass;
+    }
+
+    /**
+     * Gets Java class of the value of this SQL type.
+     *
+     * @return Java class of the value of this SQL type.
+     */
+    public Class<?> getValueClass() {
+        return valueClass;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnType.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlColumnType.java
@@ -76,9 +76,9 @@ public enum SqlColumnType {
     }
 
     /**
-     * Gets Java class of the value of this SQL type.
+     * Gets the Java class of the value of this SQL type.
      *
-     * @return Java class of the value of this SQL type.
+     * @return the Java class of the value of this SQL type
      */
     @Nonnull
     public Class<?> getValueClass() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlErrorCode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlErrorCode.java
@@ -23,9 +23,6 @@ public final class SqlErrorCode {
     /** Generic error. */
     public static final int GENERIC = -1;
 
-    /** Query completed successfully. */
-    public static final int OK = 0;
-
     /** Member cannot be reached. */
     public static final int MEMBER_CONNECTION = 1001;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
@@ -39,7 +39,9 @@ public class SqlException extends HazelcastException {
     }
 
     /**
-     * @return ID of the member where the error occurred.
+     * Gets ID of the member that caused or initiated an error condition.
+     *
+     * @return ID of the member that caused or initiated an error condition
      */
     @Nonnull
     public UUID getOriginatingMemberId() {
@@ -47,7 +49,13 @@ public class SqlException extends HazelcastException {
     }
 
     /**
-     * @return Error code from {@link SqlErrorCode}.
+     * Gets the error code associated with the exception.
+     * <p>
+     * The returned value is one of the constants defined in the {@link SqlErrorCode} class.
+     *
+     * @return the error code associated with the exception
+     *
+     * @see SqlErrorCode
      */
     public int getCode() {
         return code;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.core.HazelcastException;
+
+import java.util.UUID;
+
+/**
+ * An exception occurred during SQL query execution.
+ */
+public class SqlException extends HazelcastException {
+
+    private final UUID originatingMemberId;
+    private final int code;
+
+    public SqlException(UUID originatingMemberId, int code, String message, Throwable cause) {
+        super(message, cause);
+
+        this.originatingMemberId = originatingMemberId;
+        this.code = code;
+    }
+
+    /**
+     * @return ID of the member where the error occurred.
+     */
+    public UUID getOriginatingMemberId() {
+        return originatingMemberId;
+    }
+
+    /**
+     * @return Error code from {@link SqlErrorCode}.
+     */
+    public int getCode() {
+        return code;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import javax.annotation.Nonnull;
 import java.util.UUID;
@@ -29,6 +30,7 @@ public class SqlException extends HazelcastException {
     private final UUID originatingMemberId;
     private final int code;
 
+    @PrivateApi
     public SqlException(@Nonnull UUID originatingMemberId, int code, String message, Throwable cause) {
         super(message, cause);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
@@ -29,7 +29,7 @@ public class SqlException extends HazelcastException {
     private final UUID originatingMemberId;
     private final int code;
 
-    public SqlException(UUID originatingMemberId, int code, String message, Throwable cause) {
+    public SqlException(@Nonnull UUID originatingMemberId, int code, String message, Throwable cause) {
         super(message, cause);
 
         this.originatingMemberId = originatingMemberId;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlException.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql;
 
 import com.hazelcast.core.HazelcastException;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -38,6 +39,7 @@ public class SqlException extends HazelcastException {
     /**
      * @return ID of the member where the error occurred.
      */
+    @Nonnull
     public UUID getOriginatingMemberId() {
         return originatingMemberId;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.config.SqlConfig;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Definition of the SQL query.
+ * <p>
+ * This object is mutable. Properties are read once before the execution is started.
+ * Changes to properties do not affect the behavior of already running queries.
+ */
+public class SqlQuery implements Serializable {
+    /** Value for the timeout that is not set. */
+    public static final long TIMEOUT_NOT_SET = -1;
+
+    /** Default timeout. */
+    public static final long DEFAULT_TIMEOUT = TIMEOUT_NOT_SET;
+
+    /** Default page size. */
+    public static final int DEFAULT_CURSOR_BUFFER_SIZE = 4096;
+
+    private static final long serialVersionUID = -2553856965040677191L;
+
+    private String sql;
+    private List<Object> parameters;
+    private long timeout = DEFAULT_TIMEOUT;
+    private int cursorBufferSize = DEFAULT_CURSOR_BUFFER_SIZE;
+
+    public SqlQuery(String sql) {
+        setSql(sql);
+    }
+
+    /**
+     * Copying constructor.
+     */
+    private SqlQuery(String sql, List<Object> parameters, long timeout, int cursorBufferSize) {
+        this.sql = sql;
+        this.parameters = parameters;
+        this.timeout = timeout;
+        this.cursorBufferSize = cursorBufferSize;
+    }
+
+    /**
+     * Gets the SQL query to be executed.
+     *
+     * @return SQL query.
+     */
+    public String getSql() {
+        return sql;
+    }
+
+    /**
+     * Sets the SQL query to be executed.
+     * <p>
+     * SQL query cannot be null or empty.
+     *
+     * @param sql SQL query.
+     * @return This instance for chaining.
+     */
+    public SqlQuery setSql(String sql) {
+        if (sql == null || sql.length() == 0) {
+            throw new IllegalArgumentException("SQL cannot be null or empty.");
+        }
+
+        this.sql = sql;
+
+        return this;
+    }
+
+    /**
+     * Gets query parameters.
+     *
+     * @return Query parameters.
+     */
+    public List<Object> getParameters() {
+        return parameters != null ? parameters : Collections.emptyList();
+    }
+
+    /**
+     * Sets query parameters.
+     * <p>
+     * You may define parameter placeholders in the query with the {@code "?"} character. For every placeholder, a parameter's
+     * value must be provided.
+     * <p>
+     * When the method is called, the content of the parameters list is copied. Subsequent changes to the original list don't
+     * change query parameters.
+     *
+     * @see #addParameter(Object)
+     * @see #clearParameters()
+     * @param parameters Query parameters.
+     * @return This instance for chaining.
+     */
+    public SqlQuery setParameters(List<Object> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            this.parameters = null;
+        } else {
+            this.parameters = new ArrayList<>(parameters);
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds a single parameter to the end of parameters list.
+     *
+     * @see #setParameters(List)
+     * @see #clearParameters()
+     * @param parameter Parameter.
+     * @return This instance for chaining.
+     */
+    public SqlQuery addParameter(Object parameter) {
+        if (parameters == null) {
+            parameters = new ArrayList<>(1);
+        }
+
+        parameters.add(parameter);
+
+        return this;
+    }
+
+    /**
+     * Clear query parameters.
+     *
+     * @see #setParameters(List)
+     * @see #addParameter(Object)
+     * @return This instance for chaining.
+     */
+    public SqlQuery clearParameters() {
+        this.parameters = null;
+
+        return this;
+    }
+
+    /**
+     * Gets the query timeout in milliseconds.
+     *
+     * @return Query timeout in milliseconds.
+     */
+    public long getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Sets the query timeout in milliseconds.
+     * <p>
+     * If the timeout is reached for a running query, it will be cancelled forcefully.
+     * <p>
+     * Zero value means no timeout. {@code -1} means that the value from {@link SqlConfig#getQueryTimeout()} will be used. Other
+     * negative values are prohibited.
+     * <p>
+     * Defaults to {@code -1}, which means that the value from {@link SqlConfig#getQueryTimeout()} will be used.
+     *
+     * @see SqlConfig#getQueryTimeout()
+     * @param timeout Query timeout in milliseconds, {@code 0} for no timeout, {@code -1} to user member's default timeout.
+     * @return This instance for chaining.
+     */
+    public SqlQuery setTimeout(long timeout) {
+        if (timeout < 0 && timeout != TIMEOUT_NOT_SET) {
+            throw new IllegalArgumentException("Timeout should be non-negative or -1: " + timeout);
+        }
+
+        this.timeout = timeout;
+
+        return this;
+    }
+
+    /**
+     * Gets the cursor buffer size (measured in the number of rows).
+     *
+     * @return Cursor buffer size (measured in the number of rows).
+     */
+    public int getCursorBufferSize() {
+        return cursorBufferSize;
+    }
+
+    /**
+     * Sets the cursor buffer size (measured in the number of rows).
+     * <p>
+     * When a query is submitted for execution, the {@link SqlResult} is returned as a result. When rows are ready to be
+     * consumed, they are put into an internal buffer of the cursor. This parameter defines the maximum number of rows in
+     * the buffer. When the threshold is reached, the backpressure mechanism will slow down the query execution, possibly to a
+     * complete halt, to prevent out-of-memory.
+     * <p>
+     * Only positive values are allowed.
+     * <p>
+     * The default value is expected to work well for the most workloads. A bigger buffer size may give you a slight performance
+     * boost for queries with large result sets at the cost of increased memory consumption.
+     * <p>
+     * Defaults to {@link #DEFAULT_CURSOR_BUFFER_SIZE}.
+     *
+     * @see SqlService#query(SqlQuery)
+     * @see SqlResult
+     * @param cursorBufferSize Cursor buffer size (measured in the number of rows).
+     * @return This instance for chaining.
+     */
+    public SqlQuery setCursorBufferSize(int cursorBufferSize) {
+        if (cursorBufferSize <= 0) {
+            throw new IllegalArgumentException("Cursor buffer size should be positive: " + cursorBufferSize);
+        }
+
+        this.cursorBufferSize = cursorBufferSize;
+
+        return this;
+    }
+
+    /**
+     * Creates copy of this instance.
+     *
+     * @return Copy of this instance.
+     */
+    public SqlQuery copy() {
+        return new SqlQuery(sql, parameters, timeout, cursorBufferSize);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SqlQuery sqlQuery = (SqlQuery) o;
+
+        return Objects.equals(sql, sqlQuery.sql)
+            && Objects.equals(getParameters(), sqlQuery.getParameters())
+            && timeout == sqlQuery.timeout
+            && cursorBufferSize == sqlQuery.cursorBufferSize;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = sql != null ? sql.hashCode() : 0;
+
+        result = 31 * result + getParameters().hashCode();
+        result = 31 * result + (int) (timeout ^ (timeout >>> 32));
+        result = 31 * result + cursorBufferSize;
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "SqlQuery{"
+            + "sql=" + sql
+            + ", parameters=" + getParameters()
+            + ", timeout=" + timeout
+            + ", cursorBufferSize=" + cursorBufferSize
+            + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -35,6 +35,9 @@ public class SqlQuery {
     /** Value for the timeout that is not set. */
     public static final long TIMEOUT_NOT_SET = -1;
 
+    /** Value for the timeout that is disabled. */
+    public static final long TIMEOUT_DISABLED = 0;
+
     /** Default timeout. */
     public static final long DEFAULT_TIMEOUT = TIMEOUT_NOT_SET;
 
@@ -46,7 +49,7 @@ public class SqlQuery {
     private long timeout = DEFAULT_TIMEOUT;
     private int cursorBufferSize = DEFAULT_CURSOR_BUFFER_SIZE;
 
-    public SqlQuery(String sql) {
+    public SqlQuery(@Nonnull String sql) {
         setSql(sql);
     }
 
@@ -242,7 +245,7 @@ public class SqlQuery {
      */
     @Nonnull
     public SqlQuery copy() {
-        return new SqlQuery(sql, parameters, timeout, cursorBufferSize);
+        return new SqlQuery(sql, new ArrayList<>(getParameters()), timeout, cursorBufferSize);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * This object is mutable. Properties are read once before the execution is started.
  * Changes to properties do not affect the behavior of already running queries.
  */
-public class SqlQuery {
+public final class SqlQuery {
     /** Value for the timeout that is not set. */
     public static final long TIMEOUT_NOT_SET = -1;
 
@@ -40,7 +40,7 @@ public class SqlQuery {
     /** Default timeout. */
     public static final long DEFAULT_TIMEOUT = TIMEOUT_NOT_SET;
 
-    /** Default page size. */
+    /** Default cursor buffer size. */
     public static final int DEFAULT_CURSOR_BUFFER_SIZE = 4096;
 
     private String sql;
@@ -148,7 +148,7 @@ public class SqlQuery {
     }
 
     /**
-     * Clear query parameters.
+     * Clears query parameters.
      *
      * @return this instance for chaining
      *

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql;
 
 import com.hazelcast.config.SqlConfig;
+import com.hazelcast.internal.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -76,10 +77,15 @@ public class SqlQuery {
      *
      * @param sql SQL query.
      * @return This instance for chaining.
+     * @throws NullPointerException If passed SQL query is null
+     * @throws IllegalArgumentException If passed SQL query is empty
      */
-    public SqlQuery setSql(String sql) {
-        if (sql == null || sql.length() == 0) {
-            throw new IllegalArgumentException("SQL cannot be null or empty.");
+    @Nonnull
+    public SqlQuery setSql(@Nonnull String sql) {
+        Preconditions.checkNotNull(sql, "SQL cannot be null");
+
+        if (sql.length() == 0) {
+            throw new IllegalArgumentException("SQL cannot be empty");
         }
 
         this.sql = sql;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -66,7 +66,7 @@ public class SqlQuery {
     /**
      * Gets the SQL query to be executed.
      *
-     * @return SQL query.
+     * @return SQL query
      */
     @Nonnull
     public String getSql() {
@@ -78,10 +78,10 @@ public class SqlQuery {
      * <p>
      * The SQL query cannot be null or empty.
      *
-     * @param sql SQL query.
-     * @return This instance for chaining.
-     * @throws NullPointerException If passed SQL query is null
-     * @throws IllegalArgumentException If passed SQL query is empty
+     * @param sql SQL query
+     * @return this instance for chaining
+     * @throws NullPointerException if passed SQL query is null
+     * @throws IllegalArgumentException if passed SQL query is empty
      */
     @Nonnull
     public SqlQuery setSql(@Nonnull String sql) {
@@ -99,7 +99,7 @@ public class SqlQuery {
     /**
      * Gets the query parameters.
      *
-     * @return Query parameters.
+     * @return query parameters
      */
     @Nonnull
     public List<Object> getParameters() {
@@ -115,10 +115,11 @@ public class SqlQuery {
      * When the method is called, the content of the parameters list is copied. Subsequent changes to the original list don't
      * change the query parameters.
      *
+     * @param parameters query parameters
+     * @return this instance for chaining
+     *
      * @see #addParameter(Object)
      * @see #clearParameters()
-     * @param parameters Query parameters.
-     * @return This instance for chaining.
      */
     @Nonnull
     public SqlQuery setParameters(List<Object> parameters) {
@@ -134,10 +135,11 @@ public class SqlQuery {
     /**
      * Adds a single parameter to the end of the parameters list.
      *
+     * @param parameter parameter
+     * @return this instance for chaining
+     *
      * @see #setParameters(List)
      * @see #clearParameters()
-     * @param parameter Parameter.
-     * @return This instance for chaining.
      */
     @Nonnull
     public SqlQuery addParameter(Object parameter) {
@@ -153,9 +155,10 @@ public class SqlQuery {
     /**
      * Clear query parameters.
      *
+     * @return this instance for chaining
+     *
      * @see #setParameters(List)
      * @see #addParameter(Object)
-     * @return This instance for chaining.
      */
     @Nonnull
     public SqlQuery clearParameters() {
@@ -167,7 +170,7 @@ public class SqlQuery {
     /**
      * Gets the query timeout in milliseconds.
      *
-     * @return Query timeout in milliseconds.
+     * @return query timeout in milliseconds
      */
     public long getTimeoutMillis() {
         return timeout;
@@ -183,9 +186,10 @@ public class SqlQuery {
      * <p>
      * Defaults to {@value #TIMEOUT_NOT_SET}.
      *
+     * @param timeout query timeout in milliseconds, {@code 0} for no timeout, {@code -1} to user member's default timeout
+     * @return this instance for chaining
+     *
      * @see SqlConfig#getQueryTimeoutMillis()
-     * @param timeout Query timeout in milliseconds, {@code 0} for no timeout, {@code -1} to user member's default timeout.
-     * @return This instance for chaining.
      */
     @Nonnull
     public SqlQuery setTimeoutMillis(long timeout) {
@@ -201,7 +205,7 @@ public class SqlQuery {
     /**
      * Gets the cursor buffer size (measured in the number of rows).
      *
-     * @return Cursor buffer size (measured in the number of rows).
+     * @return cursor buffer size (measured in the number of rows)
      */
     public int getCursorBufferSize() {
         return cursorBufferSize;
@@ -222,10 +226,11 @@ public class SqlQuery {
      * <p>
      * Defaults to {@value #DEFAULT_CURSOR_BUFFER_SIZE}.
      *
+     * @param cursorBufferSize cursor buffer size (measured in the number of rows)
+     * @return this instance for chaining
+     *
      * @see SqlService#query(SqlQuery)
      * @see SqlResult
-     * @param cursorBufferSize Cursor buffer size (measured in the number of rows).
-     * @return This instance for chaining.
      */
     @Nonnull
     public SqlQuery setCursorBufferSize(int cursorBufferSize) {
@@ -239,9 +244,9 @@ public class SqlQuery {
     }
 
     /**
-     * Creates a copy of this instance.
+     * Creates a copy of this instance
      *
-     * @return Copy of this instance.
+     * @return Copy of this instance
      */
     @Nonnull
     public SqlQuery copy() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,7 +44,7 @@ public class SqlQuery {
     public static final int DEFAULT_CURSOR_BUFFER_SIZE = 4096;
 
     private String sql;
-    private List<Object> parameters;
+    private List<Object> parameters = new ArrayList<>();
     private long timeout = DEFAULT_TIMEOUT;
     private int cursorBufferSize = DEFAULT_CURSOR_BUFFER_SIZE;
 
@@ -103,7 +102,7 @@ public class SqlQuery {
      */
     @Nonnull
     public List<Object> getParameters() {
-        return parameters != null ? parameters : Collections.emptyList();
+        return parameters;
     }
 
     /**
@@ -124,7 +123,7 @@ public class SqlQuery {
     @Nonnull
     public SqlQuery setParameters(List<Object> parameters) {
         if (parameters == null || parameters.isEmpty()) {
-            this.parameters = null;
+            this.parameters = new ArrayList<>();
         } else {
             this.parameters = new ArrayList<>(parameters);
         }
@@ -143,10 +142,6 @@ public class SqlQuery {
      */
     @Nonnull
     public SqlQuery addParameter(Object parameter) {
-        if (parameters == null) {
-            parameters = new ArrayList<>(1);
-        }
-
         parameters.add(parameter);
 
         return this;
@@ -162,7 +157,7 @@ public class SqlQuery {
      */
     @Nonnull
     public SqlQuery clearParameters() {
-        this.parameters = null;
+        this.parameters = new ArrayList<>();
 
         return this;
     }
@@ -250,7 +245,7 @@ public class SqlQuery {
      */
     @Nonnull
     public SqlQuery copy() {
-        return new SqlQuery(sql, new ArrayList<>(getParameters()), timeout, cursorBufferSize);
+        return new SqlQuery(sql, new ArrayList<>(parameters), timeout, cursorBufferSize);
     }
 
     @Override
@@ -266,7 +261,7 @@ public class SqlQuery {
         SqlQuery sqlQuery = (SqlQuery) o;
 
         return Objects.equals(sql, sqlQuery.sql)
-            && Objects.equals(getParameters(), sqlQuery.getParameters())
+            && Objects.equals(parameters, sqlQuery.parameters)
             && timeout == sqlQuery.timeout
             && cursorBufferSize == sqlQuery.cursorBufferSize;
     }
@@ -275,7 +270,7 @@ public class SqlQuery {
     public int hashCode() {
         int result = sql != null ? sql.hashCode() : 0;
 
-        result = 31 * result + getParameters().hashCode();
+        result = 31 * result + parameters.hashCode();
         result = 31 * result + (int) (timeout ^ (timeout >>> 32));
         result = 31 * result + cursorBufferSize;
 
@@ -286,7 +281,7 @@ public class SqlQuery {
     public String toString() {
         return "SqlQuery{"
             + "sql=" + sql
-            + ", parameters=" + getParameters()
+            + ", parameters=" + parameters
             + ", timeout=" + timeout
             + ", cursorBufferSize=" + cursorBufferSize
             + '}';

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -18,7 +18,6 @@ package com.hazelcast.sql;
 
 import com.hazelcast.config.SqlConfig;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +29,7 @@ import java.util.Objects;
  * This object is mutable. Properties are read once before the execution is started.
  * Changes to properties do not affect the behavior of already running queries.
  */
-public class SqlQuery implements Serializable {
+public class SqlQuery {
     /** Value for the timeout that is not set. */
     public static final long TIMEOUT_NOT_SET = -1;
 
@@ -39,8 +38,6 @@ public class SqlQuery implements Serializable {
 
     /** Default page size. */
     public static final int DEFAULT_CURSOR_BUFFER_SIZE = 4096;
-
-    private static final long serialVersionUID = -2553856965040677191L;
 
     private String sql;
     private List<Object> parameters;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql;
 
 import com.hazelcast.config.SqlConfig;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -63,6 +64,7 @@ public class SqlQuery {
      *
      * @return SQL query.
      */
+    @Nonnull
     public String getSql() {
         return sql;
     }
@@ -90,6 +92,7 @@ public class SqlQuery {
      *
      * @return Query parameters.
      */
+    @Nonnull
     public List<Object> getParameters() {
         return parameters != null ? parameters : Collections.emptyList();
     }
@@ -108,6 +111,7 @@ public class SqlQuery {
      * @param parameters Query parameters.
      * @return This instance for chaining.
      */
+    @Nonnull
     public SqlQuery setParameters(List<Object> parameters) {
         if (parameters == null || parameters.isEmpty()) {
             this.parameters = null;
@@ -126,6 +130,7 @@ public class SqlQuery {
      * @param parameter Parameter.
      * @return This instance for chaining.
      */
+    @Nonnull
     public SqlQuery addParameter(Object parameter) {
         if (parameters == null) {
             parameters = new ArrayList<>(1);
@@ -143,6 +148,7 @@ public class SqlQuery {
      * @see #addParameter(Object)
      * @return This instance for chaining.
      */
+    @Nonnull
     public SqlQuery clearParameters() {
         this.parameters = null;
 
@@ -172,6 +178,7 @@ public class SqlQuery {
      * @param timeout Query timeout in milliseconds, {@code 0} for no timeout, {@code -1} to user member's default timeout.
      * @return This instance for chaining.
      */
+    @Nonnull
     public SqlQuery setTimeout(long timeout) {
         if (timeout < 0 && timeout != TIMEOUT_NOT_SET) {
             throw new IllegalArgumentException("Timeout should be non-negative or -1: " + timeout);
@@ -211,6 +218,7 @@ public class SqlQuery {
      * @param cursorBufferSize Cursor buffer size (measured in the number of rows).
      * @return This instance for chaining.
      */
+    @Nonnull
     public SqlQuery setCursorBufferSize(int cursorBufferSize) {
         if (cursorBufferSize <= 0) {
             throw new IllegalArgumentException("Cursor buffer size should be positive: " + cursorBufferSize);
@@ -226,6 +234,7 @@ public class SqlQuery {
      *
      * @return Copy of this instance.
      */
+    @Nonnull
     public SqlQuery copy() {
         return new SqlQuery(sql, parameters, timeout, cursorBufferSize);
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlQuery.java
@@ -166,7 +166,7 @@ public class SqlQuery {
      *
      * @return Query timeout in milliseconds.
      */
-    public long getTimeout() {
+    public long getTimeoutMillis() {
         return timeout;
     }
 
@@ -175,17 +175,17 @@ public class SqlQuery {
      * <p>
      * If the timeout is reached for a running query, it will be cancelled forcefully.
      * <p>
-     * Zero value means no timeout. {@value #TIMEOUT_NOT_SET} means that the value from {@link SqlConfig#getQueryTimeout()} will
-     * be used. Other negative values are prohibited.
+     * Zero value means no timeout. {@value #TIMEOUT_NOT_SET} means that the value from
+     * {@link SqlConfig#getQueryTimeoutMillis()} will be used. Other negative values are prohibited.
      * <p>
      * Defaults to {@value #TIMEOUT_NOT_SET}.
      *
-     * @see SqlConfig#getQueryTimeout()
+     * @see SqlConfig#getQueryTimeoutMillis()
      * @param timeout Query timeout in milliseconds, {@code 0} for no timeout, {@code -1} to user member's default timeout.
      * @return This instance for chaining.
      */
     @Nonnull
-    public SqlQuery setTimeout(long timeout) {
+    public SqlQuery setTimeoutMillis(long timeout) {
         if (timeout < 0 && timeout != TIMEOUT_NOT_SET) {
             throw new IllegalArgumentException("Timeout should be non-negative or -1: " + timeout);
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+
+/**
+ * SQL query result. Represents a stream of rows.
+ * <p>
+ * Use {@link #iterator()} to iterate over rows. The iterator could be requested only once.
+ * <p>
+ * Use {@link #close()} to release the resources associated with the result.
+ * <p>
+ * Typical usage pattern:
+ * <pre>
+ * try (SqlResult result = hazelcastInstance.getSqlQuery().query("SELECT ...")) {
+ *     for (SqlRow row : result) {
+ *         // Process the row.
+ *     }
+ * }
+ * </pre>
+ *
+ * @see #iterator()
+ * @see #close()
+ */
+public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
+    /**
+     * Gets row metadata.
+     *
+     * @return Row metadata.
+     */
+    SqlRowMetadata getRowMetadata();
+
+    /**
+     * Returns the iterator over query rows.
+     * <p>
+     * The iterator may be requested only once.
+     *
+     * @return Iterator.
+     * @throws IllegalStateException If the method is invoked more than once.
+     * @throws SqlException In case of an SQL-related error condition.
+     */
+    @Override
+    @Nonnull
+    Iterator<SqlRow> iterator();
+
+    /**
+     * Release the resources associated with the query result.
+     * <p>
+     * The query engine delivers results asynchronously. The query may become inactive even before all rows are
+     * consumed. The invocation of this command will cancel the execution of the query on all members if the query
+     * is still active. Otherwise it is no-op.
+     */
+    @Override
+    void close();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
@@ -56,8 +56,8 @@ public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
      * @throws IllegalStateException If the method is invoked more than once.
      * @throws SqlException In case of an SQL-related error condition.
      */
-    @Override
     @Nonnull
+    @Override
     Iterator<SqlRow> iterator();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
@@ -44,6 +44,7 @@ public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
      *
      * @return Row metadata.
      */
+    @Nonnull
     SqlRowMetadata getRowMetadata();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
@@ -53,7 +53,7 @@ public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
      * The iterator may be requested only once.
      *
      * @return iterator
-     * @throws IllegalStateException ff the method is invoked more than once
+     * @throws IllegalStateException if the method is invoked more than once
      * @throws SqlException in case of an SQL-related error condition
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
@@ -42,7 +42,7 @@ public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
     /**
      * Gets row metadata.
      *
-     * @return Row metadata.
+     * @return row metadata
      */
     @Nonnull
     SqlRowMetadata getRowMetadata();
@@ -52,9 +52,9 @@ public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
      * <p>
      * The iterator may be requested only once.
      *
-     * @return Iterator.
-     * @throws IllegalStateException If the method is invoked more than once.
-     * @throws SqlException In case of an SQL-related error condition.
+     * @return iterator
+     * @throws IllegalStateException ff the method is invoked more than once
+     * @throws SqlException in case of an SQL-related error condition
      */
     @Nonnull
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -26,7 +26,7 @@ public interface SqlRow {
     /**
      * Gets the value of the column by index.
      * <p>
-     * The class of the returned value depends on the SQL type of the column.
+     * The class of the returned value depends on the SQL type of the column. No implicit conversions are performed on the value.
      *
      * @see #getMetadata()
      * @see SqlColumnMetadata#getType()
@@ -35,7 +35,7 @@ public interface SqlRow {
      * @throws IndexOutOfBoundsException If the column index is out of bounds.
      */
     @Nullable
-    Object getObject(int columnIndex);
+    <T> T getObject(int columnIndex);
 
     /**
      * Gets the value of the column by column name.
@@ -43,7 +43,7 @@ public interface SqlRow {
      * Column name should be one of those defined in {@link SqlRowMetadata}, case-sensitive. You may also use
      * {@link SqlRowMetadata#findColumn(String)} to test for column existence.
      * <p>
-     * The class of the returned value depends on the SQL type of the column.
+     * The class of the returned value depends on the SQL type of the column. No implicit conversions are performed on the value.
      *
      * @see #getMetadata()
      * @see SqlRowMetadata#findColumn(String)
@@ -55,7 +55,7 @@ public interface SqlRow {
      * @throws IllegalArgumentException If a column with the given name is not found
      */
     @Nullable
-    Object getObject(@Nonnull String columnName);
+    <T> T getObject(@Nonnull String columnName);
 
     /**
      * @see SqlRowMetadata

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -28,11 +28,11 @@ public interface SqlRow {
      * <p>
      * The class of the returned value depends on the SQL type of the column. No implicit conversions are performed on the value.
      *
-     * @param columnIndex Column index, 0-based.
-     * @return Value of the column.
+     * @param columnIndex column index, zero-based.
+     * @return value of the column
      *
-     * @throws IndexOutOfBoundsException If the column index is out of bounds
-     * @throws ClassCastException If the type of the column type isn't assignable to the type {@code T}
+     * @throws IndexOutOfBoundsException if the column index is out of bounds
+     * @throws ClassCastException if the type of the column type isn't assignable to the type {@code T}
      *
      * @see #getMetadata()
      * @see SqlColumnMetadata#getType()
@@ -48,12 +48,12 @@ public interface SqlRow {
      * <p>
      * The class of the returned value depends on the SQL type of the column. No implicit conversions are performed on the value.
      *
-     * @param columnName Column name.
-     * @return Value of the column
+     * @param columnName column name
+     * @return value of the column
      *
-     * @throws NullPointerException If column name is null
-     * @throws IllegalArgumentException If a column with the given name is not found
-     * @throws ClassCastException If the type of the column type isn't assignable to the type {@code T}
+     * @throws NullPointerException if column name is null
+     * @throws IllegalArgumentException if a column with the given name is not found
+     * @throws ClassCastException if the type of the column type isn't assignable to the type {@code T}
      *
      * @see #getMetadata()
      * @see SqlRowMetadata#findColumn(String)
@@ -64,8 +64,11 @@ public interface SqlRow {
     <T> T getObject(@Nonnull String columnName);
 
     /**
+     * Gets row metadata.
+     *
+     * @return row metadata
+     *
      * @see SqlRowMetadata
-     * @return Row metadata.
      */
     @Nonnull
     SqlRowMetadata getMetadata();

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -38,6 +38,26 @@ public interface SqlRow {
     Object getObject(int columnIndex);
 
     /**
+     * Gets the value of the column by column name.
+     * <p>
+     * Column name should be one of those defined in {@link SqlRowMetadata}, case-sensitive. You may also use
+     * {@link SqlRowMetadata#findColumn(String)} to test for column existence.
+     * <p>
+     * The class of the returned value depends on the SQL type of the column.
+     *
+     * @see #getRowMetadata()
+     * @see SqlRowMetadata#findColumn(String)
+     * @see SqlColumnMetadata#getName()
+     * @see SqlColumnMetadata#getType()
+     * @param columnName Column name.
+     * @return Value of the column
+     * @throws NullPointerException If column name is null
+     * @throws IllegalArgumentException If a column with the given name is not found
+     */
+    @Nullable
+    Object getObject(@Nonnull String columnName);
+
+    /**
      * @see SqlRowMetadata
      * @return Row metadata.
      */

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -17,7 +17,6 @@
 package com.hazelcast.sql;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * SQL row.
@@ -37,7 +36,6 @@ public interface SqlRow {
      * @see #getMetadata()
      * @see SqlColumnMetadata#getType()
      */
-    @Nullable
     <T> T getObject(int columnIndex);
 
     /**
@@ -60,7 +58,6 @@ public interface SqlRow {
      * @see SqlColumnMetadata#getName()
      * @see SqlColumnMetadata#getType()
      */
-    @Nullable
     <T> T getObject(@Nonnull String columnName);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql;
 
+import javax.annotation.Nonnull;
+
 /**
  * SQL row.
  */
@@ -34,7 +36,9 @@ public interface SqlRow {
     Object getObject(int columnIndex);
 
     /**
+     * @see SqlRowMetadata
      * @return Row metadata.
      */
+    @Nonnull
     SqlRowMetadata getRowMetadata();
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+/**
+ * SQL row.
+ */
+public interface SqlRow {
+    /**
+     * Gets the value of the column by index.
+     * <p>
+     * The class of the returned value depends on the SQL type of the column.
+     *
+     * @see #getRowMetadata()
+     * @see SqlColumnMetadata#getType()
+     * @param columnIndex Column index, 0-based.
+     * @return Value of the column.
+     * @throws IndexOutOfBoundsException If column index is out of bounds.
+     */
+    Object getObject(int columnIndex);
+
+    /**
+     * @return Row metadata.
+     */
+    SqlRowMetadata getRowMetadata();
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -28,7 +28,7 @@ public interface SqlRow {
      * <p>
      * The class of the returned value depends on the SQL type of the column.
      *
-     * @see #getRowMetadata()
+     * @see #getMetadata()
      * @see SqlColumnMetadata#getType()
      * @param columnIndex Column index, 0-based.
      * @return Value of the column.
@@ -45,7 +45,7 @@ public interface SqlRow {
      * <p>
      * The class of the returned value depends on the SQL type of the column.
      *
-     * @see #getRowMetadata()
+     * @see #getMetadata()
      * @see SqlRowMetadata#findColumn(String)
      * @see SqlColumnMetadata#getName()
      * @see SqlColumnMetadata#getType()
@@ -62,5 +62,5 @@ public interface SqlRow {
      * @return Row metadata.
      */
     @Nonnull
-    SqlRowMetadata getRowMetadata();
+    SqlRowMetadata getMetadata();
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -28,11 +28,14 @@ public interface SqlRow {
      * <p>
      * The class of the returned value depends on the SQL type of the column. No implicit conversions are performed on the value.
      *
-     * @see #getMetadata()
-     * @see SqlColumnMetadata#getType()
      * @param columnIndex Column index, 0-based.
      * @return Value of the column.
-     * @throws IndexOutOfBoundsException If the column index is out of bounds.
+     *
+     * @throws IndexOutOfBoundsException If the column index is out of bounds
+     * @throws ClassCastException If the type of the column type isn't assignable to the type {@code T}
+     *
+     * @see #getMetadata()
+     * @see SqlColumnMetadata#getType()
      */
     @Nullable
     <T> T getObject(int columnIndex);
@@ -45,14 +48,17 @@ public interface SqlRow {
      * <p>
      * The class of the returned value depends on the SQL type of the column. No implicit conversions are performed on the value.
      *
+     * @param columnName Column name.
+     * @return Value of the column
+     *
+     * @throws NullPointerException If column name is null
+     * @throws IllegalArgumentException If a column with the given name is not found
+     * @throws ClassCastException If the type of the column type isn't assignable to the type {@code T}
+     *
      * @see #getMetadata()
      * @see SqlRowMetadata#findColumn(String)
      * @see SqlColumnMetadata#getName()
      * @see SqlColumnMetadata#getType()
-     * @param columnName Column name.
-     * @return Value of the column
-     * @throws NullPointerException If column name is null
-     * @throws IllegalArgumentException If a column with the given name is not found
      */
     @Nullable
     <T> T getObject(@Nonnull String columnName);

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRow.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * SQL row.
@@ -33,6 +34,7 @@ public interface SqlRow {
      * @return Value of the column.
      * @throws IndexOutOfBoundsException If column index is out of bounds.
      */
+    @Nullable
     Object getObject(int columnIndex);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql;
 
 import com.hazelcast.internal.util.Preconditions;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ public final class SqlRowMetadata {
     private final List<SqlColumnMetadata> columns;
     private final Map<String, Integer> nameToIndex;
 
+    @PrivateApi
     @SuppressWarnings("ConstantConditions")
     public SqlRowMetadata(@Nonnull List<SqlColumnMetadata> columns) {
         assert columns != null && !columns.isEmpty();

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -53,7 +53,7 @@ public final class SqlRowMetadata {
     /**
      * Gets the number of columns in the row.
      *
-     * @return The number of columns in the row.
+     * @return the number of columns in the row
      */
     public int getColumnCount() {
         return columns.size();
@@ -62,8 +62,9 @@ public final class SqlRowMetadata {
     /**
      * Get column metadata.
      *
-     * @param index Column index, 0-based.
-     * @return Column metadata.
+     * @param index column index, zero-based
+     * @return column metadata
+     * @throws IndexOutOfBoundsException If the column index is out of bounds
      */
     @Nonnull
     public SqlColumnMetadata getColumn(int index) {
@@ -78,10 +79,11 @@ public final class SqlRowMetadata {
      * Find index of the column with the given name. Returned index can be used to get column value
      * from {@link SqlRow}.
      *
+     * @param columnName column name (case sensitive)
+     * @return column index or {@link #COLUMN_NOT_FOUND} if a column with the given name is not found
+     * @throws NullPointerException if column name is null
+     *
      * @see SqlRow
-     * @param columnName Column name (case sensitive).
-     * @return Column index or {@link #COLUMN_NOT_FOUND} if a column with the given name is not found.
-     * @throws NullPointerException If column name is null.
      */
     public int findColumn(@Nonnull String columnName) {
         Preconditions.checkNotNull(columnName, "Column name cannot be null");

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * SQL row metadata.
+ */
+public class SqlRowMetadata implements Serializable {
+    /** Constant indicating that the column is not found. */
+    public static final int COLUMN_NOT_FOUND = -1;
+
+    private static final long serialVersionUID = 1595632576318481583L;
+
+    private final List<SqlColumnMetadata> columns;
+    private final Map<String, Integer> nameToIndex;
+
+    public SqlRowMetadata(List<SqlColumnMetadata> columns) {
+        assert columns != null && !columns.isEmpty();
+
+        this.columns = new ArrayList<>(columns);
+
+        nameToIndex = new HashMap<>(columns.size());
+
+        for (int i = 0; i < columns.size(); i++) {
+            nameToIndex.put(columns.get(i).getName(), i);
+        }
+    }
+
+    /**
+     * Gets the number of columns in the row.
+     *
+     * @return The number of columns in the row.
+     */
+    public int getColumnCount() {
+        return columns.size();
+    }
+
+    /**
+     * Get column metadata.
+     *
+     * @param index Column index, 0-based.
+     * @return Column metadata.
+     */
+    @Nonnull
+    public SqlColumnMetadata getColumn(int index) {
+        if (index < 0) {
+            throw new IndexOutOfBoundsException("Column index cannot be negative: " + index);
+        }
+
+        if (index >= columns.size()) {
+            throw new IndexOutOfBoundsException("Column index is out of bounds: " + index);
+        }
+
+        return columns.get(index);
+    }
+
+    /**
+     * Find index of the column with the given name. Returned index can be used to get column value
+     * from {@link SqlRow}.
+     *
+     * @see SqlRow
+     * @param name Column name (case sensitive).
+     * @return Column index or {@link #COLUMN_NOT_FOUND} if a column with the given name is not found.
+     */
+    public int findColumn(String name) {
+        Integer index = nameToIndex.get(name);
+
+        return index != null ? index : COLUMN_NOT_FOUND;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SqlRowMetadata that = (SqlRowMetadata) o;
+
+        return columns.equals(that.columns);
+    }
+
+    @Override
+    public int hashCode() {
+        return columns.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return columns.stream()
+            .map((column) -> column.getName() + ":" + column.getType())
+            .collect(Collectors.joining(", ", "[", "]"));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -64,11 +64,7 @@ public class SqlRowMetadata {
      */
     @Nonnull
     public SqlColumnMetadata getColumn(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException("Column index cannot be negative: " + index);
-        }
-
-        if (index >= columns.size()) {
+        if (index < 0 || index >= columns.size()) {
             throw new IndexOutOfBoundsException("Column index is out of bounds: " + index);
         }
 
@@ -113,7 +109,7 @@ public class SqlRowMetadata {
     @Override
     public String toString() {
         return columns.stream()
-            .map((column) -> column.getName() + ":" + column.getType())
+            .map((column) -> column.getName() + ' ' + column.getType())
             .collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -28,14 +28,15 @@ import java.util.stream.Collectors;
 /**
  * SQL row metadata.
  */
-public class SqlRowMetadata {
+public final class SqlRowMetadata {
     /** Constant indicating that the column is not found. */
     public static final int COLUMN_NOT_FOUND = -1;
 
     private final List<SqlColumnMetadata> columns;
     private final Map<String, Integer> nameToIndex;
 
-    public SqlRowMetadata(List<SqlColumnMetadata> columns) {
+    @SuppressWarnings("ConstantConditions")
+    public SqlRowMetadata(@Nonnull List<SqlColumnMetadata> columns) {
         assert columns != null && !columns.isEmpty();
 
         this.columns = new ArrayList<>(columns);

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql;
 
+import com.hazelcast.internal.util.Preconditions;
+
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -78,11 +80,14 @@ public class SqlRowMetadata {
      * from {@link SqlRow}.
      *
      * @see SqlRow
-     * @param name Column name (case sensitive).
+     * @param columnName Column name (case sensitive).
      * @return Column index or {@link #COLUMN_NOT_FOUND} if a column with the given name is not found.
+     * @throws NullPointerException If column name is null.
      */
-    public int findColumn(String name) {
-        Integer index = nameToIndex.get(name);
+    public int findColumn(@Nonnull String columnName) {
+        Preconditions.checkNotNull(columnName, "Column name cannot be null");
+
+        Integer index = nameToIndex.get(columnName);
 
         return index != null ? index : COLUMN_NOT_FOUND;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -17,7 +17,6 @@
 package com.hazelcast.sql;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,11 +26,9 @@ import java.util.stream.Collectors;
 /**
  * SQL row metadata.
  */
-public class SqlRowMetadata implements Serializable {
+public class SqlRowMetadata {
     /** Constant indicating that the column is not found. */
     public static final int COLUMN_NOT_FOUND = -1;
-
-    private static final long serialVersionUID = 1595632576318481583L;
 
     private final List<SqlColumnMetadata> columns;
     private final Map<String, Integer> nameToIndex;

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -60,7 +60,7 @@ public final class SqlRowMetadata {
     }
 
     /**
-     * Get column metadata.
+     * Gets column metadata.
      *
      * @param index column index, zero-based
      * @return column metadata

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlRowMetadata.java
@@ -87,9 +87,7 @@ public class SqlRowMetadata {
     public int findColumn(@Nonnull String columnName) {
         Preconditions.checkNotNull(columnName, "Column name cannot be null");
 
-        Integer index = nameToIndex.get(columnName);
-
-        return index != null ? index : COLUMN_NOT_FOUND;
+        return nameToIndex.getOrDefault(columnName, COLUMN_NOT_FOUND);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -32,28 +32,28 @@ import javax.annotation.Nonnull;
  * <a href="https://calcite.apache.org">Apache Calcite</a>. The {@code hazelcast-sql} must be in the classpath, otherwise
  * an exception will be thrown.
  * <p>
- * During optimization a query is converted into a direct acyclic graph (DAG) that is sent to cluster members for execution.
- * Query results are sent back to the originating member asynchronously, and returned to the user via {@link SqlResult}.
+ * During optimization a query is converted into a directed acyclic graph (DAG) that is sent to cluster members for execution.
+ * Query results are sent back to the originating member asynchronously and returned to the user via {@link SqlResult}.
  *
- * <h1>Querying IMap</h1>
+ * <h1>Querying an IMap</h1>
  * Every IMap instance is exposed as a table with the same name in the {@code partitioned} schema. The {@code partitioned}
- * schema is included into a default search path, therefore an IMap could be referenced in an SQL query with or without schema
- * name.
+ * schema is included into a default search path, therefore an IMap could be referenced in an SQL query with or without the
+ * schema name.
  * <h2>Column resolution</h2>
  * Every table backed by an IMap has a set of columns that are resolved automatically. Column resolution uses IMap entries
- * located on the member that initiates the query. The engine extracts columns from a key and a value, and then merges them
+ * located on the member that initiates the query. The engine extracts columns from a key and a value and then merges them
  * into a single column set. In case the key and the value have columns with the same name, the key takes precedence.
  * <p>
  * Columns are extracted from objects as follows:
  * <ul>
  *     <li>For non-Portable objects, public getters and fields are used to populate the column list. For getters, the first
  *     letter is converted to lower case. A getter takes precedence over a field in case of naming conflict</li>
- *     <li>For {@link Portable} objects, field names used in {@link Portable#writePortable(PortableWriter)}</li> method
- *     are used to populate the column list
+ *     <li>For {@link Portable} objects, field names used in the {@link Portable#writePortable(PortableWriter)} method
+ *     are used to populate the column list</li>
  * </ul>
- * The whole key and value objects could be accessed through a special fields {@code __key} and {@code this} respectively. If
- * key (value) object has fields, then the whole key (value) field is exposed as normal field. Otherwise the field is hidden.
- * Hidden fields could be accessed directly, but are not returned by {@code SELECT * FROM ...} queries.
+ * The whole key and value objects could be accessed through a special fields {@code __key} and {@code this}, respectively. If
+ * key (value) object has fields, then the whole key (value) field is exposed as a normal field. Otherwise the field is hidden.
+ * Hidden fields can be accessed directly, but are not returned by {@code SELECT * FROM ...} queries.
  * <p>
  * If the member that initiates a query doesn't have local entries for the given IMap, the query fails.
  * <p>
@@ -82,12 +82,12 @@ import javax.annotation.Nonnull;
  * <h2>Consistency</h2>
  * Results returned from IMap query are weakly consistent:
  * <ul>
- *     <li>If an entry was not updated during iteration, it is guaranteed to be returned exactly once. If an en</li>
- *     <li>If an entry was modified during iteration, it might be returned zero, one or several time</li>
+ *     <li>If an entry was not updated during iteration, it is guaranteed to be returned exactly once</li>
+ *     <li>If an entry was modified during iteration, it might be returned zero, one or several times</li>
  * </ul>
  * <h1>Usage</h1>
- * When query is executed, an {@link SqlResult} is returned. You may get row iterator from the result. The result must be closed
- * in the end. The code snippet below demonstrates a typical usage pattern:
+ * When a query is executed, an {@link SqlResult} is returned. You may get row iterator from the result. The result must be closed
+ * at the end. The code snippet below demonstrates a typical usage pattern:
  * <pre>
  *     HazelcastInstance instance = ...;
  *

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
  * <h1>Overview</h1>
  * Hazelcast is able to execute distributed SQL queries over the following entities:
  * <ul>
- *     <li>IMap</li>
+ *     <li>IMap
  * </ul>
  * When a query is submitted to a member, it is parsed and optimized by the {@code hazelcast-sql} module, that is based on
  * <a href="https://calcite.apache.org">Apache Calcite</a>. The {@code hazelcast-sql} must be in the classpath, otherwise
@@ -47,9 +47,9 @@ import javax.annotation.Nonnull;
  * Columns are extracted from objects as follows:
  * <ul>
  *     <li>For non-Portable objects, public getters and fields are used to populate the column list. For getters, the first
- *     letter is converted to lower case. A getter takes precedence over a field in case of naming conflict</li>
+ *     letter is converted to lower case. A getter takes precedence over a field in case of naming conflict
  *     <li>For {@link Portable} objects, field names used in the {@link Portable#writePortable(PortableWriter)} method
- *     are used to populate the column list</li>
+ *     are used to populate the column list
  * </ul>
  * The whole key and value objects could be accessed through a special fields {@code __key} and {@code this}, respectively. If
  * key (value) object has fields, then the whole key (value) field is exposed as a normal field. Otherwise the field is hidden.
@@ -73,17 +73,17 @@ import javax.annotation.Nonnull;
  * </pre>
  * This model will be resolved to the following table columns:
  * <ul>
- *     <li>personId BIGINT</li>
- *     <li>departmentId BIGINT</li>
- *     <li>name VARCHAR</li>
- *     <li>__key OBJECT (hidden)</li>
- *     <li>this OBJECT (hidden)</li>
+ *     <li>personId BIGINT
+ *     <li>departmentId BIGINT
+ *     <li>name VARCHAR
+ *     <li>__key OBJECT (hidden)
+ *     <li>this OBJECT (hidden)
  * </ul>
  * <h2>Consistency</h2>
  * Results returned from IMap query are weakly consistent:
  * <ul>
- *     <li>If an entry was not updated during iteration, it is guaranteed to be returned exactly once</li>
- *     <li>If an entry was modified during iteration, it might be returned zero, one or several times</li>
+ *     <li>If an entry was not updated during iteration, it is guaranteed to be returned exactly once
+ *     <li>If an entry was modified during iteration, it might be returned zero, one or several times
  * </ul>
  * <h1>Usage</h1>
  * When a query is executed, an {@link SqlResult} is returned. You may get row iterator from the result. The result must be closed

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql;
 
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 
@@ -100,6 +101,7 @@ import javax.annotation.Nonnull;
  *     }
  * </pre>
  */
+@Beta
 public interface SqlService {
     /**
      * Convenient method to execute a distributed query with the given parameters.

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql;
 
+import javax.annotation.Nonnull;
+
 /**
  * Service to execute SQL queries.
  */
@@ -27,6 +29,7 @@ public interface SqlService {
      * @param params Parameters.
      * @return Cursor.
      */
+    @Nonnull
     default SqlResult query(String sql, Object... params) {
         SqlQuery query = new SqlQuery(sql);
 
@@ -45,5 +48,6 @@ public interface SqlService {
      * @param query Query.
      * @return Cursor.
      */
+    @Nonnull
     SqlResult query(SqlQuery query);
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -23,14 +23,21 @@ import javax.annotation.Nonnull;
  */
 public interface SqlService {
     /**
-     * Execute query.
+     * Convenient method to execute a query with the given parameters.
+     * <p>
+     * Converts passed SQL string and parameters into an {@link SqlQuery} object and invokes {@link #query(SqlQuery)}.
      *
+     * @see SqlQuery
+     * @see #query(SqlQuery)
      * @param sql SQL.
      * @param params Parameters.
-     * @return Cursor.
+     * @return Result.
+     * @throws NullPointerException If sql is null
+     * @throws IllegalArgumentException If sql is empty
+     * @throws SqlException In case of execution error
      */
     @Nonnull
-    default SqlResult query(String sql, Object... params) {
+    default SqlResult query(@Nonnull String sql, Object... params) {
         SqlQuery query = new SqlQuery(sql);
 
         if (params != null) {
@@ -43,11 +50,13 @@ public interface SqlService {
     }
 
     /**
-     * Execute query.
+     * Executes query.
      *
      * @param query Query.
-     * @return Cursor.
+     * @return Result.
+     * @throws NullPointerException If query is null
+     * @throws SqlException In case of execution error
      */
     @Nonnull
-    SqlResult query(SqlQuery query);
+    SqlResult query(@Nonnull SqlQuery query);
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -21,9 +21,13 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Service to execute distributed SQL queries.
+ * <p>
+ * The service is in beta state. Behavior and API might be changed in future releases. Binary compatibility is not
+ * guaranteed between minor and patch releases.
  * <h1>Overview</h1>
  * Hazelcast is able to execute distributed SQL queries over the following entities:
  * <ul>
@@ -109,7 +113,7 @@ public interface SqlService {
      * Converts passed SQL string and parameters into an {@link SqlQuery} object and invokes {@link #query(SqlQuery)}.
      *
      * @param sql SQL string
-     * @param params parameters
+     * @param params query parameters that will be passed to {@link SqlQuery#setParameters(List)}
      * @return result
      * @throws NullPointerException if the SQL string is null
      * @throws IllegalArgumentException if the SQL string is empty

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -106,15 +106,16 @@ public interface SqlService {
      * <p>
      * Converts passed SQL string and parameters into an {@link SqlQuery} object and invokes {@link #query(SqlQuery)}.
      *
+     * @param sql SQL string
+     * @param params parameters
+     * @return result
+     * @throws NullPointerException if the SQL string is null
+     * @throws IllegalArgumentException if the SQL string is empty
+     * @throws SqlException in case of execution error
+     *
      * @see SqlService
      * @see SqlQuery
      * @see #query(SqlQuery)
-     * @param sql SQL.
-     * @param params Parameters.
-     * @return Result.
-     * @throws NullPointerException If sql is null
-     * @throws IllegalArgumentException If sql is empty
-     * @throws SqlException In case of execution error
      */
     @Nonnull
     default SqlResult query(@Nonnull String sql, Object... params) {
@@ -132,11 +133,12 @@ public interface SqlService {
     /**
      * Executes a distributed query.
      *
+     * @param query query to be executed
+     * @return result
+     * @throws NullPointerException if the query is null
+     * @throws SqlException in case of execution error
+     *
      * @see SqlService
-     * @param query Query object
-     * @return Result.
-     * @throws NullPointerException If query is null
-     * @throws SqlException In case of execution error
      */
     @Nonnull
     SqlResult query(@Nonnull SqlQuery query);

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -16,17 +16,97 @@
 
 package com.hazelcast.sql;
 
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableWriter;
+
 import javax.annotation.Nonnull;
 
 /**
- * Service to execute SQL queries.
+ * Service to execute distributed SQL queries.
+ * <h1>Overview</h1>
+ * Hazelcast is able to execute distributed SQL queries over the following entities:
+ * <ul>
+ *     <li>IMap</li>
+ * </ul>
+ * When a query is submitted to a member, it is parsed and optimized by the {@code hazelcast-sql} module, that is based on
+ * <a href="https://calcite.apache.org">Apache Calcite</a>. The {@code hazelcast-sql} must be in the classpath, otherwise
+ * an exception will be thrown.
+ * <p>
+ * During optimization a query is converted into a direct acyclic graph (DAG) that is sent to cluster members for execution.
+ * Query results are sent back to the originating member asynchronously, and returned to the user via {@link SqlResult}.
+ *
+ * <h1>Querying IMap</h1>
+ * Every IMap instance is exposed as a table with the same name in the {@code partitioned} schema. The {@code partitioned}
+ * schema is included into a default search path, therefore an IMap could be referenced in an SQL query with or without schema
+ * name.
+ * <h2>Column resolution</h2>
+ * Every table backed by an IMap has a set of columns that are resolved automatically. Column resolution uses IMap entries
+ * located on the member that initiates the query. The engine extracts columns from a key and a value, and then merges them
+ * into a single column set. In case the key and the value have columns with the same name, the key takes precedence.
+ * <p>
+ * Columns are extracted from objects as follows:
+ * <ul>
+ *     <li>For non-Portable objects, public getters and fields are used to populate the column list. For getters, the first
+ *     letter is converted to lower case. A getter takes precedence over a field in case of naming conflict</li>
+ *     <li>For {@link Portable} objects, field names used in {@link Portable#writePortable(PortableWriter)}</li> method
+ *     are used to populate the column list
+ * </ul>
+ * The whole key and value objects could be accessed through a special fields {@code __key} and {@code this} respectively. If
+ * key (value) object has fields, then the whole key (value) field is exposed as normal field. Otherwise the field is hidden.
+ * Hidden fields could be accessed directly, but are not returned by {@code SELECT * FROM ...} queries.
+ * <p>
+ * If the member that initiates a query doesn't have local entries for the given IMap, the query fails.
+ * <p>
+ * Consider the following key/value model:
+ * <pre>
+ *     class PersonKey {
+ *         private long personId;
+ *         private long deptId;
+ *
+ *         public long getPersonId() { ... }
+ *         public long getDepartmentId() { ... }
+ *     }
+ *
+ *     class Person {
+ *         public String name;
+ *     }
+ * </pre>
+ * This model will be resolved to the following table columns:
+ * <ul>
+ *     <li>personId BIGINT</li>
+ *     <li>departmentId BIGINT</li>
+ *     <li>name VARCHAR</li>
+ *     <li>__key OBJECT (hidden)</li>
+ *     <li>this OBJECT (hidden)</li>
+ * </ul>
+ * <h2>Consistency</h2>
+ * Results returned from IMap query are weakly consistent:
+ * <ul>
+ *     <li>If an entry was not updated during iteration, it is guaranteed to be returned exactly once. If an en</li>
+ *     <li>If an entry was modified during iteration, it might be returned zero, one or several time</li>
+ * </ul>
+ * <h1>Usage</h1>
+ * When query is executed, an {@link SqlResult} is returned. You may get row iterator from the result. The result must be closed
+ * in the end. The code snippet below demonstrates a typical usage pattern:
+ * <pre>
+ *     HazelcastInstance instance = ...;
+ *
+ *     try (SqlResult result = instance.sql().query("SELECT * FROM person")) {
+ *         for (SqlRow row : result) {
+ *             long personId = row.getObject("personId");
+ *             String name = row.getObject("name");
+ *             ...
+ *         }
+ *     }
+ * </pre>
  */
 public interface SqlService {
     /**
-     * Convenient method to execute a query with the given parameters.
+     * Convenient method to execute a distributed query with the given parameters.
      * <p>
      * Converts passed SQL string and parameters into an {@link SqlQuery} object and invokes {@link #query(SqlQuery)}.
      *
+     * @see SqlService
      * @see SqlQuery
      * @see #query(SqlQuery)
      * @param sql SQL.
@@ -50,9 +130,10 @@ public interface SqlService {
     }
 
     /**
-     * Executes query.
+     * Executes a distributed query.
      *
-     * @param query Query.
+     * @see SqlService
+     * @param query Query object
      * @return Result.
      * @throws NullPointerException If query is null
      * @throws SqlException In case of execution error

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -20,9 +20,6 @@ package com.hazelcast.sql;
  * Service to execute SQL queries.
  */
 public interface SqlService {
-    /** Unique service name. */
-    String SERVICE_NAME = "hz:impl:sqlService";
-
     /**
      * Execute query.
      *

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+/**
+ * Service to execute SQL queries.
+ */
+public interface SqlService {
+    /** Unique service name. */
+    String SERVICE_NAME = "hz:impl:sqlService";
+
+    /**
+     * Execute query.
+     *
+     * @param sql SQL.
+     * @param params Parameters.
+     * @return Cursor.
+     */
+    default SqlResult query(String sql, Object... params) {
+        SqlQuery query = new SqlQuery(sql);
+
+        if (params != null) {
+            for (Object param : params) {
+                query.addParameter(param);
+            }
+        }
+
+        return query(query);
+    }
+
+    /**
+     * Execute query.
+     *
+     * @param query Query.
+     * @return Cursor.
+     */
+    SqlResult query(SqlQuery query);
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryException.java
@@ -105,13 +105,4 @@ public final class QueryException extends HazelcastException {
     public UUID getOriginatingMemberId() {
         return originatingMemberId;
     }
-
-    @Override
-    public String getMessage() {
-        if (originatingMemberId != null) {
-            return super.getMessage() + " (code=" + code + ", originatingMemberId=" + originatingMemberId + ')';
-        } else {
-            return super.getMessage() + " (code=" + code + ')';
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -16,6 +16,14 @@
 
 package com.hazelcast.sql.impl;
 
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlColumnMetadata;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.util.UUID;
+
 /**
  * Common SQL engine utility methods used by both "core" and "sql" modules.
  */
@@ -38,5 +46,108 @@ public final class QueryUtils {
 
     public static String workerName(String instanceName, String workerType, long index) {
         return instanceName + "-" + workerType + "-" + index;
+    }
+
+    public static SqlException toPublicException(Exception e, UUID localMemberId) {
+        assert !(e instanceof SqlException) : "Do not wrap multiple times: " + e;
+
+        if (e instanceof QueryException) {
+            QueryException e0 = (QueryException) e;
+
+            UUID originatingMemberId = e0.getOriginatingMemberId();
+
+            if (originatingMemberId == null) {
+                originatingMemberId = localMemberId;
+            }
+
+            return new SqlException(originatingMemberId, e0.getCode(), e0.getMessage(), e);
+        } else {
+            return new SqlException(localMemberId, SqlErrorCode.GENERIC, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Convert internal column type to public type.
+     *
+     * @param columnType Internal type.
+     * @return Public type.
+     */
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    public static SqlColumnMetadata getColumnMetadata(String columnName, QueryDataType columnType) {
+        SqlColumnType type;
+
+        switch (columnType.getTypeFamily()) {
+            case VARCHAR:
+                type = SqlColumnType.VARCHAR;
+
+                break;
+
+            case BOOLEAN:
+                type = SqlColumnType.BOOLEAN;
+
+                break;
+
+            case TINYINT:
+                type = SqlColumnType.TINYINT;
+
+                break;
+
+            case SMALLINT:
+                type = SqlColumnType.SMALLINT;
+
+                break;
+
+            case INT:
+                type = SqlColumnType.INT;
+
+                break;
+
+            case BIGINT:
+                type = SqlColumnType.BIGINT;
+
+                break;
+
+            case DECIMAL:
+                type = SqlColumnType.DECIMAL;
+
+                break;
+
+            case REAL:
+                type = SqlColumnType.REAL;
+
+                break;
+
+            case DOUBLE:
+                type = SqlColumnType.DOUBLE;
+
+                break;
+
+            case TIME:
+                type = SqlColumnType.TIME;
+
+                break;
+
+            case DATE:
+                type = SqlColumnType.DATE;
+
+                break;
+
+            case TIMESTAMP:
+                type = SqlColumnType.TIMESTAMP;
+
+                break;
+
+            case TIMESTAMP_WITH_TIME_ZONE:
+                type = SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
+
+                break;
+
+            default:
+                assert columnType == QueryDataType.OBJECT;
+
+                type = SqlColumnType.OBJECT;
+        }
+
+        return new SqlColumnMetadata(columnName, type);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
@@ -113,6 +113,10 @@ public class SqlInternalService {
      * @return Query state.
      */
     public QueryState execute(Plan plan, List<Object> params, long timeout, int pageSize) {
+        if (!params.isEmpty()) {
+            throw new UnsupportedOperationException("SQL queries with parameters are not supported yet!");
+        }
+
         // Get local member ID and check if it is still part of the plan.
         UUID localMemberId = nodeServiceProvider.getLocalMemberId();
 
@@ -134,9 +138,9 @@ public class SqlInternalService {
             localMemberId,
             timeout,
             plan,
+            plan.getRowMetadata(),
             consumer,
-            operationHandler,
-            true
+            operationHandler
         );
 
         try {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl;
+
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.SqlRowMetadata;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.state.QueryInitiatorState;
+import com.hazelcast.sql.impl.state.QueryState;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Cursor implementation.
+ */
+public class SqlResultImpl implements SqlResult {
+
+    private final QueryState state;
+    private final SqlRowMetadata rowMetadata;
+    private Iterator<SqlRow> iterator;
+
+    public SqlResultImpl(QueryState state) {
+        this.state = state;
+
+        rowMetadata = state.getInitiatorState().getRowMetadata();
+    }
+
+    @Override
+    public SqlRowMetadata getRowMetadata() {
+        return rowMetadata;
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<SqlRow> iterator() {
+        if (iterator == null) {
+            Iterator<SqlRow> iterator0 = new RowToSqlRowIterator(getQueryInitiatorState().getResultProducer().iterator());
+
+            iterator = iterator0;
+
+            return iterator0;
+        } else {
+            throw new IllegalStateException("Iterator can be requested only once.");
+        }
+    }
+
+    @Override
+    public void close() {
+        closeOnError(QueryException.cancelledByUser());
+    }
+
+    public void closeOnError(QueryException error) {
+        state.cancel(error);
+    }
+
+    private QueryInitiatorState getQueryInitiatorState() {
+        return state.getInitiatorState();
+    }
+
+    private final class RowToSqlRowIterator implements Iterator<SqlRow> {
+
+        private final Iterator<Row> delegate;
+
+        private RowToSqlRowIterator(Iterator<Row> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            try {
+                return delegate.hasNext();
+            } catch (Exception e) {
+                throw QueryUtils.toPublicException(e, state.getLocalMemberId());
+            }
+        }
+
+        @Override
+        public SqlRow next() {
+            try {
+                return new SqlRowImpl(rowMetadata, delegate.next());
+            } catch (NoSuchElementException e) {
+                throw e;
+            } catch (Exception e) {
+                throw QueryUtils.toPublicException(e, state.getLocalMemberId());
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
@@ -42,13 +42,14 @@ public class SqlResultImpl implements SqlResult {
         rowMetadata = state.getInitiatorState().getRowMetadata();
     }
 
+    @Nonnull
     @Override
     public SqlRowMetadata getRowMetadata() {
         return rowMetadata;
     }
 
-    @Override
     @Nonnull
+    @Override
     public Iterator<SqlRow> iterator() {
         if (iterator == null) {
             Iterator<SqlRow> iterator0 = new RowToSqlRowIterator(getQueryInitiatorState().getResultProducer().iterator());

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -42,7 +42,7 @@ public class SqlRowImpl implements SqlRow {
 
     @Nullable
     @Override
-    public Object getObject(int columnIndex) {
+    public <T> T getObject(int columnIndex) {
         checkIndex(columnIndex);
 
         return getObject0(columnIndex);
@@ -50,13 +50,13 @@ public class SqlRowImpl implements SqlRow {
 
     @Nullable
     @Override
-    public Object getObject(@Nonnull String columnName) {
+    public <T> T getObject(@Nonnull String columnName) {
         int columnIndex = resolveIndex(columnName);
 
         return getObject0(columnIndex);
     }
 
-    private Object getObject0(int columnIndex) {
+    private <T> T getObject0(int columnIndex) {
         return row.get(columnIndex);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.row.Row;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Default implementation of the SQL row which is exposed to users. We merely wrap the internal row, but add more checks which
@@ -37,6 +38,7 @@ public class SqlRowImpl implements SqlRow {
         this.row = row;
     }
 
+    @Nullable
     @Override
     public Object getObject(int columnIndex) {
         checkIndex(columnIndex);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -49,7 +49,7 @@ public class SqlRowImpl implements SqlRow {
 
     private void checkIndex(int index) {
         if (index < 0 || index >= rowMetadata.getColumnCount()) {
-            throw new IllegalArgumentException("Column index is out of range: " + index);
+            throw new IndexOutOfBoundsException("Column index is out of range: " + index);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -17,6 +17,7 @@
 
 package com.hazelcast.sql.impl;
 
+import com.hazelcast.sql.SqlException;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.row.Row;
@@ -43,7 +44,29 @@ public class SqlRowImpl implements SqlRow {
     public Object getObject(int columnIndex) {
         checkIndex(columnIndex);
 
+        return getObject0(columnIndex);
+    }
+
+    @Nullable
+    @Override
+    public Object getObject(@Nonnull String columnName) {
+        int columnIndex = resolveIndex(columnName);
+
+        return getObject0(columnIndex);
+    }
+
+    private Object getObject0(int columnIndex) {
         return row.get(columnIndex);
+    }
+
+    private int resolveIndex(String columnName) {
+        int index = rowMetadata.findColumn(columnName);
+
+        if (index == SqlRowMetadata.COLUMN_NOT_FOUND) {
+            throw new IllegalArgumentException("Column \"" + columnName + "\" doesn't exist");
+        }
+
+        return index;
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -71,7 +71,7 @@ public class SqlRowImpl implements SqlRow {
 
     @Nonnull
     @Override
-    public SqlRowMetadata getRowMetadata() {
+    public SqlRowMetadata getMetadata() {
         return rowMetadata;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -17,13 +17,14 @@
 
 package com.hazelcast.sql.impl;
 
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlColumnMetadata;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.row.Row;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.StringJoiner;
 
 /**
  * Default implementation of the SQL row which is exposed to users. We merely wrap the internal row, but add more checks which
@@ -79,5 +80,19 @@ public class SqlRowImpl implements SqlRow {
         if (index < 0 || index >= rowMetadata.getColumnCount()) {
             throw new IndexOutOfBoundsException("Column index is out of range: " + index);
         }
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "[", "]");
+
+        for (int i = 0; i < rowMetadata.getColumnCount(); i++) {
+            SqlColumnMetadata columnMetadata = rowMetadata.getColumn(i);
+            Object columnValue = row.get(i);
+
+            joiner.add(columnMetadata.getName() + ":" + columnMetadata.getType() + "=" + columnValue);
+        }
+
+        return joiner.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -90,7 +90,7 @@ public class SqlRowImpl implements SqlRow {
             SqlColumnMetadata columnMetadata = rowMetadata.getColumn(i);
             Object columnValue = row.get(i);
 
-            joiner.add(columnMetadata.getName() + ":" + columnMetadata.getType() + "=" + columnValue);
+            joiner.add(columnMetadata.getName() + ' ' + columnMetadata.getType() + '=' + columnValue);
         }
 
         return joiner.toString();

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -21,6 +21,8 @@ import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.row.Row;
 
+import javax.annotation.Nonnull;
+
 /**
  * Default implementation of the SQL row which is exposed to users. We merely wrap the internal row, but add more checks which
  * is important for user-facing code, but which could cause performance degradation if implemented in the internal classes.
@@ -42,6 +44,7 @@ public class SqlRowImpl implements SqlRow {
         return row.get(columnIndex);
     }
 
+    @Nonnull
     @Override
     public SqlRowMetadata getRowMetadata() {
         return rowMetadata;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlRowImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.hazelcast.sql.impl;
+
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.SqlRowMetadata;
+import com.hazelcast.sql.impl.row.Row;
+
+/**
+ * Default implementation of the SQL row which is exposed to users. We merely wrap the internal row, but add more checks which
+ * is important for user-facing code, but which could cause performance degradation if implemented in the internal classes.
+ */
+public class SqlRowImpl implements SqlRow {
+
+    private final SqlRowMetadata rowMetadata;
+    private final Row row;
+
+    public SqlRowImpl(SqlRowMetadata rowMetadata, Row row) {
+        this.rowMetadata = rowMetadata;
+        this.row = row;
+    }
+
+    @Override
+    public Object getObject(int columnIndex) {
+        checkIndex(columnIndex);
+
+        return row.get(columnIndex);
+    }
+
+    @Override
+    public SqlRowMetadata getRowMetadata() {
+        return rowMetadata;
+    }
+
+    private void checkIndex(int index) {
+        if (index < 0 || index >= rowMetadata.getColumnCount()) {
+            throw new IllegalArgumentException("Column index is out of range: " + index);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -33,6 +33,7 @@ import com.hazelcast.sql.impl.optimizer.SqlPlan;
 import com.hazelcast.sql.impl.plan.Plan;
 import com.hazelcast.sql.impl.state.QueryState;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -123,6 +124,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
         return optimizer;
     }
 
+    @Nonnull
     @Override
     public SqlResult query(SqlQuery query) {
         try {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -72,7 +72,15 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
 
         int executorPoolSize = config.getExecutorPoolSize();
         int operationPoolSize = config.getOperationPoolSize();
-        long queryTimeout = config.getQueryTimeout();
+        long queryTimeout = config.getQueryTimeoutMillis();
+
+        if (executorPoolSize == SqlConfig.DEFAULT_EXECUTOR_POOL_SIZE) {
+            executorPoolSize = Runtime.getRuntime().availableProcessors();
+        }
+
+        if (operationPoolSize == SqlConfig.DEFAULT_OPERATION_POOL_SIZE) {
+            operationPoolSize = Runtime.getRuntime().availableProcessors();
+        }
 
         assert executorPoolSize > 0;
         assert operationPoolSize > 0;
@@ -135,7 +143,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
                 throw QueryException.error("SQL queries cannot be executed on lite members");
             }
 
-            long timeout = query.getTimeout();
+            long timeout = query.getTimeoutMillis();
 
             if (timeout == SqlQuery.TIMEOUT_NOT_SET) {
                 timeout = queryTimeout;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -24,8 +24,8 @@ import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.impl.optimizer.DisabledSqlOptimizer;
 import com.hazelcast.sql.impl.optimizer.OptimizationTask;
@@ -37,7 +37,6 @@ import com.hazelcast.sql.impl.state.QueryState;
 import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -166,13 +165,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
             throw QueryException.error("SQL statement cannot be empty.");
         }
 
-        List<Object> params0;
-
-        if (params == null || params.isEmpty()) {
-            params0 = Collections.emptyList();
-        } else {
-            params0 = new ArrayList<>(params);
-        }
+        List<Object> params0 = new ArrayList<>(params);
 
         if (timeout < 0) {
             throw QueryException.error("Timeout cannot be negative: " + timeout);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.SqlConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -126,7 +127,9 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
 
     @Nonnull
     @Override
-    public SqlResult query(SqlQuery query) {
+    public SqlResult query(@Nonnull SqlQuery query) {
+        Preconditions.checkNotNull(query, "Query cannot be null");
+
         try {
             if (nodeEngine.getLocalMember().isLiteMember()) {
                 throw QueryException.error("SQL queries cannot be executed on lite members");

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -16,12 +16,16 @@
 
 package com.hazelcast.sql.impl;
 
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.impl.optimizer.DisabledSqlOptimizer;
 import com.hazelcast.sql.impl.optimizer.OptimizationTask;
 import com.hazelcast.sql.impl.optimizer.SqlOptimizer;
@@ -30,6 +34,8 @@ import com.hazelcast.sql.impl.plan.Plan;
 import com.hazelcast.sql.impl.state.QueryState;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -37,12 +43,12 @@ import java.util.logging.Level;
 /**
  * Base SQL service implementation that bridges optimizer implementation, public and private APIs.
  */
-public class SqlServiceImpl implements Consumer<Packet> {
+public class SqlServiceImpl implements SqlService, Consumer<Packet> {
     /** Outbox batch size in bytes. */
     private static final int OUTBOX_BATCH_SIZE = 512 * 1024;
 
     /** Default state check frequency. */
-    private static final long STATE_CHECK_FREQUENCY = 10_000L;
+    private static final long STATE_CHECK_FREQUENCY = 1_000L;
 
     private static final String OPTIMIZER_CLASS_PROPERTY_NAME = "hazelcast.sql.optimizerClass";
     private static final String SQL_MODULE_OPTIMIZER_CLASS = "com.hazelcast.sql.impl.calcite.CalciteSqlOptimizer";
@@ -50,6 +56,9 @@ public class SqlServiceImpl implements Consumer<Packet> {
     private SqlOptimizer optimizer;
     private final ILogger logger;
     private final NodeEngineImpl nodeEngine;
+    private final long queryTimeout;
+
+    private final NodeServiceProviderImpl nodeServiceProvider;
 
     private volatile SqlInternalService internalService;
 
@@ -57,11 +66,19 @@ public class SqlServiceImpl implements Consumer<Packet> {
         this.nodeEngine = nodeEngine;
         logger = nodeEngine.getLogger(getClass());
 
-        // These two parameters will be taken from the config, when public API is ready.
-        int operationThreadCount = Runtime.getRuntime().availableProcessors();
-        int fragmentThreadCount = Runtime.getRuntime().availableProcessors();
+        SqlConfig config = nodeEngine.getConfig().getSqlConfig();
 
-        NodeServiceProviderImpl nodeServiceProvider = new NodeServiceProviderImpl(nodeEngine);
+        int executorPoolSize = config.getExecutorPoolSize();
+        int operationPoolSize = config.getOperationPoolSize();
+        long queryTimeout = config.getQueryTimeout();
+
+        assert executorPoolSize > 0;
+        assert operationPoolSize > 0;
+        assert queryTimeout >= 0L;
+
+        this.queryTimeout = queryTimeout;
+
+        nodeServiceProvider = new NodeServiceProviderImpl(nodeEngine);
 
         String instanceName = nodeEngine.getHazelcastInstance().getName();
         InternalSerializationService serializationService = (InternalSerializationService) nodeEngine.getSerializationService();
@@ -70,13 +87,11 @@ public class SqlServiceImpl implements Consumer<Packet> {
             instanceName,
             nodeServiceProvider,
             serializationService,
-            operationThreadCount,
-            fragmentThreadCount,
+            operationPoolSize,
+            executorPoolSize,
             OUTBOX_BATCH_SIZE,
             STATE_CHECK_FREQUENCY
         );
-
-        optimizer = createOptimizer(nodeEngine);
     }
 
     public void start() {
@@ -109,20 +124,78 @@ public class SqlServiceImpl implements Consumer<Packet> {
     }
 
     @Override
+    public SqlResult query(SqlQuery query) {
+        try {
+            if (nodeEngine.getLocalMember().isLiteMember()) {
+                throw QueryException.error("SQL queries cannot be executed on lite members");
+            }
+
+            long timeout = query.getTimeout();
+
+            if (timeout == SqlQuery.TIMEOUT_NOT_SET) {
+                timeout = queryTimeout;
+            }
+
+            return query0(query.getSql(), query.getParameters(), timeout, query.getCursorBufferSize());
+        } catch (Exception e) {
+            throw QueryUtils.toPublicException(e, nodeServiceProvider.getLocalMemberId());
+        }
+    }
+
+    @Override
     public void accept(Packet packet) {
         internalService.onPacket(packet);
     }
 
-    QueryState executeImdg(Plan plan, List<Object> params, long timeout, int pageSize) {
-        return internalService.execute(plan, params, timeout, pageSize);
+    private SqlResult query0(String sql, List<Object> params, long timeout, int pageSize) {
+        // Validate and normalize.
+        if (sql == null || sql.isEmpty()) {
+            throw QueryException.error("SQL statement cannot be empty.");
+        }
+
+        List<Object> params0;
+
+        if (params == null || params.isEmpty()) {
+            params0 = Collections.emptyList();
+        } else {
+            params0 = new ArrayList<>(params);
+        }
+
+        if (timeout < 0) {
+            throw QueryException.error("Timeout cannot be negative: " + timeout);
+        }
+
+        if (pageSize <= 0) {
+            throw QueryException.error("Page size must be positive: " + pageSize);
+        }
+
+        // Execute.
+        SqlPlan plan = prepare(sql);
+
+        return execute(plan, params0, timeout, pageSize);
     }
 
-    SqlPlan prepare(String sql) {
+    private SqlResult execute(SqlPlan plan, List<Object> params, long timeout, int pageSize) {
+        switch (plan.getType()) {
+            case IMDG:
+                return executeImdg((Plan) plan, params, timeout, pageSize);
+            default:
+                throw new IllegalArgumentException("Unknown plan type - " + plan.getType());
+        }
+    }
+
+    private SqlResult executeImdg(Plan plan, List<Object> params, long timeout, int pageSize) {
+        QueryState state = internalService.execute(plan, params, timeout, pageSize);
+
+        return new SqlResultImpl(state);
+    }
+
+    private SqlPlan prepare(String sql) {
         return optimizer.prepare(new OptimizationTask.Builder(sql).build());
     }
 
     /**
-     * Create either normal or no-op optimizer instance.
+     * Create either normal or not-implemented optimizer instance.
      *
      * @param nodeEngine Node engine.
      * @return Optimizer.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitor.java
@@ -78,6 +78,9 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
     /** Recommended outbox batch size in bytes. */
     private final int outboxBatchSize;
 
+    /** Hook to alter produced Exec (for testing purposes). */
+    private final CreateExecPlanNodeVisitorHook hook;
+
     /** Stack of elements to be merged. */
     private final ArrayList<Exec> stack = new ArrayList<>(1);
 
@@ -98,7 +101,8 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
         QueryExecuteOperation operation,
         FlowControlFactory flowControlFactory,
         PartitionIdSet localParts,
-        int outboxBatchSize
+        int outboxBatchSize,
+        CreateExecPlanNodeVisitorHook hook
     ) {
         this.operationHandler = operationHandler;
         this.nodeServiceProvider = nodeServiceProvider;
@@ -108,6 +112,7 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
         this.flowControlFactory = flowControlFactory;
         this.localParts = localParts;
         this.outboxBatchSize = outboxBatchSize;
+        this.hook = hook;
     }
 
     @Override
@@ -294,6 +299,12 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
      * Public for testing purposes only.
      */
     public void push(Exec exec) {
+        CreateExecPlanNodeVisitorHook hook0 = hook;
+
+        if (hook0 != null) {
+            exec = hook0.onExec(exec);
+        }
+
         stack.add(exec);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitorHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitorHook.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+/**
+ * An interface that could be injected to alter produced Execs.
+ */
+public interface CreateExecPlanNodeVisitorHook {
+    /**
+     * @param exec Current exec.
+     * @return Altered exec.
+     */
+    Exec onExec(Exec exec);
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -91,12 +91,12 @@ public abstract class AbstractMapScanExec extends AbstractExec {
      * 1) Check filter
      * 2) Extract projections
      *
-     * @param rawkey Key (data or object)
+     * @param rawKey Key (data or object)
      * @param rawValue Value (data or object)
      * @return Row that is ready for processing by parent operators or {@code null} if the row hasn't passed the filter.
      */
-    protected Row prepareRow(Object rawkey, Object rawValue) {
-        row.setKeyValue(rawkey, rawValue);
+    protected Row prepareRow(Object rawKey, Object rawValue) {
+        row.setKeyValue(rawKey, rawValue);
 
         // Filter.
         if (filter != null && !filter.eval(row, ctx)) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/GenericTargetExtractor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/GenericTargetExtractor.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql.impl.extract;
 
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeMismatchException;
 
 /**
  * An extractor that returns the target itself.
@@ -30,9 +31,15 @@ public class GenericTargetExtractor extends AbstractGenericExtractor {
     @Override
     public Object get() {
         try {
-            return type.convert(getTarget());
+            Object target = getTarget();
+
+            return type.normalize(target);
+        } catch (QueryDataTypeMismatchException e) {
+            throw QueryException.dataException("Failed to extract map entry " + (key ? "key" : "value")
+                + " because of type mismatch [expectedClass=" + e.getExpectedClass().getName()
+                + ", actualClass=" + e.getActualClass().getName() + ']');
         } catch (Exception e) {
-            throw QueryException.dataException("Cannot convert " + (key ? "key" : "value") + " to " + type + ": "
+            throw QueryException.dataException("Failed to extract map entry " + (key ? "key" : "value") + ": "
                 + e.getMessage(), e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerImpl.java
@@ -24,6 +24,7 @@ import com.hazelcast.sql.SqlErrorCode;
 import com.hazelcast.sql.impl.NodeServiceProvider;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.exec.CreateExecPlanNodeVisitor;
+import com.hazelcast.sql.impl.exec.CreateExecPlanNodeVisitorHook;
 import com.hazelcast.sql.impl.exec.Exec;
 import com.hazelcast.sql.impl.exec.io.InboundHandler;
 import com.hazelcast.sql.impl.exec.io.OutboundHandler;
@@ -54,6 +55,7 @@ public class QueryOperationHandlerImpl implements QueryOperationHandler, QuerySt
     private final QueryOperationWorkerPool operationPool;
     private final int outboxBatchSize;
     private final FlowControlFactory flowControlFactory;
+    private volatile CreateExecPlanNodeVisitorHook execHook;
 
     public QueryOperationHandlerImpl(
         String instanceName,
@@ -195,7 +197,8 @@ public class QueryOperationHandlerImpl implements QueryOperationHandler, QuerySt
                 operation,
                 flowControlFactory,
                 operation.getPartitionMap().get(localMemberId),
-                outboxBatchSize
+                outboxBatchSize,
+                execHook
             );
 
             fragmentDescriptor.getNode().visit(visitor);
@@ -369,5 +372,9 @@ public class QueryOperationHandlerImpl implements QueryOperationHandler, QuerySt
             throw QueryException.error(
                 "Failed to serialize " + operation.getClass().getSimpleName() + ": " + e.getMessage(), e);
         }
+    }
+
+    public void setExecHook(CreateExecPlanNodeVisitorHook execHook) {
+        this.execHook = execHook;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/Plan.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/Plan.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql.impl.plan;
 
 import com.hazelcast.internal.util.collection.PartitionIdSet;
+import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.optimizer.SqlPlan;
 import com.hazelcast.sql.impl.optimizer.SqlPlanType;
 import com.hazelcast.sql.impl.plan.node.PlanNode;
@@ -48,13 +49,16 @@ public class Plan implements SqlPlan {
     /** Map from inbound edge ID to number of members which will write into it. */
     private final Map<Integer, Integer> inboundEdgeMemberCountMap;
 
+    private final SqlRowMetadata rowMetadata;
+
     public Plan(
         Map<UUID, PartitionIdSet> partMap,
         List<PlanNode> fragments,
         List<PlanFragmentMapping> fragmentMappings,
         Map<Integer, Integer> outboundEdgeMap,
         Map<Integer, Integer> inboundEdgeMap,
-        Map<Integer, Integer> inboundEdgeMemberCountMap
+        Map<Integer, Integer> inboundEdgeMemberCountMap,
+        SqlRowMetadata rowMetadata
     ) {
         this.partMap = partMap;
         this.fragments = fragments;
@@ -62,6 +66,7 @@ public class Plan implements SqlPlan {
         this.outboundEdgeMap = outboundEdgeMap;
         this.inboundEdgeMap = inboundEdgeMap;
         this.inboundEdgeMemberCountMap = inboundEdgeMemberCountMap;
+        this.rowMetadata = rowMetadata;
     }
 
     @Override
@@ -99,5 +104,9 @@ public class Plan implements SqlPlan {
 
     public Map<Integer, Integer> getInboundEdgeMemberCountMap() {
         return inboundEdgeMemberCountMap;
+    }
+
+    public SqlRowMetadata getRowMetadata() {
+        return rowMetadata;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/AbstractMapTable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/AbstractMapTable.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql.impl.schema.map;
 
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.extract.QueryTargetDescriptor;
+import com.hazelcast.sql.impl.schema.ConstantTableStatistics;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.TableStatistics;
@@ -50,7 +51,7 @@ public abstract class AbstractMapTable extends Table {
     }
 
     protected AbstractMapTable(String schemaName, String name, QueryException exception) {
-        super(schemaName, name, null, null);
+        super(schemaName, name, null, new ConstantTableStatistics(0));
 
         this.keyDescriptor = null;
         this.valueDescriptor = null;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolver.java
@@ -115,8 +115,6 @@ public class PartitionedMapTableResolver extends AbstractMapTableResolver {
                 throw QueryException.error("IMap with InMemoryFormat.NATIVE is not supported: " + name);
             }
 
-            boolean binary = config.getInMemoryFormat() == InMemoryFormat.BINARY;
-
             for (PartitionContainer partitionContainer : context.getPartitionContainers()) {
                 // Resolve sample.
                 RecordStore<?> recordStore = partitionContainer.getExistingRecordStore(name);
@@ -138,14 +136,12 @@ public class PartitionedMapTableResolver extends AbstractMapTableResolver {
                 MapSampleMetadata keyMetadata = MapSampleMetadataResolver.resolve(
                     ss,
                     entry.getKey(),
-                    binary,
                     true
                 );
 
                 MapSampleMetadata valueMetadata = MapSampleMetadataResolver.resolve(
                     ss,
                     entry.getValue().getValue(),
-                    binary,
                     false
                 );
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
@@ -55,7 +55,6 @@ public final class MapSampleMetadataResolver {
      *
      * @param ss Serialization service.
      * @param target Target to be analyzed.
-     * @param binary Whether map objects are stored in binary form.
      * @param key Whether passed target is key or value.
      * @return Sample metadata.
      * @throws QueryException If metadata cannot be resolved.
@@ -63,14 +62,18 @@ public final class MapSampleMetadataResolver {
     public static MapSampleMetadata resolve(
         InternalSerializationService ss,
         Object target,
-        boolean binary,
         boolean key
     ) {
         try {
+            // Convert Portable object to Data to have a consistent on object fields irrespectively of map's InMemoryFormat.
+            if (target instanceof Portable) {
+                target = ss.toData(target);
+            }
+
             if (target instanceof Data) {
                 Data data = (Data) target;
 
-                if (data.isPortable() && binary) {
+                if (data.isPortable()) {
                     return resolvePortable(ss.getPortableContext().lookupClassDefinition(data), key);
                 } else if (data.isJson()) {
                     throw new UnsupportedOperationException("JSON objects are not supported.");

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryInitiatorState.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryInitiatorState.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.state;
 
+import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.QueryResultProducer;
 import com.hazelcast.sql.impl.plan.Plan;
@@ -27,17 +28,20 @@ public class QueryInitiatorState {
 
     private final QueryId queryId;
     private final Plan plan;
+    private final SqlRowMetadata rowMetadata;
     private final QueryResultProducer resultProducer;
     private final long timeout;
 
     public QueryInitiatorState(
         QueryId queryId,
         Plan plan,
+        SqlRowMetadata rowMetadata,
         QueryResultProducer resultProducer,
         long timeout
     ) {
         this.queryId = queryId;
         this.plan = plan;
+        this.rowMetadata = rowMetadata;
         this.resultProducer = resultProducer;
         this.timeout = timeout;
     }
@@ -48,6 +52,10 @@ public class QueryInitiatorState {
 
     public Plan getPlan() {
         return plan;
+    }
+
+    public SqlRowMetadata getRowMetadata() {
+        return rowMetadata;
     }
 
     public QueryResultProducer getResultProducer() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql.impl.state;
 
 import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.ClockProvider;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryId;
@@ -68,6 +69,7 @@ public final class QueryState implements QueryStateCallback {
         boolean initiator,
         long initiatorTimeout,
         Plan initiatorPlan,
+        SqlRowMetadata initiatorRowMetadata,
         QueryResultProducer initiatorRowSource,
         ClockProvider clockProvider
     ) {
@@ -80,6 +82,7 @@ public final class QueryState implements QueryStateCallback {
             initiatorState = new QueryInitiatorState(
                 queryId,
                 initiatorPlan,
+                initiatorRowMetadata,
                 initiatorRowSource,
                 initiatorTimeout
             );
@@ -99,6 +102,7 @@ public final class QueryState implements QueryStateCallback {
         QueryStateCompletionCallback completionCallback,
         long initiatorTimeout,
         Plan initiatorPlan,
+        SqlRowMetadata initiatorRowMetadata,
         QueryResultProducer initiatorResultProducer,
         ClockProvider clockProvider
     ) {
@@ -109,6 +113,7 @@ public final class QueryState implements QueryStateCallback {
             true,
             initiatorTimeout,
             initiatorPlan,
+            initiatorRowMetadata,
             initiatorResultProducer,
             clockProvider
         );
@@ -132,6 +137,7 @@ public final class QueryState implements QueryStateCallback {
             completionCallback,
             false,
             -1,
+            null,
             null,
             null,
             clockProvider

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateRegistry.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.state;
 
+import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.ClockProvider;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.QueryResultProducer;
@@ -44,19 +45,18 @@ public class QueryStateRegistry {
      * @param localMemberId Cache local member ID.
      * @param initiatorTimeout Query timeout.
      * @param initiatorPlan Query plan.
+     * @param initiatorRowMetadata Metadata.
      * @param initiatorResultProducer An object that will produce final query results.
      * @param completionCallback Callback that will be invoked when the query is completed.
-     * @param register Whether th query should be registered. {@code true} for distributed queries, {@code false} for queries
-     *                 that return predefined values, e.g. EXPLAIN.
      * @return Query state.
      */
     public QueryState onInitiatorQueryStarted(
         UUID localMemberId,
         long initiatorTimeout,
         Plan initiatorPlan,
+        SqlRowMetadata initiatorRowMetadata,
         QueryResultProducer initiatorResultProducer,
-        QueryStateCompletionCallback completionCallback,
-        boolean register
+        QueryStateCompletionCallback completionCallback
     ) {
         QueryId queryId = QueryId.create(localMemberId);
 
@@ -66,13 +66,12 @@ public class QueryStateRegistry {
             completionCallback,
             initiatorTimeout,
             initiatorPlan,
+            initiatorRowMetadata,
             initiatorResultProducer,
             clockProvider
         );
 
-        if (register) {
-            states.put(queryId, state);
-        }
+        states.put(queryId, state);
 
         return state;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
@@ -111,18 +111,32 @@ public class QueryDataType implements IdentifiedDataSerializable {
         return precision;
     }
 
-    public Object convert(Object value) {
+    /**
+     * Normalize the given value to a value returned by this instance. If the value doesn't match
+     * the type expected by the converter, and exception is thrown.
+     *
+     * @param value Value
+     * @return Normalized value
+     * @throws QueryDataTypeMismatchException In case of data type mismatch.
+     */
+    public Object normalize(Object value) {
         if (value == null) {
             return value;
         }
 
         Class<?> valueClass = value.getClass();
 
-        if (valueClass == converter.getValueClass()) {
+        if (!converter.getValueClass().isAssignableFrom(valueClass)) {
+            // Expected and actual class doesn't match. Throw an error.
+            throw new QueryDataTypeMismatchException(converter.getValueClass(), valueClass);
+        }
+
+        if (valueClass == converter.getNormalizedValueClass()) {
+            // Do nothing if the value is already in the normalized form.
             return value;
         }
 
-        return converter.convertToSelf(Converters.getConverter(valueClass), value);
+        return converter.convertToSelf(converter, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeMismatchException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.type;
+
+/**
+ * Exception thrown in case of data type mismatch.
+ */
+public class QueryDataTypeMismatchException extends RuntimeException {
+
+    private final Class<?> expectedClass;
+    private final Class<?> actualClass;
+
+    public QueryDataTypeMismatchException(Class<?> expectedClass, Class<?> actualClass) {
+        this.expectedClass = expectedClass;
+        this.actualClass = actualClass;
+    }
+
+    public Class<?> getExpectedClass() {
+        return expectedClass;
+    }
+
+    public Class<?> getActualClass() {
+        return actualClass;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractDecimalConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractDecimalConverter.java
@@ -18,9 +18,16 @@ package com.hazelcast.sql.impl.type.converter;
 
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 
+import java.math.BigDecimal;
+
 public abstract class AbstractDecimalConverter extends Converter {
     protected AbstractDecimalConverter(int id) {
         super(id, QueryDataTypeFamily.DECIMAL);
+    }
+
+    @Override
+    public Class<?> getNormalizedValueClass() {
+        return BigDecimal.class;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -36,6 +36,11 @@ public abstract class AbstractStringConverter extends Converter {
     }
 
     @Override
+    public Class<?> getNormalizedValueClass() {
+        return String.class;
+    }
+
+    @Override
     public final boolean asBoolean(Object val) {
         String val0 = cast(val);
 
@@ -45,7 +50,7 @@ public abstract class AbstractStringConverter extends Converter {
             return false;
         }
 
-        throw QueryException.error(SqlErrorCode.DATA_EXCEPTION, "VARCHAR value cannot be converted to BIT: " + val);
+        throw QueryException.error(SqlErrorCode.DATA_EXCEPTION, "VARCHAR value cannot be converted to BOOLEAN: " + val);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractTimestampWithTimezoneConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractTimestampWithTimezoneConverter.java
@@ -21,6 +21,7 @@ import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 /**
  * Common converter class for TIMESTAMP WITH TIMEZONE type.
@@ -28,6 +29,11 @@ import java.time.LocalTime;
 public abstract class AbstractTimestampWithTimezoneConverter extends AbstractTemporalConverter {
     protected AbstractTimestampWithTimezoneConverter(int id) {
         super(id, QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE);
+    }
+
+    @Override
+    public Class<?> getNormalizedValueClass() {
+        return OffsetDateTime.class;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
@@ -111,7 +111,17 @@ public abstract class Converter {
         return typeFamily;
     }
 
+    /**
+     * @return Class of the value that is handled by this converter.
+     */
     public abstract Class<?> getValueClass();
+
+    /**
+     * @return Class the value should be converted to as a result of {@link #convertToSelf(Converter, Object)} call.
+     */
+    public Class<?> getNormalizedValueClass() {
+        return getValueClass();
+    }
 
     @NotConvertible
     public boolean asBoolean(Object val) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.worker;
 
+import com.hazelcast.sql.impl.exec.Exec;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.state.QueryStateCallback;
 
@@ -49,8 +50,12 @@ public final class QueryFragmentContext implements ExpressionEvalContext {
         return arguments.get(index);
     }
 
+    /**
+     * Reschedule fragment execution. Guarantees that {@link Exec#advance()} will be called after this call if the fragment
+     * is not completed yet.
+     */
     public void schedule() {
-        scheduleCallback.schedule();
+        scheduleCallback.schedule(true);
     }
 
     public void checkCancelled() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentScheduleCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/worker/QueryFragmentScheduleCallback.java
@@ -16,11 +16,26 @@
 
 package com.hazelcast.sql.impl.worker;
 
+import com.hazelcast.sql.impl.exec.root.BlockingRootResultConsumer;
+
 public interface QueryFragmentScheduleCallback {
+    /**
+     * Schedule the fragment for execution without the {@code force} flag.
+     *
+     * @see #schedule(boolean)
+     * @return {@code true} if the fragment was scheduled, {@code false} if already scheduled.
+     */
+    default boolean schedule() {
+        return schedule(false);
+    }
+
     /**
      * Schedule the fragment for execution.
      *
+     * @param force {@code true} to ensure that the fragment is re-executed after the call to the "schedule" even if there
+     *     are no new exchange operations. This is required by the result consumer.     *
+     * @see BlockingRootResultConsumer
      * @return {@code true} if the fragment was scheduled, {@code false} if already scheduled.
      */
-    boolean schedule();
+    boolean schedule(boolean force);
 }

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -71,6 +71,7 @@
                 <xs:element name="advanced-network" type="advanced-network" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="cp-subsystem" type="cp-subsystem" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="sql" type="sql" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -3962,7 +3963,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            
+
             <xs:element name="node-id-offset" type="xs:long" minOccurs="0" default="0">
                 <xs:annotation>
                     <xs:documentation>
@@ -3973,7 +3974,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            
+
             <xs:element name="bits-sequence" minOccurs="0" default="6">
                 <xs:annotation>
                     <xs:documentation>
@@ -4815,6 +4816,54 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:complexType name="sql">
+        <xs:annotation>
+            <xs:documentation>
+                SQL service configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="executor-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the number of threads responsible for query execution.
+                        Normally the value of this parameter should be equal to the number of CPU cores.
+                        Setting the value to less than the number of CPU cores will limit the degree of parallelism of the SQL
+                        subsystem. This may be beneficial if you would like to prioritize other CPU-intensive workloads on the
+                        same machine.
+                        It is not recommended to set the value of this parameter greater than the number of CPU cores because it
+                        may decrease the system's overall performance due to excessive context switches.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="operation-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the number of threads responsible for network operations processing.
+                        When Hazelcast members execute a query, they send commands to each other over the network to coordinate
+                        the execution. This includes requests to start or stop query execution, or a request to process a batch
+                        of data. These commands are processed in a separate operation thread pool, to avoid frequent interruption
+                        of running query fragments.
+                        The default value should be good enough for the most workloads. You may want to increase the default
+                        value if you run very small queries, or the machine has a big number of CPU cores.
+                        It is not recommended to set the value of this parameter greater than the number of CPU cores because it
+                        may decrease the system's overall performance due to excessive context switches.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="query-timeout" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the timeout in milliseconds that is applied to queries without an explicit timeout.
+                        It is possible to set a query timeout through the SqlQuery.setTimeout(long) method. If the query
+                        timeout is not set, then the value of this parameter will be used.
+                        Zero value means no timeout. Negative values are prohibited.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
     <xs:complexType name="realms">
         <xs:sequence>
             <xs:element name="realm" type="realm" minOccurs="0" maxOccurs="unbounded"/>
@@ -4855,7 +4904,7 @@
                 <xs:choice maxOccurs="unbounded">
                     <xs:element name="url" type="xs:string"/>
                     <xs:element name="socket-factory-class-name" type="xs:string" minOccurs="0"/>
-        
+
                     <xs:element name="parse-dn" type="xs:boolean" minOccurs="0"/>
                     <xs:element name="role-context" type="xs:string" minOccurs="0"/>
                     <xs:element name="role-filter" type="xs:string" minOccurs="0"/>
@@ -4865,7 +4914,7 @@
                     <xs:element name="role-recursion-max-depth" type="xs:int" minOccurs="0"/>
                     <xs:element name="role-search-scope" type="ldap-search-scope" minOccurs="0"/>
                     <xs:element name="user-name-attribute" type="xs:string" minOccurs="0"/>
-        
+
                     <xs:element name="system-user-dn" type="xs:string" minOccurs="0"/>
                     <xs:element name="system-user-password" type="xs:string" minOccurs="0"/>
                     <xs:element name="system-authentication" type="xs:string" minOccurs="0"/>

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -4823,11 +4823,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="executor-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+            <xs:element name="executor-pool-size" type="xs:int" minOccurs="0" maxOccurs="1" default="-1">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the number of threads responsible for query execution.
-                        Normally the value of this parameter should be equal to the number of CPU cores.
+                        The default value -1 sets the pool size equal to the number of CPU cores, and should be good enough
+                        for the most workloads.
                         Setting the value to less than the number of CPU cores will limit the degree of parallelism of the SQL
                         subsystem. This may be beneficial if you would like to prioritize other CPU-intensive workloads on the
                         same machine.
@@ -4836,7 +4837,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="operation-pool-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+            <xs:element name="operation-pool-size" type="xs:int" minOccurs="0" maxOccurs="1" default="-1">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the number of threads responsible for network operations processing.
@@ -4844,14 +4845,16 @@
                         the execution. This includes requests to start or stop query execution, or a request to process a batch
                         of data. These commands are processed in a separate operation thread pool, to avoid frequent interruption
                         of running query fragments.
-                        The default value should be good enough for the most workloads. You may want to increase the default
-                        value if you run very small queries, or the machine has a big number of CPU cores.
+                        The default value -1 sets the pool size equal to the number of CPU cores, and should be good enough
+                        for the most workloads.
+                        Setting the value to less than the number of CPU cores may improve the overall performance on machines
+                        with large CPU count, because it will decrease the number of context switches.
                         It is not recommended to set the value of this parameter greater than the number of CPU cores because it
                         may decrease the system's overall performance due to excessive context switches.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="query-timeout" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
+            <xs:element name="query-timeout-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the timeout in milliseconds that is applied to queries without an explicit timeout.

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -4854,7 +4854,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="query-timeout-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1">
+            <xs:element name="query-timeout-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
                         Sets the timeout in milliseconds that is applied to queries without an explicit timeout.

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -320,4 +320,10 @@
         <jmx enabled="true"/>
         <collection-frequency-seconds>5</collection-frequency-seconds>
     </metrics>
+
+    <sql>
+        <executor-pool-size>-1</executor-pool-size>
+        <operation-pool-size>-1</operation-pool-size>
+        <query-timeout-millis>0</query-timeout-millis>
+    </sql>
 </hazelcast>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -323,3 +323,8 @@ hazelcast:
     jmx:
       enabled: true
     collection-frequency-seconds: 5
+
+  sql:
+    executor-pool-size: -1
+    operation-pool-size: -1
+    query-timeout-millis: 0

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3442,4 +3442,26 @@
         <collection-frequency-seconds>10</collection-frequency-seconds>
     </metrics>
 
+    <!--
+        ===== HAZELCAST SQL CONFIGURATION =====
+
+        Configuration element's name is <sql>.
+
+        It has the following sub-elements:
+        * <executor-pool-sizer>:
+            Defines the number of threads responsible for query execution.
+
+        * <operation-pool-size>
+            Defines the number of threads responsible for network operations processing.
+
+        * <query-timeout>
+            Defines the timeout in milliseconds that is applied to queries without an explicit timeout.
+
+    -->
+    <sql>
+        <executor-pool-size>8</executor-pool-size>
+        <operation-pool-size>8</operation-pool-size>
+        <query-timeout>0</query-timeout>
+    </sql>
+
 </hazelcast>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3461,7 +3461,7 @@
     <sql>
         <executor-pool-size>8</executor-pool-size>
         <operation-pool-size>8</operation-pool-size>
-        <query-timeout>0</query-timeout>
+        <query-timeout-millis>0</query-timeout-millis>
     </sql>
 
 </hazelcast>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3331,3 +3331,23 @@ hazelcast:
     jmx:
       enabled: false
     collection-frequency-seconds: 10
+
+  #
+  # ===== HAZELCAST SQL CONFIGURATION =====
+  #
+  # Configuration element's name is "sql".
+  #
+  # It has the following sub-elements:
+  #     * "executor-pool-size":
+  #         Defines the number of threads responsible for query execution.
+  #
+  #     * "operation-pool-size":
+  #         Defines the number of threads responsible for network operations processing.
+  #
+  #     * "query-timeout":
+  #         Defines the timeout in milliseconds that is applied to queries without an explicit timeout.
+  #
+  sql:
+    executor-pool-size: 8
+    operation-pool-size: 8
+    query-timeout: 0

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3350,4 +3350,4 @@ hazelcast:
   sql:
     executor-pool-size: 8
     operation-pool-size: 8
-    query-timeout: 0
+    query-timeout-millis: 0

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -535,6 +535,8 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
 
     public abstract void testMetricsConfigJmxDisabled();
 
+    public abstract void testSqlConfig();
+
     protected static void assertAwsConfig(AwsConfig aws) {
         assertEquals("sample-access-key", aws.getProperties().get("access-key"));
         assertEquals("sample-secret-key", aws.getProperties().get("secret-key"));

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1802,13 +1802,13 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
 
         confiig.getSqlConfig().setExecutorPoolSize(10);
         confiig.getSqlConfig().setOperationPoolSize(20);
-        confiig.getSqlConfig().setQueryTimeout(30L);
+        confiig.getSqlConfig().setQueryTimeoutMillis(30L);
 
         SqlConfig generatedConfig = getNewConfigViaXMLGenerator(confiig).getSqlConfig();
 
         assertEquals(confiig.getSqlConfig().getExecutorPoolSize(), generatedConfig.getExecutorPoolSize());
         assertEquals(confiig.getSqlConfig().getOperationPoolSize(), generatedConfig.getOperationPoolSize());
-        assertEquals(confiig.getSqlConfig().getQueryTimeout(), generatedConfig.getQueryTimeout());
+        assertEquals(confiig.getSqlConfig().getQueryTimeoutMillis(), generatedConfig.getQueryTimeoutMillis());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1797,6 +1797,21 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testSqlConfig() {
+        Config confiig = new Config();
+
+        confiig.getSqlConfig().setExecutorPoolSize(10);
+        confiig.getSqlConfig().setOperationPoolSize(20);
+        confiig.getSqlConfig().setQueryTimeout(30L);
+
+        SqlConfig generatedConfig = getNewConfigViaXMLGenerator(confiig).getSqlConfig();
+
+        assertEquals(confiig.getSqlConfig().getExecutorPoolSize(), generatedConfig.getExecutorPoolSize());
+        assertEquals(confiig.getSqlConfig().getOperationPoolSize(), generatedConfig.getOperationPoolSize());
+        assertEquals(confiig.getSqlConfig().getQueryTimeout(), generatedConfig.getQueryTimeout());
+    }
+
+    @Test
     public void testMemcacheProtocolConfig() {
         MemcacheProtocolConfig memcacheProtocolConfig = new MemcacheProtocolConfig().setEnabled(true);
         Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/config/SqlConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SqlConfigTest.java
@@ -34,7 +34,7 @@ public class SqlConfigTest {
 
         assertEquals(SqlConfig.DEFAULT_EXECUTOR_POOL_SIZE, config.getExecutorPoolSize());
         assertEquals(SqlConfig.DEFAULT_OPERATION_POOL_SIZE, config.getOperationPoolSize());
-        assertEquals(SqlConfig.DEFAULT_QUERY_TIMEOUT, config.getQueryTimeout());
+        assertEquals(SqlConfig.DEFAULT_QUERY_TIMEOUT, config.getQueryTimeoutMillis());
     }
 
     @Test
@@ -42,11 +42,15 @@ public class SqlConfigTest {
         SqlConfig config = new SqlConfig()
             .setExecutorPoolSize(10)
             .setOperationPoolSize(20)
-            .setQueryTimeout(30L);
+            .setQueryTimeoutMillis(30L);
 
         assertEquals(10, config.getExecutorPoolSize());
         assertEquals(20, config.getOperationPoolSize());
-        assertEquals(30L, config.getQueryTimeout());
+        assertEquals(30L, config.getQueryTimeoutMillis());
+    }
+
+    public void testExecutorPoolSizeDefault() {
+        new SqlConfig().setExecutorPoolSize(-1);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -56,6 +60,10 @@ public class SqlConfigTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testExecutorPoolSizeNegative() {
+        new SqlConfig().setExecutorPoolSize(-2);
+    }
+
+    public void testOperationPoolSizeDefault() {
         new SqlConfig().setExecutorPoolSize(-1);
     }
 
@@ -66,16 +74,16 @@ public class SqlConfigTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testOperationPoolSizeNegative() {
-        new SqlConfig().setOperationPoolSize(-1);
+        new SqlConfig().setOperationPoolSize(-2);
     }
 
     @Test
     public void testQueryTimeoutZero() {
-        new SqlConfig().setQueryTimeout(0);
+        new SqlConfig().setQueryTimeoutMillis(0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testQueryTimeoutNegative() {
-        new SqlConfig().setQueryTimeout(-1L);
+        new SqlConfig().setQueryTimeoutMillis(-1L);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/SqlConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SqlConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlConfigTest {
+    @Test
+    public void testEmpty() {
+        SqlConfig config = new SqlConfig();
+
+        assertEquals(SqlConfig.DEFAULT_EXECUTOR_POOL_SIZE, config.getExecutorPoolSize());
+        assertEquals(SqlConfig.DEFAULT_OPERATION_POOL_SIZE, config.getOperationPoolSize());
+        assertEquals(SqlConfig.DEFAULT_QUERY_TIMEOUT, config.getQueryTimeout());
+    }
+
+    @Test
+    public void testNonEmpty() {
+        SqlConfig config = new SqlConfig()
+            .setExecutorPoolSize(10)
+            .setOperationPoolSize(20)
+            .setQueryTimeout(30L);
+
+        assertEquals(10, config.getExecutorPoolSize());
+        assertEquals(20, config.getOperationPoolSize());
+        assertEquals(30L, config.getQueryTimeout());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExecutorPoolSizeZero() {
+        new SqlConfig().setExecutorPoolSize(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExecutorPoolSizeNegative() {
+        new SqlConfig().setExecutorPoolSize(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOperationPoolSizeZero() {
+        new SqlConfig().setOperationPoolSize(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOperationPoolSizeNegative() {
+        new SqlConfig().setOperationPoolSize(-1);
+    }
+
+    @Test
+    public void testQueryTimeoutZero() {
+        new SqlConfig().setQueryTimeout(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQueryTimeoutNegative() {
+        new SqlConfig().setQueryTimeout(-1L);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3478,4 +3478,21 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertTrue(metricsConfig.getManagementCenterConfig().isEnabled());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
     }
+
+    @Override
+    @Test
+    public void testSqlConfig() {
+        String xml = HAZELCAST_START_TAG
+            + "<sql>\n"
+            + "  <executor-pool-size>10</executor-pool-size>\n"
+            + "  <operation-pool-size>20</operation-pool-size>\n"
+            + "  <query-timeout>30</query-timeout>\n"
+            + "</sql>"
+            + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        SqlConfig sqlConfig = config.getSqlConfig();
+        assertEquals(10, sqlConfig.getExecutorPoolSize());
+        assertEquals(20, sqlConfig.getOperationPoolSize());
+        assertEquals(30L, sqlConfig.getQueryTimeout());
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3486,13 +3486,13 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
             + "<sql>\n"
             + "  <executor-pool-size>10</executor-pool-size>\n"
             + "  <operation-pool-size>20</operation-pool-size>\n"
-            + "  <query-timeout>30</query-timeout>\n"
+            + "  <query-timeout-millis>30</query-timeout-millis>\n"
             + "</sql>"
             + HAZELCAST_END_TAG;
         Config config = new InMemoryXmlConfig(xml);
         SqlConfig sqlConfig = config.getSqlConfig();
         assertEquals(10, sqlConfig.getExecutorPoolSize());
         assertEquals(20, sqlConfig.getOperationPoolSize());
-        assertEquals(30L, sqlConfig.getQueryTimeout());
+        assertEquals(30L, sqlConfig.getQueryTimeoutMillis());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3401,12 +3401,12 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
             + "  sql:\n"
             + "    executor-pool-size: 10\n"
             + "    operation-pool-size: 20\n"
-            + "    query-timeout: 30\n";
+            + "    query-timeout-millis: 30\n";
         Config config = buildConfig(yaml);
         SqlConfig sqlConfig = config.getSqlConfig();
         assertEquals(10, sqlConfig.getExecutorPoolSize());
         assertEquals(20, sqlConfig.getOperationPoolSize());
-        assertEquals(30L, sqlConfig.getQueryTimeout());
+        assertEquals(30L, sqlConfig.getQueryTimeoutMillis());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3395,6 +3395,21 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    public void testSqlConfig() {
+        String yaml = ""
+            + "hazelcast:\n"
+            + "  sql:\n"
+            + "    executor-pool-size: 10\n"
+            + "    operation-pool-size: 20\n"
+            + "    query-timeout: 30\n";
+        Config config = buildConfig(yaml);
+        SqlConfig sqlConfig = config.getSqlConfig();
+        assertEquals(10, sqlConfig.getExecutorPoolSize());
+        assertEquals(20, sqlConfig.getOperationPoolSize());
+        assertEquals(30L, sqlConfig.getQueryTimeout());
+    }
+
+    @Override
     public void testWhitespaceInNonSpaceStrings() {
         String yaml = ""
                 + "hazelcast:\n"

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -29,10 +29,14 @@ import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.operation.MultipleEntryWithPredicateOperation;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
@@ -69,6 +73,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -1039,6 +1044,54 @@ public class EntryProcessorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testIssue16987_customTtls() {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = getConfig();
+        cfg.getMapConfig(MAP_NAME).setReadBackupData(true);
+
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
+
+        IMap<Integer, Integer> instance1Map = instance1.getMap(MAP_NAME);
+        instance1Map.put(1, 1);
+        instance1Map.setTtl(1, 1337, TimeUnit.SECONDS);
+
+        EntryView<Integer, Integer> view = instance1Map.getEntryView(1);
+        assertEquals(1337000L, view.getTtl());
+        assertEquals(1, view.getValue().intValue());
+
+        instance1Map.executeOnKey(1, new TTLChangingEntryProcessor<>(3, Duration.ofSeconds(1234)));
+
+        view = instance1Map.getEntryView(1);
+        assertEquals("ttl was not updated", 1234000L, view.getTtl());
+
+        Data key = new DefaultSerializationServiceBuilder().build().toData(1);
+        if (instance1.getPartitionService().getPartition(1).getOwner().localMember()) {
+            assertTtlFromLocalRecordStore(instance2, key, 1234000L);
+        } else {
+            assertTtlFromLocalRecordStore(instance1, key, 1234000L);
+        }
+    }
+
+    private void assertTtlFromLocalRecordStore(HazelcastInstance instance, Data key, long expectedTtl) {
+        MapProxyImpl<Integer, Integer> map = (MapProxyImpl) instance.getMap(MAP_NAME);
+        MapService mapService = map.getNodeEngine().getService(MapService.SERVICE_NAME);
+        PartitionContainer[] partitionContainers = mapService.getMapServiceContext().getPartitionContainers();
+        for (PartitionContainer partitionContainer : partitionContainers) {
+            RecordStore rs = partitionContainer.getExistingRecordStore(MAP_NAME);
+            if (rs != null) {
+                Record record = rs.getRecordOrNull(key);
+
+                if (record != null) {
+                    assertEquals(expectedTtl, record.getTtl());
+                    return;
+                }
+            }
+        }
+        fail("Backup not found.");
+    }
+
+    @Test
     public void testExecuteOnKeys() throws Exception {
         testExecuteOrSubmitOnKeys(false);
     }
@@ -1413,6 +1466,23 @@ public class EntryProcessorTest extends HazelcastTestSupport {
             entry.setValue(null);
             return null;
         }
+    }
+
+    private static class TTLChangingEntryProcessor<K, V> implements EntryProcessor<K, V, V> {
+
+        private V newValue;
+        private Duration newTtl;
+
+        TTLChangingEntryProcessor(V newValue, Duration newTtl) {
+            this.newValue = newValue;
+            this.newTtl = newTtl;
+        }
+
+        @Override
+        public V process(Entry<K, V> entry) {
+            return ((ExtendedMapEntry<V>) entry).setValue(newValue, newTtl.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlColumnTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlColumnTypeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlColumnTypeTest {
+    @Test
+    public void testColumnTypes() {
+        checkType(SqlColumnType.BOOLEAN, Boolean.class);
+        checkType(SqlColumnType.TINYINT, Byte.class);
+        checkType(SqlColumnType.SMALLINT, Short.class);
+        checkType(SqlColumnType.INT, Integer.class);
+        checkType(SqlColumnType.BIGINT, Long.class);
+        checkType(SqlColumnType.REAL, Float.class);
+        checkType(SqlColumnType.DOUBLE, Double.class);
+        checkType(SqlColumnType.DECIMAL, BigDecimal.class);
+
+        checkType(SqlColumnType.DATE, LocalDate.class);
+        checkType(SqlColumnType.TIME, LocalTime.class);
+        checkType(SqlColumnType.TIMESTAMP, LocalDateTime.class);
+        checkType(SqlColumnType.TIMESTAMP_WITH_TIME_ZONE, OffsetDateTime.class);
+
+        checkType(SqlColumnType.OBJECT, Object.class);
+    }
+
+    private static void checkType(SqlColumnType type, Class<?> valueClass) {
+        assertEquals(valueClass, type.getValueClass());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlExceptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlExceptionTest {
+    @Test
+    public void testFields() {
+        UUID memberId = UUID.randomUUID();
+        int errorCode = SqlErrorCode.DATA_EXCEPTION;
+        String errorMessage = "error";
+        Exception cause = new IllegalArgumentException();
+
+        SqlException exception = new SqlException(memberId, errorCode, errorMessage, cause);
+
+        assertEquals(memberId, exception.getOriginatingMemberId());
+        assertEquals(errorCode, exception.getCode());
+        assertEquals(errorMessage, exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
@@ -45,6 +45,7 @@ public class SqlMetadataTest extends SqlTestSupport {
 
         assertEquals("a", column.getName());
         assertEquals(SqlColumnType.INT, column.getType());
+        assertEquals("a INT", column.toString());
 
         checkEquals(column, new SqlColumnMetadata("a", SqlColumnType.INT), true);
         checkEquals(column, new SqlColumnMetadata("b", SqlColumnType.INT), false);
@@ -61,7 +62,7 @@ public class SqlMetadataTest extends SqlTestSupport {
             HeapRow.of(1, "2")
         );
 
-        assertEquals("[a:INT=1, b:VARCHAR=2]", row.toString());
+        assertEquals("[a INT=1, b VARCHAR=2]", row.toString());
     }
 
     @Test
@@ -72,7 +73,7 @@ public class SqlMetadataTest extends SqlTestSupport {
 
         SqlRowMetadata row = new SqlRowMetadata(Arrays.asList(column0, column1));
 
-        assertEquals("[a:INT, b:BIGINT]", row.toString());
+        assertEquals("[a INT, b BIGINT]", row.toString());
 
         assertEquals(2, row.getColumnCount());
         assertEquals(column0, row.getColumn(0));

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.sql;
 
+import com.hazelcast.sql.impl.SqlRowImpl;
 import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.row.HeapRow;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -50,12 +52,27 @@ public class SqlMetadataTest extends SqlTestSupport {
     }
 
     @Test
+    public void testRow() {
+        SqlColumnMetadata column0Metadata = new SqlColumnMetadata("a", SqlColumnType.INT);
+        SqlColumnMetadata column1Metadata = new SqlColumnMetadata("b", SqlColumnType.VARCHAR);
+
+        SqlRow row = new SqlRowImpl(
+            new SqlRowMetadata(Arrays.asList(column0Metadata, column1Metadata)),
+            HeapRow.of(1, "2")
+        );
+
+        assertEquals("[a:INT=1, b:VARCHAR=2]", row.toString());
+    }
+
+    @Test
     public void testRowMetadata() {
         SqlColumnMetadata column0 = new SqlColumnMetadata("a", SqlColumnType.INT);
         SqlColumnMetadata column1 = new SqlColumnMetadata("b", SqlColumnType.BIGINT);
         SqlColumnMetadata column2 = new SqlColumnMetadata("c", SqlColumnType.VARCHAR);
 
         SqlRowMetadata row = new SqlRowMetadata(Arrays.asList(column0, column1));
+
+        assertEquals("[a:INT, b:BIGINT]", row.toString());
 
         assertEquals(2, row.getColumnCount());
         assertEquals(column0, row.getColumn(0));

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
@@ -47,8 +47,6 @@ public class SqlMetadataTest extends SqlTestSupport {
         checkEquals(column, new SqlColumnMetadata("a", SqlColumnType.INT), true);
         checkEquals(column, new SqlColumnMetadata("b", SqlColumnType.INT), false);
         checkEquals(column, new SqlColumnMetadata("a", SqlColumnType.BIGINT), false);
-
-        checkEquals(column, serialize(column), true);
     }
 
     @Test
@@ -74,8 +72,6 @@ public class SqlMetadataTest extends SqlTestSupport {
         checkEquals(row, new SqlRowMetadata(Collections.singletonList(column0)), false);
         checkEquals(row, new SqlRowMetadata(Arrays.asList(column0, column2)), false);
         checkEquals(row, new SqlRowMetadata(Arrays.asList(column0, column1, column2)), false);
-
-        checkEquals(row, serialize(row), true);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static com.hazelcast.sql.impl.QueryUtils.getColumnMetadata;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for row and column metadata.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlMetadataTest extends SqlTestSupport {
+    @Test
+    public void testColumnMetadata() {
+        SqlColumnMetadata column = new SqlColumnMetadata("a", SqlColumnType.INT);
+
+        assertEquals("a", column.getName());
+        assertEquals(SqlColumnType.INT, column.getType());
+
+        checkEquals(column, new SqlColumnMetadata("a", SqlColumnType.INT), true);
+        checkEquals(column, new SqlColumnMetadata("b", SqlColumnType.INT), false);
+        checkEquals(column, new SqlColumnMetadata("a", SqlColumnType.BIGINT), false);
+
+        checkEquals(column, serialize(column), true);
+    }
+
+    @Test
+    public void testRowMetadata() {
+        SqlColumnMetadata column0 = new SqlColumnMetadata("a", SqlColumnType.INT);
+        SqlColumnMetadata column1 = new SqlColumnMetadata("b", SqlColumnType.BIGINT);
+        SqlColumnMetadata column2 = new SqlColumnMetadata("c", SqlColumnType.VARCHAR);
+
+        SqlRowMetadata row = new SqlRowMetadata(Arrays.asList(column0, column1));
+
+        assertEquals(2, row.getColumnCount());
+        assertEquals(column0, row.getColumn(0));
+        assertEquals(column1, row.getColumn(1));
+
+        assertEquals(0, row.findColumn("a"));
+        assertEquals(1, row.findColumn("b"));
+        assertEquals(SqlRowMetadata.COLUMN_NOT_FOUND, row.findColumn("c"));
+
+        assertThrows(IndexOutOfBoundsException.class, () -> row.getColumn(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> row.getColumn(2));
+
+        checkEquals(row, new SqlRowMetadata(Arrays.asList(column0, column1)), true);
+        checkEquals(row, new SqlRowMetadata(Collections.singletonList(column0)), false);
+        checkEquals(row, new SqlRowMetadata(Arrays.asList(column0, column2)), false);
+        checkEquals(row, new SqlRowMetadata(Arrays.asList(column0, column1, column2)), false);
+
+        checkEquals(row, serialize(row), true);
+    }
+
+    @Test
+    public void testConversions() {
+        String name = "a";
+
+        assertEquals(column(name, SqlColumnType.BOOLEAN), getColumnMetadata(name, QueryDataType.BOOLEAN));
+        assertEquals(column(name, SqlColumnType.TINYINT), getColumnMetadata(name, QueryDataType.TINYINT));
+        assertEquals(column(name, SqlColumnType.SMALLINT), getColumnMetadata(name, QueryDataType.SMALLINT));
+        assertEquals(column(name, SqlColumnType.INT), getColumnMetadata(name, QueryDataType.INT));
+        assertEquals(column(name, SqlColumnType.BIGINT), getColumnMetadata(name, QueryDataType.BIGINT));
+        assertEquals(column(name, SqlColumnType.DECIMAL), getColumnMetadata(name, QueryDataType.DECIMAL));
+        assertEquals(column(name, SqlColumnType.DECIMAL), getColumnMetadata(name, QueryDataType.DECIMAL_BIG_INTEGER));
+        assertEquals(column(name, SqlColumnType.REAL), getColumnMetadata(name, QueryDataType.REAL));
+        assertEquals(column(name, SqlColumnType.DOUBLE), getColumnMetadata(name, QueryDataType.DOUBLE));
+
+        assertEquals(column(name, SqlColumnType.VARCHAR), getColumnMetadata(name, QueryDataType.VARCHAR));
+        assertEquals(column(name, SqlColumnType.VARCHAR), getColumnMetadata(name, QueryDataType.VARCHAR_CHARACTER));
+
+        assertEquals(column(name, SqlColumnType.DATE), getColumnMetadata(name, QueryDataType.DATE));
+        assertEquals(column(name, SqlColumnType.TIME), getColumnMetadata(name, QueryDataType.TIME));
+        assertEquals(column(name, SqlColumnType.TIMESTAMP), getColumnMetadata(name, QueryDataType.TIMESTAMP));
+
+        assertEquals(
+            column(name, SqlColumnType.TIMESTAMP_WITH_TIME_ZONE),
+            getColumnMetadata(name, QueryDataType.TIMESTAMP_WITH_TZ_DATE)
+        );
+
+        assertEquals(
+            column(name, SqlColumnType.TIMESTAMP_WITH_TIME_ZONE),
+            getColumnMetadata(name, QueryDataType.TIMESTAMP_WITH_TZ_CALENDAR)
+        );
+
+        assertEquals(
+            column(name, SqlColumnType.TIMESTAMP_WITH_TIME_ZONE),
+            getColumnMetadata(name, QueryDataType.TIMESTAMP_WITH_TZ_INSTANT)
+        );
+
+        assertEquals(
+            column(name, SqlColumnType.TIMESTAMP_WITH_TIME_ZONE),
+            getColumnMetadata(name, QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME)
+        );
+
+        assertEquals(
+            column(name, SqlColumnType.TIMESTAMP_WITH_TIME_ZONE),
+            getColumnMetadata(name, QueryDataType.TIMESTAMP_WITH_TZ_ZONED_DATE_TIME)
+        );
+    }
+
+    private static SqlColumnMetadata column(String name, SqlColumnType type) {
+        return new SqlColumnMetadata(name, type);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlQueryTest.java
@@ -45,7 +45,7 @@ public class SqlQueryTest extends SqlTestSupport {
         assertEquals(SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE, query.getCursorBufferSize());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testSql_null() {
         new SqlQuery(null);
     }

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlQueryTest.java
@@ -41,7 +41,7 @@ public class SqlQueryTest extends SqlTestSupport {
 
         assertEquals(SQL, query.getSql());
         assertEquals(0, query.getParameters().size());
-        assertEquals(SqlQuery.DEFAULT_TIMEOUT, query.getTimeout());
+        assertEquals(SqlQuery.DEFAULT_TIMEOUT, query.getTimeoutMillis());
         assertEquals(SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE, query.getCursorBufferSize());
     }
 
@@ -85,19 +85,19 @@ public class SqlQueryTest extends SqlTestSupport {
 
     @Test
     public void testTimeout() {
-        SqlQuery query = create().setTimeout(1);
-        assertEquals(1, query.getTimeout());
+        SqlQuery query = create().setTimeoutMillis(1);
+        assertEquals(1, query.getTimeoutMillis());
 
-        query.setTimeout(0);
-        assertEquals(0, query.getTimeout());
+        query.setTimeoutMillis(0);
+        assertEquals(0, query.getTimeoutMillis());
 
-        query.setTimeout(SqlQuery.TIMEOUT_NOT_SET);
-        assertEquals(SqlQuery.TIMEOUT_NOT_SET, query.getTimeout());
+        query.setTimeoutMillis(SqlQuery.TIMEOUT_NOT_SET);
+        assertEquals(SqlQuery.TIMEOUT_NOT_SET, query.getTimeoutMillis());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testTimeout_negative() {
-        create().setTimeout(-2);
+        create().setTimeoutMillis(-2);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class SqlQueryTest extends SqlTestSupport {
         SqlQuery original = create();
         checkEquals(original, original.copy(), true);
 
-        original.setParameters(Arrays.asList(1, 2)).setTimeout(3L).setCursorBufferSize(4);
+        original.setParameters(Arrays.asList(1, 2)).setTimeoutMillis(3L).setCursorBufferSize(4);
         checkEquals(original, original.copy(), true);
     }
 
@@ -131,26 +131,26 @@ public class SqlQueryTest extends SqlTestSupport {
         SqlQuery another = create();
         checkEquals(query, another, true);
 
-        query.setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(20);
-        another.setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(20);
+        query.setParameters(Arrays.asList(1, 2)).setTimeoutMillis(10L).setCursorBufferSize(20);
+        another.setParameters(Arrays.asList(1, 2)).setTimeoutMillis(10L).setCursorBufferSize(20);
         checkEquals(query, another, true);
 
-        another.setSql(SQL + "1").setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(20);
+        another.setSql(SQL + "1").setParameters(Arrays.asList(1, 2)).setTimeoutMillis(10L).setCursorBufferSize(20);
         checkEquals(query, another, false);
 
-        another.setSql(SQL).setParameters(Arrays.asList(1, 2, 3)).setTimeout(10L).setCursorBufferSize(20);
+        another.setSql(SQL).setParameters(Arrays.asList(1, 2, 3)).setTimeoutMillis(10L).setCursorBufferSize(20);
         checkEquals(query, another, false);
 
-        another.setSql(SQL).setParameters(Arrays.asList(1, 2)).setTimeout(11L).setCursorBufferSize(20);
+        another.setSql(SQL).setParameters(Arrays.asList(1, 2)).setTimeoutMillis(11L).setCursorBufferSize(20);
         checkEquals(query, another, false);
 
-        another.setSql(SQL).setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(21);
+        another.setSql(SQL).setParameters(Arrays.asList(1, 2)).setTimeoutMillis(10L).setCursorBufferSize(21);
         checkEquals(query, another, false);
     }
 
     @Test
     public void testToString() {
-        SqlQuery query = create().setParameters(Arrays.asList(1, 2)).setTimeout(3L).setCursorBufferSize(4);
+        SqlQuery query = create().setParameters(Arrays.asList(1, 2)).setTimeoutMillis(3L).setCursorBufferSize(4);
 
         String string = query.toString();
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlQueryTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlQueryTest extends SqlTestSupport {
+
+    private static final String SQL = "sql";
+
+    @Test
+    public void testDefaults() {
+        SqlQuery query = create();
+
+        assertEquals(SQL, query.getSql());
+        assertEquals(0, query.getParameters().size());
+        assertEquals(SqlQuery.DEFAULT_TIMEOUT, query.getTimeout());
+        assertEquals(SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE, query.getCursorBufferSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSql_null() {
+        new SqlQuery(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSql_empty() {
+        new SqlQuery("");
+    }
+
+    @Test
+    public void testParameters() {
+        Object param0 = new Object();
+        Object param1 = new Object();
+        Object param2 = new Object();
+
+        SqlQuery query = create();
+        assertEquals(0, query.getParameters().size());
+
+        query.setParameters(Arrays.asList(param0, param1));
+        assertEquals(2, query.getParameters().size());
+        assertEquals(param0, query.getParameters().get(0));
+        assertEquals(param1, query.getParameters().get(1));
+
+        query.addParameter(param2);
+        assertEquals(3, query.getParameters().size());
+        assertEquals(param0, query.getParameters().get(0));
+        assertEquals(param1, query.getParameters().get(1));
+        assertEquals(param2, query.getParameters().get(2));
+
+        query.clearParameters();
+        assertEquals(0, query.getParameters().size());
+
+        query.addParameter(param0);
+        assertEquals(1, query.getParameters().size());
+        assertEquals(param0, query.getParameters().get(0));
+    }
+
+    @Test
+    public void testTimeout() {
+        SqlQuery query = create().setTimeout(1);
+        assertEquals(1, query.getTimeout());
+
+        query.setTimeout(0);
+        assertEquals(0, query.getTimeout());
+
+        query.setTimeout(SqlQuery.TIMEOUT_NOT_SET);
+        assertEquals(SqlQuery.TIMEOUT_NOT_SET, query.getTimeout());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTimeout_negative() {
+        create().setTimeout(-2);
+    }
+
+    @Test
+    public void testCursorBufferSize() {
+        SqlQuery query = create().setCursorBufferSize(1);
+        assertEquals(1, query.getCursorBufferSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCursorBufferSize_zero() {
+        create().setCursorBufferSize(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCursorBufferSize_negative() {
+        create().setCursorBufferSize(-1);
+    }
+
+    @Test
+    public void testCopy() {
+        SqlQuery original = create();
+        checkEquals(original, original.copy(), true);
+
+        original.setParameters(Arrays.asList(1, 2)).setTimeout(3L).setCursorBufferSize(4);
+        checkEquals(original, original.copy(), true);
+    }
+
+    @Test
+    public void testEquals() {
+        SqlQuery query = create();
+        SqlQuery another = create();
+        checkEquals(query, another, true);
+
+        query.setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(20);
+        another.setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(20);
+        checkEquals(query, another, true);
+
+        another.setSql(SQL + "1").setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(20);
+        checkEquals(query, another, false);
+
+        another.setSql(SQL).setParameters(Arrays.asList(1, 2, 3)).setTimeout(10L).setCursorBufferSize(20);
+        checkEquals(query, another, false);
+
+        another.setSql(SQL).setParameters(Arrays.asList(1, 2)).setTimeout(11L).setCursorBufferSize(20);
+        checkEquals(query, another, false);
+
+        another.setSql(SQL).setParameters(Arrays.asList(1, 2)).setTimeout(10L).setCursorBufferSize(21);
+        checkEquals(query, another, false);
+    }
+
+    @Test
+    public void testToString() {
+        SqlQuery query = create().setParameters(Arrays.asList(1, 2)).setTimeout(3L).setCursorBufferSize(4);
+
+        String string = query.toString();
+
+        assertTrue(string.contains("sql="));
+        assertTrue(string.contains("parameters="));
+        assertTrue(string.contains("timeout="));
+        assertTrue(string.contains("cursorBufferSize="));
+    }
+
+    private static SqlQuery create() {
+        return new SqlQuery(SQL);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/LoggingQueryFragmentScheduleCallback.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/LoggingQueryFragmentScheduleCallback.java
@@ -25,7 +25,7 @@ public class LoggingQueryFragmentScheduleCallback implements QueryFragmentSchedu
     private final AtomicInteger count = new AtomicInteger();
 
     @Override
-    public boolean schedule() {
+    public boolean schedule(boolean force) {
         count.incrementAndGet();
 
         return true;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
@@ -167,7 +167,7 @@ public class SqlTestSupport extends HazelcastTestSupport {
 
     public static void setExecHook(HazelcastInstance instance, CreateExecPlanNodeVisitorHook hook) {
         QueryOperationHandlerImpl operationHandler =
-            ((SqlServiceImpl) instance.getSqlService()).getInternalService().getOperationHandler();
+            ((SqlServiceImpl) instance.getSql()).getInternalService().getOperationHandler();
 
         operationHandler.setExecHook(hook);
     }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
@@ -22,7 +22,9 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.sql.impl.exec.CreateExecPlanNodeVisitorHook;
 import com.hazelcast.sql.impl.extract.QueryPath;
+import com.hazelcast.sql.impl.operation.QueryOperationHandlerImpl;
 import com.hazelcast.sql.impl.plan.Plan;
 import com.hazelcast.sql.impl.row.HeapRow;
 import com.hazelcast.sql.impl.row.ListRowBatch;
@@ -135,7 +137,8 @@ public class SqlTestSupport extends HazelcastTestSupport {
             Collections.emptyList(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            null
         );
     }
 
@@ -160,5 +163,12 @@ public class SqlTestSupport extends HazelcastTestSupport {
         assertTrue(values.length > 0);
 
         return new HeapRow(values);
+    }
+
+    public static void setExecHook(HazelcastInstance instance, CreateExecPlanNodeVisitorHook hook) {
+        QueryOperationHandlerImpl operationHandler =
+            ((SqlServiceImpl) instance.getSqlService()).getInternalService().getOperationHandler();
+
+        operationHandler.setExecHook(hook);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/BlockingExec.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/BlockingExec.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.sql.impl.worker.QueryFragmentContext;
+
+import java.util.concurrent.CountDownLatch;
+
+public class BlockingExec extends AbstractExec {
+
+    private final Exec exec;
+    private final Blocker blocker;
+
+    public BlockingExec(Exec exec, Blocker blocker) {
+        super(exec.getId());
+
+        this.exec = exec;
+        this.blocker = blocker;
+    }
+
+    @Override
+    protected void setup0(QueryFragmentContext ctx) {
+        exec.setup(ctx);
+    }
+
+    @Override
+    protected IterationResult advance0() {
+        blocker.awaitUnblock();
+
+        return exec.advance();
+    }
+
+    @Override
+    protected RowBatch currentBatch0() {
+        return exec.currentBatch();
+    }
+
+    public static class Blocker {
+
+        private final CountDownLatch awaitLatch = new CountDownLatch(1);
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        public void awaitReached() {
+            try {
+                awaitLatch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+
+                throw new RuntimeException(e);
+            }
+        }
+
+        private void awaitUnblock() {
+            awaitLatch.countDown();
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void unblock() {
+            latch.countDown();
+        }
+
+        public void unblockAfter(long timeout) {
+            Thread thread = new Thread(() -> {
+                try {
+                    Thread.sleep(timeout);
+
+                    unblock();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+
+                    throw new RuntimeException(e);
+                }
+            });
+
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitorTest.java
@@ -99,7 +99,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
     private static final int[] PARTITIONS_MEMBER_2 = new int[] { 3, 4 };
     private static Map<UUID, PartitionIdSet> partitionMapping;
 
-    private static UUID membedId1;
+    private static UUID memberId1;
     private static final UUID MEMBER_ID_2 = UUID.randomUUID();
 
     private static NodeServiceProviderImpl nodeServiceProvider;
@@ -116,10 +116,10 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
             ((HazelcastInstanceProxy) instance).getOriginal().node.nodeEngine
         );
 
-        membedId1 = instance.getLocalEndpoint().getUuid();
+        memberId1 = instance.getLocalEndpoint().getUuid();
 
         partitionMapping = new HashMap<>();
-        partitionMapping.put(membedId1, createPartitionIdSet(PARTITION_COUNT, PARTITIONS_MEMBER_1));
+        partitionMapping.put(memberId1, createPartitionIdSet(PARTITION_COUNT, PARTITIONS_MEMBER_1));
         partitionMapping.put(MEMBER_ID_2, createPartitionIdSet(PARTITION_COUNT, PARTITIONS_MEMBER_2));
     }
 
@@ -136,7 +136,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         QueryExecuteOperationFragment rootFragment = new QueryExecuteOperationFragment(
             rootNode,
             EXPLICIT,
-            Collections.singletonList(membedId1)
+            Collections.singletonList(memberId1)
         );
 
         QueryExecuteOperation operation = createOperation(
@@ -171,7 +171,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         QueryExecuteOperationFragment receiveFragment = new QueryExecuteOperationFragment(
             null,
             EXPLICIT,
-            Collections.singletonList(membedId1)
+            Collections.singletonList(memberId1)
         );
 
         QueryExecuteOperation operation = createOperation(
@@ -191,8 +191,8 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         assertEquals(QUERY_ID, outbox.getQueryId());
         assertEquals(EDGE_1_ID, outbox.getEdgeId());
         assertEquals(upstreamNode.getSchema().getEstimatedRowSize(), outbox.getRowWidth());
-        assertEquals(membedId1, outbox.getLocalMemberId());
-        assertEquals(membedId1, outbox.getTargetMemberId());
+        assertEquals(memberId1, outbox.getLocalMemberId());
+        assertEquals(memberId1, outbox.getTargetMemberId());
         assertEquals(OUTBOX_BATCH_SIZE, outbox.getBatchSize());
         assertEquals(EDGE_1_INITIAL_MEMORY, outbox.getRemainingMemory());
 
@@ -203,7 +203,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
 
         assertEquals(1, visitor.getOutboxes().size());
         assertEquals(1, visitor.getOutboxes().get(EDGE_1_ID).size());
-        assertSame(outbox, visitor.getOutboxes().get(EDGE_1_ID).get(membedId1));
+        assertSame(outbox, visitor.getOutboxes().get(EDGE_1_ID).get(memberId1));
     }
 
     @Test
@@ -228,7 +228,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         QueryExecuteOperationFragment receiveFragment = new QueryExecuteOperationFragment(
             downstreamNode,
             EXPLICIT,
-            Collections.singletonList(membedId1)
+            Collections.singletonList(memberId1)
         );
 
         QueryExecuteOperation operation = createOperation(
@@ -250,7 +250,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         assertEquals(QUERY_ID, inbox.getQueryId());
         assertEquals(EDGE_1_ID, inbox.getEdgeId());
         assertEquals(receiveNode.getSchema().getEstimatedRowSize(), inbox.getRowWidth());
-        assertEquals(membedId1, inbox.getLocalMemberId());
+        assertEquals(memberId1, inbox.getLocalMemberId());
         assertEquals(partitionMapping.size(), inbox.getRemainingStreams());
         assertEquals(EDGE_1_INITIAL_MEMORY, ((SimpleFlowControl) inbox.getFlowControl()).getMaxMemory());
 
@@ -273,7 +273,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         QueryExecuteOperationFragment rootFragment = new QueryExecuteOperationFragment(
             projectNode,
             EXPLICIT,
-            Collections.singletonList(membedId1)
+            Collections.singletonList(memberId1)
         );
 
         QueryExecuteOperation operation = createOperation(
@@ -306,7 +306,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         QueryExecuteOperationFragment rootFragment = new QueryExecuteOperationFragment(
             filterNode,
             EXPLICIT,
-            Collections.singletonList(membedId1)
+            Collections.singletonList(memberId1)
         );
 
         QueryExecuteOperation operation = createOperation(
@@ -333,7 +333,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
 
         // Map with data, but no partitions.
         Map<UUID, PartitionIdSet> partitionMapping = new HashMap<>();
-        partitionMapping.put(membedId1, createPartitionIdSet(PARTITION_COUNT));
+        partitionMapping.put(memberId1, createPartitionIdSet(PARTITION_COUNT));
         partitionMapping.put(MEMBER_ID_2, createPartitionIdSet(PARTITION_COUNT, PARTITIONS_MEMBER_2));
 
         checkMapScan(MAP_NAME, partitionMapping, true);
@@ -362,7 +362,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         QueryExecuteOperationFragment fragment = new QueryExecuteOperationFragment(
             downstreamNode,
             EXPLICIT,
-            Collections.singletonList(membedId1)
+            Collections.singletonList(memberId1)
         );
 
         QueryExecuteOperation operation = createOperation(
@@ -401,11 +401,12 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
             new LoggingQueryOperationHandler(),
             nodeServiceProvider,
             new DefaultSerializationServiceBuilder().build(),
-            membedId1,
+            memberId1,
             operation,
             SimpleFlowControlFactory.INSTANCE,
-            operation.getPartitionMap().get(membedId1),
-            OUTBOX_BATCH_SIZE
+            operation.getPartitionMap().get(memberId1),
+            OUTBOX_BATCH_SIZE,
+            null
         );
 
         fragment.getNode().visit(res);
@@ -439,7 +440,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
             Collections.emptyList()
         );
 
-        operation.setRootConsumer(new TestRootResultConusmer(), ROOT_BATCH_SIZE);
+        operation.setRootConsumer(new TestRootResultConsumer(), ROOT_BATCH_SIZE);
 
         return operation;
     }
@@ -577,7 +578,7 @@ public class CreateExecPlanNodeVisitorTest extends SqlTestSupport {
         }
     }
 
-    private static class TestRootResultConusmer implements RootResultConsumer {
+    private static class TestRootResultConsumer implements RootResultConsumer {
         @Override
         public void setup(QueryFragmentContext context) {
             // No-op.

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/FaultyExec.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/FaultyExec.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.exec;
+
+import com.hazelcast.sql.impl.row.RowBatch;
+import com.hazelcast.sql.impl.worker.QueryFragmentContext;
+
+public class FaultyExec extends AbstractExec {
+
+    private final Exec exec;
+    private final RuntimeException error;
+
+    public FaultyExec(Exec exec, RuntimeException error) {
+        super(exec.getId());
+
+        this.exec = exec;
+        this.error = error;
+    }
+
+    @Override
+    protected void setup0(QueryFragmentContext ctx) {
+        super.setup0(ctx);
+    }
+
+    @Override
+    protected IterationResult advance0() {
+        throw error;
+    }
+
+    @Override
+    protected RowBatch currentBatch0() {
+        return exec.currentBatch();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/root/BlockingRootResultConsumerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/root/BlockingRootResultConsumerTest.java
@@ -103,7 +103,7 @@ public class BlockingRootResultConsumerTest extends HazelcastTestSupport {
         BlockingRootResultConsumer consumer = new BlockingRootResultConsumer();
         AtomicInteger scheduleInvocationCount = new AtomicInteger();
 
-        QueryFragmentScheduleCallback scheduleCallback = () -> {
+        QueryFragmentScheduleCallback scheduleCallback = (force) -> {
             assertFalse(batches.isEmpty());
 
             List<Row> batch = batches.poll();
@@ -150,7 +150,7 @@ public class BlockingRootResultConsumerTest extends HazelcastTestSupport {
         AtomicInteger scheduleInvocationCount = new AtomicInteger();
         QueryException error = QueryException.error("Test");
 
-        QueryFragmentScheduleCallback scheduleCallback = () -> {
+        QueryFragmentScheduleCallback scheduleCallback = (force) -> {
             // Trigger an error asynchronously.
             new Thread(() -> consumer.onError(error)).start();
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
@@ -67,7 +67,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -386,10 +385,11 @@ public class MapScanExecTest extends SqlTestSupport {
 
         QueryException exception = assertThrows(QueryException.class, exec::advance);
         assertEquals(SqlErrorCode.DATA_EXCEPTION, exception.getCode());
-
-        QueryException cause = (QueryException) exception.getCause();
-        assertEquals(SqlErrorCode.DATA_EXCEPTION, cause.getCode());
-        assertTrue(cause.getMessage().contains("Cannot convert BIGINT to TIMESTAMP"));
+        assertEquals(
+            "Failed to extract map entry value field \"val2\" because of type mismatch "
+                + "[expectedClass=java.time.LocalDateTime, actualClass=java.lang.Long]",
+            exception.getMessage()
+        );
     }
 
     /**
@@ -426,7 +426,7 @@ public class MapScanExecTest extends SqlTestSupport {
 
     /**
      * Simulates the case when partitions are migrated during query execution. Tp achieve this we load keys into local
-     * paritions in a way that iteration stops before the first partition is read. Then we start the new member, that
+     * partitions in a way that iteration stops before the first partition is read. Then we start the new member, that
      * chagnes the migration stamp. Then we try to read the remaining data.
      */
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
@@ -74,7 +74,7 @@ public class GenericQueryTargetTest extends SqlTestSupport {
         QueryExtractor badTargetExtractor = target.createExtractor(null, QueryDataType.INT);
         QueryException error = assertThrows(QueryException.class, badTargetExtractor::get);
         assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
-        assertTrue(error.getMessage().startsWith("Cannot convert " + (target.isKey() ? "key" : "value")));
+        assertTrue(error.getMessage().startsWith("Failed to extract map entry " + (target.isKey() ? "key" : "value")));
 
         // Good field executor.
         QueryExtractor fieldExtractor = target.createExtractor("field", QueryDataType.OBJECT);
@@ -85,13 +85,13 @@ public class GenericQueryTargetTest extends SqlTestSupport {
         QueryExtractor badFieldTypeExtractor = target.createExtractor("field", QueryDataType.DATE);
         error = assertThrows(QueryException.class, badFieldTypeExtractor::get);
         assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
-        assertTrue(error.getMessage().startsWith("Cannot extract " + (target.isKey() ? "key" : "value") + " field"));
+        assertTrue(error.getMessage().startsWith("Failed to extract map entry " + (target.isKey() ? "key" : "value") + " field"));
 
         // Bad field extractor (name).
         QueryExtractor badFieldNameExtractor = target.createExtractor("field2", QueryDataType.INT);
         error = assertThrows(QueryException.class, badFieldNameExtractor::get);
         assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
-        assertTrue(error.getMessage().startsWith("Cannot extract " + (target.isKey() ? "key" : "value") + " field"));
+        assertTrue(error.getMessage().startsWith("Failed to extract map entry " + (target.isKey() ? "key" : "value") + " field"));
     }
 
     private static Data toData(TestObject object) {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryExecuteOperationFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryExecuteOperationFactoryTest.java
@@ -72,7 +72,8 @@ public class QueryExecuteOperationFactoryTest {
             fragmentMappings,
             outboundEdgeMap,
             inboundEdgeMap,
-            inboundEdgeMemberCountMap
+            inboundEdgeMemberCountMap,
+            null
         );
 
         QueryId queryId = QueryId.create(UUID.randomUUID());

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerTest.java
@@ -501,16 +501,17 @@ public class QueryOperationHandlerTest extends SqlTestSupport {
             Collections.emptyList(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            null
         );
 
         QueryId queryId = initiatorService.getStateRegistry().onInitiatorQueryStarted(
             initiatorId,
             timeout,
             plan,
+            null,
             new BlockingRootResultConsumer(),
-            initiatorService.getOperationHandler(),
-            true
+            initiatorService.getOperationHandler()
         ).getQueryId();
 
         testState = new State(queryId);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/PlanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/PlanTest.java
@@ -53,7 +53,8 @@ public class PlanTest extends SqlTestSupport {
             fragmentMappings,
             outboundEdgeMap,
             inboundEdgeMap,
-            inboundEdgeMemberCountMap
+            inboundEdgeMemberCountMap,
+            null
         );
 
         assertSame(partitionMap, plan.getPartitionMap());

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolverTest.java
@@ -223,17 +223,17 @@ public class PartitionedMapTableResolverTest extends MapSchemaTestSupport {
         checkFields(getExistingTable(tables, MAP_SERIALIZABLE_BINARY), expectedFields);
         checkFields(getExistingTable(tables, MAP_FROM_WILDCARD), expectedFields);
 
-        // Check portable in the OBJECT mode. Both key and value are processed as object.
+        // Check portable in the OBJECT mode.
         checkFields(
             getExistingTable(tables, MAP_PORTABLE_OBJECT),
             hiddenField(KEY, QueryDataType.OBJECT, true),
-            field("field1", QueryDataType.INT, true),
-            field("field2", QueryDataType.INT, true),
-            field("field3", QueryDataType.INT, false),
+            field("portableField1", QueryDataType.INT, true),
+            field("portableField2", QueryDataType.INT, true),
+            field("portableField3", QueryDataType.INT, false),
             hiddenField(VALUE, QueryDataType.OBJECT, false)
         );
 
-        // Check portable in the BINARY mode. Both key and value are processed as portable.
+        // Check portable in the BINARY mode.
         checkFields(
             getExistingTable(tables, MAP_PORTABLE_BINARY),
             hiddenField(KEY, QueryDataType.OBJECT, true),

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
@@ -123,38 +123,38 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
             .build();
 
         // Test key.
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), false, true);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), true);
 
         checkFields(
             metadata,
-            field("fBoolean", QueryDataType.BOOLEAN, true),
-            field("fByte", QueryDataType.TINYINT, true),
-            field("fChar", QueryDataType.VARCHAR_CHARACTER, true),
-            field("fShort", QueryDataType.SMALLINT, true),
-            field("fInt", QueryDataType.INT, true),
-            field("fLong", QueryDataType.BIGINT, true),
-            field("fFloat", QueryDataType.REAL, true),
-            field("fDouble", QueryDataType.DOUBLE, true),
-            field("fString", QueryDataType.VARCHAR, true),
-            field("fObject", QueryDataType.OBJECT, true),
+            field("_boolean", QueryDataType.BOOLEAN, true),
+            field("_byte", QueryDataType.TINYINT, true),
+            field("_char", QueryDataType.VARCHAR_CHARACTER, true),
+            field("_short", QueryDataType.SMALLINT, true),
+            field("_int", QueryDataType.INT, true),
+            field("_long", QueryDataType.BIGINT, true),
+            field("_float", QueryDataType.REAL, true),
+            field("_double", QueryDataType.DOUBLE, true),
+            field("_string", QueryDataType.VARCHAR, true),
+            field("_object", QueryDataType.OBJECT, true),
             hiddenField(KEY, QueryDataType.OBJECT, true)
         );
 
         // Test value.
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), false, false);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), false);
 
         checkFields(
             metadata,
-            field("fBoolean", QueryDataType.BOOLEAN, false),
-            field("fByte", QueryDataType.TINYINT, false),
-            field("fChar", QueryDataType.VARCHAR_CHARACTER, false),
-            field("fShort", QueryDataType.SMALLINT, false),
-            field("fInt", QueryDataType.INT, false),
-            field("fLong", QueryDataType.BIGINT, false),
-            field("fFloat", QueryDataType.REAL, false),
-            field("fDouble", QueryDataType.DOUBLE, false),
-            field("fString", QueryDataType.VARCHAR, false),
-            field("fObject", QueryDataType.OBJECT, false),
+            field("_boolean", QueryDataType.BOOLEAN, false),
+            field("_byte", QueryDataType.TINYINT, false),
+            field("_char", QueryDataType.VARCHAR_CHARACTER, false),
+            field("_short", QueryDataType.SMALLINT, false),
+            field("_int", QueryDataType.INT, false),
+            field("_long", QueryDataType.BIGINT, false),
+            field("_float", QueryDataType.REAL, false),
+            field("_double", QueryDataType.DOUBLE, false),
+            field("_string", QueryDataType.VARCHAR, false),
+            field("_object", QueryDataType.OBJECT, false),
             hiddenField(VALUE, QueryDataType.OBJECT, false)
         );
     }
@@ -164,7 +164,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         InternalSerializationService ss = getSerializationService();
 
         // Test key.
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), true, true);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), true);
 
         checkFields(
             metadata,
@@ -182,7 +182,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         );
 
         // Test value.
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), true, false);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableParent()), false);
 
         checkFields(
             metadata,
@@ -209,7 +209,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
 
         JavaFields object = new JavaFields();
 
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, object, true, true);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, object, true);
 
         checkFields(
             metadata,
@@ -217,7 +217,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
             hiddenField(KEY, QueryDataType.OBJECT, true)
         );
 
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, true);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true);
 
         checkFields(
             metadata,
@@ -235,7 +235,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
 
         JavaGetters object = new JavaGetters();
 
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, object, true, true);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, object, true);
 
         checkFields(
             metadata,
@@ -245,7 +245,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
             hiddenField(KEY, QueryDataType.OBJECT, true)
         );
 
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, true);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true);
 
         checkFields(
             metadata,
@@ -265,10 +265,10 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
 
         JavaFieldClashChild object = new JavaFieldClashChild();
 
-        TableField field = MapSampleMetadataResolver.resolve(ss, object, true, true).getFields().get("field");
+        TableField field = MapSampleMetadataResolver.resolve(ss, object, true).getFields().get("field");
         assertEquals(field("field", QueryDataType.BIGINT, true), field);
 
-        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, true).getFields().get("field");
+        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true).getFields().get("field");
         assertEquals(field("field", QueryDataType.BIGINT, true), field);
     }
 
@@ -281,10 +281,10 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
 
         JavaFieldGetterClash object = new JavaFieldGetterClash();
 
-        TableField field = MapSampleMetadataResolver.resolve(ss, object, true, true).getFields().get("field");
+        TableField field = MapSampleMetadataResolver.resolve(ss, object, true).getFields().get("field");
         assertEquals(field("field", QueryDataType.BIGINT, true), field);
 
-        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, true).getFields().get("field");
+        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true).getFields().get("field");
         assertEquals(field("field", QueryDataType.BIGINT, true), field);
     }
 
@@ -298,17 +298,17 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         JavaTopFieldClash object = new JavaTopFieldClash();
 
         // Key
-        TableField field = MapSampleMetadataResolver.resolve(ss, object, true, true).getFields().get(KEY);
+        TableField field = MapSampleMetadataResolver.resolve(ss, object, true).getFields().get(KEY);
         assertEquals(hiddenField(KEY, QueryDataType.OBJECT, true), field);
 
-        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, true).getFields().get(KEY);
+        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true).getFields().get(KEY);
         assertEquals(hiddenField(KEY, QueryDataType.OBJECT, true), field);
 
         // Value
-        field = MapSampleMetadataResolver.resolve(ss, object, true, false).getFields().get(VALUE);
+        field = MapSampleMetadataResolver.resolve(ss, object, false).getFields().get(VALUE);
         assertEquals(hiddenField(VALUE, QueryDataType.OBJECT, false), field);
 
-        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, false).getFields().get(VALUE);
+        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), false).getFields().get(VALUE);
         assertEquals(hiddenField(VALUE, QueryDataType.OBJECT, false), field);
     }
 
@@ -322,17 +322,17 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         JavaTopGetterClash object = new JavaTopGetterClash();
 
         // Key
-        TableField field = MapSampleMetadataResolver.resolve(ss, object, true, true).getFields().get(KEY);
+        TableField field = MapSampleMetadataResolver.resolve(ss, object, true).getFields().get(KEY);
         assertEquals(hiddenField(KEY, QueryDataType.OBJECT, true), field);
 
-        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, true).getFields().get(KEY);
+        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true).getFields().get(KEY);
         assertEquals(hiddenField(KEY, QueryDataType.OBJECT, true), field);
 
         // Value
-        field = MapSampleMetadataResolver.resolve(ss, object, true, false).getFields().get(VALUE);
+        field = MapSampleMetadataResolver.resolve(ss, object, false).getFields().get(VALUE);
         assertEquals(hiddenField(VALUE, QueryDataType.OBJECT, false), field);
 
-        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), true, false).getFields().get(VALUE);
+        field = MapSampleMetadataResolver.resolve(ss, ss.toData(object), false).getFields().get(VALUE);
         assertEquals(hiddenField(VALUE, QueryDataType.OBJECT, false), field);
     }
 
@@ -351,7 +351,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         InternalSerializationService ss = getSerializationService();
 
         // Key clash
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableClash()), true, true);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableClash()), true);
 
         checkFields(
             metadata,
@@ -360,7 +360,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         );
 
         // Value clash
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableClash()), true, false);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(new PortableClash()), false);
 
         checkFields(
             metadata,
@@ -374,7 +374,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         InternalSerializationService ss = getSerializationService();
 
         try {
-            MapSampleMetadataResolver.resolve(ss, ss.toData(new HazelcastJsonValue("{ \"test\": 10 }")), true, true);
+            MapSampleMetadataResolver.resolve(ss, ss.toData(new HazelcastJsonValue("{ \"test\": 10 }")), true);
         } catch (QueryException e) {
             assertEquals(SqlErrorCode.GENERIC, e.getCode());
             assertTrue(e.getMessage().contains("JSON objects are not supported"));
@@ -385,19 +385,19 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
         InternalSerializationService ss = getSerializationService();
 
         // Key
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, value, true, true);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(ss, value, true);
         checkFields(metadata, field(KEY, expectedType, true));
 
         // Serialized key
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(value), true, true);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(value), true);
         checkFields(metadata, field(KEY, expectedType, true));
 
         // Value
-        metadata = MapSampleMetadataResolver.resolve(ss, value, true, false);
+        metadata = MapSampleMetadataResolver.resolve(ss, value, false);
         checkFields(metadata, field(VALUE, expectedType, false));
 
         // Serialized value
-        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(value), true, false);
+        metadata = MapSampleMetadataResolver.resolve(ss, ss.toData(value), false);
         checkFields(metadata, field(VALUE, expectedType, false));
     }
 
@@ -430,7 +430,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
     }
 
     private void checkJavaTypes(Object object, boolean key) {
-        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(getSerializationService(), object, true, key);
+        MapSampleMetadata metadata = MapSampleMetadataResolver.resolve(getSerializationService(), object, key);
 
         assertEquals(GenericQueryTargetDescriptor.INSTANCE, metadata.getDescriptor());
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/state/QueryInitiatorStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/state/QueryInitiatorStateTest.java
@@ -38,11 +38,11 @@ public class QueryInitiatorStateTest {
     @Test
     public void testInitiatorState() {
         QueryId queryId = QueryId.create(UUID.randomUUID());
-        Plan plan = new Plan(null, null, null, null, null, null);
+        Plan plan = new Plan(null, null, null, null, null, null, null);
         QueryResultProducer resultProducer = new BlockingRootResultConsumer();
         long timeout = 1000L;
 
-        QueryInitiatorState state = new QueryInitiatorState(queryId, plan, resultProducer, timeout);
+        QueryInitiatorState state = new QueryInitiatorState(queryId, plan, null, resultProducer, timeout);
 
         assertEquals(queryId, state.getQueryId());
         assertSame(plan, state.getPlan());

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/state/QueryStateRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/state/QueryStateRegistryTest.java
@@ -52,36 +52,14 @@ public class QueryStateRegistryTest extends SqlTestSupport {
         QueryResultProducer resultProducer = new BlockingRootResultConsumer();
         QueryStateCompletionCallback completionCallback = new TestQueryStateCompletionCallback();
 
-        // Test without registration.
+        // Test with registration.
         QueryState state = registry.onInitiatorQueryStarted(
             localMemberId,
             timeout,
             initiatorPlan,
+            null,
             resultProducer,
-            completionCallback,
-            false
-        );
-
-        assertEquals(state.getQueryId().getMemberId(), localMemberId);
-        assertEquals(state.getLocalMemberId(), localMemberId);
-        assertEquals(state.getStartTime(), currentTime);
-
-        assertTrue(state.isInitiator());
-        assertEquals(state.getQueryId(), state.getInitiatorState().getQueryId());
-        assertEquals(initiatorPlan, state.getInitiatorState().getPlan());
-        assertEquals(resultProducer, state.getInitiatorState().getResultProducer());
-        assertEquals(timeout, state.getInitiatorState().getTimeout());
-
-        assertTrue(registry.getStates().isEmpty());
-
-        // Test with registration.
-        state = registry.onInitiatorQueryStarted(
-            localMemberId,
-            timeout,
-            initiatorPlan,
-            resultProducer,
-            completionCallback,
-            true
+            completionCallback
         );
 
         assertEquals(1, registry.getStates().size());

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -973,4 +973,10 @@
         <jmx enabled="false"/>
         <collection-frequency-seconds>24</collection-frequency-seconds>
     </metrics>
+
+    <sql>
+        <executor-pool-size>16</executor-pool-size>
+        <operation-pool-size>8</operation-pool-size>
+        <query-timeout>0</query-timeout>
+    </sql>
 </hazelcast>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -977,6 +977,6 @@
     <sql>
         <executor-pool-size>16</executor-pool-size>
         <operation-pool-size>8</operation-pool-size>
-        <query-timeout>0</query-timeout>
+        <query-timeout-millis>0</query-timeout-millis>
     </sql>
 </hazelcast>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -922,4 +922,4 @@ hazelcast:
   sql:
     executor-pool-size: 16
     operation-pool-size: 8
-    query-timeout: 0
+    query-timeout-millis: 0

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -918,3 +918,8 @@ hazelcast:
     jmx:
       enabled: false
     collection-frequency-seconds: 24
+
+  sql:
+    executor-pool-size: 16
+    operation-pool-size: 8
+    query-timeout: 0


### PR DESCRIPTION
This PR introduces a public API for the SQL engine.

The PR mostly follow what was discussed in #17042. Major highlights:
1. SQL API is exposed as a new service: `HazelcastInstance.getSqlService()`
1. Major API parts: `SqlService`, `SqlQuery`, `SqlResult`, `SqlRow`
1. There are no result types yet, the only possible result is a set of rows. Other result types will be added as we progress with DDL/DML
1. Query parameters are exposed to the public API but are not supported internally. The proper parameter support requires the Calcite-related type inference part, which is not ready yet

Closes #17042 