### PR TITLE
[Backport] Resolved performance problem with PagingPredicate JDK8

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -61,7 +60,7 @@ import java.util.Map;
  */
 public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializable, Iterable<QueryResultRow> {
 
-    private List rows = new LinkedList();
+    private List rows = new ArrayList();
 
     private Collection<Integer> partitionIds;
     private IterationType iterationType;


### PR DESCRIPTION
There is a very severe performance issue with JDK 8 in combination with
the paging predicate. This is caused by SubList.sort.

The problem is fixed by switching from LinkedList to ArrayList in the
QueryResult. Benchmarks are included in the ticket

fix #17207