### PR TITLE
Integrate concurrent off-heap B+tree index into the old engine

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalIndexOperationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalIndexOperationStats.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitor.impl;
+
+/**
+ * The implementation of operation index stats specialized for HD global indexes.
+ */
+public final class HDGlobalIndexOperationStats implements IndexOperationStats {
+
+    private long entryCountDelta;
+
+    @Override
+    public long getEntryCountDelta() {
+        return entryCountDelta;
+    }
+
+    @Override
+    public long getMemoryCostDelta() {
+        // Memory cost tracking for HD global indexes is done on the native memory
+        // allocator level.
+        return 0;
+    }
+
+    @Override
+    public void onEntryAdded(Object replacedValue, Object addedValue) {
+        if (replacedValue == null) {
+            ++entryCountDelta;
+        }
+    }
+
+    @Override
+    public void onEntryRemoved(Object removedValue) {
+        if (removedValue != null) {
+            --entryCountDelta;
+        }
+    }
+
+    /**
+     * Resets this stats instance to be ready for reuse.
+     */
+    public void reset() {
+        entryCountDelta = 0;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalIndexesStats.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitor.impl;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * The implementation of internal indexes stats specialized for HD global indexes.
+ * <p>
+ * The main trait of the implementation is the concurrency support, which is
+ * required for global indexes because they are shared among partitions.
+ */
+public final class HDGlobalIndexesStats implements IndexesStats {
+
+    private static final AtomicLongFieldUpdater<HDGlobalIndexesStats> QUERY_COUNT = newUpdater(HDGlobalIndexesStats.class,
+            "queryCount");
+    private static final AtomicLongFieldUpdater<HDGlobalIndexesStats> INDEXED_QUERY_COUNT = newUpdater(HDGlobalIndexesStats.class,
+            "indexedQueryCount");
+
+    private volatile long queryCount;
+    private volatile long indexedQueryCount;
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    @Override
+    public void incrementQueryCount() {
+        QUERY_COUNT.incrementAndGet(this);
+    }
+
+    @Override
+    public long getIndexedQueryCount() {
+        return indexedQueryCount;
+    }
+
+    @Override
+    public void incrementIndexedQueryCount() {
+        INDEXED_QUERY_COUNT.incrementAndGet(this);
+    }
+
+    @Override
+    public PerIndexStats createPerIndexStats(boolean ordered, boolean usesCachedQueryableEntries) {
+        return new HDGlobalPerIndexStats(ordered, usesCachedQueryableEntries);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalPerIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalPerIndexStats.java
@@ -50,11 +50,11 @@ public final class HDGlobalPerIndexStats extends GlobalPerIndexStats {
     }
 
     private void updateMemoryCost(long delta) {
-        MEMORY_COST.lazySet(HDGlobalPerIndexStats.this, memoryCost + delta);
+        MEMORY_COST.addAndGet(HDGlobalPerIndexStats.this, delta);
     }
 
     private void resetMemoryCost() {
-        MEMORY_COST.lazySet(HDGlobalPerIndexStats.this, 0);
+        memoryCost = 0;
     }
 
     private class MemoryAllocatorWithStats implements MemoryAllocator {

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalPerIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/HDGlobalPerIndexStats.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitor.impl;
+
+import com.hazelcast.internal.memory.MemoryAllocator;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * The implementation of internal index stats specialized for HD global indexes.
+ * <p>
+ * The main trait of the implementation is the concurrency support, which is
+ * required for HD global indexes because they are shared among partitions.
+ */
+public final class HDGlobalPerIndexStats extends GlobalPerIndexStats {
+
+    private static final AtomicLongFieldUpdater<HDGlobalPerIndexStats> MEMORY_COST = newUpdater(HDGlobalPerIndexStats.class,
+            "memoryCost");
+
+    private volatile long memoryCost;
+
+    public HDGlobalPerIndexStats(boolean ordered, boolean usesCachedQueryableEntries) {
+        super(ordered, usesCachedQueryableEntries);
+    }
+
+    @Override
+    public long getMemoryCost() {
+        return memoryCost;
+    }
+
+    @Override
+    public MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator) {
+        return new MemoryAllocatorWithStats(memoryAllocator);
+    }
+
+    private void updateMemoryCost(long delta) {
+        MEMORY_COST.lazySet(HDGlobalPerIndexStats.this, memoryCost + delta);
+    }
+
+    private void resetMemoryCost() {
+        MEMORY_COST.lazySet(HDGlobalPerIndexStats.this, 0);
+    }
+
+    private class MemoryAllocatorWithStats implements MemoryAllocator {
+
+        private final MemoryAllocator delegate;
+
+        MemoryAllocatorWithStats(MemoryAllocator delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long allocate(long size) {
+            long result = delegate.allocate(size);
+            updateMemoryCost(size);
+            return result;
+        }
+
+        @Override
+        public long reallocate(long address, long currentSize, long newSize) {
+            long result = delegate.reallocate(address, currentSize, newSize);
+            updateMemoryCost(newSize - currentSize);
+            return result;
+        }
+
+        @Override
+        public void free(long address, long size) {
+            delegate.free(address, size);
+            updateMemoryCost(-size);
+        }
+
+        @Override
+        public void dispose() {
+            delegate.dispose();
+            resetMemoryCost();
+        }
+    }
+
+    @Override
+    public IndexOperationStats createOperationStats() {
+        return new HDGlobalIndexOperationStats();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -270,7 +270,7 @@ public class MapContainer {
     }
 
     /**
-     * @return the global index, if the global index is in use (on-heap) or null.
+     * @return the global index, if the global index is in use or null.
      */
     public Indexes getIndexes() {
         return globalIndexes;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -177,9 +177,7 @@ public class MapContainer {
     }
 
     public boolean shouldUseGlobalIndex() {
-        // for non-native memory populate a single global index
-        return !mapConfig.getInMemoryFormat().equals(NATIVE)
-                || mapConfig.getInMemoryFormat().equals(NATIVE) && mapServiceContext.globalIndexEnabled();
+        return mapConfig.getInMemoryFormat() != NATIVE || mapServiceContext.globalIndexEnabled();
     }
 
     protected static MemoryInfoAccessor getMemoryInfoAccessor() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -22,12 +22,13 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.ObjectNamespace;
@@ -45,7 +46,6 @@ import com.hazelcast.map.impl.query.QueryEntryFactory;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.ObjectRecordFactory;
 import com.hazelcast.map.impl.record.RecordFactory;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
@@ -76,8 +76,7 @@ import static java.lang.System.getProperty;
  * supporting structures for all of the maps' functionalities.
  */
 @SuppressWarnings({"WeakerAccess", "checkstyle:classfanoutcomplexity"})
-public class
-MapContainer {
+public class MapContainer {
 
     protected final String name;
     protected final String splitBrainProtectionName;
@@ -150,7 +149,7 @@ MapContainer {
      * @return a new Indexes object
      */
     public Indexes createIndexes(boolean global) {
-        return Indexes.newBuilder(serializationService, mapServiceContext.getIndexCopyBehavior())
+        return Indexes.newBuilder(serializationService, mapServiceContext.getIndexCopyBehavior(), mapConfig.getInMemoryFormat())
                 .global(global)
                 .extractors(extractors)
                 .statsEnabled(mapConfig.isStatisticsEnabled())
@@ -179,7 +178,8 @@ MapContainer {
 
     public boolean shouldUseGlobalIndex() {
         // for non-native memory populate a single global index
-        return !mapConfig.getInMemoryFormat().equals(NATIVE);
+        return !mapConfig.getInMemoryFormat().equals(NATIVE)
+                || mapConfig.getInMemoryFormat().equals(NATIVE) && mapServiceContext.globalIndexEnabled();
     }
 
     protected static MemoryInfoAccessor getMemoryInfoAccessor() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -192,6 +192,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
 
     IndexCopyBehavior getIndexCopyBehavior();
 
+    boolean globalIndexEnabled();
+
     ValueComparator getValueComparatorOf(InMemoryFormat inMemoryFormat);
 
     NodeWideUsedCapacityCounter getNodeWideUsedCapacityCounter();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -863,6 +863,11 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
+    public boolean globalIndexEnabled() {
+        return true;
+    }
+
+    @Override
     public ValueComparator getValueComparatorOf(InMemoryFormat inMemoryFormat) {
         return ValueComparatorUtil.getValueComparatorOf(inMemoryFormat);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -82,7 +82,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
         // We are not using injected index provider since we're not supporting off-heap indexes in CQC due
         // to threading incompatibility. If we injected the IndexProvider from the MapServiceContext
         // the EE side would create HD indexes which is undesired.
-        this.indexes = Indexes.newBuilder(serializationService, COPY_ON_READ).build();
+        this.indexes = Indexes.newBuilder(serializationService, COPY_ON_READ, queryCacheConfig.getInMemoryFormat()).build();
         this.includeValue = isIncludeValue();
         this.partitioningStrategy = getPartitioningStrategy();
         this.extractors = Extractors.newBuilder(serializationService).build();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1308,8 +1308,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     private void destroyStorageImmediate(boolean isDuringShutdown, boolean internal) {
-        storage.destroy(isDuringShutdown);
         mutationObserver.onDestroy(isDuringShutdown, internal);
+        // Destroy storage in the end
+        storage.destroy(isDuringShutdown);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
@@ -100,7 +100,8 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
 
     @Override
     public void onDestroy(boolean isDuringShutdown, boolean internal) {
-        clearGlobalIndexes(isDuringShutdown);
+        boolean destroyGlobalIndexes = isDuringShutdown || mapContainer.isDestroyed();
+        clearGlobalIndexes(destroyGlobalIndexes);
         clearPartitionedIndexes(true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseSingleValueIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseSingleValueIndexStore.java
@@ -28,7 +28,7 @@ import java.util.List;
  * attributes natively. For such indexes {@link MultiResult}s are split into
  * individual values and each value is inserted/removed separately.
  * <p>
- * All operations on the index store like insert/remove/getRecords are
+ * All operations on the off-heap index store like insert/remove/getRecords are
  * not guarded by a global lock. The subclasses must either implement thread-safe
  * access operations or the index should be used as single-threaded by design.
  */

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.hazelcast.query.impl.QueryableEntry.extractAttributeValue;
 
@@ -71,10 +70,6 @@ public final class BitmapIndexStore extends BaseIndexStore {
         EVALUABLE_PREDICATES.add(InPredicate.class);
     }
 
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
-    private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
-
     private final String keyAttribute;
     private final InternalSerializationService serializationService;
     private final Extractors extractors;
@@ -87,7 +82,7 @@ public final class BitmapIndexStore extends BaseIndexStore {
     private long internalKeyCounter;
 
     public BitmapIndexStore(IndexConfig config, InternalSerializationService serializationService, Extractors extractors) {
-        super(IndexCopyBehavior.NEVER);
+        super(IndexCopyBehavior.NEVER, true);
 
         this.keyAttribute = config.getBitmapIndexOptions().getUniqueKey();
         this.serializationService = serializationService;
@@ -511,21 +506,4 @@ public final class BitmapIndexStore extends BaseIndexStore {
         }
 
     }
-
-    void takeWriteLock() {
-        writeLock.lock();
-    }
-
-    void releaseWriteLock() {
-        writeLock.unlock();
-    }
-
-    void takeReadLock() {
-        readLock.lock();
-    }
-
-    void releaseReadLock() {
-        readLock.unlock();
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.hazelcast.query.impl.QueryableEntry.extractAttributeValue;
 
@@ -69,6 +70,10 @@ public final class BitmapIndexStore extends BaseIndexStore {
         EVALUABLE_PREDICATES.add(NotEqualPredicate.class);
         EVALUABLE_PREDICATES.add(InPredicate.class);
     }
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+    private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
 
     private final String keyAttribute;
     private final InternalSerializationService serializationService;
@@ -505,6 +510,22 @@ public final class BitmapIndexStore extends BaseIndexStore {
             return canonicalize(converter.convert(value));
         }
 
+    }
+
+    void takeWriteLock() {
+        writeLock.lock();
+    }
+
+    void releaseWriteLock() {
+        writeLock.unlock();
+    }
+
+    void takeReadLock() {
+        readLock.lock();
+    }
+
+    void releaseReadLock() {
+        readLock.unlock();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultIndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultIndexProvider.java
@@ -17,7 +17,6 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.config.IndexConfig;
-import com.hazelcast.internal.monitor.impl.GlobalPerIndexStats;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
@@ -37,10 +36,5 @@ public class DefaultIndexProvider implements IndexProvider {
         StoreAdapter partitionStoreAdapter
     ) {
         return new IndexImpl(config, ss, extractors, copyBehavior, stats);
-    }
-
-    @Override
-    public PerIndexStats createPerIndexStats(boolean ordered, boolean usesCachedQueryableEntries) {
-        return new GlobalPerIndexStats(ordered, usesCachedQueryableEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultIndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultIndexProvider.java
@@ -17,6 +17,7 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.config.IndexConfig;
+import com.hazelcast.internal.monitor.impl.GlobalPerIndexStats;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
@@ -38,4 +39,8 @@ public class DefaultIndexProvider implements IndexProvider {
         return new IndexImpl(config, ss, extractors, copyBehavior, stats);
     }
 
+    @Override
+    public PerIndexStats createPerIndexStats(boolean ordered, boolean usesCachedQueryableEntries) {
+        return new GlobalPerIndexStats(ordered, usesCachedQueryableEntries);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
@@ -43,11 +43,13 @@ public interface IndexProvider {
      * @return the created index instance.
      */
     InternalIndex createIndex(
-        IndexConfig config,
-        Extractors extractors,
-        InternalSerializationService ss,
-        IndexCopyBehavior copyBehavior,
-        PerIndexStats stats,
-        StoreAdapter storeAdapter
+            IndexConfig config,
+            Extractors extractors,
+            InternalSerializationService ss,
+            IndexCopyBehavior copyBehavior,
+            PerIndexStats stats,
+            StoreAdapter storeAdapter
     );
+
+    PerIndexStats createPerIndexStats(boolean ordered, boolean usesCachedQueryableEntries);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
@@ -50,6 +50,4 @@ public interface IndexProvider {
             PerIndexStats stats,
             StoreAdapter storeAdapter
     );
-
-    PerIndexStats createPerIndexStats(boolean ordered, boolean usesCachedQueryableEntries);
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -82,6 +82,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -89,6 +90,10 @@ public class EvictionTest extends HazelcastTestSupport {
 
     @Rule
     public final OverridePropertyRule overrideTaskSecondsRule = set(PROP_TASK_PERIOD_SECONDS, String.valueOf(1));
+
+    boolean updateRecordAccessTime() {
+        return true;
+    }
 
     @Test
     public void testTTL_entryShouldNotBeReachableAfterTTL() {
@@ -177,11 +182,13 @@ public class EvictionTest extends HazelcastTestSupport {
 
     @Test
     public void testMaxIdle_readThroughOrderedIndex() {
+        assumeTrue(updateRecordAccessTime());
         testMaxIdle_readThroughIndex(IndexType.SORTED);
     }
 
     @Test
     public void testMaxIdle_readThroughUnorderedIndex() {
+        assumeTrue(updateRecordAccessTime());
         testMaxIdle_readThroughIndex(IndexType.HASH);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
@@ -17,9 +17,9 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.config.IndexType;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
 import static com.hazelcast.query.impl.TypeConverters.LONG_CONVERTER;
 import static org.junit.Assert.assertNull;
@@ -48,7 +49,8 @@ public class ConverterResolutionTest {
     public void before() {
         serializationService = new DefaultSerializationServiceBuilder().build();
         extractors = Extractors.newBuilder(serializationService).build();
-        indexes = Indexes.newBuilder(serializationService, IndexCopyBehavior.COPY_ON_READ).extractors(extractors).build();
+        indexes = Indexes.newBuilder(serializationService,
+                IndexCopyBehavior.COPY_ON_READ, DEFAULT_IN_MEMORY_FORMAT).extractors(extractors).build();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -39,6 +39,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static org.junit.Assert.assertEquals;
 
@@ -64,7 +65,7 @@ public class IndexJsonTest {
     @Test
     public void testJsonIndex() {
         InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
-        Indexes is = Indexes.newBuilder(ss, copyBehavior).extractors(Extractors.newBuilder(ss).build()).indexProvider(
+        Indexes is = Indexes.newBuilder(ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).extractors(Extractors.newBuilder(ss).build()).indexProvider(
                 new DefaultIndexProvider()).usesCachedQueryableEntries(true).statsEnabled(true).global(true).build();
         Index numberIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "age"), null);
         Index boolIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "active"), null);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.monitor.impl.PerIndexStats;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.impl.record.DataRecordFactory;
@@ -27,7 +28,6 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
@@ -57,6 +57,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.instance.impl.TestUtil.toData;
 import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
@@ -101,7 +102,7 @@ public class IndexTest {
     public void testRemoveEnumIndex() {
         IndexConfig config = IndexUtils.createTestIndexConfig(IndexType.HASH, "favoriteCity");
 
-        Indexes is = Indexes.newBuilder(ss, copyBehavior).build();
+        Indexes is = Indexes.newBuilder(ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         is.addOrGetIndex(config, null);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -116,7 +117,7 @@ public class IndexTest {
     public void testUpdateEnumIndex() {
         IndexConfig config = IndexUtils.createTestIndexConfig(IndexType.HASH, "favoriteCity");
 
-        Indexes is = Indexes.newBuilder(ss, copyBehavior).build();
+        Indexes is = Indexes.newBuilder(ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         is.addOrGetIndex(config, null);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -135,7 +136,7 @@ public class IndexTest {
 
     @Test
     public void testIndex() throws QueryException {
-        Indexes is = Indexes.newBuilder(ss, copyBehavior).build();
+        Indexes is = Indexes.newBuilder(ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         Index dIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "d"), null);
         Index boolIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "bool"), null);
         Index strIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "str"), null);
@@ -198,7 +199,7 @@ public class IndexTest {
 
     @Test
     public void testIndexWithNull() throws QueryException {
-        Indexes is = Indexes.newBuilder(ss, copyBehavior).build();
+        Indexes is = Indexes.newBuilder(ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         Index strIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "str"), null);
 
         Data value = ss.toData(new MainPortable(false, 1, null));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.instance.impl.TestUtil.toData;
 import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
@@ -68,13 +69,13 @@ public class IndexesTest {
         return asList(new Object[][]{
                 {IndexCopyBehavior.COPY_ON_READ},
                 {IndexCopyBehavior.COPY_ON_WRITE},
-                {IndexCopyBehavior.NEVER}
+                {IndexCopyBehavior.NEVER},
         });
     }
 
     @Test
     public void testAndWithSingleEntry() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"), null);
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "age"), null);
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "salary"), null);
@@ -97,7 +98,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"), null);
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "age"), null);
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "salary"), null);
@@ -116,7 +117,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex2() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"), null);
         indexes.putEntry(new QueryEntry(serializationService, toData(1), new Value("abc"), newExtractor()), null,
                 Index.OperationSource.USER);
@@ -150,7 +151,7 @@ public class IndexesTest {
      */
     @Test
     public void shouldNotThrowException_withNullValues_whenIndexAddedForValueField() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"), null);
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
@@ -158,7 +159,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValues_whenNoIndexAdded() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
     }
@@ -177,7 +178,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValue_whenIndexAddedForKeyField() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "__key"), null);
 
         for (int i = 0; i < 100; i++) {
@@ -193,7 +194,7 @@ public class IndexesTest {
 
     @Test
     public void testNoDuplicateIndexes() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
 
         IndexConfig config1 = IndexUtils.createTestIndexConfig(IndexType.HASH, "a");
 
@@ -210,7 +211,7 @@ public class IndexesTest {
 
     @Test
     public void testEvaluateOnlyIndexesMatching() {
-        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
+        Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
 
         Index hashIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "a"), null);
         Index matched = indexes.matchIndex("a", IndexMatchHint.NONE, SKIP_PARTITIONS_COUNT_CHECK);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.query.impl.IndexUtils.canonicalizeAttribute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -64,7 +65,8 @@ public class AttributeCanonicalizationTest {
 
     @Test
     public void testIndexes() {
-        Indexes indexes = Indexes.newBuilder(new DefaultSerializationServiceBuilder().build(), IndexCopyBehavior.NEVER).build();
+        Indexes indexes = Indexes.newBuilder(
+                new DefaultSerializationServiceBuilder().build(), IndexCopyBehavior.NEVER, DEFAULT_IN_MEMORY_FORMAT).build();
 
         checkIndex(indexes, "foo", "foo");
         checkIndex(indexes, "this.foo", "foo");
@@ -78,7 +80,8 @@ public class AttributeCanonicalizationTest {
 
     @Test
     public void testCompositeIndexes() {
-        Indexes indexes = Indexes.newBuilder(new DefaultSerializationServiceBuilder().build(), IndexCopyBehavior.NEVER).build();
+        Indexes indexes = Indexes.newBuilder(
+                new DefaultSerializationServiceBuilder().build(), IndexCopyBehavior.NEVER, DEFAULT_IN_MEMORY_FORMAT).build();
 
         checkIndex(indexes, new String[] { "foo", "bar" }, new String[] { "foo", "bar"});
         checkIndex(indexes, new String[] { "this.foo", "bar" }, new String[] { "foo", "bar"});


### PR DESCRIPTION
* Introduced a global system property to enable global HD indexes;

* Introduced a new HDOrderedConcurrentIndexStore (based on BPlusTree) for global HD indexes
support;

* Fallback to the old partitioned HD index if the global indices are
disabled for HD.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3653
Closes https://github.com/hazelcast/hazelcast-enterprise/issues/3652