### PR TITLE
Reduce put garbage when using InMemoryFormat OBJECT (#17206)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -65,10 +65,27 @@ public interface MapEventPublisher {
      * @param eventType the event type
      * @param dataKey   the key of the event map entry
      * @param oldValue  the old value of the map entry
-     * @param dataValue the new value of the map entry
+     * @param newValue  the new value of the map entry
      */
     void publishEvent(Address caller, String mapName,
-                      EntryEventType eventType, Data dataKey, Object oldValue, Object dataValue);
+                      EntryEventType eventType, Data dataKey, Object oldValue, Object newValue);
+
+    /**
+     * Publish an event to the event subsystem.
+     * Note: Exceptions during publications are caught and logged.
+     *
+     * @param caller    the address of the caller that caused the event
+     * @param mapName   the map name
+     * @param eventType the event type
+     * @param dataKey   the key of the event map entry
+     * @param oldValue  the old value of the map entry
+     * @param newValue  the new value of the map entry
+     * @param newDataValue the new value of the map entry, possibly encoded as
+     *                     {@link Data} to reduce re-serialization costs
+     */
+    void publishEvent(Address caller, String mapName,
+                      EntryEventType eventType, Data dataKey, Object oldValue, Object newValue,
+                      Object newDataValue);
 
     /**
      * Publish an event to the event subsystem. This method
@@ -81,13 +98,16 @@ public interface MapEventPublisher {
      * @param eventType        the event type
      * @param dataKey          the key of the event map entry
      * @param oldValue         the old value of the map entry
-     * @param dataValue        the new value of the map entry
+     * @param newValue         the new value of the map entry
+     * @param newDataValue     the new value of the map entry, possibly encoded as
+     *                         {@link Data} to reduce re-serialization costs
      * @param dataMergingValue the value used when performing a merge
      *                         operation in case of a {@link EntryEventType#MERGED} event.
      *                         This value together with the old value produced the new value.
      */
     void publishEvent(Address caller, String mapName, EntryEventType eventType,
-                      Data dataKey, Object oldValue, Object dataValue, Object dataMergingValue);
+                      Data dataKey, Object oldValue, Object newValue, Object newDataValue,
+                      Object dataMergingValue);
 
     void publishMapPartitionLostEvent(Address caller, String mapName, int partitionId);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -17,8 +17,8 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
@@ -37,13 +37,13 @@ public abstract class BasePutOperation
 
     @Override
     protected void afterRunInternal() {
-        Object value = isPostProcessing(recordStore)
-                ? recordStore.getRecord(dataKey).getValue() : dataValue;
+        Object newValue = getValueForFiltering();
+        Object newDataValue = getDataValueForPublishing();
         mapServiceContext.interceptAfterPut(mapContainer.getInterceptorRegistry(), dataValue);
         mapEventPublisher.publishEvent(getCallerAddress(), name, getEventType(),
-                dataKey, oldValue, value);
+                dataKey, oldValue, newValue, newDataValue);
         invalidateNearCache(dataKey);
-        publishWanUpdate(dataKey, value);
+        publishWanUpdate(dataKey, newDataValue);
         evict(dataKey);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -17,9 +17,9 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
 import java.io.IOException;
@@ -61,6 +61,22 @@ public abstract class KeyBasedMapOperation extends MapOperation
 
     public final Data getValue() {
         return dataValue;
+    }
+
+    protected final Object getValueForFiltering() {
+        if (isObjectInMemoryFormat() || isPostProcessing(recordStore)) {
+            return recordStore.getRecord(dataKey).getValue();
+        } else {
+            return dataValue;
+        }
+    }
+
+    protected final Object getDataValueForPublishing() {
+        if (isPostProcessing(recordStore)) {
+            return recordStore.getRecord(dataKey).getValue();
+        } else {
+            return dataValue;
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
@@ -222,6 +223,10 @@ public abstract class MapOperation extends AbstractNamedOperation
     @Override
     public String getServiceName() {
         return MapService.SERVICE_NAME;
+    }
+
+    protected boolean isObjectInMemoryFormat() {
+        return mapContainer.getMapConfig().getInMemoryFormat() == OBJECT;
     }
 
     public boolean isPostProcessing(RecordStore recordStore) {


### PR DESCRIPTION
When we use InMemoryFormat OBJECT event publishing in
BasePutOperation still publishes serialized data.  This is
inefficient when we have predicates as it causes extra
de-serialization and garbage creation.

Add and use a helper function to get the object from the data
record when we know we have InMemoryFormat OBJECT.