### PR TITLE
Use hazelcast-hibernate53 instead hazelcast-hibernate in hazelcast-all

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -171,8 +171,8 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-hibernate5</artifactId>
-            <version>2.0.0</version>
+            <artifactId>hazelcast-hibernate53</artifactId>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
`hazelcast-hibernate5` can be used only with Hibernate 5.0.x and 5.1.x which are quite old.