### PR TITLE
MemberHandshake Options

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SendMemberHandshakeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SendMemberHandshakeTask.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.internal.cluster.impl.MemberHandshake.OPTION_PLANE_COUNT;
+import static com.hazelcast.internal.cluster.impl.MemberHandshake.OPTION_PLANE_INDEX;
 import static com.hazelcast.internal.cluster.impl.MemberHandshake.SCHEMA_VERSION_2;
 
 public class SendMemberHandshakeTask implements Runnable {
@@ -70,9 +72,9 @@ public class SendMemberHandshakeTask implements Runnable {
                 getConfiguredLocalAddresses(),
                 remoteAddress,
                 reply,
-                serverContext.getUuid(),
-                planeIndex,
-                planeCount);
+                serverContext.getUuid())
+                .addOption(OPTION_PLANE_COUNT, planeCount)
+                .addOption(OPTION_PLANE_INDEX, planeIndex);
         byte[] bytes = serverContext.getSerializationService().toBytes(memberHandshake);
         Packet packet = new Packet(bytes).setPacketType(Packet.Type.MEMBER_HANDSHAKE);
         connection.write(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
@@ -210,7 +210,7 @@ public class MemberHandshakeHandlerTest {
     }
 
     private Packet bindMessage() {
-        MemberHandshake handshake = new MemberHandshake(SCHEMA_VERSION_2, localAddresses, new Address(CLIENT_SOCKET_ADDRESS), reply, uuid, 0, 1);
+        MemberHandshake handshake = new MemberHandshake(SCHEMA_VERSION_2, localAddresses, new Address(CLIENT_SOCKET_ADDRESS), reply, uuid);
 
         Packet packet = new Packet(serializationService.toBytes(handshake));
         TcpServerConnection connection = new TcpServerConnection(connectionManager, mock(ConnectionLifecycleListener.class), 1, channel);


### PR DESCRIPTION
A options map has been added to the MemberHandshake. This way we can easily
add extra handshake options without changing the member handshake protocol.

The options are always of type string/string; it is up to the code that uses the option
to do the appropriate conversion.

If a memberhandshake of version 1 is received, the options will be empty.