### PR TITLE
Cleaned up MemberHandshake logic.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -89,7 +89,6 @@ public final class Packet extends HeapData implements OutboundFrame {
      */
     public static final int FLAG_OP_CONTROL = 1 << 6;
 
-
     // 3.b Jet packet flags
 
     /**
@@ -303,11 +302,11 @@ public final class Packet extends HeapData implements OutboundFrame {
             }
         },
         /**
-         * The type of a Bind Message packet.
+         * TcpServer specific control messages.
          * <p>
          * {@code ordinal = 4}
          */
-        MEMBER_HANDSHAKE,
+        SERVER_CONTROL,
         /**
          * The type of an SQL packet.
          * <p>

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/AbstractChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/AbstractChannelInitializer.java
@@ -16,36 +16,16 @@
 
 package com.hazelcast.internal.server.tcp;
 
-import com.hazelcast.cluster.Address;
 import com.hazelcast.config.EndpointConfig;
-import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.instance.ProtocolType;
-import com.hazelcast.internal.cluster.impl.MemberHandshake;
 import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.nio.ConnectionType;
-import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.ServerContext;
-import com.hazelcast.logging.ILogger;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-
-import static com.hazelcast.spi.properties.ClusterProperty.BIND_SPOOFING_CHECKS;
-import static com.hazelcast.spi.properties.ClusterProperty.CHANNEL_COUNT;
 
 /**
  * A {@link ChannelInitializer} that runs on a member and used for unencrypted
  * channels. It will deal with the exchange of protocols and based on that it
  * will set up the appropriate handlers in the pipeline.
  */
-public abstract class AbstractChannelInitializer
-        implements ChannelInitializer {
+public abstract class AbstractChannelInitializer implements ChannelInitializer {
 
     protected final ServerContext serverContext;
     private final EndpointConfig config;
@@ -53,168 +33,5 @@ public abstract class AbstractChannelInitializer
     protected AbstractChannelInitializer(ServerContext serverContext, EndpointConfig config) {
         this.config = config;
         this.serverContext = serverContext;
-    }
-
-    public static final class MemberHandshakeHandler {
-
-        private final TcpServerConnectionManager connectionManager;
-        private final ServerContext serverContext;
-        private final ILogger logger;
-        private final boolean spoofingChecks;
-        private final boolean unifiedEndpointManager;
-        private final Set<ProtocolType> supportedProtocolTypes;
-        private final int expectedPlaneCount;
-
-        public MemberHandshakeHandler(TcpServerConnectionManager connectionManager,
-                                      ServerContext serverContext,
-                                      ILogger logger,
-                                      Set<ProtocolType> supportedProtocolTypes) {
-            this.connectionManager = connectionManager;
-            this.serverContext = serverContext;
-            this.logger = logger;
-            this.spoofingChecks = serverContext.properties().getBoolean(BIND_SPOOFING_CHECKS);
-            this.supportedProtocolTypes = supportedProtocolTypes;
-            this.unifiedEndpointManager = connectionManager.getEndpointQualifier() == null;
-            this.expectedPlaneCount = serverContext.properties().getInteger(CHANNEL_COUNT);
-        }
-
-        public void process(Packet packet) {
-            MemberHandshake handshake = serverContext.getSerializationService().toObject(packet);
-            TcpServerConnection connection = (TcpServerConnection) packet.getConn();
-            if (!connection.setHandshake()) {
-                if (logger.isFinestEnabled()) {
-                    logger.finest("Connection " + connection + " handshake is already completed, ignoring incoming " + handshake);
-                }
-                return;
-            }
-
-            if (handshake.getPlaneCount() != expectedPlaneCount) {
-                connection.close("The connection handshake has incorrect number of planes. "
-                        + "Expected " + expectedPlaneCount + " found " + handshake.getPlaneCount(), null);
-                return;
-            }
-
-            // before we register the connection on the plane, we make sure the plane index is set on the connection
-            // so that we can safely remove the connection from the plane.
-            connection.setPlaneIndex(handshake.getPlaneIndex());
-            process(connection, handshake);
-        }
-
-        private synchronized void process(TcpServerConnection connection, MemberHandshake handshake) {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Handshake " + connection + ", complete message is " + handshake);
-            }
-
-            Map<ProtocolType, Collection<Address>> remoteAddressesPerProtocolType = handshake.getLocalAddresses();
-            List<Address> allAliases = new ArrayList<Address>();
-            for (Map.Entry<ProtocolType, Collection<Address>> remoteAddresses : remoteAddressesPerProtocolType.entrySet()) {
-                if (supportedProtocolTypes.contains(remoteAddresses.getKey())) {
-                    allAliases.addAll(remoteAddresses.getValue());
-                }
-            }
-            // member connections must be registered with their public address in connectionsMap
-            // eg member 192.168.1.1:5701 initiates a connection to 192.168.1.2:5701; the connection
-            // is created from an outbound port (eg 192.168.1.1:54003 --> 192.168.1.2:5701), but
-            // in 192.168.1.2:5701's connectionsMap the connection must be registered with
-            // key 192.168.1.1:5701.
-            assert (connectionManager.getEndpointQualifier() != EndpointQualifier.MEMBER
-                    || connection.getConnectionType().equals(ConnectionType.MEMBER))
-                    : "When handling MEMBER connections, connection type"
-                    + " must be already set";
-            boolean isMemberConnection = (connection.getConnectionType().equals(ConnectionType.MEMBER)
-                    && (connectionManager.getEndpointQualifier() == EndpointQualifier.MEMBER
-                    || unifiedEndpointManager));
-            boolean mustRegisterRemoteSocketAddress = !handshake.isReply();
-
-            Address remoteEndpoint = null;
-            if (isMemberConnection) {
-                // when a member connection is being bound on the connection initiator side
-                // add the remote socket address as last alias. This way the intended public
-                // address of the target member will be set correctly in TcpIpConnection.setEndpoint.
-                if (mustRegisterRemoteSocketAddress) {
-                    allAliases.add(new Address(connection.getRemoteSocketAddress()));
-                }
-            } else {
-                // when not a member connection, register the remote socket address
-                remoteEndpoint = new Address(connection.getRemoteSocketAddress());
-            }
-
-            process0(connection, remoteEndpoint, allAliases, handshake);
-        }
-
-        /**
-         * Performs the processing of the handshake (sets the endpoint on the Connection, registers the connection)
-         * without any spoofing or other validation checks.
-         * When executed on the connection initiator side, the connection is registered on the remote address
-         * with which it was registered in {@link TcpServerConnectionManager#connectionsInProgressArray},
-         * ignoring the {@code remoteEndpoint} argument.
-         *
-         * @param connection           the connection that send the handshake
-         * @param remoteEndpoint       the address of the remote endpoint
-         * @param remoteAddressAliases alias addresses as provided by the remote endpoint, under which the connection
-         *                             will be registered. These are the public addresses configured on the remote.
-         */
-        @SuppressWarnings({"checkstyle:npathcomplexity"})
-        @SuppressFBWarnings("RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED")
-        private synchronized void process0(TcpServerConnection connection,
-                                           Address remoteEndpoint,
-                                           Collection<Address> remoteAddressAliases,
-                                           MemberHandshake handshake) {
-            final Address remoteAddress = new Address(connection.getRemoteSocketAddress());
-            if (connectionManager.planes[handshake.getPlaneIndex()].connectionsInProgress.contains(remoteAddress)) {
-                // this is the connection initiator side --> register the connection under the address that was requested
-                remoteEndpoint = remoteAddress;
-            }
-            if (remoteEndpoint == null) {
-                if (remoteAddressAliases == null) {
-                    throw new IllegalStateException("Remote endpoint and remote address aliases cannot be both null");
-                } else {
-                    // let it fail if no remoteEndpoint and no aliases are defined
-                    remoteEndpoint = remoteAddressAliases.iterator().next();
-                }
-            }
-            connection.setRemoteAddress(remoteEndpoint);
-            serverContext.onSuccessfulConnection(remoteEndpoint);
-            if (handshake.isReply()) {
-                new SendMemberHandshakeTask(logger, serverContext, connection, remoteEndpoint, false,
-                        handshake.getPlaneIndex(), handshake.getPlaneCount()).run();
-            }
-
-            if (checkAlreadyConnected(connection, remoteEndpoint, handshake.getPlaneIndex())) {
-                return;
-            }
-
-            if (logger.isLoggable(Level.FINEST)) {
-                logger.finest("Registering connection " + connection + " to address " + remoteEndpoint
-                        + " planeIndex:" + handshake.getPlaneIndex());
-            }
-            boolean registered = connectionManager.register(remoteEndpoint, connection, handshake.getPlaneIndex());
-
-            if (remoteAddressAliases != null && registered) {
-                for (Address remoteAddressAlias : remoteAddressAliases) {
-                    if (logger.isLoggable(Level.FINEST)) {
-                        logger.finest("Registering connection " + connection + " to address alias " + remoteAddressAlias
-                                + " planeIndex:" + handshake.getPlaneIndex());
-                    }
-                    connectionManager.planes[handshake.getPlaneIndex()].connectionMap.putIfAbsent(remoteAddressAlias, connection);
-                }
-            }
-        }
-
-        private boolean checkAlreadyConnected(TcpServerConnection connection, Address remoteEndPoint, int planeIndex) {
-            Connection existingConnection = connectionManager.planes[planeIndex].connectionMap.get(remoteEndPoint);
-            if (existingConnection != null && existingConnection.isAlive()) {
-                if (existingConnection != connection) {
-                    if (logger.isFinestEnabled()) {
-                        logger.finest(existingConnection + " is already bound to " + remoteEndPoint
-                                + ", new one is " + connection + " planeIndex:" + planeIndex);
-                    }
-                    // todo probably it's already in activeConnections (ConnectTask , AcceptorIOThread)
-                    connectionManager.connections.add(connection);
-                }
-                return true;
-            }
-            return false;
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SendMemberHandshakeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SendMemberHandshakeTask.java
@@ -76,7 +76,7 @@ public class SendMemberHandshakeTask implements Runnable {
                 .addOption(OPTION_PLANE_COUNT, planeCount)
                 .addOption(OPTION_PLANE_INDEX, planeIndex);
         byte[] bytes = serverContext.getSerializationService().toBytes(memberHandshake);
-        Packet packet = new Packet(bytes).setPacketType(Packet.Type.MEMBER_HANDSHAKE);
+        Packet packet = new Packet(bytes).setPacketType(Packet.Type.SERVER_CONTROL);
         connection.write(packet);
         //now you can send anything...
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.cluster.Address;
@@ -36,7 +35,6 @@ import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.server.ServerContext;
-import com.hazelcast.internal.server.tcp.AbstractChannelInitializer.MemberHandshakeHandler;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.MutableLong;
 import com.hazelcast.internal.util.counters.MwCounter;
@@ -114,7 +112,7 @@ public class TcpServerConnectionManager
     private final Function<EndpointQualifier, ChannelInitializer> channelInitializerFn;
     private final TcpServer server;
     private final TcpServerConnector connector;
-    private final MemberHandshakeHandler memberHandshakeHandler;
+    private final TcpServerControl serverControl;
     private final NetworkStatsImpl networkStats;
     private final ConstructorFunction<Address, TcpServerConnectionErrorHandler> errorHandlerConstructor =
             endpoint -> new TcpServerConnectionErrorHandler(TcpServerConnectionManager.this, endpoint);
@@ -141,7 +139,7 @@ public class TcpServerConnectionManager
         this.serverContext = serverContext;
         this.logger = serverContext.getLoggingService().getLogger(TcpServerConnectionManager.class);
         this.connector = new TcpServerConnector(this);
-        this.memberHandshakeHandler = new MemberHandshakeHandler(this, serverContext, logger, supportedProtocolTypes);
+        this.serverControl = new TcpServerControl(this, serverContext, logger, supportedProtocolTypes);
         this.networkStats = endpointQualifier == null ? null : new NetworkStatsImpl();
         this.planes = new Plane[planeCount];
         for (int planeIndex = 0; planeIndex < planes.length; planeIndex++) {
@@ -170,7 +168,7 @@ public class TcpServerConnectionManager
 
     @Override
     public synchronized void accept(Packet packet) {
-        memberHandshakeHandler.process(packet);
+        serverControl.process(packet);
     }
 
     public ServerConnection get(Address address, int streamId) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.server.tcp;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.cluster.impl.MemberHandshake;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.nio.ConnectionType;
+import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.server.ServerContext;
+import com.hazelcast.logging.ILogger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+
+import static com.hazelcast.spi.properties.ClusterProperty.BIND_SPOOFING_CHECKS;
+import static com.hazelcast.spi.properties.ClusterProperty.CHANNEL_COUNT;
+
+/**
+ * The ServerControl is responsible for sending/receiving TcpServerControl messages.
+ */
+public final class TcpServerControl {
+
+    private final TcpServerConnectionManager connectionManager;
+    private final ServerContext serverContext;
+    private final ILogger logger;
+    private final boolean spoofingChecks;
+    private final boolean unifiedEndpointManager;
+    private final Set<ProtocolType> supportedProtocolTypes;
+    private final int expectedPlaneCount;
+
+    public TcpServerControl(TcpServerConnectionManager connectionManager,
+                            ServerContext serverContext,
+                            ILogger logger,
+                            Set<ProtocolType> supportedProtocolTypes) {
+        this.connectionManager = connectionManager;
+        this.serverContext = serverContext;
+        this.logger = logger;
+        this.spoofingChecks = serverContext.properties().getBoolean(BIND_SPOOFING_CHECKS);
+        this.supportedProtocolTypes = supportedProtocolTypes;
+        this.unifiedEndpointManager = connectionManager.getEndpointQualifier() == null;
+        this.expectedPlaneCount = serverContext.properties().getInteger(CHANNEL_COUNT);
+    }
+
+    public void process(Packet packet) {
+        MemberHandshake handshake = serverContext.getSerializationService().toObject(packet);
+        TcpServerConnection connection = (TcpServerConnection) packet.getConn();
+        if (!connection.setHandshake()) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Connection " + connection + " handshake is already completed, ignoring incoming " + handshake);
+            }
+            return;
+        }
+
+        if (handshake.getPlaneCount() != expectedPlaneCount) {
+            connection.close("The connection handshake has incorrect number of planes. "
+                    + "Expected " + expectedPlaneCount + " found " + handshake.getPlaneCount(), null);
+            return;
+        }
+
+        // before we register the connection on the plane, we make sure the plane index is set on the connection
+        // so that we can safely remove the connection from the plane.
+        connection.setPlaneIndex(handshake.getPlaneIndex());
+        process(connection, handshake);
+    }
+
+    private synchronized void process(TcpServerConnection connection, MemberHandshake handshake) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("Handshake " + connection + ", complete message is " + handshake);
+        }
+
+        Map<ProtocolType, Collection<Address>> remoteAddressesPerProtocolType = handshake.getLocalAddresses();
+        List<Address> allAliases = new ArrayList<Address>();
+        for (Map.Entry<ProtocolType, Collection<Address>> remoteAddresses : remoteAddressesPerProtocolType.entrySet()) {
+            if (supportedProtocolTypes.contains(remoteAddresses.getKey())) {
+                allAliases.addAll(remoteAddresses.getValue());
+            }
+        }
+        // member connections must be registered with their public address in connectionsMap
+        // eg member 192.168.1.1:5701 initiates a connection to 192.168.1.2:5701; the connection
+        // is created from an outbound port (eg 192.168.1.1:54003 --> 192.168.1.2:5701), but
+        // in 192.168.1.2:5701's connectionsMap the connection must be registered with
+        // key 192.168.1.1:5701.
+        assert (connectionManager.getEndpointQualifier() != EndpointQualifier.MEMBER
+                || connection.getConnectionType().equals(ConnectionType.MEMBER))
+                : "When handling MEMBER connections, connection type"
+                + " must be already set";
+        boolean isMemberConnection = (connection.getConnectionType().equals(ConnectionType.MEMBER)
+                && (connectionManager.getEndpointQualifier() == EndpointQualifier.MEMBER
+                || unifiedEndpointManager));
+        boolean mustRegisterRemoteSocketAddress = !handshake.isReply();
+
+        Address remoteEndpoint = null;
+        if (isMemberConnection) {
+            // when a member connection is being bound on the connection initiator side
+            // add the remote socket address as last alias. This way the intended public
+            // address of the target member will be set correctly in TcpIpConnection.setEndpoint.
+            if (mustRegisterRemoteSocketAddress) {
+                allAliases.add(new Address(connection.getRemoteSocketAddress()));
+            }
+        } else {
+            // when not a member connection, register the remote socket address
+            remoteEndpoint = new Address(connection.getRemoteSocketAddress());
+        }
+
+        process0(connection, remoteEndpoint, allAliases, handshake);
+    }
+
+    /**
+     * Performs the processing of the handshake (sets the endpoint on the Connection, registers the connection)
+     * without any spoofing or other validation checks.
+     * When executed on the connection initiator side, the connection is registered on the remote address
+     * with which it was registered in {@link TcpServerConnectionManager#connectionsInProgressArray},
+     * ignoring the {@code remoteEndpoint} argument.
+     *
+     * @param connection           the connection that send the handshake
+     * @param remoteEndpoint       the address of the remote endpoint
+     * @param remoteAddressAliases alias addresses as provided by the remote endpoint, under which the connection
+     *                             will be registered. These are the public addresses configured on the remote.
+     */
+    @SuppressWarnings({"checkstyle:npathcomplexity"})
+    @SuppressFBWarnings("RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED")
+    private synchronized void process0(TcpServerConnection connection,
+                                       Address remoteEndpoint,
+                                       Collection<Address> remoteAddressAliases,
+                                       MemberHandshake handshake) {
+        final Address remoteAddress = new Address(connection.getRemoteSocketAddress());
+        if (connectionManager.planes[handshake.getPlaneIndex()].connectionsInProgress.contains(remoteAddress)) {
+            // this is the connection initiator side --> register the connection under the address that was requested
+            remoteEndpoint = remoteAddress;
+        }
+        if (remoteEndpoint == null) {
+            if (remoteAddressAliases == null) {
+                throw new IllegalStateException("Remote endpoint and remote address aliases cannot be both null");
+            } else {
+                // let it fail if no remoteEndpoint and no aliases are defined
+                remoteEndpoint = remoteAddressAliases.iterator().next();
+            }
+        }
+        connection.setRemoteAddress(remoteEndpoint);
+        serverContext.onSuccessfulConnection(remoteEndpoint);
+        if (handshake.isReply()) {
+            new SendMemberHandshakeTask(logger, serverContext, connection, remoteEndpoint, false,
+                    handshake.getPlaneIndex(), handshake.getPlaneCount()).run();
+        }
+
+        if (checkAlreadyConnected(connection, remoteEndpoint, handshake.getPlaneIndex())) {
+            return;
+        }
+
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest("Registering connection " + connection + " to address " + remoteEndpoint
+                    + " planeIndex:" + handshake.getPlaneIndex());
+        }
+        boolean registered = connectionManager.register(remoteEndpoint, connection, handshake.getPlaneIndex());
+
+        if (remoteAddressAliases != null && registered) {
+            for (Address remoteAddressAlias : remoteAddressAliases) {
+                if (logger.isLoggable(Level.FINEST)) {
+                    logger.finest("Registering connection " + connection + " to address alias " + remoteAddressAlias
+                            + " planeIndex:" + handshake.getPlaneIndex());
+                }
+                connectionManager.planes[handshake.getPlaneIndex()].connectionMap.putIfAbsent(remoteAddressAlias, connection);
+            }
+        }
+    }
+
+    private boolean checkAlreadyConnected(TcpServerConnection connection, Address remoteEndPoint, int planeIndex) {
+        Connection existingConnection = connectionManager.planes[planeIndex].connectionMap.get(remoteEndPoint);
+        if (existingConnection != null && existingConnection.isAlive()) {
+            if (existingConnection != connection) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest(existingConnection + " is already bound to " + remoteEndPoint
+                            + ", new one is " + connection + " planeIndex:" + planeIndex);
+                }
+                // todo probably it's already in activeConnections (ConnectTask , AcceptorIOThread)
+                connectionManager.connections.add(connection);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
@@ -75,7 +75,7 @@ public final class PacketDispatcher implements Consumer<Packet> {
                 case EVENT:
                     eventService.accept(packet);
                     break;
-                case MEMBER_HANDSHAKE:
+                case SERVER_CONTROL:
                     ServerConnection connection = packet.getConn();
                     ServerConnectionManager connectionManager = connection.getConnectionManager();
                     connectionManager.accept(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -58,7 +58,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
-import static com.hazelcast.internal.nio.Packet.Type.MEMBER_HANDSHAKE;
+import static com.hazelcast.internal.nio.Packet.Type.SERVER_CONTROL;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_OUTPUT_THREAD_COUNT;
 
@@ -358,7 +358,7 @@ public class MockServerContext implements ServerContext {
     public InboundHandler[] createInboundHandlers(EndpointQualifier qualifier, final ServerConnection connection) {
         return new InboundHandler[]{new PacketDecoder(connection, packet -> {
             try {
-                if (packet.getPacketType() == MEMBER_HANDSHAKE) {
+                if (packet.getPacketType() == SERVER_CONTROL) {
                     connection.getConnectionManager().accept(packet);
                 } else {
                     Consumer<Packet> consumer = packetConsumer;

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
@@ -123,7 +123,7 @@ public class MemberHandshakeHandlerTest {
     private final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
 
     private InternalSerializationService serializationService;
-    private AbstractChannelInitializer.MemberHandshakeHandler handshakeHandler;
+    private TcpServerControl tcpServerControl;
     private UUID uuid = UUID.randomUUID();
 
     // mocks
@@ -163,7 +163,7 @@ public class MemberHandshakeHandlerTest {
         Node node = getNode(hz);
         connectionManager = TcpServerConnectionManager.class.cast(
                 node.getServer().getConnectionManager(EndpointQualifier.resolve(protocolType, "wan")));
-        handshakeHandler = getFieldValueReflectively(connectionManager, "memberHandshakeHandler");
+        tcpServerControl = getFieldValueReflectively(connectionManager, "serverControl");
 
         // setup mock channel & socket
         Socket socket = mock(Socket.class);
@@ -183,7 +183,7 @@ public class MemberHandshakeHandlerTest {
 
     @Test
     public void process() {
-        handshakeHandler.process(bindMessage());
+        tcpServerControl.process(bindMessage());
         assertExpectedAddressesRegistered();
     }
 


### PR DESCRIPTION
The memberhandshake is a form of server control; messages that are only send
between servers and end up at the TcpServer logic.

This pr generalizes that concept and renames it to server control. This way we
can easily hook in new stuff like ping messages.

No Enterprise change needed. No wire level change.