### PR TITLE
Remove duplicate slf4j dependecy

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -326,14 +326,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.api.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.5.8</version>
+            <version>${slf4j.api.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -391,15 +391,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.api.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>net.spy</groupId>
             <artifactId>spymemcached</artifactId>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -330,13 +330,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.api.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
`mvn dependency:tree -Dverbose `

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for 
com.hazelcast:hazelcast:jar:4.1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: 
org.slf4j:slf4j-api:jar -> version 1.7.25 vs ${slf4j.api.version} @ line 395, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your 
build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed 
projects.
[WARNING] 
```

			