### PR TITLE
Resolved performance problem with PagingPredicate JDK8

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -30,8 +30,8 @@ import com.hazelcast.internal.util.SortingUtil;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -62,7 +62,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeN
  */
 public class QueryResult implements Result<QueryResult>, Iterable<QueryResultRow> {
 
-    private List rows = new LinkedList();
+    private List rows = new ArrayList();
 
     private PartitionIdSet partitionIds;
     private IterationType iterationType;


### PR DESCRIPTION
There is a very severe performance issue with JDK 8 in combination with
the paging predicate. This is caused by SubList.sort. This issue is resolved
with JDK9 but we need to fix the issue for a large number of people using 
JDK 8

The problem is fixed by switching from LinkedList to ArrayList in the
QueryResult. Benchmarks are included in the ticket

fix #17207