### PR TITLE
Log terminate in finest when the client is closing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableMessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableMessageRunner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.proxy;
 
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
@@ -64,7 +65,13 @@ public class ClientReliableMessageRunner<E> extends MessageRunner<E> {
 
     @Override
     protected boolean handleInternalException(Throwable t) {
-        if (t instanceof HazelcastClientOfflineException) {
+        if (t instanceof HazelcastClientNotActiveException) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Terminating MessageListener " + listener + " on topic: " + topicName + ". "
+                        + " Reason: HazelcastClient is shutting down");
+            }
+            return false;
+        } else if (t instanceof HazelcastClientOfflineException) {
             if (logger.isFinestEnabled()) {
                 logger.finest("MessageListener " + listener + " on topic: " + topicName + " got exception: " + t
                         + ". Continuing from last known sequence: " + sequence);


### PR DESCRIPTION
ReliableTopicMessageListener should not warn the user when
the client is shutting down. InstanceNotActiveException is
already in finest. This pr makes ClientNotActiveException log level
finest too.

fixes https://github.com/hazelcast/hazelcast/issues/17070