### PR TITLE
Fix issue #897

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlParser.java
@@ -41,6 +41,7 @@ class SqlParser {
     private static final int IN_PRECEDENCE = 10;
     private static final int LIKE_PRECEDENCE = 10;
     private static final int ILIKE_PRECEDENCE = 10;
+    private static final int ESCAPE_PRECEDENCE = 15;
     private static final int REGEX_PRECEDENCE = 10;
     private static final int AND_PRECEDENCE = 5;
     private static final int OR_PRECEDENCE = 3;
@@ -64,6 +65,7 @@ class SqlParser {
         precedence.put("in", IN_PRECEDENCE);
         precedence.put("like", LIKE_PRECEDENCE);
         precedence.put("ilike", ILIKE_PRECEDENCE);
+        precedence.put("escape", ESCAPE_PRECEDENCE);
         precedence.put("regex", REGEX_PRECEDENCE);
         precedence.put("and", AND_PRECEDENCE);
         precedence.put("or", OR_PRECEDENCE);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -189,6 +189,12 @@ public class SqlPredicate
                         createComparison(mapPhrases, tokens, i, LESS_EQUAL_FACTORY);
                     } else if ("<".equals(token)) {
                         createComparison(mapPhrases, tokens, i, LESS_THAN_FACTORY);
+                    } else if ("ESCAPE".equalsIgnoreCase(token)) {
+                        int position = (i - 2);
+                        validateOperandPosition(position);
+                        String first = (String) toValue(tokens.remove(position), mapPhrases);
+                        String second = (String) toValue(tokens.remove(position), mapPhrases);
+                        tokens.set(position, first.replace(second, "\\"));
                     } else if ("LIKE".equalsIgnoreCase(token)) {
                         int position = (i - 2);
                         validateOperandPosition(position);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SqlPredicateTest.java
@@ -449,6 +449,20 @@ public class SqlPredicateTest {
     public void testSqlPredicateEscape() {
         assertEquals("(active=true AND name=abc x'yz 1'23)", sql("active AND name='abc x''yz 1''23'"));
         assertEquals("(active=true AND name=)", sql("active AND name=''"));
+        assertSqlMatching("name = 'Larry''s'", createValue("Larry's"));
+        assertSqlMatching("name = ''", createValue(""));
+        assertSqlMatching("name = '\"'", createValue("\""));
+        assertSqlMatching("name LIKE 'Stri%'", createValue("String"));
+        assertSqlMatching("name LIKE 'Stri%'", createValue("Stri"));
+        assertSqlMatching("name LIKE 'Stri\\%'", createValue("Stri%"));
+        assertSqlNotMatching("name LIKE 'Stri\\%'", createValue("String"));
+        assertSqlMatching("name LIKE 'Stg''.'", createValue("Stg'."));
+        assertSqlNotMatching("name LIKE 'Stg''.'", createValue("Stg'1"));
+        assertSqlMatching("name LIKE 'Strin_'", createValue("String"));
+        assertSqlNotMatching("name LIKE 'Strin\\_'", createValue("String"));
+        assertSqlMatching("name LIKE 'Strin\\_'", createValue("Strin_"));
+        assertSqlNotMatching("name LIKE 'Strin*'", createValue("Strinn"));
+        assertSqlMatching("name LIKE 'Strin*'", createValue("Strin*"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SqlPredicateTest.java
@@ -465,6 +465,15 @@ public class SqlPredicateTest {
         assertSqlMatching("name LIKE 'Strin*'", createValue("Strin*"));
     }
 
+    @Test
+    public void testSqlPredicateEscapeKeyword() {
+        assertSqlMatching("name LIKE 'Stg/%%' ESCAPE '/'", createValue("Stg%abc"));
+        assertSqlMatching("name LIKE 'Stg123%_123_' ESCAPE '123'", createValue("Stg%a_"));
+        assertSqlMatching("name LIKE 'Stg\\%' ESCAPE '\\'", createValue("Stg%"));
+        assertSqlMatching("name ILIKE 'Stg/%_' ESCAPE '/' AND (age = '24' OR active = 'true')", createValue("stg%1"));
+        assertSqlMatching("(age = '24' OR active = 'true') AND name ILIKE 'Stg/%_' ESCAPE '/'", createValue("stg%1"));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidSqlPredicate1() {
         new SqlPredicate("invalid sql");


### PR DESCRIPTION
It appears that everything described in the issue already works. Escaping of ' character can be done by doubling the ' character, and escaping of characters % and _ can be done by using \ character. The only thing which been added is the support of the ESCAPE keyword, which replaces specified characters by \ 