### PR TITLE
Reverted dependency upgrades

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -38,7 +38,7 @@
         <servlet.api.version>3.0.1</servlet.api.version>
 
         <pax.exam.version>2.6.0</pax.exam.version>
-        <pax.runner.version>1.9.0</pax.runner.version>
+        <pax.runner.version>1.8.6</pax.runner.version>
         <javax.inject.version>1</javax.inject.version>
     </properties>
 
@@ -430,7 +430,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.19</version>
+            <version>2.1.8</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1248,7 +1248,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.4.1</version>
+            <version>1.7.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
equals verifier
pax-runner-no-jcl
groovy

Reverting:
https://github.com/hazelcast/hazelcast/pull/17232
https://github.com/hazelcast/hazelcast/pull/17233
https://github.com/hazelcast/hazelcast/pull/17235

The version bumper doesn't trigger the build. So you can't rely on the 'green status' of these PRs.