### PR TITLE
Don't retry authenticationException on same cluster

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
@@ -61,6 +61,17 @@ public class ClientAuthenticationTest extends HazelcastTestSupport {
         hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testFailImmediately_onAuthenticationMismatch() {
+        hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClusterName("wrongClusterName");
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
+                .setClusterConnectTimeoutMillis(Integer.MAX_VALUE);
+        hazelcastFactory.newHazelcastClient(clientConfig);
+    }
+
     @Test
     public void testAuthenticationWithCustomCredentials_when_singleNode() {
         DataSerializableFactory factory = new CustomCredentialsIdentifiedFactory();


### PR DESCRIPTION
In 3.12.x series authenticationException was used for ownership
logic, as well as basic authentication. In that logic, in case
of split brain the exception should be retried in other members of
the cluster.
In 4.x series, that logic is removed and it makes more sense to
not retry the exception anymore on the other members of the
same cluster.

fixes https://github.com/hazelcast/hazelcast/issues/17136