### PR TITLE
Don't exclude com.hazelcast.collection from JavaDoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
             *.impl:*.impl.*:*.internal:*.internal.*:*.operations:*.proxy:*.util:
             com.hazelcast.aws.security:*.handlermigration:*.client.connection.nio:
             *.client.console:*.client.protocol.generator:*.cluster.client:
-            *.concurrent:*.collection:*.nio.ascii:*.nio.ssl:*.nio.tcp:*.partition.client:
+            *.concurrent:*.nio.ascii:*.nio.ssl:*.nio.tcp:*.partition.client:
             *.transaction.client:*.core.server:com.hazelcast.instance:com.hazelcast.PlaceHolder
         </maven.javadoc.plugin.excludePackageNames>
         <maven.antrun.plugin.version>1.7</maven.antrun.plugin.version>


### PR DESCRIPTION
Fixes missing collection package in the generated JavaDoc.

Issue found by Linkchecker run on the Reference manual - the following link doesn't work:
* https://docs.hazelcast.org/docs/4.1-SNAPSHOT/javadoc/com/hazelcast/collection/LocalQueueStats.html

Verified by:
```bash
mvn clean javadoc:aggregate -Prelease-snapshot -DskipTests
find target/site/apidocs -name collection
```