### PR TITLE
Logging for Node creation failures

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -75,6 +75,7 @@ import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentClassLoader;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.FutureUtil;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.partition.MigrationListener;
@@ -223,6 +224,7 @@ public class Node {
 
         ServerSocketRegistry serverSocketRegistry = new ServerSocketRegistry(addressPicker.getServerSocketChannels(),
                 !config.getAdvancedNetworkConfig().isEnabled());
+        ILogger tmpLogger = null;
 
         try {
             boolean liteMember = config.isLiteMember();
@@ -239,7 +241,8 @@ public class Node {
                     .instance(hazelcastInstance)
                     .build();
             loggingService.setThisMember(localMember);
-            logger = loggingService.getLogger(Node.class.getName());
+            tmpLogger = loggingService.getLogger(Node.class.getName());
+            logger = tmpLogger;
 
             nodeExtension.printNodeInfo();
             nodeExtension.beforeStart();
@@ -266,6 +269,14 @@ public class Node {
             multicastService = createMulticastService(addressPicker.getBindAddress(MEMBER), this, config, logger);
             joiner = nodeContext.createJoiner(this);
         } catch (Throwable e) {
+            try {
+                if (tmpLogger == null) {
+                    tmpLogger = Logger.getLogger(Node.class);
+                }
+                tmpLogger.severe("Node creation failed", e);
+            } catch (Exception e1) {
+                e.addSuppressed(e1);
+            }
             serverSocketRegistry.destroy();
             try {
                 shutdownServices(true);


### PR DESCRIPTION
Fixes hazelcast/hazelcast-enterprise#3629

This PR could replace the hazelcast/hazelcast-enterprise#3630 with a wider set of problems in Node creation covered.
The original issue is for 3.12.z so if this solution is accepted I would prepare also backports for 4.0.z and 3.12.z