### PR TITLE
Add instance tracking via files created on node startup

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -36,6 +36,7 @@ import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.MetricsJmxConfig;
@@ -193,6 +194,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                     configBuilder.addPropertyValue("backupAckToClientEnabled", getTextContent(node));
                 } else if ("metrics".equals(nodeName)) {
                     handleMetrics(node);
+                } else if ("instance-tracking".equals(nodeName)) {
+                    handleInstanceTracking(node);
                 }
             }
             return configBuilder.getBeanDefinition();
@@ -525,6 +528,21 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                 labels.add(label);
             }
             configBuilder.addPropertyValue("labels", labels);
+        }
+
+        private void handleInstanceTracking(Node node) {
+            BeanDefinitionBuilder configBuilder = createBeanBuilder(InstanceTrackingConfig.class);
+            fillAttributeValues(node, configBuilder);
+
+            for (Node child : childElements(node)) {
+                final String name = cleanNodeName(child);
+                if ("file-name".equals(name)) {
+                    configBuilder.addPropertyValue("fileName", getTextContent(child));
+                } else if ("format-pattern".equals(name)) {
+                    configBuilder.addPropertyValue("formatPattern", getTextContent(child));
+                }
+            }
+            this.configBuilder.addPropertyValue("instanceTrackingConfig", configBuilder.getBeanDefinition());
         }
 
         private void handleMetrics(Node node) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -30,9 +30,6 @@ import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
-import com.hazelcast.config.SqlConfig;
-import com.hazelcast.config.WanBatchPublisherConfig;
-import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EncryptionAtRestConfig;
 import com.hazelcast.config.EndpointConfig;
@@ -44,6 +41,7 @@ import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.IcmpFailureDetectorConfig;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ItemListenerConfig;
@@ -100,11 +98,14 @@ import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.config.SplitBrainProtectionConfigBuilder;
 import com.hazelcast.config.SplitBrainProtectionListenerConfig;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.config.VaultSecureStoreConfig;
+import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
@@ -334,6 +335,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleCPSubSystem(node);
                     } else if ("metrics".equals(nodeName)) {
                         handleMetrics(node);
+                    } else if ("instance-tracking".equals(nodeName)) {
+                        handleInstanceTracking(node);
                     } else if ("sql".equals(nodeName)) {
                         handleSql(node);
                     }
@@ -2054,6 +2057,21 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         // endpoint-config or server-socket-endpoint-config node
         private EndpointQualifier createEndpointQualifier(ProtocolType type, Node node) {
             return EndpointQualifier.resolve(type, getAttribute(node, "name"));
+        }
+
+        private void handleInstanceTracking(Node node) {
+            BeanDefinitionBuilder configBuilder = createBeanBuilder(InstanceTrackingConfig.class);
+            fillAttributeValues(node, configBuilder);
+
+            for (Node child : childElements(node)) {
+                final String name = cleanNodeName(child);
+                if ("file-name".equals(name)) {
+                    configBuilder.addPropertyValue("fileName", getTextContent(child));
+                } else if ("format-pattern".equals(name)) {
+                    configBuilder.addPropertyValue("formatPattern", getTextContent(child));
+                }
+            }
+            this.configBuilder.addPropertyValue("instanceTrackingConfig", configBuilder.getBeanDefinition());
         }
 
         private void handleMetrics(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -1358,6 +1358,7 @@
                         </xs:element>
                         <xs:element name="cp-subsystem" type="cp-subsystem" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="sql" type="sql" minOccurs="0" maxOccurs="1"/>
                     </xs:choice>
                 </xs:extension>
@@ -1572,6 +1573,7 @@
                     <xs:element name="flake-id-generator" type="client-flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="reliable-topic" type="client-reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="metrics" type="client-metrics" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
                 </xs:choice>
             </xs:extension>
         </xs:complexContent>
@@ -4857,6 +4859,69 @@
                 </xs:annotation>
             </xs:element>
         </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="instance-tracking">
+        <xs:annotation>
+            <xs:documentation>
+                Configures tracking of a running Hazelcast instance. For now, this is
+                limited to writing information about the Hazelcast instance to a file
+                while the instance is starting.
+                The file is overwritten on every start of the Hazelcast instance and if
+                multiple instance share the same file system, every instance will
+                overwrite the tracking file of a previously started instance.
+                If this instance is unable to write the file, the exception is logged and
+                the instance is allowed to start.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="file-name" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the name of the file which will contain the tracking metadata. If left unset
+                        a file named "Hazelcast.process" will be created in the directory as returned by
+                        System.getProperty("java.io.tmpdir").
+                        The filename can contain placeholders that will be resolved in the same way
+                        as placeholders for the format pattern.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="format-pattern" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the pattern used to render the contents of the instance tracking file.
+                        It may contain placeholders for these properties:
+                        - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+                        - "version": The instance version.
+                        - "mode": The instance mode which can be "server", "embedded" or "client".
+                        - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+                        measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+                        - "licensed": If this instance is using a license or not. The value 0 signifies
+                        that there is no license set and the value 1 signifies that a license is in use.
+                        - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+                        process ID on all JVMs and operating systems so please test before use. In case we are unable to
+                        get the PID, the value will be -1.
+
+                        The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }.
+                        For instance, a placeholder for the "start_timestamp" would be $HZ_INSTANCE_TRACKING{start_timestamp}.
+                        The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+                        is ignored and only the known properties are resolved, placeholders for
+                        any parameters which do not have defined values will be ignored. This also
+                        means that if there is a missing closing bracket in one of the placeholders,
+                        the property name will be resolved as anything from the opening bracket
+                        to the next closing bracket, which might contain additional opening brackets.
+                        If unset, a JSON formatted output will be used.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enables or disables instance tracking.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="metrics">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -41,6 +41,7 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.NearCacheConfig;
@@ -141,6 +142,9 @@ public class TestClientApplicationContext {
 
     @Resource(name = "client18-metrics")
     private HazelcastClientProxy metricsClient;
+
+    @Resource(name = "client19-instance-tracking")
+    private HazelcastClientProxy instanceTrackingClient;
 
     @Resource(name = "instance")
     private HazelcastInstance instance;
@@ -519,5 +523,15 @@ public class TestClientApplicationContext {
         assertFalse(metricsConfig.isEnabled());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
         assertEquals(42, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Test
+    public void testInstanceTracking() {
+        InstanceTrackingConfig trackingConfig = instanceTrackingClient.getClientConfig().getInstanceTrackingConfig();
+
+        assertFalse(trackingConfig.isEnabled());
+        assertEquals("/dummy/file", trackingConfig.getFileName());
+        assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
+                trackingConfig.getFormatPattern());
     }
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -529,7 +529,7 @@ public class TestClientApplicationContext {
     public void testInstanceTracking() {
         InstanceTrackingConfig trackingConfig = instanceTrackingClient.getClientConfig().getInstanceTrackingConfig();
 
-        assertFalse(trackingConfig.isEnabled());
+        assertTrue(trackingConfig.isEnabled());
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -33,6 +33,7 @@ import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConsistencyCheckStrategy;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanCustomPublisherConfig;
@@ -1434,6 +1435,15 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(42, metricsConfig.getManagementCenterConfig().getRetentionSeconds());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
         assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Test
+    public void testInstanceTrackingConfig() {
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+        assertFalse(trackingConfig.isEnabled());
+        assertEquals("/dummy/file", trackingConfig.getFileName());
+        assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
+                trackingConfig.getFormatPattern());
     }
 
     @Test

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1440,7 +1440,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     @Test
     public void testInstanceTrackingConfig() {
         InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
-        assertFalse(trackingConfig.isEnabled());
+        assertTrue(trackingConfig.isEnabled());
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -965,6 +965,11 @@
                 <hz:collection-frequency-seconds>24</hz:collection-frequency-seconds>
             </hz:metrics>
 
+            <hz:instance-tracking enabled="false">
+                <hz:file-name>/dummy/file</hz:file-name>
+                <hz:format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</hz:format-pattern>
+            </hz:instance-tracking>
+
             <hz:sql>
                 <hz:executor-pool-size>10</hz:executor-pool-size>
                 <hz:operation-pool-size>20</hz:operation-pool-size>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -965,7 +965,7 @@
                 <hz:collection-frequency-seconds>24</hz:collection-frequency-seconds>
             </hz:metrics>
 
-            <hz:instance-tracking enabled="false">
+            <hz:instance-tracking enabled="true">
                 <hz:file-name>/dummy/file</hz:file-name>
                 <hz:format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</hz:format-pattern>
             </hz:instance-tracking>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -417,7 +417,7 @@
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-        <hz:instance-tracking enabled="false">
+        <hz:instance-tracking enabled="true">
             <hz:file-name>/dummy/file</hz:file-name>
             <hz:format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</hz:format-pattern>
         </hz:instance-tracking>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -411,6 +411,18 @@
         </hz:metrics>
     </hz:client>
 
+    <hz:client id="client19-instance-tracking">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
+        <hz:network>
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+        </hz:network>
+        <hz:instance-tracking enabled="false">
+            <hz:file-name>/dummy/file</hz:file-name>
+            <hz:format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</hz:format-pattern>
+        </hz:instance-tracking>
+    </hz:client>
+
     <bean id="credentials" class="com.hazelcast.security.UsernamePasswordCredentials">
         <property name="name" value="spring-cluster"/>
         <property name="password" value="spring-cluster-pass"/>

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.config.impl.XmlClientConfigLocator;
 import com.hazelcast.client.config.impl.YamlClientConfigLocator;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigPatternMatcher;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -108,6 +109,7 @@ public class ClientConfig {
     private final Set<String> labels;
     private final ConcurrentMap<String, Object> userContext;
     private ClientMetricsConfig metricsConfig = new ClientMetricsConfig();
+    private InstanceTrackingConfig instanceTrackingConfig = new InstanceTrackingConfig();
 
     public ClientConfig() {
         listenerConfigs = new LinkedList<>();
@@ -170,6 +172,7 @@ public class ClientConfig {
         labels = new HashSet<>(config.labels);
         userContext = new ConcurrentHashMap<>(config.userContext);
         metricsConfig = new ClientMetricsConfig(config.metricsConfig);
+        instanceTrackingConfig = new InstanceTrackingConfig(config.instanceTrackingConfig);
     }
 
     /**
@@ -920,13 +923,31 @@ public class ClientConfig {
         return this;
     }
 
+    /**
+     * Returns the configuration for tracking use of this Hazelcast instance.
+     */
+    @Nonnull
+    public InstanceTrackingConfig getInstanceTrackingConfig() {
+        return instanceTrackingConfig;
+    }
+
+    /**
+     * Returns the configuration for tracking use of this Hazelcast instance.
+     */
+    @Nonnull
+    public ClientConfig setInstanceTrackingConfig(@Nonnull InstanceTrackingConfig instanceTrackingConfig) {
+        Preconditions.checkNotNull(instanceTrackingConfig, "instanceTrackingConfig");
+        this.instanceTrackingConfig = instanceTrackingConfig;
+        return this;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(backupAckToClientEnabled, classLoader, clusterName, configPatternMatcher, connectionStrategyConfig,
                 flakeIdGeneratorConfigMap, instanceName, labels, listenerConfigs, loadBalancer,
                 managedContext, metricsConfig, nativeMemoryConfig, nearCacheConfigMap, networkConfig, properties,
                 proxyFactoryConfigs, queryCacheConfigs, reliableTopicConfigMap, securityConfig, serializationConfig,
-                userCodeDeploymentConfig, userContext);
+                userCodeDeploymentConfig, userContext, instanceTrackingConfig);
     }
 
     @Override
@@ -959,7 +980,8 @@ public class ClientConfig {
                 && Objects.equals(securityConfig, other.securityConfig)
                 && Objects.equals(serializationConfig, other.serializationConfig)
                 && Objects.equals(userCodeDeploymentConfig, other.userCodeDeploymentConfig)
-                && Objects.equals(userContext, other.userContext);
+                && Objects.equals(userContext, other.userContext)
+                && Objects.equals(instanceTrackingConfig, other.instanceTrackingConfig);
     }
 
     @Override
@@ -985,6 +1007,7 @@ public class ClientConfig {
                 + ", flakeIdGeneratorConfigMap=" + flakeIdGeneratorConfigMap
                 + ", labels=" + labels
                 + ", metricsConfig=" + metricsConfig
+                + ", instanceTrackingConfig=" + instanceTrackingConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -139,6 +140,7 @@ public final class ClientConfigXmlGenerator {
         flakeIdGenerator(gen, clientConfig.getFlakeIdGeneratorConfigMap());
         //Metrics
         metrics(gen, clientConfig.getMetricsConfig());
+        instanceTrackingConfig(gen, clientConfig.getInstanceTrackingConfig());
 
         //close HazelcastClient
         gen.close();
@@ -661,6 +663,13 @@ public final class ClientConfigXmlGenerator {
            .open("jmx", "enabled", metricsConfig.getJmxConfig().isEnabled())
            .close()
            .node("collection-frequency-seconds", metricsConfig.getCollectionFrequencySeconds())
+           .close();
+    }
+
+    private static void instanceTrackingConfig(XmlGenerator gen, InstanceTrackingConfig trackingConfig) {
+        gen.open("instance-tracking", "enabled", trackingConfig.isEnabled())
+           .node("file-name", trackingConfig.getFileName())
+           .node("format-pattern", trackingConfig.getFormatPattern())
            .close();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientConfigSections.java
@@ -41,7 +41,8 @@ public enum ClientConfigSections {
     RELIABLE_TOPIC("reliable-topic", true),
     LABELS("client-labels", false),
     CLUSTER_NAME("cluster-name", false),
-    METRICS("metrics", false);
+    METRICS("metrics", false),
+    INSTANCE_TRACKING("instance-tracking", false);
 
     final boolean multipleOccurrence;
     private final String name;

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -38,7 +38,6 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MaxSizePolicy;
@@ -171,7 +170,7 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
         } else if (METRICS.isEqual(nodeName)) {
             handleMetrics(node);
         } else if (INSTANCE_TRACKING.isEqual(nodeName)) {
-            handleInstanceTracking(node);
+            handleInstanceTracking(node, clientConfig.getInstanceTrackingConfig());
         }
     }
 
@@ -718,23 +717,6 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             if ("ports".equals(nodeName)) {
                 String value = getTextContent(n);
                 clientNetworkConfig.addOutboundPortDefinition(value);
-            }
-        }
-    }
-
-    private void handleInstanceTracking(Node node) {
-        InstanceTrackingConfig trackingConfig = clientConfig.getInstanceTrackingConfig();
-
-        Node attrEnabled = node.getAttributes().getNamedItem("enabled");
-        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
-        trackingConfig.setEnabled(enabled);
-
-        for (Node n : childElements(node)) {
-            final String name = cleanNodeName(n);
-            if ("file-name".equals(name)) {
-                trackingConfig.setFileName(getTextContent(n));
-            } else if ("format-pattern".equals(name)) {
-                trackingConfig.setFormatPattern(getTextContent(n));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -38,6 +38,7 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MaxSizePolicy;
@@ -66,6 +67,7 @@ import static com.hazelcast.client.config.impl.ClientConfigSections.CLUSTER_NAME
 import static com.hazelcast.client.config.impl.ClientConfigSections.CONNECTION_STRATEGY;
 import static com.hazelcast.client.config.impl.ClientConfigSections.FLAKE_ID_GENERATOR;
 import static com.hazelcast.client.config.impl.ClientConfigSections.INSTANCE_NAME;
+import static com.hazelcast.client.config.impl.ClientConfigSections.INSTANCE_TRACKING;
 import static com.hazelcast.client.config.impl.ClientConfigSections.LABELS;
 import static com.hazelcast.client.config.impl.ClientConfigSections.LISTENERS;
 import static com.hazelcast.client.config.impl.ClientConfigSections.LOAD_BALANCER;
@@ -168,6 +170,8 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             clientConfig.setClusterName(getTextContent(node));
         } else if (METRICS.isEqual(nodeName)) {
             handleMetrics(node);
+        } else if (INSTANCE_TRACKING.isEqual(nodeName)) {
+            handleInstanceTracking(node);
         }
     }
 
@@ -714,6 +718,23 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             if ("ports".equals(nodeName)) {
                 String value = getTextContent(n);
                 clientNetworkConfig.addOutboundPortDefinition(value);
+            }
+        }
+    }
+
+    private void handleInstanceTracking(Node node) {
+        InstanceTrackingConfig trackingConfig = clientConfig.getInstanceTrackingConfig();
+
+        Node attrEnabled = node.getAttributes().getNamedItem("enabled");
+        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
+        trackingConfig.setEnabled(enabled);
+
+        for (Node n : childElements(node)) {
+            final String name = cleanNodeName(n);
+            if ("file-name".equals(name)) {
+                trackingConfig.setFileName(getTextContent(n));
+            } else if ("format-pattern".equals(name)) {
+                trackingConfig.setFormatPattern(getTextContent(n));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientExtension.java
@@ -45,6 +45,11 @@ public interface ClientExtension {
     void afterStart(HazelcastClientInstanceImpl client);
 
     /**
+     * Logs metadata about the instance to the configured instance tracking output.
+     */
+    void logInstanceTrackingMetadata();
+
+    /**
      * Creates a {@link InternalSerializationService} instance to be used by this client.
      *
      * @param version serialization version to be created. Values less than 1 will be ignored and max supported version

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -52,6 +52,7 @@ import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.ManagementCenterConfig;
@@ -988,6 +989,18 @@ public class ClientDynamicClusterConfig extends Config {
     @Override
     @Nonnull
     public MetricsConfig getMetricsConfig() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Nonnull
+    @Override
+    public Config setInstanceTrackingConfig(@Nonnull InstanceTrackingConfig instanceTrackingConfig) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Nonnull
+    @Override
+    public InstanceTrackingConfig getInstanceTrackingConfig() {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -182,6 +182,9 @@ public final class FailoverClientConfigSupport {
         if (notEqual(mainConfig.getMetricsConfig(), alternativeConfig.getMetricsConfig())) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "metricsConfig");
         }
+        if (notEqual(mainConfig.getInstanceTrackingConfig(), alternativeConfig.getInstanceTrackingConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "instanceTrackingConfig");
+        }
         if (mainConfig.isBackupAckToClientEnabled() != alternativeConfig.isBackupAckToClientEnabled()) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "isBackupAckToClientEnabled");
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -231,6 +231,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         concurrencyDetection = initConcurrencyDetection();
         clientExtension = createClientInitializer(classLoader);
         clientExtension.beforeStart(this);
+        clientExtension.logInstanceTrackingMetadata();
         lifecycleService = new LifecycleServiceImpl(this);
         metricsRegistry = initMetricsRegistry();
         serializationService = clientExtension.createSerializationService((byte) -1);

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -180,6 +180,8 @@ public class Config {
 
     private MetricsConfig metricsConfig = new MetricsConfig();
 
+    private InstanceTrackingConfig instanceTrackingConfig = new InstanceTrackingConfig();
+
     public Config() {
     }
 
@@ -2646,6 +2648,24 @@ public class Config {
     public Config setSqlConfig(@Nonnull SqlConfig sqlConfig) {
         Preconditions.checkNotNull(sqlConfig, "sqlConfig");
         this.sqlConfig = sqlConfig;
+        return this;
+    }
+
+    /**
+     * Returns the configuration for tracking use of this Hazelcast instance.
+     */
+    @Nonnull
+    public InstanceTrackingConfig getInstanceTrackingConfig() {
+        return instanceTrackingConfig;
+    }
+
+    /**
+     * Returns the configuration for tracking use of this Hazelcast instance.
+     */
+    @Nonnull
+    public Config setInstanceTrackingConfig(@Nonnull InstanceTrackingConfig instanceTrackingConfig) {
+        Preconditions.checkNotNull(instanceTrackingConfig, "instanceTrackingConfig");
+        this.instanceTrackingConfig = instanceTrackingConfig;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -166,6 +166,7 @@ public class ConfigXmlGenerator {
         splitBrainProtectionXmlGenerator(gen, config);
         cpSubsystemConfig(gen, config);
         metricsConfig(gen, config);
+        instanceTrackingConfig(gen, config);
         sqlConfig(gen, config);
         userCodeDeploymentConfig(gen, config);
 
@@ -1572,6 +1573,14 @@ public class ConfigXmlGenerator {
         }
 
         gen.close().close();
+    }
+
+    private static void instanceTrackingConfig(XmlGenerator gen, Config config) {
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+        gen.open("instance-tracking", "enabled", trackingConfig.isEnabled())
+           .node("file-name", trackingConfig.getFileName())
+           .node("format-pattern", trackingConfig.getFormatPattern())
+           .close();
     }
 
     private static void metricsConfig(XmlGenerator gen, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
@@ -109,9 +109,9 @@ public class InstanceTrackingConfig {
      * Returns the pattern used to render the contents of the instance tracking file.
      * It may contain placeholders for properties listed in the
      * {@link InstanceTrackingProperties} enum. The placeholders are defined by
-     * a $HZ_IT&#123; prefix and followed by &#125;. For instance, a placeholder for
+     * a $HZ_INSTANCE_TRACKING&#123; prefix and followed by &#125;. For instance, a placeholder for
      * the {@link InstanceTrackingProperties#START_TIMESTAMP}
-     * would be $&#123;start_timestamp&#125;.
+     * would be $HZ_INSTANCE_TRACKING&#123;start_timestamp&#125;.
      * <p>
      * The placeholders are resolved in a fail-safe manner. Any incorrect syntax
      * is ignored and only the known properties are resolved, placeholders for
@@ -133,9 +133,9 @@ public class InstanceTrackingConfig {
      * Sets the pattern used to render the contents of the instance tracking file.
      * It may contain placeholders for properties listed in the
      * {@link InstanceTrackingProperties} enum. The placeholders are defined by
-     * a $&#123; prefix and followed by &#125;. For instance, a placeholder for
+     * a $HZ_INSTANCE_TRACKING&#123; prefix and followed by &#125;. For instance, a placeholder for
      * the {@link InstanceTrackingProperties#START_TIMESTAMP}
-     * would be $&#123;start_timestamp&#125;.
+     * would be $HZ_INSTANCE_TRACKING&#123;start_timestamp&#125;.
      * <p>
      * The placeholders are resolved in a fail-safe manner. Any incorrect syntax
      * is ignored and only the known properties are resolved, placeholders for

--- a/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * Configures tracking of a running Hazelcast instance. For now, this is
+ * limited to writing information about the Hazelcast instance to a file
+ * while the instance is starting.
+ * <p>
+ * The file is overwritten on every start of the Hazelcast instance and if
+ * multiple instance share the same file system, every instance will
+ * overwrite the tracking file of a previously started instance.
+ * <p>
+ * If this instance is unable to write the file, the exception is logged and
+ * the instance is allowed to start.
+ *
+ * @since 4.1
+ */
+public class InstanceTrackingConfig {
+
+    /**
+     * Default file to which the instance metadata will be written.
+     */
+    public static final Path DEFAULT_FILE = Paths.get(System.getProperty("java.io.tmpdir"), "Hazelcast.process");
+
+    /**
+     * Namespace for the placeholders in the file name and format pattern to
+     * distinguish between different types of placeholders.
+     */
+    public static final String PLACEHOLDER_NAMESPACE = "HZ_INSTANCE_TRACKING";
+
+    private boolean enabled;
+    private String fileName;
+    private String formatPattern;
+
+    public InstanceTrackingConfig() {
+        super();
+    }
+
+    public InstanceTrackingConfig(InstanceTrackingConfig other) {
+        this.enabled = other.enabled;
+        this.fileName = other.fileName;
+        this.formatPattern = other.formatPattern;
+    }
+
+    /**
+     * Returns {@code true} if instance tracking is enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables or disables instance tracking.
+     *
+     * @param enabled {@code true} if instance tracking should be enabled
+     * @return this configuration
+     */
+    public InstanceTrackingConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns the name of the file which will contain the tracking metadata. If
+     * {@code null}, {@link InstanceTrackingConfig#DEFAULT_FILE} is used instead.
+     * <p>
+     * The filename can contain placeholders that will be resolved in the same way
+     * as placeholders for the format pattern (see {@link #setFormatPattern(String)}).
+     */
+    public String getFileName() {
+        return fileName;
+    }
+
+    /**
+     * Sets the name of the file which will contain the tracking metadata. If set
+     * to {@code null}, {@link InstanceTrackingConfig#DEFAULT_FILE} is used instead.
+     * <p>
+     * The filename can contain placeholders that will be resolved in the same way
+     * as placeholders for the format pattern (see {@link #setFormatPattern(String)}).
+     *
+     * @param fileName the name of the file to contain the tracking metadata
+     * @return this configuration
+     */
+    public InstanceTrackingConfig setFileName(String fileName) {
+        this.fileName = fileName;
+        return this;
+    }
+
+    /**
+     * Returns the pattern used to render the contents of the instance tracking file.
+     * It may contain placeholders for properties listed in the
+     * {@link InstanceTrackingProperties} enum. The placeholders are defined by
+     * a $HZ_IT&#123; prefix and followed by &#125;. For instance, a placeholder for
+     * the {@link InstanceTrackingProperties#START_TIMESTAMP}
+     * would be $&#123;start_timestamp&#125;.
+     * <p>
+     * The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+     * is ignored and only the known properties are resolved, placeholders for
+     * any parameters which do not have defined values will be ignored. This also
+     * means that if there is a missing closing bracket in one of the placeholders,
+     * the property name will be resolved as anything from the opening bracket
+     * to the next closing bracket, which might contain additional opening brackets.
+     * <p>
+     * If set to {@code null}, a JSON formatted output will be used.
+     *
+     * @return the pattern for the instance tracking file
+     * @see InstanceTrackingProperties
+     */
+    public String getFormatPattern() {
+        return formatPattern;
+    }
+
+    /**
+     * Sets the pattern used to render the contents of the instance tracking file.
+     * It may contain placeholders for properties listed in the
+     * {@link InstanceTrackingProperties} enum. The placeholders are defined by
+     * a $&#123; prefix and followed by &#125;. For instance, a placeholder for
+     * the {@link InstanceTrackingProperties#START_TIMESTAMP}
+     * would be $&#123;start_timestamp&#125;.
+     * <p>
+     * The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+     * is ignored and only the known properties are resolved, placeholders for
+     * any parameters which do not have defined values will be ignored. This also
+     * means that if there is a missing closing bracket in one of the placeholders,
+     * the property name will be resolved as anything from the opening bracket
+     * to the next closing bracket, which might contain additional opening brackets.
+     * <p>
+     * If set to {@code null}, a JSON formatted output will be used.
+     *
+     * @param formatPattern the pattern for the instance tracking file
+     * @return this configuration
+     */
+    public InstanceTrackingConfig setFormatPattern(String formatPattern) {
+        this.formatPattern = formatPattern;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InstanceTrackingConfig that = (InstanceTrackingConfig) o;
+        return enabled == that.enabled
+                && Objects.equals(fileName, that.fileName)
+                && Objects.equals(formatPattern, that.formatPattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, fileName, formatPattern);
+    }
+
+    @Override
+    public String toString() {
+        return "InstanceTrackingConfig{"
+                + "enabled=" + enabled
+                + ", fileName='" + fileName + '\''
+                + ", formatPattern='" + formatPattern + '\''
+                + '}';
+    }
+
+    /**
+     * Enumeration of instance properties provided to the format pattern for
+     * output.
+     */
+    public enum InstanceTrackingProperties {
+        /**
+         * The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+         *
+         * @see InstanceProductName
+         */
+        PRODUCT("product"),
+        /**
+         * The instance version.
+         */
+        VERSION("version"),
+        /**
+         * The instance mode, e.g. "server", "embedded" or "client".
+         *
+         * @see InstanceMode
+         */
+        MODE("mode"),
+        /**
+         * The timestamp of when the instance was started as returned by
+         * {@link System#currentTimeMillis()}.
+         */
+        START_TIMESTAMP("start_timestamp"),
+        /**
+         * If this instance is using a license or not. The value {@code 0} signifies
+         * that there is no license set and the value {@code 1} signifies that a
+         * license is in use.
+         */
+        LICENSED("licensed"),
+        /**
+         * Attempts to get the process ID value. The algorithm does not guarantee to
+         * get the process ID on all JVMs and operating systems so please test before
+         * use.
+         * In case we are unable to get the PID, the value will be {@code -1}.
+         */
+        PID("pid");
+
+        private final String propertyName;
+
+        InstanceTrackingProperties(String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        /**
+         * Returns the property name which can be used in placeholders to be resolved
+         * to an actual property value.
+         */
+        public String getPropertyName() {
+            return propertyName;
+        }
+    }
+
+    /**
+     * Product name for the Hazelcast instance
+     */
+    public enum InstanceProductName {
+        /**
+         * Hazelcast open-source
+         */
+        HAZELCAST("Hazelcast"),
+        /**
+         * Hazelcast Enterprise
+         */
+        HAZELCAST_EE("Hazelcast Enterprise"),
+        /**
+         * Hazelcast java open-source client
+         */
+        HAZELCAST_CLIENT("Hazelcast Client"),
+        /**
+         * Hazelcast java enterprise client
+         */
+        HAZELCAST_CLIENT_EE("Hazelcast Client Enterprise");
+
+        private final String productName;
+
+        InstanceProductName(String productName) {
+            this.productName = productName;
+        }
+
+        /**
+         * Returns the string representation of the instance product name
+         */
+        public String getProductName() {
+            return productName;
+        }
+    }
+
+    /**
+     * The mode in which this instance is running.
+     */
+    public enum InstanceMode {
+        /**
+         * This instance was started using the {@code start.sh} or {@code start.bat}
+         * scripts.
+         */
+        SERVER("server"),
+        /**
+         * This instance is a Hazelcast client instance.
+         */
+        CLIENT("client"),
+        /**
+         * This instance is embedded in another Java program.
+         */
+        EMBEDDED("embedded");
+
+        private final String modeName;
+
+        InstanceMode(String modeName) {
+            this.modeName = modeName;
+        }
+
+        /**
+         * Returns the string representation of the instance mode name.
+         */
+        public String getModeName() {
+            return modeName;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/server/HazelcastMemberStarter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/server/HazelcastMemberStarter.java
@@ -43,6 +43,7 @@ public final class HazelcastMemberStarter {
      * @param args none
      */
     public static void main(String[] args) throws FileNotFoundException, UnsupportedEncodingException {
+        System.setProperty("hazelcast.tracking.server", "true");
         HazelcastInstance hz = Hazelcast.newHazelcastInstance();
         printMemberPort(hz);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -246,6 +246,7 @@ public class Node {
 
             nodeExtension.printNodeInfo();
             nodeExtension.beforeStart();
+            nodeExtension.logInstanceTrackingMetadata();
 
             serializationService = nodeExtension.createSerializationService();
             securityContext = config.getSecurityConfig().isEnabled() ? nodeExtension.getSecurityContext() : null;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
@@ -34,9 +34,9 @@ import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.server.ServerContext;
-import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.server.ServerConnection;
+import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.util.ByteArrayProcessor;
 import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.security.SecurityContext;
@@ -63,6 +63,11 @@ public interface NodeExtension {
      * Called to print node information during startup
      */
     void printNodeInfo();
+
+    /**
+     * Logs metadata about the instance to the configured instance tracking output.
+     */
+    void logInstanceTrackingMetadata();
 
     /**
      * Called before node attempts to join to the cluster

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.GlobalSerializerConfig;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -307,5 +308,20 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
             }
         }
         return moduleConfig;
+    }
+
+    protected void handleInstanceTracking(Node node, InstanceTrackingConfig trackingConfig) {
+        Node attrEnabled = node.getAttributes().getNamedItem("enabled");
+        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
+        trackingConfig.setEnabled(enabled);
+
+        for (Node n : childElements(node)) {
+            final String name = cleanNodeName(n);
+            if ("file-name".equals(name)) {
+                trackingConfig.setFileName(getTextContent(n));
+            } else if ("format-pattern".equals(name)) {
+                trackingConfig.setFormatPattern(getTextContent(n));
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigSections.java
@@ -62,6 +62,7 @@ public enum ConfigSections {
     ADVANCED_NETWORK("advanced-network", false),
     CP_SUBSYSTEM("cp-subsystem", false),
     METRICS("metrics", false),
+    INSTANCE_TRACKING("instance-tracking", false),
     SQL("sql", false);
 
     final boolean multipleOccurrence;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -45,6 +45,7 @@ import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.IcmpFailureDetectorConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ItemListenerConfig;
@@ -172,6 +173,7 @@ import static com.hazelcast.internal.config.ConfigSections.FLAKE_ID_GENERATOR;
 import static com.hazelcast.internal.config.ConfigSections.HOT_RESTART_PERSISTENCE;
 import static com.hazelcast.internal.config.ConfigSections.IMPORT;
 import static com.hazelcast.internal.config.ConfigSections.INSTANCE_NAME;
+import static com.hazelcast.internal.config.ConfigSections.INSTANCE_TRACKING;
 import static com.hazelcast.internal.config.ConfigSections.LICENSE_KEY;
 import static com.hazelcast.internal.config.ConfigSections.LIST;
 import static com.hazelcast.internal.config.ConfigSections.LISTENERS;
@@ -337,6 +339,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             handleCPSubsystem(node);
         } else if (METRICS.isEqual(nodeName)) {
             handleMetrics(node);
+        } else if (INSTANCE_TRACKING.isEqual(nodeName)) {
+            handleInstanceTracking(node);
         } else if (SQL.isEqual(nodeName)) {
             handleSql(node);
         } else {
@@ -2923,6 +2927,23 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             if ("enabled".equals(att.getNodeName())) {
                 boolean enabled = getBooleanValue(getAttribute(node, "enabled"));
                 jmxConfig.setEnabled(enabled);
+            }
+        }
+    }
+
+    private void handleInstanceTracking(Node node) {
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+
+        Node attrEnabled = node.getAttributes().getNamedItem("enabled");
+        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
+        trackingConfig.setEnabled(enabled);
+
+        for (Node n : childElements(node)) {
+            final String name = cleanNodeName(n);
+            if ("file-name".equals(name)) {
+                trackingConfig.setFileName(getTextContent(n));
+            } else if ("format-pattern".equals(name)) {
+                trackingConfig.setFormatPattern(getTextContent(n));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -45,7 +45,6 @@ import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.IcmpFailureDetectorConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
-import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ItemListenerConfig;
@@ -340,7 +339,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         } else if (METRICS.isEqual(nodeName)) {
             handleMetrics(node);
         } else if (INSTANCE_TRACKING.isEqual(nodeName)) {
-            handleInstanceTracking(node);
+            handleInstanceTracking(node, config.getInstanceTrackingConfig());
         } else if (SQL.isEqual(nodeName)) {
             handleSql(node);
         } else {
@@ -2927,23 +2926,6 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             if ("enabled".equals(att.getNodeName())) {
                 boolean enabled = getBooleanValue(getAttribute(node, "enabled"));
                 jmxConfig.setEnabled(enabled);
-            }
-        }
-    }
-
-    private void handleInstanceTracking(Node node) {
-        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
-
-        Node attrEnabled = node.getAttributes().getNamedItem("enabled");
-        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
-        trackingConfig.setEnabled(enabled);
-
-        for (Node n : childElements(node)) {
-            final String name = cleanNodeName(n);
-            if ("file-name".equals(name)) {
-                trackingConfig.setFileName(getTextContent(n));
-            } else if ("format-pattern".equals(name)) {
-                trackingConfig.setFormatPattern(getTextContent(n));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
@@ -1086,6 +1087,18 @@ public class DynamicConfigurationAwareConfig extends Config {
     @Nonnull
     @Override
     public Config setMetricsConfig(@Nonnull MetricsConfig metricsConfig) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Nonnull
+    @Override
+    public InstanceTrackingConfig getInstanceTrackingConfig() {
+        return staticConfig.getInstanceTrackingConfig();
+    }
+
+    @Nonnull
+    @Override
+    public Config setInstanceTrackingConfig(@Nonnull InstanceTrackingConfig instanceTrackingConfig) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InstanceTrackingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InstanceTrackingUtil.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.config.InstanceTrackingConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.logging.ILogger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static com.hazelcast.internal.util.StringUtil.resolvePlaceholders;
+
+/**
+ * Helper class for instance tracking.
+ *
+ * @see InstanceTrackingConfig
+ */
+public final class InstanceTrackingUtil {
+
+
+    private InstanceTrackingUtil() {
+    }
+
+    /**
+     * Writes the instance tracking metadata to a file provided by the
+     * {@code fileName}. Both the file name and the format pattern may contain
+     * placeholders for values provided by {@code placeholderValues}. If the
+     * {@code fileName} is {@code null}, the {@link InstanceTrackingConfig#DEFAULT_FILE}
+     * is used instead.
+     * If the {@code formatPattern} is {@code null}, a JSON formatted output is
+     * used instead.
+     *
+     * @param fileName          the file name to which to write to
+     * @param formatPattern     the pattern for the contents of the tracking file
+     * @param placeholderValues the values for the placeholders
+     * @param logger            a logger for information on instance tracking file write progress
+     */
+    public static void writeInstanceTrackingFile(@Nullable String fileName,
+                                                 @Nullable String formatPattern,
+                                                 @Nonnull Map<String, Object> placeholderValues,
+                                                 @Nonnull ILogger logger) {
+        try {
+            String trackingFileContents = getInstanceTrackingContent(formatPattern, placeholderValues);
+            Path file = getInstanceTrackingFilePath(fileName, placeholderValues);
+            logger.fine("Writing instance tracking information to " + file);
+            Files.write(file, trackingFileContents.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            logger.warning("Failed to write instance tracking information", e);
+        }
+    }
+
+    /**
+     * Returns the path to the instance tracking file with resolved placeholders
+     * in the file name.
+     */
+    private static Path getInstanceTrackingFilePath(String fileName, Map<String, Object> trackingFileProperties) {
+        if (fileName == null) {
+            return InstanceTrackingConfig.DEFAULT_FILE;
+        }
+        return Paths.get(resolvePlaceholders(fileName, InstanceTrackingConfig.PLACEHOLDER_NAMESPACE, trackingFileProperties));
+    }
+
+    /**
+     * Returns the string containing instance tracking metadata with resolved
+     * placeholders for supported properties.
+     *
+     * @param formatPattern  the pattern which should be used to format the string
+     * @param propertyValues property values which will be used to resolve the placeholders
+     * @return the string containing instance tracking metadata
+     * @see com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties
+     */
+    private static String getInstanceTrackingContent(String formatPattern, Map<String, Object> propertyValues) {
+        if (formatPattern == null) {
+            JsonObject jsonObject = new JsonObject();
+            propertyValues.forEach((prop, value) -> {
+                if (value instanceof Boolean) {
+                    jsonObject.add(prop, (boolean) value);
+                } else if (value instanceof Integer) {
+                    jsonObject.add(prop, (int) value);
+                } else if (value instanceof Long) {
+                    jsonObject.add(prop, (long) value);
+                } else {
+                    jsonObject.add(prop, value.toString());
+                }
+            });
+            return jsonObject.toString();
+        } else {
+            return resolvePlaceholders(formatPattern, InstanceTrackingConfig.PLACEHOLDER_NAMESPACE, propertyValues);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
@@ -68,6 +68,28 @@ public final class JVMUtil {
     }
 
     /**
+     * Returns the process ID. The algorithm does not guarantee it will be able
+     * to get the correct process ID, in which case it returns {@code -1}.
+     */
+    public static long getPid() {
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+
+        if (name == null) {
+            return -1;
+        }
+        int separatorIndex = name.indexOf("@");
+        if (separatorIndex < 0) {
+            return -1;
+        }
+        String potentialPid = name.substring(0, separatorIndex);
+        try {
+            return Long.parseLong(potentialPid);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /**
      * Returns used memory as reported by the {@link Runtime} and the function (totalMemory - freeMemory)
      * It attempts to correct atomicity issues (ie. when totalMemory expands) and reported usedMemory
      * results in negative values

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -398,5 +399,50 @@ public final class StringUtil {
             return str.substring(0, str.length() - 1);
         }
         return str;
+    }
+
+    /**
+     * Returns a string where named placeholders are replaced by values from the
+     * given {@code variableValues} map. The placeholder is defined as the
+     * variable name prefixed by ${@code placeholderNamespace}&#123; and followed
+     * by &#125;. For example, if the {@code placeholderNamespace} is {@code HZ_TEST}
+     * the placeholder for "instance_name" would be $HZ_TEST&#123;instance_name&#125;.
+     * <p>
+     * The variable replacement is fail-safe which means any incorrect syntax such
+     * as missing closing brackets or missing variable values is ignored.
+     *
+     * @param pattern              the pattern in which placeholders should be replaced
+     * @param placeholderNamespace the string inserted into the placeholder prefix to distinguish between
+     *                             different types of placeholders
+     * @param variableValues       the placeholder variable values
+     * @return the formatted string
+     */
+    public static String resolvePlaceholders(String pattern,
+                                             String placeholderNamespace,
+                                             Map<String, Object> variableValues) {
+        StringBuilder sb = new StringBuilder(pattern);
+        String placeholderPrefix = "$" + placeholderNamespace + "{";
+        int endIndex;
+        int startIndex = sb.indexOf(placeholderPrefix);
+
+        while (startIndex > -1) {
+            endIndex = sb.indexOf("}", startIndex);
+            if (endIndex == -1) {
+                // ignore bad syntax, search finished
+                break;
+            }
+
+            String variableName = sb.substring(startIndex + placeholderPrefix.length(), endIndex);
+            Object variableValue = variableValues.get(variableName);
+            // ignore missing values
+            if (variableValue != null) {
+                String valueStr = variableValue.toString();
+                sb.replace(startIndex, endIndex + 1, valueStr);
+                endIndex = startIndex + valueStr.length();
+            }
+
+            startIndex = sb.indexOf(placeholderPrefix, endIndex);
+        }
+        return sb.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -69,141 +69,32 @@ public final class ActionConstants {
     public static final String LISTENER_MEMBER = "member";
     public static final String LISTENER_MIGRATION = "migration";
 
-    private static final Map<String, PermissionFactory> PERMISSION_FACTORY_MAP = new HashMap<String, PermissionFactory>();
+    private static final Map<String, PermissionFactory> PERMISSION_FACTORY_MAP = new HashMap<>();
 
     static {
-        PERMISSION_FACTORY_MAP.put(QueueService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new QueuePermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(MapService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new MapPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(MultiMapService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new MultiMapPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(ListService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new ListPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(SetService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new SetPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(AtomicLongService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new AtomicLongPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(CountDownLatchService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new CountDownLatchPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(SemaphoreService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new SemaphorePermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(TopicService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new TopicPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(LockSupportService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new LockPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(LockService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new LockPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(DistributedExecutorService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new ExecutorServicePermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(FlakeIdGeneratorService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new FlakeIdGeneratorPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(ReplicatedMapService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new ReplicatedMapPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(AtomicRefService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new AtomicReferencePermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(CacheService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new CachePermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(RingbufferService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new RingBufferPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(DistributedDurableExecutorService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new DurableExecutorServicePermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(CardinalityEstimatorService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new CardinalityEstimatorPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(UserCodeDeploymentService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new UserCodeDeploymentPermission(actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(PNCounterService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new PNCounterPermission(name, actions);
-            }
-        });
-        PERMISSION_FACTORY_MAP.put(ReliableTopicService.SERVICE_NAME, new PermissionFactory() {
-            @Override
-            public Permission create(String name, String... actions) {
-                return new ReliableTopicPermission(name, actions);
-            }
-        });
+        PERMISSION_FACTORY_MAP.put(QueueService.SERVICE_NAME, QueuePermission::new);
+        PERMISSION_FACTORY_MAP.put(MapService.SERVICE_NAME, MapPermission::new);
+        PERMISSION_FACTORY_MAP.put(MultiMapService.SERVICE_NAME, MultiMapPermission::new);
+        PERMISSION_FACTORY_MAP.put(ListService.SERVICE_NAME, ListPermission::new);
+        PERMISSION_FACTORY_MAP.put(SetService.SERVICE_NAME, SetPermission::new);
+        PERMISSION_FACTORY_MAP.put(AtomicLongService.SERVICE_NAME, AtomicLongPermission::new);
+        PERMISSION_FACTORY_MAP.put(CountDownLatchService.SERVICE_NAME, CountDownLatchPermission::new);
+        PERMISSION_FACTORY_MAP.put(SemaphoreService.SERVICE_NAME, SemaphorePermission::new);
+        PERMISSION_FACTORY_MAP.put(TopicService.SERVICE_NAME, TopicPermission::new);
+        PERMISSION_FACTORY_MAP.put(LockSupportService.SERVICE_NAME, LockPermission::new);
+        PERMISSION_FACTORY_MAP.put(LockService.SERVICE_NAME, LockPermission::new);
+        PERMISSION_FACTORY_MAP.put(DistributedExecutorService.SERVICE_NAME, ExecutorServicePermission::new);
+        PERMISSION_FACTORY_MAP.put(FlakeIdGeneratorService.SERVICE_NAME, FlakeIdGeneratorPermission::new);
+        PERMISSION_FACTORY_MAP.put(ReplicatedMapService.SERVICE_NAME, ReplicatedMapPermission::new);
+        PERMISSION_FACTORY_MAP.put(AtomicRefService.SERVICE_NAME, AtomicReferencePermission::new);
+        PERMISSION_FACTORY_MAP.put(CacheService.SERVICE_NAME, CachePermission::new);
+        PERMISSION_FACTORY_MAP.put(RingbufferService.SERVICE_NAME, RingBufferPermission::new);
+        PERMISSION_FACTORY_MAP.put(DistributedDurableExecutorService.SERVICE_NAME, DurableExecutorServicePermission::new);
+        PERMISSION_FACTORY_MAP.put(CardinalityEstimatorService.SERVICE_NAME, CardinalityEstimatorPermission::new);
+        PERMISSION_FACTORY_MAP.put(UserCodeDeploymentService.SERVICE_NAME,
+                (name, actions) -> new UserCodeDeploymentPermission(actions));
+        PERMISSION_FACTORY_MAP.put(PNCounterService.SERVICE_NAME, PNCounterPermission::new);
+        PERMISSION_FACTORY_MAP.put(ReliableTopicService.SERVICE_NAME, ReliableTopicPermission::new);
     }
 
     private ActionConstants() {

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -47,6 +47,7 @@
                 <xs:element name="reliable-topic" type="reliable-topic" minOccurs="0"
                             maxOccurs="unbounded"/>
                 <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -926,4 +927,66 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:complexType name="instance-tracking">
+        <xs:annotation>
+            <xs:documentation>
+                Configures tracking of a running Hazelcast instance. For now, this is
+                limited to writing information about the Hazelcast instance to a file
+                while the instance is starting.
+                The file is overwritten on every start of the Hazelcast instance and if
+                multiple instance share the same file system, every instance will
+                overwrite the tracking file of a previously started instance.
+                If this instance is unable to write the file, the exception is logged and
+                the instance is allowed to start.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="file-name" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the name of the file which will contain the tracking metadata. If left unset
+                        a file named "Hazelcast.process" will be created in the directory as returned by
+                        System.getProperty("java.io.tmpdir").
+                        The filename can contain placeholders that will be resolved in the same way
+                        as placeholders for the format pattern.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="format-pattern" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the pattern used to render the contents of the instance tracking file.
+                        It may contain placeholders for these properties:
+                        - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+                        - "version": The instance version.
+                        - "mode": The instance mode which can be "server", "embedded" or "client".
+                        - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+                        measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+                        - "licensed": If this instance is using a license or not. The value 0 signifies
+                        that there is no license set and the value 1 signifies that a license is in use.
+                        - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+                        process ID on all JVMs and operating systems so please test before use. In case we are unable to
+                        get the PID, the value will be -1.
+
+                        The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }.
+                        For instance, a placeholder for the "start_timestamp" would be $HZ_INSTANCE_TRACKING{start_timestamp}.
+                        The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+                        is ignored and only the known properties are resolved, placeholders for
+                        any parameters which do not have defined values will be ignored. This also
+                        means that if there is a missing closing bracket in one of the placeholders,
+                        the property name will be resolved as anything from the opening bracket
+                        to the next closing bracket, which might contain additional opening brackets.
+                        If unset, a JSON formatted output will be used.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enables or disables instance tracking.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -949,7 +949,8 @@
 
   -->
     <instance-tracking enabled="false">
-
+        <file-name>hazelcast.process</file-name>
+        <format-pattern>$HZ_INSTANCE_TRACKING{product}:$HZ_INSTANCE_TRACKING{version}</format-pattern>
     </instance-tracking>
 
 </hazelcast-client>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -908,4 +908,48 @@
         <collection-frequency-seconds>42</collection-frequency-seconds>
     </metrics>
 
+    <!--
+      ===== HAZELCAST INSTANCE TRACKING CONFIGURATION =====
+
+      Configuration element's name is <instance-tracking>.
+
+      It has the following attributes:
+      - enabled:
+          Enables or disables instance tracking.
+
+      It has the following sub-elements:
+      * <format-pattern>:
+          Sets the pattern used to render the contents of the instance tracking file.
+          It may contain placeholders for these properties:
+          - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+          - "version": The instance version.
+          - "mode": The instance mode which can be "server", "embedded" or "client".
+          - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+          measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+          - "licensed": If this instance is using a license or not. The value 0 signifies
+          that there is no license set and the value 1 signifies that a license is in use.
+          - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+          process ID on all JVMs and operating systems so please test before use. In case we are unable to
+          get the PID, the value will be -1.
+          The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }. For instance,
+          a placeholder for the "start_timestamp" would be $HZ_INSTANCE_TRACKING{start_timestamp}.
+          The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+          is ignored and only the known properties are resolved, placeholders for
+          any parameters which do not have defined values will be ignored. This also
+          means that if there is a missing closing bracket in one of the placeholders,
+          the property name will be resolved as anything from the opening bracket
+          to the next closing bracket, which might contain additional opening brackets.
+          If unset, a JSON formatted output will be used.
+      * <file-name>:
+          Sets the name of the file which will contain the tracking metadata. If left unset
+          a file named "Hazelcast.process" will be created in the directory as returned by
+          System.getProperty("java.io.tmpdir").
+          The filename can contain placeholders that will be resolved in the same way
+          as placeholders for the format pattern.
+
+  -->
+    <instance-tracking enabled="false">
+
+    </instance-tracking>
+
 </hazelcast-client>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -906,3 +906,5 @@ hazelcast-client:
   #
   instance-tracking:
     enabled: false
+    file-name: hazelcast.process
+    format-pattern: $HZ_INSTANCE_TRACKING{product}:$HZ_INSTANCE_TRACKING{version}

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -864,3 +864,45 @@ hazelcast-client:
     jmx:
       enabled: false
     collection-frequency-seconds: 42
+
+  #
+  # ===== HAZELCAST INSTANCE TRACKING CONFIGURATION =====
+  #
+  # Configuration element's name is "instance-tracking".
+  #
+  # It has the following sub-elements:
+  #     * "enabled":
+  #         Enables or disables instance tracking.
+  #
+  # * "format-pattern":
+  #     Sets the pattern used to render the contents of the instance tracking file.
+  #     It may contain placeholders for these properties:
+  #     - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+  #     - "version": The instance version.
+  #     - "mode": The instance mode which can be "server", "embedded" or "client".
+  #     - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+  #     measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+  #     - "licensed": If this instance is using a license or not. The value 0 signifies
+  #     that there is no license set and the value 1 signifies that a license is in use.
+  #     - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+  #     process ID on all JVMs and operating systems so please test before use. In case we are unable to
+  #     get the PID, the value will be -1.
+  #     The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }.
+  #     For instance, a placeholder for the "start_timestamp" would be $HZ_INSTANCE_TRACKING{start_timestamp}.
+  #     The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+  #     is ignored and only the known properties are resolved, placeholders for
+  #     any parameters which do not have defined values will be ignored. This also
+  #     means that if there is a missing closing bracket in one of the placeholders,
+  #     the property name will be resolved as anything from the opening bracket
+  #     to the next closing bracket, which might contain additional opening brackets.
+  #     If unset, a JSON formatted output will be used.
+  #
+  # * "file-name":
+  #     Sets the name of the file which will contain the tracking metadata. If left unset
+  #     a file named "Hazelcast.process" will be created in the directory as returned by
+  #     System.getProperty("java.io.tmpdir").
+  #     The filename can contain placeholders that will be resolved in the same way
+  #     as placeholders for the format pattern.
+  #
+  instance-tracking:
+    enabled: false

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -71,6 +71,7 @@
                 <xs:element name="advanced-network" type="advanced-network" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="cp-subsystem" type="cp-subsystem" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="metrics" type="metrics" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="sql" type="sql" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
@@ -4811,6 +4812,70 @@
                     to be enabled via the enabled master-switch attribute.
                     May be overridden by 'hazelcast.metrics.jmx.enabled'
                     system property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="instance-tracking">
+        <xs:annotation>
+            <xs:documentation>
+                Configures tracking of a running Hazelcast instance. For now, this is
+                limited to writing information about the Hazelcast instance to a file
+                while the instance is starting.
+                The file is overwritten on every start of the Hazelcast instance and if
+                multiple instance share the same file system, every instance will
+                overwrite the tracking file of a previously started instance.
+                If this instance is unable to write the file, the exception is logged and
+                the instance is allowed to start.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="file-name" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the name of the file which will contain the tracking metadata. If left unset
+                        a file named "Hazelcast.process" will be created in the directory as returned by
+                        System.getProperty("java.io.tmpdir").
+                        The filename can contain placeholders that will be resolved in the same way
+                        as placeholders for the format pattern.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="format-pattern" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the pattern used to render the contents of the instance tracking file.
+                        It may contain placeholders for these properties:
+                        - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+                        - "version": The instance version.
+                        - "mode": The instance mode which can be "server", "embedded" or "client".
+                        - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+                        measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+                        - "licensed": If this instance is using a license or not. The value 0 signifies
+                        that there is no license set and the value 1 signifies that a license is in use.
+                        - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+                        process ID on all JVMs and operating systems so please test before use. In case we are unable to
+                        get the PID, the value will be -1.
+
+                        The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }.
+                        For instance, a placeholder for the "start_timestamp" would be
+                        $HZ_INSTANCE_TRACKING{start_timestamp}.
+                        The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+                        is ignored and only the known properties are resolved, placeholders for
+                        any parameters which do not have defined values will be ignored. This also
+                        means that if there is a missing closing bracket in one of the placeholders,
+                        the property name will be resolved as anything from the opening bracket
+                        to the next closing bracket, which might contain additional opening brackets.
+                        If unset, a JSON formatted output will be used.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enables or disables instance tracking.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -321,6 +321,10 @@
         <collection-frequency-seconds>5</collection-frequency-seconds>
     </metrics>
 
+    <instance-tracking enabled="false">
+
+    </instance-tracking>
+
     <sql>
         <executor-pool-size>-1</executor-pool-size>
         <operation-pool-size>-1</operation-pool-size>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -324,6 +324,12 @@ hazelcast:
       enabled: true
     collection-frequency-seconds: 5
 
+  instance-tracking:
+    enabled: false
+
+  instance-config:
+    enabled: false
+
   sql:
     executor-pool-size: -1
     operation-pool-size: -1

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -327,9 +327,6 @@ hazelcast:
   instance-tracking:
     enabled: false
 
-  instance-config:
-    enabled: false
-
   sql:
     executor-pool-size: -1
     operation-pool-size: -1

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3443,6 +3443,50 @@
     </metrics>
 
     <!--
+      ===== HAZELCAST INSTANCE TRACKING CONFIGURATION =====
+
+      Configuration element's name is <instance-tracking>.
+
+      It has the following attributes:
+      - enabled:
+          Enables or disables instance tracking.
+
+      It has the following sub-elements:
+      * <format-pattern>:
+          Sets the pattern used to render the contents of the instance tracking file.
+          It may contain placeholders for these properties:
+          - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+          - "version": The instance version.
+          - "mode": The instance mode which can be "server", "embedded" or "client".
+          - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+          measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+          - "licensed": If this instance is using a license or not. The value 0 signifies
+          that there is no license set and the value 1 signifies that a license is in use.
+          - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+          process ID on all JVMs and operating systems so please test before use. In case we are unable to
+          get the PID, the value will be -1.
+          The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }.
+          For instance, a placeholder for the "start_timestamp" would be $HZ_INSTANCE_TRACKING{start_timestamp}.
+          The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+          is ignored and only the known properties are resolved, placeholders for
+          any parameters which do not have defined values will be ignored. This also
+          means that if there is a missing closing bracket in one of the placeholders,
+          the property name will be resolved as anything from the opening bracket
+          to the next closing bracket, which might contain additional opening brackets.
+          If unset, a JSON formatted output will be used.
+      * <file-name>:
+          Sets the name of the file which will contain the tracking metadata. If left unset
+          a file named "Hazelcast.process" will be created in the directory as returned by
+          System.getProperty("java.io.tmpdir").
+          The filename can contain placeholders that will be resolved in the same way
+          as placeholders for the format pattern.
+
+  -->
+    <instance-tracking enabled="false">
+
+    </instance-tracking>
+
+    <!--
         ===== HAZELCAST SQL CONFIGURATION =====
 
         Configuration element's name is <sql>.

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3483,7 +3483,8 @@
 
   -->
     <instance-tracking enabled="false">
-
+        <file-name>hazelcast.process</file-name>
+        <format-pattern>$HZ_INSTANCE_TRACKING{product}:$HZ_INSTANCE_TRACKING{version}</format-pattern>
     </instance-tracking>
 
     <!--

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3333,6 +3333,48 @@ hazelcast:
     collection-frequency-seconds: 10
 
   #
+  # ===== HAZELCAST INSTANCE TRACKING CONFIGURATION =====
+  #
+  # Configuration element's name is "instance-tracking".
+  #
+  # It has the following sub-elements:
+  #     * "enabled":
+  #         Enables or disables instance tracking.
+  #
+  # * "format-pattern":
+  #     Sets the pattern used to render the contents of the instance tracking file.
+  #     It may contain placeholders for these properties:
+  #     - "product": The instance product name, e.g. "Hazelcast" or "Hazelcast Enterprise".
+  #     - "version": The instance version.
+  #     - "mode": The instance mode which can be "server", "embedded" or "client".
+  #     - "start_timestamp": The timestamp of when the instance was started expressed the difference,
+  #     measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+  #     - "licensed": If this instance is using a license or not. The value 0 signifies
+  #     that there is no license set and the value 1 signifies that a license is in use.
+  #     - "pid": Attempts to get the process ID value. The algorithm does not guarantee to get the
+  #     process ID on all JVMs and operating systems so please test before use. In case we are unable to
+  #     get the PID, the value will be -1.
+  #     The placeholders are defined by a $HZ_INSTANCE_TRACKING{ prefix and followed by }.
+  #     For instance, a placeholder for the "start_timestamp" would be $HZ_INSTANCE_TRACKING{start_timestamp}.
+  #     The placeholders are resolved in a fail-safe manner. Any incorrect syntax
+  #     is ignored and only the known properties are resolved, placeholders for
+  #     any parameters which do not have defined values will be ignored. This also
+  #     means that if there is a missing closing bracket in one of the placeholders,
+  #     the property name will be resolved as anything from the opening bracket
+  #     to the next closing bracket, which might contain additional opening brackets.
+  #     If unset, a JSON formatted output will be used.
+  #
+  # * "file-name":
+  #     Sets the name of the file which will contain the tracking metadata. If left unset
+  #     a file named "Hazelcast.process" will be created in the directory as returned by
+  #     System.getProperty("java.io.tmpdir").
+  #     The filename can contain placeholders that will be resolved in the same way
+  #     as placeholders for the format pattern.
+  #
+  instance-tracking:
+    enabled: false
+
+  #
   # ===== HAZELCAST SQL CONFIGURATION =====
   #
   # Configuration element's name is "sql".

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3373,6 +3373,8 @@ hazelcast:
   #
   instance-tracking:
     enabled: false
+    file-name: hazelcast.process
+    format-pattern: $HZ_INSTANCE_TRACKING{product}:$HZ_INSTANCE_TRACKING{version}
 
   #
   # ===== HAZELCAST SQL CONFIGURATION =====

--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -40,6 +40,6 @@ ECHO # JAVA_OPTS=%JAVA_OPTS%
 ECHO # starting now...."
 ECHO ########################################
 
-start "hazelcast-imdg" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" "com.hazelcast.core.server.HazelcastMemberStarter"
+start "hazelcast-imdg" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" -Dhazelcast.tracking.server=true "com.hazelcast.core.server.HazelcastMemberStarter"
 
 ENDLOCAL

--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -40,6 +40,6 @@ ECHO # JAVA_OPTS=%JAVA_OPTS%
 ECHO # starting now...."
 ECHO ########################################
 
-start "hazelcast-imdg" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" -Dhazelcast.tracking.server=true "com.hazelcast.core.server.HazelcastMemberStarter"
+start "hazelcast-imdg" "%RUN_JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" "com.hazelcast.core.server.HazelcastMemberStarter"
 
 ENDLOCAL

--- a/hazelcast/src/main/resources/start.sh
+++ b/hazelcast/src/main/resources/start.sh
@@ -47,4 +47,4 @@ echo "# JAVA_OPTS=$JAVA_OPTS"
 echo "# starting now...."
 echo "########################################"
 
-"$RUN_JAVA" -server $JAVA_OPTS com.hazelcast.core.server.HazelcastMemberStarter
+"$RUN_JAVA" -server $JAVA_OPTS -Dhazelcast.tracking.server=true com.hazelcast.core.server.HazelcastMemberStarter

--- a/hazelcast/src/main/resources/start.sh
+++ b/hazelcast/src/main/resources/start.sh
@@ -47,4 +47,4 @@ echo "# JAVA_OPTS=$JAVA_OPTS"
 echo "# starting now...."
 echo "########################################"
 
-"$RUN_JAVA" -server $JAVA_OPTS -Dhazelcast.tracking.server=true com.hazelcast.core.server.HazelcastMemberStarter
+"$RUN_JAVA" -server $JAVA_OPTS com.hazelcast.core.server.HazelcastMemberStarter

--- a/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
@@ -62,13 +62,14 @@ public class FailoverConfigTest {
                 "setConnectionStrategyConfig", "getUserCodeDeploymentConfig", "setUserCodeDeploymentConfig",
                 "getOrCreateQueryCacheConfig", "getOrNullQueryCacheConfig", "addLabel", "setLabels",
                 "setUserContext", "getUserContext", "setMetricsConfig", "load",
-                "setBackupAckToClientEnabled", "isBackupAckToClientEnabled", "getMetricsConfig", "equals", "hashCode", "toString");
+                "setBackupAckToClientEnabled", "isBackupAckToClientEnabled", "getMetricsConfig", "equals", "hashCode", "toString",
+                "setInstanceTrackingConfig", "getInstanceTrackingConfig");
         Method[] declaredMethods = ClientConfig.class.getDeclaredMethods();
         for (Method method : declaredMethods) {
             String methodName = method.getName();
             if (!methodName.startsWith("$") && !allClientConfigMethods.contains(methodName)) {
                 throw new IllegalStateException("There is a new method on client config. " + methodName
-                        + "Handle it on FailoverClientConfigSupport first, and add it to  allClientConfigMethods set above.");
+                        + ". Handle it on FailoverClientConfigSupport first, and add it to  allClientConfigMethods set above.");
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -478,6 +478,9 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     public abstract void testMetricsConfig();
 
     @Test
+    public abstract void testInstanceTrackingConfig();
+
+    @Test
     public abstract void testMetricsConfigMasterSwitchDisabled();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -654,7 +654,7 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
     @Test
     public void testInstanceTrackingConfig() {
         clientConfig.getInstanceTrackingConfig()
-                    .setEnabled(false)
+                    .setEnabled(true)
                     .setFileName("/dummy/file")
                     .setFormatPattern("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}");
 

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -29,8 +29,10 @@ import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType;
 import com.hazelcast.config.NearCacheConfig;
@@ -41,7 +43,6 @@ import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
-import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.RealmConfig;
@@ -648,6 +649,20 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         assertEquals(originalConfig.isEnabled(), generatedConfig.isEnabled());
         assertEquals(originalConfig.getJmxConfig().isEnabled(), generatedConfig.getJmxConfig().isEnabled());
         assertEquals(originalConfig.getCollectionFrequencySeconds(), generatedConfig.getCollectionFrequencySeconds());
+    }
+
+    @Test
+    public void testInstanceTrackingConfig() {
+        clientConfig.getInstanceTrackingConfig()
+                    .setEnabled(false)
+                    .setFileName("/dummy/file")
+                    .setFormatPattern("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}");
+
+        InstanceTrackingConfig originalConfig = clientConfig.getInstanceTrackingConfig();
+        InstanceTrackingConfig generatedConfig = newConfigViaGenerator().getInstanceTrackingConfig();
+        assertEquals(originalConfig.isEnabled(), generatedConfig.isEnabled());
+        assertEquals(originalConfig.getFileName(), generatedConfig.getFileName());
+        assertEquals(originalConfig.getFormatPattern(), generatedConfig.getFormatPattern());
     }
 
     private ClientConfig newConfigViaGenerator() {

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -423,14 +423,14 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     @Override
     public void testInstanceTrackingConfig() {
         String xml = HAZELCAST_CLIENT_START_TAG
-                + "<instance-tracking enabled=\"false\">"
+                + "<instance-tracking enabled=\"true\">"
                 + "  <file-name>/dummy/file</file-name>"
                 + "  <format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</format-pattern>"
                 + "</instance-tracking>"
                 + HAZELCAST_CLIENT_END_TAG;
         ClientConfig config = buildConfig(xml);
         InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
-        assertFalse(trackingConfig.isEnabled());
+        assertTrue(trackingConfig.isEnabled());
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.XMLConfigBuilderTest;
@@ -417,6 +418,22 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         assertFalse(metricsConfig.isEnabled());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
         assertEquals(10, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Override
+    public void testInstanceTrackingConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<instance-tracking enabled=\"false\">"
+                + "  <file-name>/dummy/file</file-name>"
+                + "  <format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</format-pattern>"
+                + "</instance-tracking>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig config = buildConfig(xml);
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+        assertFalse(trackingConfig.isEnabled());
+        assertEquals("/dummy/file", trackingConfig.getFileName());
+        assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
+                trackingConfig.getFormatPattern());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.YamlConfigBuilderTest;
@@ -422,6 +423,22 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         assertFalse(metricsConfig.isEnabled());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
         assertEquals(10, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Override
+    public void testInstanceTrackingConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  instance-tracking:\n"
+                + "    enabled: false\n"
+                + "    file-name: /dummy/file\n"
+                + "    format-pattern: dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}";
+        ClientConfig config = buildConfig(yaml);
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+        assertFalse(trackingConfig.isEnabled());
+        assertEquals("/dummy/file", trackingConfig.getFileName());
+        assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
+                trackingConfig.getFormatPattern());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -430,12 +430,12 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         String yaml = ""
                 + "hazelcast-client:\n"
                 + "  instance-tracking:\n"
-                + "    enabled: false\n"
+                + "    enabled: true\n"
                 + "    file-name: /dummy/file\n"
                 + "    format-pattern: dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}";
         ClientConfig config = buildConfig(yaml);
         InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
-        assertFalse(trackingConfig.isEnabled());
+        assertTrue(trackingConfig.isEnabled());
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -529,6 +529,8 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
 
     public abstract void testMetricsConfig();
 
+    public abstract void testInstanceTrackingConfig();
+
     public abstract void testMetricsConfigMasterSwitchDisabled();
 
     public abstract void testMetricsConfigMcDisabled();

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -129,6 +129,12 @@ public class ConfigCompatibilityChecker {
         checkCompatibleConfigs("cp subsystem", c1, c2, singletonMap("", c1.getCPSubsystemConfig()),
                 singletonMap("", c2.getCPSubsystemConfig()), new CPSubsystemConfigChecker());
 
+        checkCompatibleConfigs("metrics", c1.getMetricsConfig(), c2.getMetricsConfig(), new MetricsConfigChecker());
+        checkCompatibleConfigs("sql", c1.getSqlConfig(), c2.getSqlConfig(), new SqlConfigChecker());
+
+        checkCompatibleConfigs("instance-tracking", c1.getInstanceTrackingConfig(), c2.getInstanceTrackingConfig(),
+                new InstanceTrackingConfigChecker());
+
         return true;
     }
 
@@ -772,6 +778,51 @@ public class ConfigCompatibilityChecker {
         @Override
         MetricsConfig getDefault(Config c) {
             return c.getMetricsConfig();
+        }
+    }
+
+    public static class SqlConfigChecker extends ConfigChecker<SqlConfig> {
+
+        @Override
+        boolean check(SqlConfig c1, SqlConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+
+            return c1.getExecutorPoolSize() == c2.getExecutorPoolSize()
+                    && c1.getOperationPoolSize() == c2.getOperationPoolSize()
+                    && c1.getOperationPoolSize() == c2.getOperationPoolSize()
+                    && c1.getQueryTimeoutMillis() == c2.getQueryTimeoutMillis();
+        }
+
+        @Override
+        SqlConfig getDefault(Config c) {
+            return c.getSqlConfig();
+        }
+    }
+
+    public static class InstanceTrackingConfigChecker extends ConfigChecker<InstanceTrackingConfig> {
+
+        @Override
+        boolean check(InstanceTrackingConfig c1, InstanceTrackingConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+
+            return c1.isEnabled() == c2.isEnabled()
+                    && nullSafeEqual(c1.getFileName(), c2.getFileName())
+                    && nullSafeEqual(c1.getFormatPattern(), c2.getFormatPattern());
+        }
+
+        @Override
+        InstanceTrackingConfig getDefault(Config c) {
+            return c.getInstanceTrackingConfig();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -794,7 +794,6 @@ public class ConfigCompatibilityChecker {
 
             return c1.getExecutorPoolSize() == c2.getExecutorPoolSize()
                     && c1.getOperationPoolSize() == c2.getOperationPoolSize()
-                    && c1.getOperationPoolSize() == c2.getOperationPoolSize()
                     && c1.getQueryTimeoutMillis() == c2.getQueryTimeoutMillis();
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.ConfigCompatibilityChecker.CPSubsystemConfigChecker;
+import com.hazelcast.config.ConfigCompatibilityChecker.InstanceTrackingConfigChecker;
 import com.hazelcast.config.ConfigCompatibilityChecker.MetricsConfigChecker;
 import com.hazelcast.config.ConfigCompatibilityChecker.SplitBrainProtectionConfigChecker;
 import com.hazelcast.config.cp.CPSubsystemConfig;
@@ -982,11 +983,11 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
     @Test
     public void testRingbufferWithStoreFactoryImplementation() {
         RingbufferStoreConfig ringbufferStoreConfig = new RingbufferStoreConfig()
-            .setEnabled(true)
-            .setFactoryImplementation(new TestRingbufferStoreFactory())
-            .setProperty("p1", "v1")
-            .setProperty("p2", "v2")
-            .setProperty("p3", "v3");
+                .setEnabled(true)
+                .setFactoryImplementation(new TestRingbufferStoreFactory())
+                .setProperty("p1", "v1")
+                .setProperty("p2", "v2")
+                .setProperty("p3", "v3");
 
         testRingbuffer(ringbufferStoreConfig);
     }
@@ -1794,6 +1795,20 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         MetricsConfig generatedConfig = getNewConfigViaXMLGenerator(config).getMetricsConfig();
         assertTrue(generatedConfig + " should be compatible with " + config.getMetricsConfig(),
                 new MetricsConfigChecker().check(config.getMetricsConfig(), generatedConfig));
+    }
+
+    @Test
+    public void testInstanceTrackingConfig() {
+        Config config = new Config();
+
+        config.getInstanceTrackingConfig()
+              .setEnabled(false)
+              .setFileName("/dummy/file")
+              .setFormatPattern("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}");
+
+        InstanceTrackingConfig generatedConfig = getNewConfigViaXMLGenerator(config).getInstanceTrackingConfig();
+        assertTrue(generatedConfig + " should be compatible with " + config.getInstanceTrackingConfig(),
+                new InstanceTrackingConfigChecker().check(config.getInstanceTrackingConfig(), generatedConfig));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1802,7 +1802,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         Config config = new Config();
 
         config.getInstanceTrackingConfig()
-              .setEnabled(false)
+              .setEnabled(true)
               .setFileName("/dummy/file")
               .setFormatPattern("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}");
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3438,6 +3438,23 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testInstanceTrackingConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "<instance-tracking enabled=\"false\">"
+                + "  <file-name>/dummy/file</file-name>"
+                + "  <format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</format-pattern>"
+                + "</instance-tracking>"
+                + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+        assertFalse(trackingConfig.isEnabled());
+        assertEquals("/dummy/file", trackingConfig.getFileName());
+        assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
+                trackingConfig.getFormatPattern());
+    }
+
+    @Override
+    @Test
     public void testMetricsConfigMasterSwitchDisabled() {
         String xml = HAZELCAST_START_TAG
                 + "<metrics enabled=\"false\"/>"

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3440,14 +3440,14 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testInstanceTrackingConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<instance-tracking enabled=\"false\">"
+                + "<instance-tracking enabled=\"true\">"
                 + "  <file-name>/dummy/file</file-name>"
                 + "  <format-pattern>dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}</format-pattern>"
                 + "</instance-tracking>"
                 + HAZELCAST_END_TAG;
         Config config = new InMemoryXmlConfig(xml);
         InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
-        assertFalse(trackingConfig.isEnabled());
+        assertTrue(trackingConfig.isEnabled());
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3464,12 +3464,12 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         String yaml = ""
                 + "hazelcast:\n"
                 + "  instance-tracking:\n"
-                + "    enabled: false\n"
+                + "    enabled: true\n"
                 + "    file-name: /dummy/file\n"
                 + "    format-pattern: dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}";
         Config config = new InMemoryYamlConfig(yaml);
         InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
-        assertFalse(trackingConfig.isEnabled());
+        assertTrue(trackingConfig.isEnabled());
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3460,6 +3460,23 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testInstanceTrackingConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  instance-tracking:\n"
+                + "    enabled: false\n"
+                + "    file-name: /dummy/file\n"
+                + "    format-pattern: dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}";
+        Config config = new InMemoryYamlConfig(yaml);
+        InstanceTrackingConfig trackingConfig = config.getInstanceTrackingConfig();
+        assertFalse(trackingConfig.isEnabled());
+        assertEquals("/dummy/file", trackingConfig.getFileName());
+        assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
+                trackingConfig.getFormatPattern());
+    }
+
+    @Override
+    @Test
     public void testMetricsConfigMasterSwitchDisabled() {
         String yaml = ""
                 + "hazelcast:\n"

--- a/hazelcast/src/test/java/com/hazelcast/instance/InstanceTrackingInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/InstanceTrackingInfoTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.function.Consumer;
+
+import static com.hazelcast.internal.util.StringUtil.bytesToString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class InstanceTrackingInfoTest extends HazelcastTestSupport {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testJsonFormat() throws IOException {
+        assertTrackingFileContents(null, content -> {
+            JsonObject json = Json.parse(content).asObject();
+            assertEquals("embedded", json.getString("mode", ""));
+            assertEquals("Hazelcast", json.getString("product", ""));
+            assertEquals(0, json.getInt("licensed", -1));
+        });
+    }
+
+    @Test
+    public void testCustomFormat() throws IOException {
+        String format = "mode: $HZ_INSTANCE_TRACKING{mode}\n"
+                + "product: $HZ_INSTANCE_TRACKING{product}\n"
+                + "licensed: $HZ_INSTANCE_TRACKING{licensed}\n"
+                + "missing:$HZ_INSTANCE_TRACKING{missing}\n"
+                + "broken: $HZ_INSTANCE_TRACKING{broken ";
+        String expected = "mode: embedded\n"
+                + "product: Hazelcast\n"
+                + "licensed: 0\n"
+                + "missing:$HZ_INSTANCE_TRACKING{missing}\n"
+                + "broken: $HZ_INSTANCE_TRACKING{broken ";
+        assertTrackingFileContents(format, content -> assertEquals(expected, content));
+    }
+
+    @Test
+    public void testBrokenFormat() throws IOException {
+        String format = "broken: $HZ_INSTANCE_TRACKING{broken \n mode: $HZ_INSTANCE_TRACKING{mode}";
+        String expected = "broken: $HZ_INSTANCE_TRACKING{broken \n mode: $HZ_INSTANCE_TRACKING{mode}";
+        assertTrackingFileContents(format, content -> assertEquals(expected, content));
+    }
+
+    @Test
+    public void testCustomFileName() throws IOException {
+        Config config = new Config();
+        File tmpDir = tempFolder.newFolder();
+        File trackingFile = new File(tmpDir,
+                "hz-$HZ_INSTANCE_TRACKING{mode}-$HZ_INSTANCE_TRACKING{pid}-$HZ_INSTANCE_TRACKING{start_timestamp}.process");
+        config.getInstanceTrackingConfig()
+              .setEnabled(true)
+              .setFileName(trackingFile.getAbsolutePath())
+              .setFormatPattern("dummy");
+
+        createHazelcastInstance(config);
+
+        File[] files = tmpDir.listFiles((dir, name) -> name.startsWith("hz-embedded-"));
+        assertNotNull(files);
+        assertEquals(1, files.length);
+        assertEquals("dummy", bytesToString(Files.readAllBytes(files[0].toPath())));
+    }
+
+    // test hazelcast.tracking.server
+
+    private void assertTrackingFileContents(String pattern, Consumer<String> contentAssertion) throws IOException {
+        Config config = new Config();
+        File tempFile = tempFolder.newFile();
+        config.getInstanceTrackingConfig()
+              .setEnabled(true)
+              .setFileName(tempFile.getAbsolutePath())
+              .setFormatPattern(pattern);
+
+        createHazelcastInstance(config);
+
+        String actualContents = new String(Files.readAllBytes(tempFile.toPath()), StandardCharsets.UTF_8);
+        contentAssertion.accept(actualContents);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -84,6 +84,11 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void logInstanceTrackingMetadata() {
+        nodeExtension.logInstanceTrackingMetadata();
+    }
+
+    @Override
     public void beforeJoin() {
         nodeExtension.beforeJoin();
     }

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -327,4 +327,8 @@
         <collection-frequency-seconds>42</collection-frequency-seconds>
     </metrics>
 
+    <instance-tracking enabled="false">
+
+    </instance-tracking>
+
 </hazelcast-client>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -307,3 +307,6 @@ hazelcast-client:
     jmx:
       enabled: false
     collection-frequency-seconds: 42
+
+  instance-tracking:
+    enabled: false

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -974,6 +974,10 @@
         <collection-frequency-seconds>24</collection-frequency-seconds>
     </metrics>
 
+    <instance-tracking enabled="false">
+
+    </instance-tracking>
+
     <sql>
         <executor-pool-size>16</executor-pool-size>
         <operation-pool-size>8</operation-pool-size>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -919,6 +919,9 @@ hazelcast:
       enabled: false
     collection-frequency-seconds: 24
 
+  instance-tracking:
+    enabled: false
+
   sql:
     executor-pool-size: 16
     operation-pool-size: 8


### PR DESCRIPTION
Adds instance tracking which is basically a file created at node startup
which contains some metadata about the instance such as version, product
name, PID etc.

The file name and the file contents are configurable and may
contain placeholders. The placeholders have a prefix to be able to
distinguish between a placeholder for the instance tracking feature as
opposed to some other placeholder like XML placeholders. We use the same
style as the EncryptionReplacer by adding a "namespace" to the
placeholder prefix. For example, $HZ_INSTANCE_TRACKING{start_timestamp}.

The feature supports both OS and EE members and clients, is disabled by
default and uses a JVM argument to distinguish if the instance was
started using start.sh/bat or inside another application by invoking
Hazelcast.newHazelcastInstance().

The file overwrites any existing file with the same name. Placeholders
in the file name can be used to create a new file each time. Failing to
write the file will only generate a warning and the instance is allowed
to start.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3677

Leftover:
• jet integration
• more tests?

Some additional information for the reviewers:
• PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/2179432512/Tracking+Hazelcast+Usage
• the name "instance tracking" is the best I could come up with but I'm open to other suggestions
• there were some alternatives for the prefix `HZ_INSTANCE_TRACKING` like `IT` or `HZ-IT` or `HZ.IT` or `HZ_IT`. These were rejected because of various reasons. Although much longer, the one in this PR is most clear when seen for the first time and it's prepended by `HZ` to indicate that it's a Hazelcast feature. I'm open to other suggestions
• as opposed to the note on the PRD, this PR also supports OS. I don't see this as a problem.
• adding new configuration is hell.