### PR TITLE
Handle the null result of ManagementFactory.getPlatformMBeanServer in JmxPublisher#shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -247,6 +247,9 @@ public class JmxPublisher implements MetricsPublisher {
     @Override
     public void shutdown() {
         isShutdown = true;
+        if (platformMBeanServer == null) {
+            return;
+        }
         try {
             // unregister the MBeans registered by this JmxPublisher
             // the mBeans map can't be used since it is not thread-safe


### PR DESCRIPTION
Better safe than sorry. Applicable to GraalVM. 

Related: https://github.com/hazelcast/quarkus-hazelcast-client/issues/66