### PR TITLE
Reduce initial log messages

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -148,8 +148,11 @@ class DefaultAddressPicker
         int port = serverSocketChannel.socket().getLocalPort();
         bindAddress = createAddress(bindAddressDef, port);
 
-        logger.info("Picked " + bindAddress + (endpointQualifier == null ? "" : ", for endpoint " + endpointQualifier)
-                + ", using socket " + serverSocketChannel.socket() + ", bind any local is " + bindAny);
+        if (logger.isFineEnabled()) {
+            logger.fine("Picked " + bindAddress + (endpointQualifier == null ? "" : ", for endpoint " + endpointQualifier)
+                  + ", using socket " + serverSocketChannel.socket() + ", bind any local is " + bindAny);
+        }
+
         return getPublicAddress(port);
     }
 
@@ -183,7 +186,11 @@ class DefaultAddressPicker
         if (interfaces.contains(new InterfaceDefinition("127.0.0.1"))) {
             return pickLoopbackAddress(null);
         }
-        logger.info("Prefer IPv4 stack is " + preferIPv4Stack() + ", prefer IPv6 addresses is " + preferIPv6Addresses());
+
+        if (logger.isFineEnabled()) {
+            logger.fine("Prefer IPv4 stack is " + preferIPv4Stack() + ", prefer IPv6 addresses is " + preferIPv6Addresses());
+        }
+
         if (interfaces.size() > 0) {
             AddressDefinition addressDef = pickMatchingAddress(interfaces);
             if (addressDef != null) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -235,7 +235,6 @@ public class DefaultNodeExtension implements NodeExtension {
     private void printNodeInfoInternal(BuildInfo buildInfo, String build) {
         systemLogger.info(getEditionString() + " " + buildInfo.getVersion()
                 + " (" + build + ") starting at " + node.getThisAddress());
-        systemLogger.info("Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.");
         systemLogger.fine("Configured Hazelcast Serialization version: " + buildInfo.getSerializationVersion());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -820,14 +820,14 @@ public class Node {
         join.verify();
 
         if (shouldUseMulticastJoiner(join)) {
-            logger.info("Creating MulticastJoiner");
+            logger.info("Using Multicast discovery");
             return new MulticastJoiner(this);
         } else if (join.getTcpIpConfig().isEnabled()) {
-            logger.info("Creating TcpIpJoiner");
+            logger.info("Using TCP/IP discovery");
             return new TcpIpJoiner(this);
         } else if (properties.getBoolean(DISCOVERY_SPI_ENABLED) || isAnyAliasedConfigEnabled(join)
                 || join.isAutoDetectionEnabled()) {
-            logger.info("Activating Discovery SPI Joiner");
+            logger.info("Using Discovery SPI");
             return new DiscoveryJoiner(this, discoveryService, usePublicAddress(join));
         }
         return null;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -514,8 +514,10 @@ public final class OperationExecutorImpl implements OperationExecutor, StaticMet
 
     @Override
     public void start() {
-        logger.info("Starting " + partitionThreads.length + " partition threads and "
-                + genericThreads.length + " generic threads (" + priorityThreadCount + " dedicated for priority tasks)");
+        if (logger.isFineEnabled()) {
+            logger.fine("Starting " + partitionThreads.length + " partition threads and "
+                  + genericThreads.length + " generic threads (" + priorityThreadCount + " dedicated for priority tasks)");
+        }
         startAll(partitionThreads);
         startAll(genericThreads);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
@@ -100,7 +100,9 @@ class BackpressureRegulator {
                                 OPERATION_BACKUP_TIMEOUT_MILLIS.getName()));
             }
         } else {
-            logger.info("Backpressure is disabled");
+            if (logger.isFineEnabled()) {
+                logger.fine("Backpressure is disabled");
+            }
         }
     }
 


### PR DESCRIPTION
Hazelcast prints a lot of information during startup. It becomes very messy, especially if you're a new developer trying it out. You tend to look at the messages and this might actually scare you. 

This PRs moves the unnecessary log messages to FINE level. 