### PR TITLE
Don't retry authenticationException on same cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -417,22 +417,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         return false;
     }
 
-    private Connection connect(Address address) {
-        try {
-            logger.info("Trying to connect to " + address);
-            return getOrConnect(address);
-        } catch (InvalidConfigurationException e) {
-            logger.warning("Exception during initial connection to " + address + ": " + e);
-            throw rethrow(e);
-        } catch (ClientNotAllowedInClusterException e) {
-            logger.warning("Exception during initial connection to " + address + ": " + e);
-            throw e;
-        } catch (Exception e) {
-            logger.warning("Exception during initial connection to " + address + ": " + e);
-            return null;
-        }
-    }
-
     private void fireLifecycleEvent(LifecycleState state) {
         LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
         lifecycleService.fireLifecycleEvent(state);
@@ -440,27 +424,30 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     private boolean doConnectToCandidateCluster(CandidateClusterContext context) {
         Set<Address> triedAddresses = new HashSet<>();
-        try {
-            waitStrategy.reset();
-            do {
-                Collection<Address> addresses = getPossibleMemberAddresses(context.getAddressProvider());
-                for (Address address : addresses) {
-                    checkClientActive();
-                    triedAddresses.add(address);
-
-                    Connection connection = connect(address);
-                    if (connection != null) {
-                        return true;
-                    }
-                }
-                // If the address providers load no addresses (which seems to be possible), then the above loop is not entered
-                // and the lifecycle check is missing, hence we need to repeat the same check at this point.
+        waitStrategy.reset();
+        exit:
+        do {
+            Collection<Address> addresses = getPossibleMemberAddresses(context.getAddressProvider());
+            for (Address address : addresses) {
                 checkClientActive();
-            } while (waitStrategy.sleep());
-        } catch (ClientNotAllowedInClusterException | InvalidConfigurationException e) {
-            logger.warning("Stopped trying on the cluster: " + context.getClusterName()
-                    + " reason: " + e.getMessage());
-        }
+                triedAddresses.add(address);
+
+                try {
+                    logger.info("Trying to connect to " + address);
+                    getOrConnect(address);
+                    return true;
+                } catch (InvalidConfigurationException | ClientNotAllowedInClusterException | AuthenticationException e) {
+                    logger.warning("Stopped trying on the cluster: " + context.getClusterName()
+                            + " reason: " + e.getMessage());
+                    break exit;
+                } catch (Exception e) {
+                    logger.warning("Exception during initial connection to " + address + ": " + e);
+                }
+            }
+            // If the address providers load no addresses (which seems to be possible), then the above loop is not entered
+            // and the lifecycle check is missing, hence we need to repeat the same check at this point.
+            checkClientActive();
+        } while (waitStrategy.sleep());
 
         logger.info("Unable to connect to any address from the cluster with name: " + context.getClusterName()
                 + ". The following addresses were tried: " + triedAddresses);

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
@@ -61,6 +61,17 @@ public class ClientAuthenticationTest extends HazelcastTestSupport {
         hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testFailImmediately_onAuthenticationMismatch() {
+        hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClusterName("wrongClusterName");
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
+                .setClusterConnectTimeoutMillis(Integer.MAX_VALUE);
+        hazelcastFactory.newHazelcastClient(clientConfig);
+    }
+
     @Test
     public void testAuthenticationWithCustomCredentials_when_singleNode() {
         DataSerializableFactory factory = new CustomCredentialsIdentifiedFactory();


### PR DESCRIPTION
In 3.12.x series authenticationException was used for ownership
logic, as well as basic authentication. In that logic, in case
of split brain the exception should be retried in other members of
the cluster.
In 4.x series, that logic is removed and it makes more sense to
not retry the exception anymore on the other members of the
same cluster.

fixes https://github.com/hazelcast/hazelcast/issues/17136

backport of https://github.com/hazelcast/hazelcast/pull/17149
(cherry picked from commit 5440828e55efc83e34299862524aea149a2b8275)