### PR TITLE
Allow diagnostics to log to logger

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -286,8 +286,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private Diagnostics initDiagnostics() {
         String name = "diagnostics-client-" + id + "-" + currentTimeMillis();
-        ILogger logger = loggingService.getLogger(Diagnostics.class);
-        return new Diagnostics(name, logger, instanceName, properties);
+
+        return new Diagnostics(name, loggingService, instanceName, properties);
     }
 
     private MetricsRegistryImpl initMetricsRegistry() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
@@ -28,6 +29,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.internal.diagnostics.DiagnosticsOutputType.FILE;
 import static com.hazelcast.internal.diagnostics.DiagnosticsPlugin.DISABLED;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
@@ -83,8 +85,7 @@ public class Diagnostics {
     /**
      * Configures if the epoch time should be included in the 'top' section.
      * This makes it easy to determine the time in epoch format and prevents
-     * needing to parse the date-format section. The default is {@code false}
-     * since it will cause more noise.
+     * needing to parse the date-format section. The default is {@code true}.
      */
     public static final HazelcastProperty INCLUDE_EPOCH_TIME = new HazelcastProperty("hazelcast.diagnostics.include.epoch", true);
 
@@ -105,17 +106,16 @@ public class Diagnostics {
             = new HazelcastProperty("hazelcast.diagnostics.filename.prefix");
 
     /**
-     * Send all the Diagnostics logs to the stdout, instead of storing on the file system.
-     * <p>
-     * The default is false.
+     * Configures the output for the diagnostics. The default value is
+     * {@link DiagnosticsOutputType#FILE} which is a set of files managed by the
+     * Hazelcast process.
      */
-    public static final HazelcastProperty STDOUT = new HazelcastProperty("hazelcast.diagnostics.stdout", false);
+    public static final HazelcastProperty OUTPUT_TYPE = new HazelcastProperty("hazelcast.diagnostics.stdout", FILE);
 
-    final AtomicReference<DiagnosticsPlugin[]> staticTasks = new AtomicReference<>(
-            new DiagnosticsPlugin[0]
-    );
+    final AtomicReference<DiagnosticsPlugin[]> staticTasks = new AtomicReference<>(new DiagnosticsPlugin[0]);
     final String baseFileName;
     final ILogger logger;
+    final LoggingService loggingService;
     final String hzName;
     final HazelcastProperties properties;
     final boolean includeEpochTime;
@@ -125,25 +125,26 @@ public class Diagnostics {
 
     private final ConcurrentMap<Class<? extends DiagnosticsPlugin>, DiagnosticsPlugin> pluginsMap = new ConcurrentHashMap<>();
     private final boolean enabled;
-    private final boolean stdout;
+    private final DiagnosticsOutputType outputType;
 
     private ScheduledExecutorService scheduler;
 
-    public Diagnostics(String baseFileName, ILogger logger, String hzName, HazelcastProperties properties) {
+    public Diagnostics(String baseFileName, LoggingService loggingService, String hzName, HazelcastProperties properties) {
         String optionalPrefix = properties.getString(FILENAME_PREFIX);
         this.baseFileName = optionalPrefix == null ? baseFileName : optionalPrefix + "-" + baseFileName;
-        this.logger = logger;
+        this.logger = loggingService.getLogger(Diagnostics.class);
+        this.loggingService = loggingService;
         this.hzName = hzName;
         this.properties = properties;
         this.includeEpochTime = properties.getBoolean(INCLUDE_EPOCH_TIME);
         this.directory = new File(properties.getString(DIRECTORY));
         this.enabled = properties.getBoolean(ENABLED);
-        this.stdout = properties.getBoolean(STDOUT);
+        this.outputType = properties.getEnum(OUTPUT_TYPE, DiagnosticsOutputType.class);
     }
 
     // just for testing (returns the current file the system is writing to)
     public File currentFile() throws UnsupportedOperationException {
-        if (stdout) {
+        if (outputType != FILE) {
             throw new UnsupportedOperationException();
         }
         return ((DiagnosticsLogFile) diagnosticsLog).file;
@@ -219,7 +220,7 @@ public class Diagnostics {
             return;
         }
 
-        this.diagnosticsLog = stdout ? new DiagnosticsStdout(this) :  new DiagnosticsLogFile(this);
+        this.diagnosticsLog = outputType.newLog(this);
         this.scheduler = new ScheduledThreadPoolExecutor(1, new DiagnosticSchedulerThreadFactory());
 
         logger.info("Diagnostics started");

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLog.java
@@ -16,6 +16,16 @@
 
 package com.hazelcast.internal.diagnostics;
 
+/**
+ * The diagnostics log output.
+ */
 public interface DiagnosticsLog {
+
+    /**
+     * Writes the output of the provided {@code plugin} to the diagnostics
+     * output.
+     *
+     * @param plugin the plugin to log
+     */
     void write(DiagnosticsPlugin plugin);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.logging.ILogger;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Forwards the diagnostic plugin output to a Hazelcast {@link ILogger}.
+ */
+final class DiagnosticsLogger implements DiagnosticsLog {
+    private final Diagnostics diagnostics;
+    private final ILogger logger;
+    private final ILogger diagnosticsLogger;
+    private final DiagnosticsLogWriterImpl logWriter;
+    private final StringWriter stringWriter;
+    private boolean staticPluginsRendered;
+
+    DiagnosticsLogger(Diagnostics diagnostics) {
+        this.diagnostics = diagnostics;
+        this.logger = diagnostics.logger;
+        this.diagnosticsLogger = diagnostics.loggingService.getLogger("com.hazelcast.diagnostics");
+        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
+        this.stringWriter = new StringWriter();
+        logWriter.init(new PrintWriter(stringWriter));
+        logger.info("Sending diagnostics to the Hazelcast logger");
+    }
+
+    public void write(DiagnosticsPlugin plugin) {
+        try {
+            if (!staticPluginsRendered) {
+                renderStaticPlugins();
+                staticPluginsRendered = true;
+            }
+
+            renderPlugin(plugin);
+            if (stringWriter.getBuffer().length() > 0) {
+                String message = stringWriter.toString();
+                diagnosticsLogger.fine(message);
+                stringWriter.getBuffer().setLength(0);
+            }
+        } catch (RuntimeException e) {
+            logger.warning("Failed to write to log: ", e);
+        }
+    }
+
+    private void renderStaticPlugins() {
+        for (DiagnosticsPlugin plugin : diagnostics.staticTasks.get()) {
+            renderPlugin(plugin);
+        }
+    }
+
+    private void renderPlugin(DiagnosticsPlugin plugin) {
+        plugin.run(logWriter);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
@@ -18,8 +18,8 @@ package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.logging.ILogger;
 
+import java.io.CharArrayWriter;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 
 /**
  * Forwards the diagnostic plugin output to a Hazelcast {@link ILogger}.
@@ -29,7 +29,7 @@ final class DiagnosticsLogger implements DiagnosticsLog {
     private final ILogger logger;
     private final ILogger diagnosticsLogger;
     private final DiagnosticsLogWriterImpl logWriter;
-    private final StringWriter stringWriter;
+    private final CharArrayWriter writer;
     private boolean staticPluginsRendered;
 
     DiagnosticsLogger(Diagnostics diagnostics) {
@@ -37,8 +37,8 @@ final class DiagnosticsLogger implements DiagnosticsLog {
         this.logger = diagnostics.logger;
         this.diagnosticsLogger = diagnostics.loggingService.getLogger("com.hazelcast.diagnostics");
         this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
-        this.stringWriter = new StringWriter();
-        logWriter.init(new PrintWriter(stringWriter));
+        this.writer = new CharArrayWriter();
+        logWriter.init(new PrintWriter(writer));
         logger.info("Sending diagnostics to the 'com.hazelcast.diagnostics' logger");
     }
 
@@ -50,10 +50,10 @@ final class DiagnosticsLogger implements DiagnosticsLog {
             }
 
             renderPlugin(plugin);
-            if (stringWriter.getBuffer().length() > 0) {
-                String message = stringWriter.toString();
+            if (writer.size() > 0) {
+                String message = writer.toString();
                 diagnosticsLogger.fine(message);
-                stringWriter.getBuffer().setLength(0);
+                writer.reset();
             }
         } catch (RuntimeException e) {
             logger.warning("Failed to write to log: ", e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
@@ -39,7 +39,7 @@ final class DiagnosticsLogger implements DiagnosticsLog {
         this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
         this.stringWriter = new StringWriter();
         logWriter.init(new PrintWriter(stringWriter));
-        logger.info("Sending diagnostics to the Hazelcast logger");
+        logger.info("Sending diagnostics to the 'com.hazelcast.diagnostics' logger");
     }
 
     public void write(DiagnosticsPlugin plugin) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsOutputType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsOutputType.java
@@ -47,6 +47,8 @@ public enum DiagnosticsOutputType {
      * logging configuration to forward the diagnostics to any output supported
      * by the logging framework. You may also want to use some additional configuration
      * to control how the output format.
+     * Using the logging framework introduces a slight overhead in comparison
+     * to using other output types but allows for greater flexibility.
      *
      * @see com.hazelcast.spi.properties.ClusterProperty#LOGGING_ENABLE_DETAILS
      * @see Diagnostics#INCLUDE_EPOCH_TIME

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsOutputType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsOutputType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+/**
+ * Defines the output type for Hazelcast diagnostics.
+ */
+public enum DiagnosticsOutputType {
+
+    /**
+     * Outputs the diagnostics to a set of files managed by Hazelcast.
+     */
+    FILE {
+        @Override
+        DiagnosticsLog newLog(Diagnostics diagnostics) {
+            return new DiagnosticsLogFile(diagnostics);
+        }
+    },
+
+    /**
+     * Outputs the diagnostics to the "standard" output stream as determined by
+     * {@link System#out}.
+     */
+    STDOUT {
+        @Override
+        DiagnosticsLog newLog(Diagnostics diagnostics) {
+            return new DiagnosticsStdout(diagnostics);
+        }
+    },
+
+    /**
+     * Outputs the diagnostics to the Hazelcast logger. You may then use your
+     * logging configuration to forward the diagnostics to any output supported
+     * by the logging framework. You may also want to use some additional configuration
+     * to control how the output format.
+     *
+     * @see com.hazelcast.spi.properties.ClusterProperty#LOGGING_ENABLE_DETAILS
+     * @see Diagnostics#INCLUDE_EPOCH_TIME
+     */
+    LOGGER {
+        @Override
+        DiagnosticsLog newLog(Diagnostics diagnostics) {
+            return new DiagnosticsLogger(diagnostics);
+        }
+    };
+
+    abstract DiagnosticsLog newLog(Diagnostics diagnostics);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -196,11 +196,7 @@ public class NodeEngineImpl implements NodeEngine {
         String addressString = address.getHost().replace(":", "_") + "_" + address.getPort();
         String name = "diagnostics-" + addressString + "-" + currentTimeMillis();
 
-        return new Diagnostics(
-                name,
-                loggingService.getLogger(Diagnostics.class),
-                getHazelcastInstance().getName(),
-                node.getProperties());
+        return new Diagnostics(name, loggingService, getHazelcastInstance().getName(), node.getProperties());
     }
 
     public LoggingService getLoggingService() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
@@ -48,6 +48,10 @@ public final class HazelcastProperty {
         this.timeUnit = null;
     }
 
+    public HazelcastProperty(String name, Enum<?> defaultEnum) {
+        this(name, defaultEnum.name());
+    }
+
     public HazelcastProperty(String name, boolean defaultValue) {
         this(name, defaultValue ? "true" : "false");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLoggerTest.java
@@ -61,11 +61,7 @@ public class DiagnosticsLoggerTest extends HazelcastTestSupport {
             String content = diagnosticsOutput.toString();
             assertNotNull(content);
 
-            //assertContains(content, "SystemProperties[");
-            //assertContains(content, "BuildInfo[");
-            //assertContains(content, "ConfigProperties[");
             assertContains(content, "Metric[");
-
         });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLoggerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static com.hazelcast.instance.impl.TestUtil.getNode;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class DiagnosticsLoggerTest extends HazelcastTestSupport {
+
+    @Test
+    public void testLoggerContent() {
+        Config config = new Config()
+                .setProperty(Diagnostics.ENABLED.getName(), "true")
+                .setProperty(Diagnostics.OUTPUT_TYPE.getName(), DiagnosticsOutputType.LOGGER.name())
+                .setProperty(Diagnostics.INCLUDE_EPOCH_TIME.getName(), "false")
+                .setProperty(ClusterProperty.LOGGING_ENABLE_DETAILS.getName(), "false")
+                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+
+        StringBuilder diagnosticsOutput = new StringBuilder();
+
+        getNode(instance).loggingService.addLogListener(Level.FINE, event -> {
+            LogRecord record = event.getLogRecord();
+            if (record.getLoggerName().equals("com.hazelcast.diagnostics")) {
+                diagnosticsOutput.append(record.getMessage());
+            }
+        });
+
+
+        assertTrueEventually(() -> {
+            String content = diagnosticsOutput.toString();
+            assertNotNull(content);
+
+            //assertContains(content, "SystemProperties[");
+            //assertContains(content, "BuildInfo[");
+            //assertContains(content, "ConfigProperties[");
+            assertContains(content, "Metric[");
+
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsStdoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsStdoutTest.java
@@ -72,7 +72,7 @@ public class DiagnosticsStdoutTest extends HazelcastTestSupport {
 
         Config config = new Config()
                 .setProperty(Diagnostics.ENABLED.getName(), "true")
-                .setProperty(Diagnostics.STDOUT.getName(), "true")
+                .setProperty(Diagnostics.OUTPUT_TYPE.getName(), DiagnosticsOutputType.STDOUT.name())
                 .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
 
         createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsTest.java
@@ -16,8 +16,9 @@
 
 package com.hazelcast.internal.diagnostics;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.config.Config;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -54,7 +55,7 @@ public class DiagnosticsTest extends HazelcastTestSupport {
         Config config = new Config().setProperty(Diagnostics.FILENAME_PREFIX.getName(), "foobar");
         HazelcastProperties hzProperties = new HazelcastProperties(config);
 
-        Diagnostics diagnostics = new Diagnostics("diagnostics", getLogger(Diagnostics.class), "hz", hzProperties);
+        Diagnostics diagnostics = new Diagnostics("diagnostics", mockLoggingService(), "hz", hzProperties);
         assertEquals("foobar-diagnostics", diagnostics.baseFileName);
     }
 
@@ -63,7 +64,7 @@ public class DiagnosticsTest extends HazelcastTestSupport {
         Config config = new Config();
         HazelcastProperties hzProperties = new HazelcastProperties(config);
 
-        Diagnostics diagnostics = new Diagnostics("diagnostics", getLogger(Diagnostics.class), "hz", hzProperties);
+        Diagnostics diagnostics = new Diagnostics("diagnostics", mockLoggingService(), "hz", hzProperties);
         assertEquals("diagnostics", diagnostics.baseFileName);
     }
 
@@ -141,6 +142,12 @@ public class DiagnosticsTest extends HazelcastTestSupport {
         String addressString = address.getHost().replace(":", "_") + "#" + address.getPort();
         String name = "diagnostics-" + addressString + "-" + currentTimeMillis();
 
-        return new Diagnostics(name, getLogger(Diagnostics.class), "hz", new HazelcastProperties(config));
+        return new Diagnostics(name, mockLoggingService(), "hz", new HazelcastProperties(config));
+    }
+
+    private LoggingService mockLoggingService() {
+        LoggingService mock = mock(LoggingService.class);
+        when(mock.getLogger(Diagnostics.class)).thenReturn(getLogger(Diagnostics.class));
+        return mock;
     }
 }


### PR DESCRIPTION
Also cleaned up some diagnostics properties.

Example log4j XML to separate diagnostics to separate file:
```xml
<Configuration status="ERROR">
    <Appenders>
        <Console name="Console" target="SYSTEM_OUT">
            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
        </Console>
        <File name="MyFile" fileName="logs/app.log">
            <PatternLayout>
                <Pattern>%m%n</Pattern>
            </PatternLayout>
        </File>
    </Appenders>
    <Loggers>
        <Root level="DEBUG">
            <AppenderRef ref="Console"/>
        </Root>
        <Logger name="com.hazelcast.diagnostics" level="debug" additivity="false">
            <AppenderRef ref="MyFile" />
        </Logger>
    </Loggers>
</Configuration>
```