### PR TITLE
Fix exception wrapping for member/client comm

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -344,8 +344,8 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
                 return t;
             }
         }
-
-        return peel(t);
+        //We are passing our own message factory, because we don't want checked exceptions to be wrapped to HazelcastException
+        return peel(t, null, null, (throwable, message) -> throwable);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -26,6 +26,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.security.SecurityContext;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -33,6 +34,8 @@ import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import javax.security.auth.Subject;
 import java.security.Permission;
 import java.util.concurrent.Callable;
+
+import static java.lang.String.format;
 
 public class ExecutorServiceSubmitToAddressMessageTask
         extends AbstractInvocationMessageTask<ExecutorServiceSubmitToMemberCodec.RequestParameters> {
@@ -45,6 +48,9 @@ public class ExecutorServiceSubmitToAddressMessageTask
     protected InvocationBuilder getInvocationBuilder(Operation op) {
         final OperationServiceImpl operationService = nodeEngine.getOperationService();
         Member member = nodeEngine.getClusterService().getMember(parameters.memberUUID);
+        if (member == null) {
+            throw new TargetNotMemberException(format("Member with uuid(%s) is not in member list ", parameters.memberUUID));
+        }
         return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
@@ -32,7 +32,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
  */
 public final class ClientTransactionUtil {
 
-    private static final BiFunction<Throwable, String, Throwable> TRANSACTION_EXCEPTION_WRAPPER =
+    private static final BiFunction<Throwable, String, RuntimeException> TRANSACTION_EXCEPTION_WRAPPER =
             (throwable, message) -> new TransactionException(message, throwable);
 
     private ClientTransactionUtil() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
@@ -33,12 +33,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 public final class ClientTransactionUtil {
 
     private static final RuntimeExceptionFactory TRANSACTION_EXCEPTION_FACTORY =
-            new RuntimeExceptionFactory() {
-                @Override
-                public RuntimeException create(Throwable throwable, String message) {
-                    return new TransactionException(message, throwable);
-                }
-            };
+            (throwable, message) -> new TransactionException(message, throwable);
 
     private ClientTransactionUtil() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
@@ -21,9 +21,9 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.internal.util.ExceptionUtil.RuntimeExceptionFactory;
 
 import java.util.concurrent.Future;
+import java.util.function.BiFunction;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 
@@ -32,7 +32,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
  */
 public final class ClientTransactionUtil {
 
-    private static final RuntimeExceptionFactory TRANSACTION_EXCEPTION_FACTORY =
+    private static final BiFunction<Throwable, String, Throwable> TRANSACTION_EXCEPTION_WRAPPER =
             (throwable, message) -> new TransactionException(message, throwable);
 
     private ClientTransactionUtil() {
@@ -51,7 +51,7 @@ public final class ClientTransactionUtil {
             final Future<ClientMessage> future = clientInvocation.invoke();
             return future.get();
         } catch (Exception e) {
-            throw rethrow(e, TRANSACTION_EXCEPTION_FACTORY);
+            throw rethrow(e, TRANSACTION_EXCEPTION_WRAPPER);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -32,7 +32,7 @@ import java.util.function.BiConsumer;
  */
 public final class ExceptionUtil {
 
-    private static final RuntimeExceptionFactory HAZELCAST_EXCEPTION_FACTORY = (throwable, message) -> {
+    public static final RuntimeExceptionFactory HAZELCAST_EXCEPTION_FACTORY = (throwable, message) -> {
         if (message != null) {
             return new HazelcastException(message, throwable);
         } else {
@@ -44,7 +44,7 @@ public final class ExceptionUtil {
      * Interface used by rethrow/peel to wrap the peeled exception
      */
     public interface RuntimeExceptionFactory {
-        RuntimeException create(Throwable throwable, String message);
+        Throwable create(Throwable throwable, String message);
     }
 
     private ExceptionUtil() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -26,26 +26,20 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 /**
  * Contains various exception related utility methods.
  */
 public final class ExceptionUtil {
 
-    public static final RuntimeExceptionFactory HAZELCAST_EXCEPTION_FACTORY = (throwable, message) -> {
+    private static final BiFunction<Throwable, String, HazelcastException> HAZELCAST_EXCEPTION_WRAPPER = (throwable, message) -> {
         if (message != null) {
             return new HazelcastException(message, throwable);
         } else {
             return new HazelcastException(throwable);
         }
     };
-
-    /**
-     * Interface used by rethrow/peel to wrap the peeled exception
-     */
-    public interface RuntimeExceptionFactory {
-        Throwable create(Throwable throwable, String message);
-    }
 
     private ExceptionUtil() {
     }
@@ -64,7 +58,7 @@ public final class ExceptionUtil {
     }
 
     public static RuntimeException peel(final Throwable t) {
-        return (RuntimeException) peel(t, null, null, HAZELCAST_EXCEPTION_FACTORY);
+        return (RuntimeException) peel(t, null, null, HAZELCAST_EXCEPTION_WRAPPER);
     }
 
     /**
@@ -82,26 +76,28 @@ public final class ExceptionUtil {
      * @return the peeled {@code Throwable}
      */
     public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType, String message) {
-        return peel(t, allowedType, message, HAZELCAST_EXCEPTION_FACTORY);
+        return peel(t, allowedType, message, HAZELCAST_EXCEPTION_WRAPPER);
     }
 
     /**
-     * Processes {@code Throwable t} so that the returned {@code Throwable}'s type matches {@code allowedType} or
-     * {@code RuntimeException}. Processing may include unwrapping {@code t}'s cause hierarchy, wrapping it in a
-     * {@code RuntimeException} created by using runtimeExceptionFactory or just returning the same instance {@code t}
+     * Processes {@code Throwable t} so that the returned {@code Throwable}'s type matches {@code allowedType},
+     * {@code RuntimeException} or any {@code Throwable} returned by `exceptionWrapper`
+     * Processing may include unwrapping {@code t}'s cause hierarchy, wrapping it in a exception
+     * created by using exceptionWrapper or just returning the same instance {@code t}
      * if it is already an instance of {@code RuntimeException}.
      *
-     * @param t                       {@code Throwable} to be peeled
-     * @param allowedType             the type expected to be returned; when {@code null}, this method returns instances
-     *                                of {@code RuntimeException}
-     * @param message                 if not {@code null}, used as the message in {@code RuntimeException} that
-     *                                may wrap the peeled {@code Throwable}
-     * @param runtimeExceptionFactory wraps the peeled code using this runtimeExceptionFactory
-     * @param <T>                     expected type of {@code Throwable}
+     * @param t                {@code Throwable} to be peeled
+     * @param allowedType      the type expected to be returned; when {@code null}, this method returns instances
+     *                         of {@code RuntimeException} or <W>
+     * @param message          if not {@code null}, used as the message in {@code RuntimeException} that
+     *                         may wrap the peeled {@code Throwable}
+     * @param exceptionWrapper wraps the peeled code using this exceptionWrapper
+     * @param <W>              Type of the wrapper exception in exceptionWrapper
+     * @param <T>              allowed type of {@code Throwable}
      * @return the peeled {@code Throwable}
      */
-    public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType,
-                                                       String message, RuntimeExceptionFactory runtimeExceptionFactory) {
+    public static <T, W extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType,
+                                                          String message, BiFunction<Throwable, String, W> exceptionWrapper) {
         if (t instanceof RuntimeException) {
             return t;
         }
@@ -109,9 +105,9 @@ public final class ExceptionUtil {
         if (t instanceof ExecutionException || t instanceof InvocationTargetException) {
             final Throwable cause = t.getCause();
             if (cause != null) {
-                return peel(cause, allowedType, message, runtimeExceptionFactory);
+                return peel(cause, allowedType, message, exceptionWrapper);
             } else {
-                return runtimeExceptionFactory.create(t, message);
+                return exceptionWrapper.apply(t, message);
             }
         }
 
@@ -119,17 +115,17 @@ public final class ExceptionUtil {
             return t;
         }
 
-        return runtimeExceptionFactory.create(t, message);
+        return exceptionWrapper.apply(t, message);
     }
 
-    public static RuntimeException rethrow(final Throwable t) {
+    public static RuntimeException rethrow(Throwable t) {
         rethrowIfError(t);
         throw peel(t);
     }
 
-    public static RuntimeException rethrow(final Throwable t, RuntimeExceptionFactory runtimeExceptionFactory) {
+    public static RuntimeException rethrow(Throwable t, BiFunction<Throwable, String, RuntimeException> exceptionWrapper) {
         rethrowIfError(t);
-        throw (RuntimeException) peel(t, null, null, runtimeExceptionFactory);
+        throw (RuntimeException) peel(t, null, null, exceptionWrapper);
     }
 
     public static <T extends Throwable> RuntimeException rethrow(final Throwable t, Class<T> allowedType) throws T {

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExceptionTest.java
@@ -90,8 +90,6 @@ public class ClientExecutorServiceExceptionTest {
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         IExecutorService executorService = client.getExecutorService("test");
 
-        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
-        Member member2 = instance2.getCluster().getLocalMember();
-        assertEquals("SUCCESS", executorService.submitToMember(new SecondTimeSuccessCallable(), member2).get());
+        assertEquals("SUCCESS", executorService.submit(new SecondTimeSuccessCallable()).get());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExceptionTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.executor;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.spi.exception.RetryableIOException;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientExecutorServiceExceptionTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    @Test(expected = TargetNotMemberException.class)
+    public void testSubmitToNonMember() throws Throwable {
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setSmartRouting(false);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        IExecutorService executorService = client.getExecutorService("test");
+
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+        Member member2 = instance2.getCluster().getLocalMember();
+
+        instance2.shutdown();
+
+        try {
+            executorService.submitToMember((Serializable & Callable<String>) () -> "test", member2).get();
+        } catch (Exception e) {
+            throw e.getCause();
+        }
+    }
+
+    public static class SecondTimeSuccessCallable implements Serializable, Callable {
+        private static AtomicInteger runCount = new AtomicInteger();
+
+
+        @Override
+        public Object call() throws Exception {
+            if (runCount.incrementAndGet() == 1) {
+                throw new RetryableIOException();
+            }
+            return "SUCCESS";
+        }
+    }
+
+    @Test
+    public void testRetriableIOException() throws Throwable {
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setSmartRouting(false);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        IExecutorService executorService = client.getExecutorService("test");
+
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+        Member member2 = instance2.getCluster().getLocalMember();
+        assertEquals("SUCCESS", executorService.submitToMember(new SecondTimeSuccessCallable(), member2).get());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
@@ -77,12 +77,7 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
     public void testPeel_whenThrowableIsExecutionExceptionWithCustomFactory_thenReturnCustomException() {
         IOException expectedException = new IOException();
         RuntimeException result = (RuntimeException) ExceptionUtil.peel(new ExecutionException(expectedException),
-                null, null, new ExceptionUtil.RuntimeExceptionFactory() {
-                    @Override
-                    public RuntimeException create(Throwable throwable, String message) {
-                        return new IllegalStateException(message, throwable);
-                    }
-                });
+                null, null, (throwable, message) -> new IllegalStateException(message, throwable));
 
         assertEquals(result.getClass(), IllegalStateException.class);
         assertEquals(result.getCause(), expectedException);


### PR DESCRIPTION
Exceptions that comes from remote are wrapped to HazelcastEx
if they are not RuntimeExceptions. That prevents clients to
act accordingly to exceptions. With this pr, we are removing
the wrapping.

fixes https://github.com/hazelcast/hazelcast/issues/17022

A second NullPointerException is found and fixed while investigating
this issue. It is found in ExecutorServiceSubmitToAddressMessageTask