### PR TITLE
Log terminate in finest when the client is closing

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableMessageRunner.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableMessageRunner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -63,7 +64,13 @@ public class ClientReliableMessageRunner<E> extends MessageRunner<E> {
 
     @Override
     protected boolean handleInternalException(Throwable t) {
-        if (t instanceof HazelcastClientOfflineException) {
+        if (t instanceof HazelcastClientNotActiveException) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Terminating MessageListener " + listener + " on topic: " + topicName + ". "
+                        + " Reason: HazelcastClient is shutting down");
+            }
+            return false;
+        } else if (t instanceof HazelcastClientOfflineException) {
             if (logger.isFinestEnabled()) {
                 logger.finest("MessageListener " + listener + " on topic: " + topicName + " got exception: " + t
                         + ". Continuing from last known sequence: " + sequence);


### PR DESCRIPTION
ReliableTopicMessageListener should not warn the user when
the client is shutting down. InstanceNotActiveException is
already in finest. This pr makes ClientNotActiveException log level
finest too.

backport of https://github.com/hazelcast/hazelcast/pull/17153
fixes https://github.com/hazelcast/hazelcast/issues/17070