### PR TITLE
Fix compile problems due to bump version on test dependencies

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientMetricsConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientMetricsConfigTest.java
@@ -36,7 +36,6 @@ public class ClientMetricsConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(ClientMetricsConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -42,7 +42,6 @@ public class EvictionConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(EvictionConfig.class)
-                .allFieldsShouldBeUsedExcept("sizeConfigured")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .withPrefabValues(EvictionConfig.class,
                         new EvictionConfig().setSize(1000).setMaxSizePolicy(ENTRY_COUNT).setEvictionPolicy(LFU),

--- a/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
@@ -35,7 +35,6 @@ public class GlobalSerializerConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(GlobalSerializerConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
@@ -35,7 +35,6 @@ public class HotRestartConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(HotRestartConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
@@ -35,7 +35,6 @@ public class HotRestartPersistenceConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(HotRestartPersistenceConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
@@ -35,7 +35,6 @@ public class IcmpFailureDetectorConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(IcmpFailureDetectorConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
@@ -35,7 +35,6 @@ public class InterfacesConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(InterfacesConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ManagementCenterConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ManagementCenterConfigTest.java
@@ -67,7 +67,6 @@ public class ManagementCenterConfigTest extends HazelcastTestSupport {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(ManagementCenterConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
@@ -35,7 +35,6 @@ public class MemberGroupConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MemberGroupConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MerkleTreeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MerkleTreeConfigTest.java
@@ -35,7 +35,6 @@ public class MerkleTreeConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MerkleTreeConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MetricsConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MetricsConfigTest.java
@@ -36,7 +36,6 @@ public class MetricsConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MetricsConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MetricsJmxConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MetricsJmxConfigTest.java
@@ -36,7 +36,6 @@ public class MetricsJmxConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MetricsJmxConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MetricsManagementCenterConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MetricsManagementCenterConfigTest.java
@@ -36,7 +36,6 @@ public class MetricsManagementCenterConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MetricsManagementCenterConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
@@ -35,7 +35,6 @@ public class MulticastConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MulticastConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
@@ -35,7 +35,6 @@ public class NativeMemoryConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(NativeMemoryConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
@@ -35,7 +35,6 @@ public class PartitionGroupConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(PartitionGroupConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -232,7 +232,6 @@ public class ReliableTopicConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(ReliableTopicConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
@@ -38,7 +38,6 @@ public class ReplicatedMapConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(ReplicatedMapConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .withPrefabValues(MergePolicyConfig.class,
                         new MergePolicyConfig(PutIfAbsentMergePolicy.class.getName(), 100),

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
@@ -324,7 +324,6 @@ public class RingbufferConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(RingbufferConfig.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
                       .withPrefabValues(RingbufferStoreConfigReadOnly.class,
                               new RingbufferStoreConfigReadOnly(new RingbufferStoreConfig().setClassName("red")),

--- a/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
@@ -35,7 +35,6 @@ public class SerializerConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(SerializerConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
@@ -57,7 +57,6 @@ public class ServiceConfigTest extends HazelcastTestSupport {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(ServiceConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
@@ -35,7 +35,6 @@ public class ServicesConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(ServicesConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
@@ -35,7 +35,6 @@ public class SocketInterceptorConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(SocketInterceptorConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
@@ -35,7 +35,6 @@ public class TcpIpConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(TcpIpConfig.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
@@ -114,7 +114,6 @@ public class TopicConfigTest {
                 .withPrefabValues(TopicConfigReadOnly.class,
                         new TopicConfigReadOnly(new TopicConfig("Topic1")),
                         new TopicConfigReadOnly(new TopicConfig("Topic2")))
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/ClientBwListEntryDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/ClientBwListEntryDTOTest.java
@@ -32,7 +32,6 @@ public class ClientBwListEntryDTOTest {
     @Test
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(ClientBwListEntryDTO.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/MCEventDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/MCEventDTOTest.java
@@ -32,7 +32,6 @@ public class MCEventDTOTest {
     @Test
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(MCEventDTO.class)
-                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NULL_FIELDS)
                       .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/MemorySizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/MemorySizeTest.java
@@ -36,7 +36,6 @@ public class MemorySizeTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(MemorySize.class)
-                .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
@@ -28,7 +28,6 @@ import org.ops4j.pax.exam.options.CompositeOption;
 import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
 import org.ops4j.pax.exam.util.PathUtils;
-import org.ops4j.pax.url.maven.commons.MavenConstants;
 import org.ops4j.pax.url.mvn.ServiceConstants;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -40,6 +39,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.url.mvn.ServiceConstants.PROPERTY_REPOSITORIES;
 
 @RunWith(PaxExamTestRunner.class)
 @Category(QuickTest.class)
@@ -49,7 +49,7 @@ public class HazelcastOSGiIntegrationTest {
     @Inject
     private BundleContext bundleContext;
 
-    private static final String MAVEN_REPOSITORIES_PROP = ServiceConstants.PID + MavenConstants.PROPERTY_REPOSITORIES;
+    private static final String MAVEN_REPOSITORIES_PROP = ServiceConstants.PID + PROPERTY_REPOSITORIES;
     private static final String MAVEN_REPOSITORIES = "https://osgi.sonatype.org/content/groups/pax-runner@id=paxrunner,"
             + "https://repo1.maven.org/maven2@id=central";
     private String oldMavenRepoProperty;

--- a/hazelcast/src/test/java/com/hazelcast/query/TruePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/TruePredicateTest.java
@@ -34,7 +34,6 @@ public class TruePredicateTest {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(TruePredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
@@ -90,7 +90,6 @@ public class FalsePredicateTest extends HazelcastTestSupport {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(FalsePredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
-            .allFieldsShouldBeUsed()
             .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenPredicateTest.java
@@ -76,7 +76,6 @@ public class BetweenPredicateTest {
         EqualsVerifier.forClass(BetweenPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EqualPredicateTest.java
@@ -85,7 +85,6 @@ public class EqualPredicateTest {
         EqualsVerifier.forClass(EqualPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/GreaterLessPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/GreaterLessPredicateTest.java
@@ -182,7 +182,6 @@ public class GreaterLessPredicateTest {
         EqualsVerifier.forClass(GreaterLessPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/InPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/InPredicateTest.java
@@ -76,7 +76,6 @@ public class InPredicateTest {
         EqualsVerifier.forClass(InPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/InstanceOfPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/InstanceOfPredicateTest.java
@@ -33,7 +33,6 @@ public class InstanceOfPredicateTest {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(InstanceOfPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/LikePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/LikePredicateTest.java
@@ -80,7 +80,6 @@ public class LikePredicateTest {
         EqualsVerifier.forClass(LikePredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
@@ -107,7 +107,6 @@ public class NotEqualPredicateTest {
         EqualsVerifier.forClass(NotEqualPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
@@ -118,7 +118,6 @@ public class NotPredicateTest {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(NotPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrPredicateTest.java
@@ -75,7 +75,6 @@ public class OrPredicateTest {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(OrPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
-            .allFieldsShouldBeUsed()
             .verify();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/RegexPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/RegexPredicateTest.java
@@ -34,7 +34,6 @@ public class RegexPredicateTest {
         EqualsVerifier.forClass(RegexPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
-            .allFieldsShouldBeUsed()
             .verify();
     }
 


### PR DESCRIPTION
On in `EqualsVerifier`, allFieldsShouldBeUsed is removed. The doc
says it is the default behaviour.
https://jqno.nl/equalsverifier/migration1to2/

The second fix is about org.ops4j.pax.url . The PROPERTY_REPOSITORIES
is moved from `org.ops4j.pax.url.maven.commons.MavenConstants`
to org.ops4j.pax.url.mvn.ServiceConstants