### PR TITLE
New Types Support On Portable For Sql

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -270,7 +270,8 @@
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]GenericRecordBuilder"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]PortableReader"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]PortableWriter"/>
-    <suppress checks="" files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]GenericRecordQueryReader"/>
+    <suppress checks="CyclomaticComplexity|MethodLength|NPathComplexity|ReturnCount"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]GenericRecordQueryReader"/>
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]nio[\\/]tcp[\\/]nonblocking[\\/]NonBlockingSocketReader"/>
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling|MethodCount|ParameterNumber"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]AbstractSerializationService"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -249,9 +249,28 @@
     <suppress checks="MethodCount"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]PortableInternalGenericRecord"/>
     <suppress checks="MagicNumber"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]PortableValueReader"/>
+    <suppress checks="MagicNumber|MethodCount"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]DefaultPortableWriter"/>
-    <suppress checks=""
-              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]GenericRecordQueryReader"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]Portable"/>
+    <suppress checks="MethodCount"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]PortableGenericRecordBuilder"/>
+    <suppress checks="MethodCount"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]MorphingPortableReader"/>
+    <suppress checks="MethodCount"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]PortableGenericRecord"/>
+    <suppress checks="MethodCount"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]ClassDefinitionWriter"/>
+    <suppress checks="ParameterNumber"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]MainPortable"/>
+    <suppress checks="ParameterNumber"
+              files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]portable[\\/]InnerPortable"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]GenericRecord"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]ClassDefinitionBuilder"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]GenericRecordBuilder"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]PortableReader"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]PortableWriter"/>
+    <suppress checks="" files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]GenericRecordQueryReader"/>
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]nio[\\/]tcp[\\/]nonblocking[\\/]NonBlockingSocketReader"/>
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling|MethodCount|ParameterNumber"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]AbstractSerializationService"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractGenericRecord.java
@@ -106,11 +106,22 @@ public abstract class AbstractGenericRecord implements GenericRecord {
                 return Arrays.hashCode(record.readUTFArray(path));
             case PORTABLE_ARRAY:
                 return Arrays.hashCode(record.readGenericRecordArray(path));
+            case DECIMAL_ARRAY:
+                return Arrays.hashCode(record.readDecimalArray(path));
+            case TIME_ARRAY:
+                return Arrays.hashCode(record.readTimeArray(path));
+            case DATE_ARRAY:
+                return Arrays.hashCode(record.readDateArray(path));
+            case TIMESTAMP_ARRAY:
+                return Arrays.hashCode(record.readTimestampArray(path));
+            case TIMESTAMP_WITH_TIMEZONE_ARRAY:
+                return Arrays.hashCode(record.readTimestampWithTimezoneArray(path));
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }
     }
 
+    @SuppressWarnings("checkstyle:MethodLength")
     private static Object readAny(GenericRecord record, String path, FieldType type) {
         switch (type) {
             case BYTE:
@@ -153,6 +164,26 @@ public abstract class AbstractGenericRecord implements GenericRecord {
                 return record.readGenericRecord(path);
             case PORTABLE_ARRAY:
                 return record.readGenericRecordArray(path);
+            case DECIMAL:
+                return record.readDecimal(path);
+            case DECIMAL_ARRAY:
+                return record.readDecimalArray(path);
+            case TIME:
+                return record.readTime(path);
+            case TIME_ARRAY:
+                return record.readTimeArray(path);
+            case DATE:
+                return record.readDate(path);
+            case DATE_ARRAY:
+                return record.readDateArray(path);
+            case TIMESTAMP:
+                return record.readTimestamp(path);
+            case TIMESTAMP_ARRAY:
+                return record.readTimestampArray(path);
+            case TIMESTAMP_WITH_TIMEZONE:
+                return record.readTimestampWithTimezone(path);
+            case TIMESTAMP_WITH_TIMEZONE_ARRAY:
+                return record.readTimestampWithTimezoneArray(path);
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }
@@ -194,6 +225,11 @@ public abstract class AbstractGenericRecord implements GenericRecord {
                         str.append(Arrays.toString((char[]) field));
                         break;
                     case UTF_ARRAY:
+                    case DECIMAL_ARRAY:
+                    case TIME_ARRAY:
+                    case DATE_ARRAY:
+                    case TIMESTAMP_ARRAY:
+                    case TIMESTAMP_WITH_TIMEZONE_ARRAY:
                     case PORTABLE_ARRAY:
                         str.append(Arrays.toString((Object[]) field));
                         break;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/GenericRecordQueryReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/GenericRecordQueryReader.java
@@ -263,6 +263,16 @@ public final class GenericRecordQueryReader implements ValueReader {
                 return record.readUTFFromArray(path, index);
             case PORTABLE_ARRAY:
                 return record.readObjectFromArray(path, index);
+            case DECIMAL_ARRAY:
+                return record.readDecimalFromArray(path, index);
+            case TIME_ARRAY:
+                return record.readTimeFromArray(path, index);
+            case DATE_ARRAY:
+                return record.readDateFromArray(path, index);
+            case TIMESTAMP_ARRAY:
+                return record.readTimestampFromArray(path, index);
+            case TIMESTAMP_WITH_TIMEZONE_ARRAY:
+                return record.readTimestampWithTimezoneFromArray(path, index);
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }
@@ -314,6 +324,26 @@ public final class GenericRecordQueryReader implements ValueReader {
                 return record.readObject(path);
             case PORTABLE_ARRAY:
                 return record.readObjectArray(path);
+            case DECIMAL:
+                return record.readDecimal(path);
+            case DECIMAL_ARRAY:
+                return record.readDecimalArray(path);
+            case TIME:
+                return record.readTime(path);
+            case TIME_ARRAY:
+                return record.readTimeArray(path);
+            case DATE:
+                return record.readDate(path);
+            case DATE_ARRAY:
+                return record.readDateArray(path);
+            case TIMESTAMP:
+                return record.readTimestamp(path);
+            case TIMESTAMP_ARRAY:
+                return record.readTimestampArray(path);
+            case TIMESTAMP_WITH_TIMEZONE:
+                return record.readTimestampWithTimezone(path);
+            case TIMESTAMP_WITH_TIMEZONE_ARRAY:
+                return record.readTimestampWithTimezoneArray(path);
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
@@ -19,6 +19,14 @@ package com.hazelcast.internal.serialization.impl;
 import com.hazelcast.nio.serialization.GenericRecord;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
 /**
  * Additionally to GenericRecord, this one has more methods to be used in Query.
  *
@@ -36,7 +44,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Boolean readBooleanFromArray(String fieldName, int index);
+    @Nullable
+    Boolean readBooleanFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -44,7 +53,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Byte readByteFromArray(String fieldName, int index);
+    @Nullable
+    Byte readByteFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -52,7 +62,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Character readCharFromArray(String fieldName, int index);
+    @Nullable
+    Character readCharFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -60,7 +71,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Double readDoubleFromArray(String fieldName, int index);
+    @Nullable
+    Double readDoubleFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -68,7 +80,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Float readFloatFromArray(String fieldName, int index);
+    @Nullable
+    Float readFloatFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -76,7 +89,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Integer readIntFromArray(String fieldName, int index);
+    @Nullable
+    Integer readIntFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -84,7 +98,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Long readLongFromArray(String fieldName, int index);
+    @Nullable
+    Long readLongFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -92,7 +107,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Short readShortFromArray(String fieldName, int index);
+    @Nullable
+    Short readShortFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -100,7 +116,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    String readUTFFromArray(String fieldName, int index);
+    @Nullable
+    String readUTFFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -108,7 +125,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    GenericRecord readGenericRecordFromArray(String fieldName, int index);
+    @Nullable
+    GenericRecord readGenericRecordFromArray(@Nonnull String fieldName, int index);
 
     /**
      * Reads same value {@link InternalGenericRecord#readGenericRecord(String)} }, but in deserialized form.
@@ -120,7 +138,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Object readObjectFromArray(String fieldName, int index);
+    @Nullable
+    Object readObjectFromArray(@Nonnull String fieldName, int index);
 
     /**
      * Reads same value {@link GenericRecord#readGenericRecordArray(String)}, but in deserialized form.
@@ -131,7 +150,8 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Object[] readObjectArray(String fieldName);
+    @Nullable
+    Object[] readObjectArray(@Nonnull String fieldName);
 
     /**
      * Reads same value {@link GenericRecord#readGenericRecord(String)} }, but in deserialized form.
@@ -142,5 +162,51 @@ public interface InternalGenericRecord extends GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    Object readObject(String fieldName);
+    @Nullable
+    Object readObject(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    BigDecimal readDecimalFromArray(@Nonnull String fieldName, int index);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalTime readTimeFromArray(@Nonnull String fieldName, int index);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalDate readDateFromArray(@Nonnull String fieldName, int index);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalDateTime readTimestampFromArray(@Nonnull String fieldName, int index);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    OffsetDateTime readTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.serialization.impl.defaultserializers;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.nio.serialization.ClassNameFilter;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.ClassNameFilter;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -39,6 +40,7 @@ import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static com.hazelcast.internal.nio.IOUtil.newObjectInputStream;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVASCRIPT_JSON_SERIALIZATION_TYPE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_BIG_DECIMAL;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_BIG_INTEGER;
@@ -47,7 +49,6 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.J
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_EXTERNALIZABLE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_OPTIONAL;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_SERIALIZABLE;
-import static com.hazelcast.internal.nio.IOUtil.newObjectInputStream;
 import static java.lang.Math.max;
 
 
@@ -221,22 +222,16 @@ public final class JavaDefaultSerializers {
 
         @Override
         public BigInteger read(final ObjectDataInput in) throws IOException {
-            final byte[] bytes = new byte[in.readInt()];
-            in.readFully(bytes);
-            return new BigInteger(bytes);
+            return IOUtil.readBigInteger(in);
         }
 
         @Override
-        public void write(final ObjectDataOutput out, final BigInteger obj) throws IOException {
-            final byte[] bytes = obj.toByteArray();
-            out.writeInt(bytes.length);
-            out.write(bytes);
+        public void write(final ObjectDataOutput out, BigInteger value) throws IOException {
+            IOUtil.writeBigInteger(out, value);
         }
     }
 
     public static final class BigDecimalSerializer extends SingletonSerializer<BigDecimal> {
-
-        final BigIntegerSerializer bigIntegerSerializer = new BigIntegerSerializer();
 
         @Override
         public int getTypeId() {
@@ -244,18 +239,13 @@ public final class JavaDefaultSerializers {
         }
 
         @Override
-        public BigDecimal read(final ObjectDataInput in) throws IOException {
-            BigInteger bigInt = bigIntegerSerializer.read(in);
-            int scale = in.readInt();
-            return new BigDecimal(bigInt, scale);
+        public BigDecimal read(ObjectDataInput in) throws IOException {
+            return IOUtil.readBigDecimal(in);
         }
 
         @Override
-        public void write(final ObjectDataOutput out, final BigDecimal obj) throws IOException {
-            BigInteger bigInt = obj.unscaledValue();
-            int scale = obj.scale();
-            bigIntegerSerializer.write(out, bigInt);
-            out.writeInt(scale);
+        public void write(final ObjectDataOutput out, BigDecimal value) throws IOException {
+            IOUtil.writeBigDecimal(out, value);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/ClassDefinitionWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/ClassDefinitionWriter.java
@@ -24,7 +24,14 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableWriter;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 final class ClassDefinitionWriter implements PortableWriter {
 
@@ -42,99 +49,97 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeInt(String fieldName, int value) {
+    public void writeInt(@Nonnull String fieldName, int value) {
         builder.addIntField(fieldName);
     }
 
     @Override
-    public void writeLong(String fieldName, long value) {
+    public void writeLong(@Nonnull String fieldName, long value) {
         builder.addLongField(fieldName);
     }
 
     @Override
-    public void writeUTF(String fieldName, String str) {
+    public void writeUTF(@Nonnull String fieldName, String str) {
         builder.addUTFField(fieldName);
     }
 
     @Override
-    public void writeBoolean(String fieldName, boolean value) throws IOException {
+    public void writeBoolean(@Nonnull String fieldName, boolean value) throws IOException {
         builder.addBooleanField(fieldName);
     }
 
     @Override
-    public void writeByte(String fieldName, byte value) throws IOException {
+    public void writeByte(@Nonnull String fieldName, byte value) throws IOException {
         builder.addByteField(fieldName);
     }
 
     @Override
-    public void writeChar(String fieldName, int value) throws IOException {
+    public void writeChar(@Nonnull String fieldName, int value) throws IOException {
         builder.addCharField(fieldName);
     }
 
     @Override
-    public void writeDouble(String fieldName, double value) throws IOException {
+    public void writeDouble(@Nonnull String fieldName, double value) throws IOException {
         builder.addDoubleField(fieldName);
     }
 
     @Override
-    public void writeFloat(String fieldName, float value) throws IOException {
+    public void writeFloat(@Nonnull String fieldName, float value) throws IOException {
         builder.addFloatField(fieldName);
     }
 
     @Override
-    public void writeShort(String fieldName, short value) throws IOException {
+    public void writeShort(@Nonnull String fieldName, short value) throws IOException {
         builder.addShortField(fieldName);
     }
 
     @Override
-    public void writeByteArray(String fieldName, byte[] bytes) throws IOException {
+    public void writeByteArray(@Nonnull String fieldName, byte[] bytes) throws IOException {
         builder.addByteArrayField(fieldName);
     }
 
     @Override
-    public void writeBooleanArray(String fieldName, boolean[] booleans)
-            throws IOException {
+    public void writeBooleanArray(@Nonnull String fieldName, boolean[] booleans) throws IOException {
         builder.addBooleanArrayField(fieldName);
     }
 
     @Override
-    public void writeCharArray(String fieldName, char[] chars) throws IOException {
+    public void writeCharArray(@Nonnull String fieldName, char[] chars) throws IOException {
         builder.addCharArrayField(fieldName);
     }
 
     @Override
-    public void writeIntArray(String fieldName, int[] ints) throws IOException {
+    public void writeIntArray(@Nonnull String fieldName, int[] ints) throws IOException {
         builder.addIntArrayField(fieldName);
     }
 
     @Override
-    public void writeLongArray(String fieldName, long[] longs) throws IOException {
+    public void writeLongArray(@Nonnull String fieldName, long[] longs) throws IOException {
         builder.addLongArrayField(fieldName);
     }
 
     @Override
-    public void writeDoubleArray(String fieldName, double[] values) throws IOException {
+    public void writeDoubleArray(@Nonnull String fieldName, double[] values) throws IOException {
         builder.addDoubleArrayField(fieldName);
     }
 
     @Override
-    public void writeFloatArray(String fieldName, float[] values) throws IOException {
+    public void writeFloatArray(@Nonnull String fieldName, float[] values) throws IOException {
         builder.addFloatArrayField(fieldName);
     }
 
     @Override
-    public void writeShortArray(String fieldName, short[] values) throws IOException {
+    public void writeShortArray(@Nonnull String fieldName, short[] values) throws IOException {
         builder.addShortArrayField(fieldName);
     }
 
     @Override
-    public void writeUTFArray(String fieldName, String[] values)
-            throws IOException {
+    public void writeUTFArray(@Nonnull String fieldName, String[] values) throws IOException {
         builder.addUTFArrayField(fieldName);
     }
 
     @Override
-    public void writePortable(String fieldName, Portable portable) throws IOException {
+    public void writePortable(@Nonnull String fieldName, @Nullable Portable portable) throws IOException {
         if (portable == null) {
             throw new HazelcastSerializationException("Cannot write null portable without explicitly "
                     + "registering class definition!");
@@ -146,7 +151,7 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeNullPortable(String fieldName, int factoryId, int classId) throws IOException {
+    public void writeNullPortable(@Nonnull String fieldName, int factoryId, int classId) throws IOException {
         final ClassDefinition nestedClassDef = context.lookupClassDefinition(factoryId, classId, context.getVersion());
         if (nestedClassDef == null) {
             throw new HazelcastSerializationException("Cannot write null portable without explicitly "
@@ -156,7 +161,32 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writePortableArray(String fieldName, Portable[] portables) throws IOException {
+    public void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) throws IOException {
+        builder.addDecimalField(fieldName);
+    }
+
+    @Override
+    public void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) throws IOException {
+        builder.addTimeField(fieldName);
+    }
+
+    @Override
+    public void writeDate(@Nonnull String fieldName, @Nullable LocalDate value) throws IOException {
+        builder.addDateField(fieldName);
+    }
+
+    @Override
+    public void writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) throws IOException {
+        builder.addTimestampField(fieldName);
+    }
+
+    @Override
+    public void writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) throws IOException {
+        builder.addTimestampWithTimezoneField(fieldName);
+    }
+
+    @Override
+    public void writePortableArray(@Nonnull String fieldName, Portable[] portables) throws IOException {
         if (portables == null || portables.length == 0) {
             throw new HazelcastSerializationException("Cannot write null portable array without explicitly "
                     + "registering class definition!");
@@ -175,6 +205,32 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
+    public void writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] values) throws IOException {
+        builder.addDecimalArrayField(fieldName);
+    }
+
+    @Override
+    public void writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] values) throws IOException {
+        builder.addTimeArrayField(fieldName);
+    }
+
+    @Override
+    public void writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] values) throws IOException {
+        builder.addDateArrayField(fieldName);
+    }
+
+    @Override
+    public void writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] values) throws IOException {
+        builder.addTimestampArrayField(fieldName);
+    }
+
+    @Override
+    public void writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] values) throws IOException {
+        builder.addTimestampWithTimezoneArrayField(fieldName);
+    }
+
+    @Override
+    @Nonnull
     public ObjectDataOutput getRawDataOutput() {
         return new EmptyObjectDataOutput();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -97,6 +97,7 @@ public class DefaultPortableReader implements PortableReader {
     }
 
     @Override
+    @Nonnull
     public FieldType getFieldType(@Nonnull String fieldName) {
         return cd.getFieldType(fieldName);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -226,6 +226,7 @@ public class DefaultPortableReader implements PortableReader {
     }
 
     @Override
+    @Nullable
     @SuppressWarnings("unchecked")
     public Portable readPortable(@Nonnull String fieldName) throws IOException {
         int currentPos = in.position();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.serialization.impl.portable;
 
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
@@ -26,7 +27,14 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableWriter;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
@@ -67,61 +75,61 @@ public class DefaultPortableWriter implements PortableWriter {
     }
 
     @Override
-    public void writeInt(String fieldName, int value) throws IOException {
+    public void writeInt(@Nonnull String fieldName, int value) throws IOException {
         setPosition(fieldName, FieldType.INT);
         out.writeInt(value);
     }
 
     @Override
-    public void writeLong(String fieldName, long value) throws IOException {
+    public void writeLong(@Nonnull String fieldName, long value) throws IOException {
         setPosition(fieldName, FieldType.LONG);
         out.writeLong(value);
     }
 
     @Override
-    public void writeUTF(String fieldName, String str) throws IOException {
+    public void writeUTF(@Nonnull String fieldName, String str) throws IOException {
         setPosition(fieldName, FieldType.UTF);
         out.writeUTF(str);
     }
 
     @Override
-    public void writeBoolean(String fieldName, boolean value) throws IOException {
+    public void writeBoolean(@Nonnull String fieldName, boolean value) throws IOException {
         setPosition(fieldName, FieldType.BOOLEAN);
         out.writeBoolean(value);
     }
 
     @Override
-    public void writeByte(String fieldName, byte value) throws IOException {
+    public void writeByte(@Nonnull String fieldName, byte value) throws IOException {
         setPosition(fieldName, FieldType.BYTE);
         out.writeByte(value);
     }
 
     @Override
-    public void writeChar(String fieldName, int value) throws IOException {
+    public void writeChar(@Nonnull String fieldName, int value) throws IOException {
         setPosition(fieldName, FieldType.CHAR);
         out.writeChar(value);
     }
 
     @Override
-    public void writeDouble(String fieldName, double value) throws IOException {
+    public void writeDouble(@Nonnull String fieldName, double value) throws IOException {
         setPosition(fieldName, FieldType.DOUBLE);
         out.writeDouble(value);
     }
 
     @Override
-    public void writeFloat(String fieldName, float value) throws IOException {
+    public void writeFloat(@Nonnull String fieldName, float value) throws IOException {
         setPosition(fieldName, FieldType.FLOAT);
         out.writeFloat(value);
     }
 
     @Override
-    public void writeShort(String fieldName, short value) throws IOException {
+    public void writeShort(@Nonnull String fieldName, short value) throws IOException {
         setPosition(fieldName, FieldType.SHORT);
         out.writeShort(value);
     }
 
     @Override
-    public void writePortable(String fieldName, Portable portable) throws IOException {
+    public void writePortable(@Nonnull String fieldName, @Nullable Portable portable) throws IOException {
         FieldDefinition fd = setPosition(fieldName, FieldType.PORTABLE);
         final boolean isNull = portable == null;
         out.writeBoolean(isNull);
@@ -135,7 +143,7 @@ public class DefaultPortableWriter implements PortableWriter {
         }
     }
 
-    public void writeGenericRecord(String fieldName, GenericRecord portable) throws IOException {
+    public void writeGenericRecord(@Nonnull String fieldName, GenericRecord portable) throws IOException {
         FieldDefinition fd = setPosition(fieldName, FieldType.PORTABLE);
         final boolean isNull = portable == null;
         out.writeBoolean(isNull);
@@ -144,7 +152,7 @@ public class DefaultPortableWriter implements PortableWriter {
         out.writeInt(fd.getClassId());
 
         if (!isNull) {
-            PortableGenericRecord  record = (PortableGenericRecord) portable;
+            PortableGenericRecord record = (PortableGenericRecord) portable;
             checkPortableAttributes(fd, record.getClassDefinition());
             serializer.writePortableGenericRecordInternal(out, record);
         }
@@ -173,7 +181,7 @@ public class DefaultPortableWriter implements PortableWriter {
     }
 
     @Override
-    public void writeNullPortable(String fieldName, int factoryId, int classId) throws IOException {
+    public void writeNullPortable(@Nonnull String fieldName, int factoryId, int classId) throws IOException {
         setPosition(fieldName, FieldType.PORTABLE);
         out.writeBoolean(true);
 
@@ -182,61 +190,111 @@ public class DefaultPortableWriter implements PortableWriter {
     }
 
     @Override
-    public void writeByteArray(String fieldName, byte[] values) throws IOException {
+    public void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) throws IOException {
+        setPosition(fieldName, FieldType.DECIMAL);
+        boolean isNull = value == null;
+        out.writeBoolean(isNull);
+        if (!isNull) {
+            IOUtil.writeBigDecimal(out, value);
+        }
+    }
+
+    @Override
+    public void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) throws IOException {
+        setPosition(fieldName, FieldType.TIME);
+        boolean isNull = value == null;
+        out.writeBoolean(isNull);
+        if (!isNull) {
+            IOUtil.writeLocalTime(out, value);
+        }
+    }
+
+    @Override
+    public void writeDate(@Nonnull String fieldName, @Nullable LocalDate value) throws IOException {
+        setPosition(fieldName, FieldType.DATE);
+        boolean isNull = value == null;
+        out.writeBoolean(isNull);
+        if (!isNull) {
+            IOUtil.writeLocalDate(out, value);
+        }
+    }
+
+    @Override
+    public void writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) throws IOException {
+        setPosition(fieldName, FieldType.TIMESTAMP);
+        boolean isNull = value == null;
+        out.writeBoolean(isNull);
+        if (!isNull) {
+            IOUtil.writeLocalDateTime(out, value);
+        }
+    }
+
+    @Override
+    public void writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) throws IOException {
+        setPosition(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
+        boolean isNull = value == null;
+        out.writeBoolean(isNull);
+        if (!isNull) {
+            IOUtil.writeOffsetDateTime(out, value);
+        }
+    }
+
+    @Override
+    public void writeByteArray(@Nonnull String fieldName, @Nullable byte[] values) throws IOException {
         setPosition(fieldName, FieldType.BYTE_ARRAY);
         out.writeByteArray(values);
     }
 
     @Override
-    public void writeBooleanArray(String fieldName, boolean[] booleans) throws IOException {
+    public void writeBooleanArray(@Nonnull String fieldName, @Nullable boolean[] booleans) throws IOException {
         setPosition(fieldName, FieldType.BOOLEAN_ARRAY);
         out.writeBooleanArray(booleans);
     }
 
     @Override
-    public void writeCharArray(String fieldName, char[] values) throws IOException {
+    public void writeCharArray(@Nonnull String fieldName, @Nullable char[] values) throws IOException {
         setPosition(fieldName, FieldType.CHAR_ARRAY);
         out.writeCharArray(values);
     }
 
     @Override
-    public void writeIntArray(String fieldName, int[] values) throws IOException {
+    public void writeIntArray(@Nonnull String fieldName, @Nullable int[] values) throws IOException {
         setPosition(fieldName, FieldType.INT_ARRAY);
         out.writeIntArray(values);
     }
 
     @Override
-    public void writeLongArray(String fieldName, long[] values) throws IOException {
+    public void writeLongArray(@Nonnull String fieldName, @Nullable long[] values) throws IOException {
         setPosition(fieldName, FieldType.LONG_ARRAY);
         out.writeLongArray(values);
     }
 
     @Override
-    public void writeDoubleArray(String fieldName, double[] values) throws IOException {
+    public void writeDoubleArray(@Nonnull String fieldName, @Nullable double[] values) throws IOException {
         setPosition(fieldName, FieldType.DOUBLE_ARRAY);
         out.writeDoubleArray(values);
     }
 
     @Override
-    public void writeFloatArray(String fieldName, float[] values) throws IOException {
+    public void writeFloatArray(@Nonnull String fieldName, @Nullable float[] values) throws IOException {
         setPosition(fieldName, FieldType.FLOAT_ARRAY);
         out.writeFloatArray(values);
     }
 
     @Override
-    public void writeShortArray(String fieldName, short[] values) throws IOException {
+    public void writeShortArray(@Nonnull String fieldName, @Nullable short[] values) throws IOException {
         setPosition(fieldName, FieldType.SHORT_ARRAY);
         out.writeShortArray(values);
     }
 
     @Override
-    public void writeUTFArray(String fieldName, String[] values) throws IOException {
+    public void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
         setPosition(fieldName, FieldType.UTF_ARRAY);
         out.writeUTFArray(values);
     }
 
     @Override
-    public void writePortableArray(String fieldName, Portable[] portables) throws IOException {
+    public void writePortableArray(@Nonnull String fieldName, @Nullable Portable[] portables) throws IOException {
         FieldDefinition fd = setPosition(fieldName, FieldType.PORTABLE_ARRAY);
         final int len = portables == null ? NULL_ARRAY_LENGTH : portables.length;
         out.writeInt(len);
@@ -257,7 +315,58 @@ public class DefaultPortableWriter implements PortableWriter {
         }
     }
 
-    void writeGenericRecordArray(String fieldName, GenericRecord[] portables) throws IOException {
+    interface Writer<O, T> {
+
+        void write(O out, T value) throws IOException;
+    }
+
+    private <T> void writeObjectArrayField(@Nonnull String fieldName, FieldType fieldType, @Nullable T[] values,
+                                           Writer<ObjectDataOutput, T> writer) throws IOException {
+        setPosition(fieldName, fieldType);
+        final int len = values == null ? NULL_ARRAY_LENGTH : values.length;
+        out.writeInt(len);
+
+        if (len > 0) {
+            final int offset = out.position();
+            out.writeZeroBytes(len * 4);
+            for (int i = 0; i < len; i++) {
+                int position = out.position();
+                if (values[i] == null) {
+                    throw new HazelcastSerializationException("Array items can not be null");
+                } else {
+                    out.writeInt(offset + i * INT_SIZE_IN_BYTES, position);
+                    writer.write(out, values[i]);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] values) throws IOException {
+        writeObjectArrayField(fieldName, FieldType.DECIMAL_ARRAY, values, IOUtil::writeBigDecimal);
+    }
+
+    @Override
+    public void writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] values) throws IOException {
+        writeObjectArrayField(fieldName, FieldType.TIME_ARRAY, values, IOUtil::writeLocalTime);
+    }
+
+    @Override
+    public void writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] values) throws IOException {
+        writeObjectArrayField(fieldName, FieldType.DATE_ARRAY, values, IOUtil::writeLocalDate);
+    }
+
+    @Override
+    public void writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] values) throws IOException {
+        writeObjectArrayField(fieldName, FieldType.TIMESTAMP_ARRAY, values, IOUtil::writeLocalDateTime);
+    }
+
+    @Override
+    public void writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] values) throws IOException {
+        writeObjectArrayField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY, values, IOUtil::writeOffsetDateTime);
+    }
+
+    void writeGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] portables) throws IOException {
         FieldDefinition fd = setPosition(fieldName, FieldType.PORTABLE_ARRAY);
         final int len = portables == null ? NULL_ARRAY_LENGTH : portables.length;
         out.writeInt(len);
@@ -278,7 +387,7 @@ public class DefaultPortableWriter implements PortableWriter {
         }
     }
 
-    private FieldDefinition setPosition(String fieldName, FieldType fieldType) throws IOException {
+    private FieldDefinition setPosition(@Nonnull String fieldName, @Nonnull FieldType fieldType) throws IOException {
         if (raw) {
             throw new HazelcastSerializationException("Cannot write Portable fields after getRawDataOutput() is called!");
         }
@@ -301,6 +410,7 @@ public class DefaultPortableWriter implements PortableWriter {
     }
 
     @Override
+    @Nonnull
     public ObjectDataOutput getRawDataOutput() throws IOException {
         if (!raw) {
             int pos = out.position();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
@@ -313,7 +313,7 @@ public class DefaultPortableWriter implements PortableWriter {
 
         if (len > 0) {
             final int offset = out.position();
-            out.writeZeroBytes(len * 4);
+            out.writeZeroBytes(len * INT_SIZE_IN_BYTES);
             for (int i = 0; i < len; i++) {
                 int position = out.position();
                 if (values[i] == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
@@ -143,7 +143,7 @@ public class DefaultPortableWriter implements PortableWriter {
         }
     }
 
-    public void writeGenericRecord(@Nonnull String fieldName, GenericRecord portable) throws IOException {
+    public void writeGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord portable) throws IOException {
         FieldDefinition fd = setPosition(fieldName, FieldType.PORTABLE);
         final boolean isNull = portable == null;
         out.writeBoolean(isNull);
@@ -189,54 +189,39 @@ public class DefaultPortableWriter implements PortableWriter {
         out.writeInt(classId);
     }
 
-    @Override
-    public void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) throws IOException {
-        setPosition(fieldName, FieldType.DECIMAL);
+    private <T> void writeNullable(@Nonnull String fieldName, FieldType fieldType, @Nullable T value,
+                                   Writer<ObjectDataOutput, T> writer) throws IOException {
+        setPosition(fieldName, fieldType);
         boolean isNull = value == null;
         out.writeBoolean(isNull);
         if (!isNull) {
-            IOUtil.writeBigDecimal(out, value);
+            writer.write(out, value);
         }
+    }
+
+    @Override
+    public void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) throws IOException {
+        writeNullable(fieldName, FieldType.DECIMAL, value, IOUtil::writeBigDecimal);
     }
 
     @Override
     public void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) throws IOException {
-        setPosition(fieldName, FieldType.TIME);
-        boolean isNull = value == null;
-        out.writeBoolean(isNull);
-        if (!isNull) {
-            IOUtil.writeLocalTime(out, value);
-        }
+        writeNullable(fieldName, FieldType.TIME, value, IOUtil::writeLocalTime);
     }
 
     @Override
     public void writeDate(@Nonnull String fieldName, @Nullable LocalDate value) throws IOException {
-        setPosition(fieldName, FieldType.DATE);
-        boolean isNull = value == null;
-        out.writeBoolean(isNull);
-        if (!isNull) {
-            IOUtil.writeLocalDate(out, value);
-        }
+        writeNullable(fieldName, FieldType.DATE, value, IOUtil::writeLocalDate);
     }
 
     @Override
     public void writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) throws IOException {
-        setPosition(fieldName, FieldType.TIMESTAMP);
-        boolean isNull = value == null;
-        out.writeBoolean(isNull);
-        if (!isNull) {
-            IOUtil.writeLocalDateTime(out, value);
-        }
+        writeNullable(fieldName, FieldType.TIMESTAMP, value, IOUtil::writeLocalDateTime);
     }
 
     @Override
     public void writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) throws IOException {
-        setPosition(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
-        boolean isNull = value == null;
-        out.writeBoolean(isNull);
-        if (!isNull) {
-            IOUtil.writeOffsetDateTime(out, value);
-        }
+        writeNullable(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE, value, IOUtil::writeOffsetDateTime);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
@@ -22,7 +22,14 @@ import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
 import com.hazelcast.nio.serialization.Portable;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 import static com.hazelcast.nio.serialization.FieldType.BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldType.BOOLEAN_ARRAY;
@@ -30,6 +37,10 @@ import static com.hazelcast.nio.serialization.FieldType.BYTE;
 import static com.hazelcast.nio.serialization.FieldType.BYTE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.CHAR;
 import static com.hazelcast.nio.serialization.FieldType.CHAR_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.DATE;
+import static com.hazelcast.nio.serialization.FieldType.DATE_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.DECIMAL;
+import static com.hazelcast.nio.serialization.FieldType.DECIMAL_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.DOUBLE;
 import static com.hazelcast.nio.serialization.FieldType.DOUBLE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.FLOAT;
@@ -42,6 +53,12 @@ import static com.hazelcast.nio.serialization.FieldType.PORTABLE;
 import static com.hazelcast.nio.serialization.FieldType.PORTABLE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.SHORT;
 import static com.hazelcast.nio.serialization.FieldType.SHORT_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIME;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_WITH_TIMEZONE;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIME_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.UTF;
 import static com.hazelcast.nio.serialization.FieldType.UTF_ARRAY;
 
@@ -58,7 +75,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public int readInt(String fieldName) throws IOException {
+    public int readInt(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0;
@@ -78,7 +95,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public long readLong(String fieldName) throws IOException {
+    public long readLong(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0L;
@@ -100,17 +117,13 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public String readUTF(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, UTF);
-        return super.readUTF(fieldName);
+    @Nullable
+    public String readUTF(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, UTF, MorphingPortableReader.super::readUTF);
     }
 
     @Override
-    public boolean readBoolean(String fieldName) throws IOException {
+    public boolean readBoolean(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return false;
@@ -120,7 +133,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public byte readByte(String fieldName) throws IOException {
+    public byte readByte(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0;
@@ -130,7 +143,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public char readChar(String fieldName) throws IOException {
+    public char readChar(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0;
@@ -140,7 +153,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public double readDouble(String fieldName) throws IOException {
+    public double readDouble(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0d;
@@ -166,7 +179,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public float readFloat(String fieldName) throws IOException {
+    public float readFloat(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0f;
@@ -188,7 +201,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public short readShort(String fieldName) throws IOException {
+    public short readShort(@Nonnull String fieldName) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return 0;
@@ -204,113 +217,118 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
-    public byte[] readByteArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, BYTE_ARRAY);
-        return super.readByteArray(fieldName);
+    public BigDecimal readDecimal(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, DECIMAL, super::readDecimal);
     }
 
     @Override
-    public boolean[] readBooleanArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, BOOLEAN_ARRAY);
-        return super.readBooleanArray(fieldName);
+    public LocalTime readTime(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, TIME, super::readTime);
     }
 
     @Override
-    public char[] readCharArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, CHAR_ARRAY);
-        return super.readCharArray(fieldName);
+    public LocalDate readDate(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, DATE, super::readDate);
     }
 
     @Override
-    public int[] readIntArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, INT_ARRAY);
-        return super.readIntArray(fieldName);
+    public LocalDateTime readTimestamp(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, TIMESTAMP, super::readTimestamp);
     }
 
     @Override
-    public long[] readLongArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, LONG_ARRAY);
-        return super.readLongArray(fieldName);
+    public OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, TIMESTAMP_WITH_TIMEZONE, super::readTimestampWithTimezone);
     }
 
     @Override
-    public double[] readDoubleArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, DOUBLE_ARRAY);
-        return super.readDoubleArray(fieldName);
+    public byte[] readByteArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, BYTE_ARRAY, super::readByteArray);
     }
 
     @Override
-    public float[] readFloatArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, FLOAT_ARRAY);
-        return super.readFloatArray(fieldName);
+    public boolean[] readBooleanArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, BOOLEAN_ARRAY, super::readBooleanArray);
     }
 
     @Override
-    public short[] readShortArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, SHORT_ARRAY);
-        return super.readShortArray(fieldName);
+    public char[] readCharArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, CHAR_ARRAY, super::readCharArray);
     }
 
     @Override
-    public String[] readUTFArray(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, UTF_ARRAY);
-        return super.readUTFArray(fieldName);
+    public int[] readIntArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, INT_ARRAY, super::readIntArray);
     }
 
     @Override
-    public Portable readPortable(String fieldName) throws IOException {
-        FieldDefinition fd = cd.getField(fieldName);
-        if (fd == null) {
-            return null;
-        }
-        validateTypeCompatibility(fd, PORTABLE);
-        return super.readPortable(fieldName);
+    public long[] readLongArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, LONG_ARRAY, super::readLongArray);
     }
 
     @Override
-    public Portable[] readPortableArray(String fieldName) throws IOException {
+    public double[] readDoubleArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, DOUBLE_ARRAY, super::readDoubleArray);
+    }
+
+    @Override
+    public float[] readFloatArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, FLOAT_ARRAY, super::readFloatArray);
+    }
+
+    @Override
+    public short[] readShortArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, SHORT_ARRAY, super::readShortArray);
+    }
+
+    @Override
+    public String[] readUTFArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, UTF_ARRAY, super::readUTFArray);
+    }
+
+    @Override
+    public Portable readPortable(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, PORTABLE, super::readPortable);
+    }
+
+    @Override
+    public Portable[] readPortableArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, PORTABLE_ARRAY, super::readPortableArray);
+    }
+
+    @Override
+    public BigDecimal[] readDecimalArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, DECIMAL_ARRAY, super::readDecimalArray);
+    }
+
+    @Override
+    public LocalTime[] readTimeArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, TIME_ARRAY, super::readTimeArray);
+    }
+
+    @Override
+    public LocalDate[] readDateArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, DATE_ARRAY, super::readDateArray);
+    }
+
+    @Override
+    public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, TIMESTAMP_ARRAY, super::readTimestampArray);
+    }
+
+    @Override
+    public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, super::readTimestampWithTimezoneArray);
+    }
+
+    private <T> T readIncompatibleField(@Nonnull String fieldName, FieldType fieldType,
+                                        Reader<String, T> reader) throws IOException {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             return null;
         }
-        validateTypeCompatibility(fd, PORTABLE_ARRAY);
-        return super.readPortableArray(fieldName);
+        validateTypeCompatibility(fd, fieldType);
+        return reader.read(fieldName);
     }
 
     private void validateTypeCompatibility(FieldDefinition fd, FieldType expectedType) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
@@ -217,106 +217,127 @@ public class MorphingPortableReader extends DefaultPortableReader {
     }
 
     @Override
+    @Nullable
     public BigDecimal readDecimal(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, DECIMAL, super::readDecimal);
     }
 
     @Override
+    @Nullable
     public LocalTime readTime(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, TIME, super::readTime);
     }
 
     @Override
+    @Nullable
     public LocalDate readDate(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, DATE, super::readDate);
     }
 
     @Override
+    @Nullable
     public LocalDateTime readTimestamp(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, TIMESTAMP, super::readTimestamp);
     }
 
     @Override
+    @Nullable
     public OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, TIMESTAMP_WITH_TIMEZONE, super::readTimestampWithTimezone);
     }
 
     @Override
+    @Nullable
     public byte[] readByteArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, BYTE_ARRAY, super::readByteArray);
     }
 
     @Override
+    @Nullable
     public boolean[] readBooleanArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, BOOLEAN_ARRAY, super::readBooleanArray);
     }
 
     @Override
+    @Nullable
     public char[] readCharArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, CHAR_ARRAY, super::readCharArray);
     }
 
     @Override
+    @Nullable
     public int[] readIntArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, INT_ARRAY, super::readIntArray);
     }
 
     @Override
+    @Nullable
     public long[] readLongArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, LONG_ARRAY, super::readLongArray);
     }
 
     @Override
+    @Nullable
     public double[] readDoubleArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, DOUBLE_ARRAY, super::readDoubleArray);
     }
 
     @Override
+    @Nullable
     public float[] readFloatArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, FLOAT_ARRAY, super::readFloatArray);
     }
 
     @Override
+    @Nullable
     public short[] readShortArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, SHORT_ARRAY, super::readShortArray);
     }
 
     @Override
+    @Nullable
     public String[] readUTFArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, UTF_ARRAY, super::readUTFArray);
     }
 
     @Override
+    @Nullable
     public Portable readPortable(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, PORTABLE, super::readPortable);
     }
 
     @Override
+    @Nullable
     public Portable[] readPortableArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, PORTABLE_ARRAY, super::readPortableArray);
     }
 
     @Override
+    @Nullable
     public BigDecimal[] readDecimalArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, DECIMAL_ARRAY, super::readDecimalArray);
     }
 
     @Override
+    @Nullable
     public LocalTime[] readTimeArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, TIME_ARRAY, super::readTimeArray);
     }
 
     @Override
+    @Nullable
     public LocalDate[] readDateArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, DATE_ARRAY, super::readDateArray);
     }
 
     @Override
+    @Nullable
     public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, TIMESTAMP_ARRAY, super::readTimestampArray);
     }
 
     @Override
+    @Nullable
     public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, super::readTimestampWithTimezoneArray);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
@@ -119,7 +119,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     @Override
     @Nullable
     public String readUTF(@Nonnull String fieldName) throws IOException {
-        return readIncompatibleField(fieldName, UTF, MorphingPortableReader.super::readUTF);
+        return readIncompatibleField(fieldName, UTF, super::readUTF);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
@@ -25,6 +25,12 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Set;
 
@@ -123,11 +129,43 @@ public class PortableGenericRecord extends AbstractGenericRecord {
     }
 
     @Override
+    @Nullable
     public String readUTF(@Nonnull String fieldName) {
         return read(fieldName, FieldType.UTF);
     }
 
     @Override
+    @Nullable
+    public BigDecimal readDecimal(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.DECIMAL);
+    }
+
+    @Override
+    @Nullable
+    public LocalTime readTime(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.TIME);
+    }
+
+    @Override
+    @Nullable
+    public LocalDate readDate(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.DATE);
+    }
+
+    @Override
+    @Nullable
+    public LocalDateTime readTimestamp(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.TIMESTAMP);
+    }
+
+    @Override
+    @Nullable
+    public OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
+    }
+
+    @Override
+    @Nullable
     public boolean[] readBooleanArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.BOOLEAN_ARRAY);
     }
@@ -172,13 +210,38 @@ public class PortableGenericRecord extends AbstractGenericRecord {
         return read(fieldName, FieldType.UTF_ARRAY);
     }
 
-    private <T> T read(String fieldName, FieldType fieldType) {
+    @Override
+    public BigDecimal[] readDecimalArray(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.DECIMAL_ARRAY);
+    }
+
+    @Override
+    public LocalTime[] readTimeArray(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.TIME_ARRAY);
+    }
+
+    @Override
+    public LocalDate[] readDateArray(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.DATE_ARRAY);
+    }
+
+    @Override
+    public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.TIMESTAMP_ARRAY);
+    }
+
+    @Override
+    public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) {
+        return read(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
+    }
+
+    private <T> T read(@Nonnull String fieldName, FieldType fieldType) {
         FieldDefinition fd = check(fieldName, fieldType);
         return (T) objects[fd.getIndex()];
     }
 
     @Nonnull
-    private FieldDefinition check(String fieldName, FieldType fieldType) {
+    private FieldDefinition check(@Nonnull String fieldName, FieldType fieldType) {
         FieldDefinition fd = classDefinition.getField(fieldName);
         if (fd == null) {
             throw new HazelcastSerializationException("Invalid field name: '" + fieldName

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
@@ -171,66 +171,79 @@ public class PortableGenericRecord extends AbstractGenericRecord {
     }
 
     @Override
+    @Nullable
     public byte[] readByteArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.BYTE_ARRAY);
     }
 
     @Override
+    @Nullable
     public char[] readCharArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.CHAR_ARRAY);
     }
 
     @Override
+    @Nullable
     public double[] readDoubleArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.DOUBLE_ARRAY);
     }
 
     @Override
+    @Nullable
     public float[] readFloatArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.FLOAT_ARRAY);
     }
 
     @Override
+    @Nullable
     public int[] readIntArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.INT_ARRAY);
     }
 
     @Override
+    @Nullable
     public long[] readLongArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.LONG_ARRAY);
     }
 
     @Override
+    @Nullable
     public short[] readShortArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.SHORT_ARRAY);
     }
 
     @Override
+    @Nullable
     public String[] readUTFArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.UTF_ARRAY);
     }
 
     @Override
+    @Nullable
     public BigDecimal[] readDecimalArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.DECIMAL_ARRAY);
     }
 
     @Override
+    @Nullable
     public LocalTime[] readTimeArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.TIME_ARRAY);
     }
 
     @Override
+    @Nullable
     public LocalDate[] readDateArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.DATE_ARRAY);
     }
 
     @Override
+    @Nullable
     public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.TIMESTAMP_ARRAY);
     }
 
     @Override
+    @Nullable
     public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) {
         return read(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -72,151 +72,181 @@ public class PortableGenericRecordBuilder implements GenericRecord.Builder {
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeInt(@Nonnull String fieldName, int value) {
         return write(fieldName, value, FieldType.INT);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeLong(@Nonnull String fieldName, long value) {
         return write(fieldName, value, FieldType.LONG);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeUTF(@Nonnull String fieldName, String value) {
         return write(fieldName, value, FieldType.UTF);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeBoolean(@Nonnull String fieldName, boolean value) {
         return write(fieldName, value, FieldType.BOOLEAN);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeByte(@Nonnull String fieldName, byte value) {
         return write(fieldName, value, FieldType.BYTE);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeChar(@Nonnull String fieldName, char value) {
         return write(fieldName, value, FieldType.CHAR);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeDouble(@Nonnull String fieldName, double value) {
         return write(fieldName, value, FieldType.DOUBLE);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeFloat(@Nonnull String fieldName, float value) {
         return write(fieldName, value, FieldType.FLOAT);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeShort(@Nonnull String fieldName, short value) {
         return write(fieldName, value, FieldType.SHORT);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
         return write(fieldName, value, FieldType.PORTABLE);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) {
         return write(fieldName, value, FieldType.DECIMAL);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value) {
         return write(fieldName, value, FieldType.TIME);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeDate(@Nonnull String fieldName, @Nullable LocalDate value) {
         return write(fieldName, value, FieldType.DATE);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) {
         return write(fieldName, value, FieldType.TIMESTAMP);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) {
         return write(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
         return write(fieldName, value, FieldType.PORTABLE_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeByteArray(@Nonnull String fieldName, byte[] value) {
         return write(fieldName, value, FieldType.BYTE_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeBooleanArray(@Nonnull String fieldName, boolean[] value) {
         return write(fieldName, value, FieldType.BOOLEAN_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeCharArray(@Nonnull String fieldName, char[] value) {
         return write(fieldName, value, FieldType.CHAR_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeIntArray(@Nonnull String fieldName, int[] value) {
         return write(fieldName, value, FieldType.INT_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeLongArray(@Nonnull String fieldName, long[] value) {
         return write(fieldName, value, FieldType.LONG_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeDoubleArray(@Nonnull String fieldName, double[] value) {
         return write(fieldName, value, FieldType.DOUBLE_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeFloatArray(@Nonnull String fieldName, float[] value) {
         return write(fieldName, value, FieldType.FLOAT_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeShortArray(@Nonnull String fieldName, short[] value) {
         return write(fieldName, value, FieldType.SHORT_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeUTFArray(@Nonnull String fieldName, String[] value) {
         return write(fieldName, value, FieldType.UTF_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeDecimalArray(@Nonnull String fieldName, BigDecimal[] value) {
         return write(fieldName, value, FieldType.DECIMAL_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeTimeArray(@Nonnull String fieldName, LocalTime[] value) {
         return write(fieldName, value, FieldType.TIME_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeDateArray(@Nonnull String fieldName, LocalDate[] value) {
         return write(fieldName, value, FieldType.DATE_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeTimestampArray(@Nonnull String fieldName, LocalDateTime[] value) {
         return write(fieldName, value, FieldType.TIMESTAMP_ARRAY);
     }
 
     @Override
+    @Nonnull
     public GenericRecord.Builder writeTimestampWithTimezoneArray(@Nonnull String fieldName, OffsetDateTime[] value) {
         return write(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -24,6 +24,11 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 public class PortableGenericRecordBuilder implements GenericRecord.Builder {
 
@@ -117,7 +122,32 @@ public class PortableGenericRecordBuilder implements GenericRecord.Builder {
     }
 
     @Override
-    public GenericRecord.Builder writeGenericRecordArray(@Nonnull String fieldName, GenericRecord[] value) {
+    public GenericRecord.Builder writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) {
+        return write(fieldName, value, FieldType.DECIMAL);
+    }
+
+    @Override
+    public GenericRecord.Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value) {
+        return write(fieldName, value, FieldType.TIME);
+    }
+
+    @Override
+    public GenericRecord.Builder writeDate(@Nonnull String fieldName, @Nullable LocalDate value) {
+        return write(fieldName, value, FieldType.DATE);
+    }
+
+    @Override
+    public GenericRecord.Builder writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) {
+        return write(fieldName, value, FieldType.TIMESTAMP);
+    }
+
+    @Override
+    public GenericRecord.Builder writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) {
+        return write(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE);
+    }
+
+    @Override
+    public GenericRecord.Builder writeGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
         return write(fieldName, value, FieldType.PORTABLE_ARRAY);
     }
 
@@ -165,6 +195,32 @@ public class PortableGenericRecordBuilder implements GenericRecord.Builder {
     public GenericRecord.Builder writeUTFArray(@Nonnull String fieldName, String[] value) {
         return write(fieldName, value, FieldType.UTF_ARRAY);
     }
+
+    @Override
+    public GenericRecord.Builder writeDecimalArray(@Nonnull String fieldName, BigDecimal[] value) {
+        return write(fieldName, value, FieldType.DECIMAL_ARRAY);
+    }
+
+    @Override
+    public GenericRecord.Builder writeTimeArray(@Nonnull String fieldName, LocalTime[] value) {
+        return write(fieldName, value, FieldType.TIME_ARRAY);
+    }
+
+    @Override
+    public GenericRecord.Builder writeDateArray(@Nonnull String fieldName, LocalDate[] value) {
+        return write(fieldName, value, FieldType.DATE_ARRAY);
+    }
+
+    @Override
+    public GenericRecord.Builder writeTimestampArray(@Nonnull String fieldName, LocalDateTime[] value) {
+        return write(fieldName, value, FieldType.TIMESTAMP_ARRAY);
+    }
+
+    @Override
+    public GenericRecord.Builder writeTimestampWithTimezoneArray(@Nonnull String fieldName, OffsetDateTime[] value) {
+        return write(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
+    }
+
 
     private GenericRecord.Builder write(@Nonnull String fieldName, Object value, FieldType fieldType) {
         FieldDefinition fd = check(fieldName, fieldType);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -18,8 +18,10 @@ package com.hazelcast.internal.serialization.impl.portable;
 
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.impl.AbstractGenericRecord;
 import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
+import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
@@ -30,6 +32,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -41,6 +48,11 @@ import static com.hazelcast.internal.nio.Bits.FLOAT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.SHORT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.serialization.FieldType.DATE_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.DECIMAL_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIME_ARRAY;
 
 public class PortableInternalGenericRecord extends AbstractGenericRecord implements InternalGenericRecord {
     protected final ClassDefinition cd;
@@ -180,6 +192,52 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         } finally {
             in.position(currentPos);
         }
+    }
+
+    protected interface Reader<T, R> {
+        R read(T t) throws IOException;
+    }
+
+    private <T> T readNullableField(@Nonnull String fieldName, FieldType fieldType, Reader<ObjectDataInput, T> reader) {
+        int currentPos = in.position();
+        try {
+            int pos = readPosition(fieldName, fieldType);
+            in.position(pos);
+            boolean isNull = in.readBoolean();
+            if (isNull) {
+                return null;
+            }
+            return reader.read(in);
+        } catch (IOException e) {
+            throw illegalStateException(e);
+        } finally {
+            in.position(currentPos);
+        }
+    }
+
+    @Override
+    public BigDecimal readDecimal(@Nonnull String fieldName) {
+        return readNullableField(fieldName, FieldType.DECIMAL, IOUtil::readBigDecimal);
+    }
+
+    @Override
+    public LocalTime readTime(@Nonnull String fieldName) {
+        return readNullableField(fieldName, FieldType.TIME, IOUtil::readLocalTime);
+    }
+
+    @Override
+    public LocalDate readDate(@Nonnull String fieldName) {
+        return readNullableField(fieldName, FieldType.DATE, IOUtil::readLocalDate);
+    }
+
+    @Override
+    public LocalDateTime readTimestamp(@Nonnull String fieldName) {
+        return readNullableField(fieldName, FieldType.TIMESTAMP, IOUtil::readLocalDateTime);
+    }
+
+    @Override
+    public OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) {
+        return readNullableField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE, IOUtil::readOffsetDateTime);
     }
 
     private boolean isNullOrEmpty(int pos) {
@@ -340,6 +398,66 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         }
     }
 
+
+    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, Function<Integer, T[]> constructor,
+                                         Reader<ObjectDataInput, T> reader) {
+        int currentPos = in.position();
+        try {
+            int position = readPosition(fieldName, fieldType);
+            if (isNullOrEmpty(position)) {
+                return null;
+            }
+            in.position(position);
+            int len = in.readInt();
+
+            if (len == Bits.NULL_ARRAY_LENGTH) {
+                return null;
+            }
+
+            T[] values = constructor.apply(len);
+            if (len > 0) {
+                int offset = in.position();
+                for (int i = 0; i < len; i++) {
+                    int pos = in.readInt(offset + i * Bits.INT_SIZE_IN_BYTES);
+                    if (pos != -1) {
+                        in.position(pos);
+                        values[i] = reader.read(in);
+                    }
+                }
+            }
+            return values;
+        } catch (IOException e) {
+            throw illegalStateException(e);
+        } finally {
+            in.position(currentPos);
+        }
+    }
+
+    @Override
+    public BigDecimal[] readDecimalArray(@Nonnull String fieldName) {
+        return readObjectArrayField(fieldName, DECIMAL_ARRAY, BigDecimal[]::new, IOUtil::readBigDecimal);
+    }
+
+    @Override
+    public LocalTime[] readTimeArray(@Nonnull String fieldName) {
+        return readObjectArrayField(fieldName, TIME_ARRAY, LocalTime[]::new, IOUtil::readLocalTime);
+    }
+
+    @Override
+    public LocalDate[] readDateArray(@Nonnull String fieldName) {
+        return readObjectArrayField(fieldName, DATE_ARRAY, LocalDate[]::new, IOUtil::readLocalDate);
+    }
+
+    @Override
+    public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) {
+        return readObjectArrayField(fieldName, TIMESTAMP_ARRAY, LocalDateTime[]::new, IOUtil::readLocalDateTime);
+    }
+
+    @Override
+    public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) {
+        return readObjectArrayField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, OffsetDateTime[]::new, IOUtil::readOffsetDateTime);
+    }
+
     private void checkFactoryAndClass(FieldDefinition fd, int factoryId, int classId) {
         if (factoryId != fd.getFactoryId()) {
             throw new IllegalArgumentException("Invalid factoryId! Expected: "
@@ -352,7 +470,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
 
-    private int readPosition(String fieldName, FieldType fieldType) {
+    private int readPosition(@Nonnull String fieldName, FieldType fieldType) {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
             throw throwUnknownFieldException(fieldName);
@@ -367,7 +485,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         return new IllegalStateException("IOException is not expected since we read from a well known format and position");
     }
 
-    private HazelcastSerializationException throwUnknownFieldException(String fieldName) {
+    private HazelcastSerializationException throwUnknownFieldException(@Nonnull String fieldName) {
         return new HazelcastSerializationException("Unknown field name: '" + fieldName
                 + "' for ClassDefinition {id: " + cd.getClassId() + ", version: " + cd.getVersion() + "}");
     }
@@ -406,7 +524,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         return readNestedArray(fieldName, GenericRecord[]::new, false);
     }
 
-    private <T> T[] readNestedArray(String fieldName, Function<Integer, T[]> constructor, boolean asPortable) {
+    private <T> T[] readNestedArray(@Nonnull String fieldName, Function<Integer, T[]> constructor, boolean asPortable) {
         int currentPos = in.position();
         try {
             FieldDefinition fd = cd.getField(fieldName);
@@ -458,7 +576,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         return readNested(fieldName, false);
     }
 
-    private <T> T readNested(String fieldName, boolean asPortable) {
+    private <T> T readNested(@Nonnull String fieldName, boolean asPortable) {
         int currentPos = in.position();
         try {
             FieldDefinition fd = cd.getField(fieldName);
@@ -504,7 +622,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Byte readByteFromArray(String fieldName, int index) {
+    public Byte readByteFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.BYTE_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -518,7 +636,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
 
     @SuppressFBWarnings({"NP_BOOLEAN_RETURN_NULL"})
     @Override
-    public Boolean readBooleanFromArray(String fieldName, int index) {
+    public Boolean readBooleanFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.BOOLEAN_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -531,7 +649,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Character readCharFromArray(String fieldName, int index) {
+    public Character readCharFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.CHAR_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -544,7 +662,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Double readDoubleFromArray(String fieldName, int index) {
+    public Double readDoubleFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.DOUBLE_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -557,7 +675,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Float readFloatFromArray(String fieldName, int index) {
+    public Float readFloatFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.FLOAT_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -570,7 +688,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Integer readIntFromArray(String fieldName, int index) {
+    public Integer readIntFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.INT_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -583,7 +701,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Long readLongFromArray(String fieldName, int index) {
+    public Long readLongFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.LONG_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -596,7 +714,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Short readShortFromArray(String fieldName, int index) {
+    public Short readShortFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.SHORT_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -609,7 +727,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public String readUTFFromArray(String fieldName, int index) {
+    public String readUTFFromArray(@Nonnull String fieldName, int index) {
         int currentPos = in.position();
         try {
             int pos = readPosition(fieldName, FieldType.UTF_ARRAY);
@@ -636,16 +754,16 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public GenericRecord readGenericRecordFromArray(String fieldName, int index) {
+    public GenericRecord readGenericRecordFromArray(@Nonnull String fieldName, int index) {
         return readNestedFromArray(fieldName, index, false);
     }
 
     @Override
-    public Object readObjectFromArray(String fieldName, int index) {
+    public Object readObjectFromArray(@Nonnull String fieldName, int index) {
         return readNestedFromArray(fieldName, index, true);
     }
 
-    private <T> T readNestedFromArray(String fieldName, int index, boolean asPortable) {
+    private <T> T readNestedFromArray(@Nonnull String fieldName, int index, boolean asPortable) {
         int currentPos = in.position();
         try {
             FieldDefinition fd = cd.getField(fieldName);
@@ -685,13 +803,68 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         }
     }
 
+
+    private <T> T readObjectFromArrayField(@Nonnull String fieldName, FieldType fieldType,
+                                           Reader<ObjectDataInput, T> reader, int index) {
+        int currentPos = in.position();
+        try {
+            int position = readPosition(fieldName, fieldType);
+            if (isNullOrEmpty(position)) {
+                return null;
+            }
+            in.position(position);
+            int len = in.readInt();
+            if (len == Bits.NULL_ARRAY_LENGTH || len == 0 || len <= index) {
+                return null;
+            }
+
+            int offset = in.position();
+            int pos = in.readInt(offset + index * Bits.INT_SIZE_IN_BYTES);
+            if (pos != -1) {
+                in.position(pos);
+                return reader.read(in);
+            }
+            return null;
+        } catch (IOException e) {
+            throw illegalStateException(e);
+        } finally {
+            in.position(currentPos);
+        }
+    }
+
     @Override
-    public Object[] readObjectArray(String fieldName) {
+    public BigDecimal readDecimalFromArray(@Nonnull String fieldName, int index) {
+        return readObjectFromArrayField(fieldName, DECIMAL_ARRAY, IOUtil::readBigDecimal, index);
+    }
+
+    @Override
+    public LocalTime readTimeFromArray(@Nonnull String fieldName, int index) {
+        return readObjectFromArrayField(fieldName, TIME_ARRAY, IOUtil::readLocalTime, index);
+    }
+
+    @Override
+    public LocalDate readDateFromArray(@Nonnull String fieldName, int index) {
+        return readObjectFromArrayField(fieldName, DATE_ARRAY, IOUtil::readLocalDate, index);
+    }
+
+    @Override
+    public LocalDateTime readTimestampFromArray(@Nonnull String fieldName, int index) {
+        return readObjectFromArrayField(fieldName, TIMESTAMP_ARRAY, IOUtil::readLocalDateTime, index);
+    }
+
+    @Override
+    public OffsetDateTime readTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
+        return readObjectFromArrayField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, IOUtil::readOffsetDateTime, index);
+    }
+
+
+    @Override
+    public Object[] readObjectArray(@Nonnull String fieldName) {
         return readNestedArray(fieldName, Portable[]::new, true);
     }
 
     @Override
-    public Object readObject(String fieldName) {
+    public Object readObject(@Nonnull String fieldName) {
         return readNested(fieldName, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -31,6 +31,7 @@ import com.hazelcast.nio.serialization.Portable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -198,6 +199,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         R read(T t) throws IOException;
     }
 
+    @Nullable
     private <T> T readNullableField(@Nonnull String fieldName, FieldType fieldType, Reader<ObjectDataInput, T> reader) {
         int currentPos = in.position();
         try {
@@ -419,10 +421,8 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
                 int offset = in.position();
                 for (int i = 0; i < len; i++) {
                     int pos = in.readInt(offset + i * Bits.INT_SIZE_IN_BYTES);
-                    if (pos != -1) {
-                        in.position(pos);
-                        values[i] = reader.read(in);
-                    }
+                    in.position(pos);
+                    values[i] = reader.read(in);
                 }
             }
             return values;
@@ -820,11 +820,8 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
 
             int offset = in.position();
             int pos = in.readInt(offset + index * Bits.INT_SIZE_IN_BYTES);
-            if (pos != -1) {
-                in.position(pos);
-                return reader.read(in);
-            }
-            return null;
+            in.position(pos);
+            return reader.read(in);
         } catch (IOException e) {
             throw illegalStateException(e);
         } finally {
@@ -856,7 +853,6 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     public OffsetDateTime readTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
         return readObjectFromArrayField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, IOUtil::readOffsetDateTime, index);
     }
-
 
     @Override
     public Object[] readObjectArray(@Nonnull String fieldName) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -114,7 +114,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readBoolean(readPosition(fieldName, FieldType.BOOLEAN));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -123,7 +123,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readByte(readPosition(fieldName, FieldType.BYTE));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -132,7 +132,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readChar(readPosition(fieldName, FieldType.CHAR));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -141,7 +141,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readDouble(readPosition(fieldName, FieldType.DOUBLE));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -150,7 +150,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readFloat(readPosition(fieldName, FieldType.FLOAT));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -159,7 +159,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readInt(readPosition(fieldName, FieldType.INT));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -168,7 +168,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readLong(readPosition(fieldName, FieldType.LONG));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -177,7 +177,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readShort(readPosition(fieldName, FieldType.SHORT));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -189,13 +189,14 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(pos);
             return in.readUTF();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
     }
 
-    protected interface Reader<T, R> {
+    @FunctionalInterface
+    private interface Reader<T, R> {
         R read(T t) throws IOException;
     }
 
@@ -211,7 +212,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             }
             return reader.read(in);
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -257,7 +258,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readBooleanArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -274,7 +275,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readByteArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -292,7 +293,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readCharArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -309,7 +310,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readDoubleArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -326,7 +327,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readFloatArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -343,7 +344,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readIntArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -360,7 +361,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readLongArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -377,7 +378,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readShortArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -394,7 +395,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(position);
             return in.readUTFArray();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -427,7 +428,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             }
             return values;
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -473,7 +474,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     private int readPosition(@Nonnull String fieldName, FieldType fieldType) {
         FieldDefinition fd = cd.getField(fieldName);
         if (fd == null) {
-            throw throwUnknownFieldException(fieldName);
+            throw newUnknownFieldException(fieldName);
         }
         if (fd.getType() != fieldType) {
             throw new HazelcastSerializationException("Not a '" + fieldType + "' field: " + fieldName);
@@ -481,11 +482,11 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         return readPosition(fd);
     }
 
-    private IllegalStateException illegalStateException(IOException e) {
-        return new IllegalStateException("IOException is not expected since we read from a well known format and position");
+    private IllegalStateException newIllegalStateException(IOException e) {
+        return new IllegalStateException("IOException is not expected since we read from a well known format and position", e);
     }
 
-    private HazelcastSerializationException throwUnknownFieldException(@Nonnull String fieldName) {
+    private HazelcastSerializationException newUnknownFieldException(@Nonnull String fieldName) {
         return new HazelcastSerializationException("Unknown field name: '" + fieldName
                 + "' for ClassDefinition {id: " + cd.getClassId() + ", version: " + cd.getVersion() + "}");
     }
@@ -497,7 +498,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             // name + len + type
             return pos + Bits.SHORT_SIZE_IN_BYTES + len + 1;
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -529,7 +530,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             FieldDefinition fd = cd.getField(fieldName);
             if (fd == null) {
-                throw throwUnknownFieldException(fieldName);
+                throw newUnknownFieldException(fieldName);
             }
             if (fd.getType() != FieldType.PORTABLE_ARRAY) {
                 throw new HazelcastSerializationException("Not a Portable array field: " + fieldName);
@@ -565,7 +566,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             }
             return portables;
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -581,7 +582,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             FieldDefinition fd = cd.getField(fieldName);
             if (fd == null) {
-                throw throwUnknownFieldException(fieldName);
+                throw newUnknownFieldException(fieldName);
             }
             if (fd.getType() != FieldType.PORTABLE) {
                 throw new HazelcastSerializationException("Not a Portable field: " + fieldName);
@@ -605,7 +606,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             }
             return null;
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -616,7 +617,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             int numberOfItems = in.readInt(beginPosition);
             return numberOfItems <= index;
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
 
     }
@@ -630,7 +631,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readByte(INT_SIZE_IN_BYTES + position + (index * BYTE_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -644,7 +645,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readBoolean(INT_SIZE_IN_BYTES + position + (index * BOOLEAN_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -657,7 +658,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readChar(INT_SIZE_IN_BYTES + position + (index * CHAR_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -670,7 +671,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readDouble(INT_SIZE_IN_BYTES + position + (index * DOUBLE_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -683,7 +684,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readFloat(INT_SIZE_IN_BYTES + position + (index * FLOAT_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -696,7 +697,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readInt(INT_SIZE_IN_BYTES + position + (index * INT_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -709,7 +710,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readLong(INT_SIZE_IN_BYTES + position + (index * LONG_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -722,7 +723,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             return in.readShort(INT_SIZE_IN_BYTES + position + (index * SHORT_SIZE_IN_BYTES));
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         }
     }
 
@@ -747,7 +748,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             }
             return in.readUTF();
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -768,7 +769,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             FieldDefinition fd = cd.getField(fieldName);
             if (fd == null) {
-                throw throwUnknownFieldException(fieldName);
+                throw newUnknownFieldException(fieldName);
             }
             if (fd.getType() != FieldType.PORTABLE_ARRAY) {
                 throw new HazelcastSerializationException("Not a Portable array field: " + fieldName);
@@ -797,7 +798,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
                 return serializer.readAndInitialize(in, factoryId, classId, readGenericLazy);
             }
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }
@@ -823,7 +824,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
             in.position(pos);
             return reader.read(in);
         } catch (IOException e) {
-            throw illegalStateException(e);
+            throw newIllegalStateException(e);
         } finally {
             in.position(currentPos);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
@@ -246,6 +246,21 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                 case UTF:
                     writer.writeUTF(fieldName, record.readUTF(fieldName));
                     break;
+                case DECIMAL:
+                    writer.writeDecimal(fieldName, record.readDecimal(fieldName));
+                    break;
+                case TIME:
+                    writer.writeTime(fieldName, record.readTime(fieldName));
+                    break;
+                case DATE:
+                    writer.writeDate(fieldName, record.readDate(fieldName));
+                    break;
+                case TIMESTAMP:
+                    writer.writeTimestamp(fieldName, record.readTimestamp(fieldName));
+                    break;
+                case TIMESTAMP_WITH_TIMEZONE:
+                    writer.writeTimestampWithTimezone(fieldName, record.readTimestampWithTimezone(fieldName));
+                    break;
                 case PORTABLE_ARRAY:
                     writer.writeGenericRecordArray(fieldName, record.readGenericRecordArray(fieldName));
                     break;
@@ -275,6 +290,21 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                     break;
                 case UTF_ARRAY:
                     writer.writeUTFArray(fieldName, record.readUTFArray(fieldName));
+                    break;
+                case DECIMAL_ARRAY:
+                    writer.writeDecimalArray(fieldName, record.readDecimalArray(fieldName));
+                    break;
+                case TIME_ARRAY:
+                    writer.writeTimeArray(fieldName, record.readTimeArray(fieldName));
+                    break;
+                case DATE_ARRAY:
+                    writer.writeDateArray(fieldName, record.readDateArray(fieldName));
+                    break;
+                case TIMESTAMP_ARRAY:
+                    writer.writeTimestampArray(fieldName, record.readTimestampArray(fieldName));
+                    break;
+                case TIMESTAMP_WITH_TIMEZONE_ARRAY:
+                    writer.writeTimestampWithTimezoneArray(fieldName, record.readTimestampWithTimezoneArray(fieldName));
                     break;
                 default:
                     throw new IllegalStateException("Unexpected field type: " + cd.getFieldType(fieldName));
@@ -343,6 +373,21 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                 case UTF:
                     genericRecordBuilder.writeUTF(fieldName, reader.readUTF(fieldName));
                     break;
+                case DECIMAL:
+                    genericRecordBuilder.writeDecimal(fieldName, reader.readDecimal(fieldName));
+                    break;
+                case TIME:
+                    genericRecordBuilder.writeTime(fieldName, reader.readTime(fieldName));
+                    break;
+                case DATE:
+                    genericRecordBuilder.writeDate(fieldName, reader.readDate(fieldName));
+                    break;
+                case TIMESTAMP:
+                    genericRecordBuilder.writeTimestamp(fieldName, reader.readTimestamp(fieldName));
+                    break;
+                case TIMESTAMP_WITH_TIMEZONE:
+                    genericRecordBuilder.writeTimestampWithTimezone(fieldName, reader.readTimestampWithTimezone(fieldName));
+                    break;
                 case PORTABLE_ARRAY:
                     genericRecordBuilder.writeGenericRecordArray(fieldName, reader.readGenericRecordArray(fieldName));
                     break;
@@ -372,6 +417,22 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                     break;
                 case UTF_ARRAY:
                     genericRecordBuilder.writeUTFArray(fieldName, reader.readUTFArray(fieldName));
+                    break;
+                case DECIMAL_ARRAY:
+                    genericRecordBuilder.writeDecimalArray(fieldName, reader.readDecimalArray(fieldName));
+                    break;
+                case TIME_ARRAY:
+                    genericRecordBuilder.writeTimeArray(fieldName, reader.readTimeArray(fieldName));
+                    break;
+                case DATE_ARRAY:
+                    genericRecordBuilder.writeDateArray(fieldName, reader.readDateArray(fieldName));
+                    break;
+                case TIMESTAMP_ARRAY:
+                    genericRecordBuilder.writeTimestampArray(fieldName, reader.readTimestampArray(fieldName));
+                    break;
+                case TIMESTAMP_WITH_TIMEZONE_ARRAY:
+                    genericRecordBuilder.writeTimestampWithTimezoneArray(fieldName,
+                            reader.readTimestampWithTimezoneArray(fieldName));
                     break;
                 default:
                     throw new IllegalStateException("Unexpected value: " + cd.getFieldType(fieldName));

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -19,7 +19,6 @@ package com.hazelcast.nio.serialization;
 import com.hazelcast.internal.serialization.impl.portable.ClassDefinitionImpl;
 import com.hazelcast.internal.serialization.impl.portable.FieldDefinitionImpl;
 import com.hazelcast.spi.annotation.PrivateApi;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -412,7 +411,6 @@ public final class ClassDefinitionBuilder {
         return addField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
     }
 
-    @NotNull
     private ClassDefinitionBuilder addField(@Nonnull String fieldName, FieldType fieldType) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, fieldType, version));

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -19,6 +19,7 @@ package com.hazelcast.nio.serialization;
 import com.hazelcast.internal.serialization.impl.portable.ClassDefinitionImpl;
 import com.hazelcast.internal.serialization.impl.portable.FieldDefinitionImpl;
 import com.hazelcast.spi.annotation.PrivateApi;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -77,9 +78,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addIntField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.INT, version));
-        return this;
+        return addField(fieldName, FieldType.INT);
     }
 
     /**
@@ -89,9 +88,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addLongField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.LONG, version));
-        return this;
+        return addField(fieldName, FieldType.LONG);
     }
 
     /**
@@ -101,9 +98,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addUTFField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.UTF, version));
-        return this;
+        return addField(fieldName, FieldType.UTF);
     }
 
     /**
@@ -113,9 +108,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addBooleanField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BOOLEAN, version));
-        return this;
+        return addField(fieldName, FieldType.BOOLEAN);
     }
 
     /**
@@ -125,9 +118,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addByteField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BYTE, version));
-        return this;
+        return addField(fieldName, FieldType.BYTE);
     }
 
     /**
@@ -137,9 +128,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addBooleanArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BOOLEAN_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.BOOLEAN_ARRAY);
     }
 
     /**
@@ -149,9 +138,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addCharField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.CHAR, version));
-        return this;
+        return addField(fieldName, FieldType.CHAR);
     }
 
     /**
@@ -161,9 +148,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addDoubleField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DOUBLE, version));
-        return this;
+        return addField(fieldName, FieldType.DOUBLE);
     }
 
     /**
@@ -173,9 +158,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addFloatField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.FLOAT, version));
-        return this;
+        return addField(fieldName, FieldType.FLOAT);
     }
 
     /**
@@ -185,9 +168,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addShortField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.SHORT, version));
-        return this;
+        return addField(fieldName, FieldType.SHORT);
     }
 
     /**
@@ -199,9 +180,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addDecimalField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DECIMAL, version));
-        return this;
+        return addField(fieldName, FieldType.DECIMAL);
     }
 
     /**
@@ -213,13 +192,11 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addTimeField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIME, version));
-        return this;
+        return addField(fieldName, FieldType.TIME);
     }
 
     /**
-     * Adds a date field consisting of year , month of the year and day of the month to the class definition
+     * Adds a date field consisting of year, month of the year and day of the month to the class definition
      *
      * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
@@ -227,14 +204,12 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addDateField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DATE, version));
-        return this;
+        return addField(fieldName, FieldType.DATE);
     }
 
     /**
      * Adds a timestamp field consisting of
-     * year , month of the year and day of the month, hour, minute, seconds, nanos parts to the class definition
+     * year, month of the year, day of the month, hour, minute, seconds, nanos parts to the class definition
      *
      * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
@@ -242,14 +217,12 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addTimestampField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP, version));
-        return this;
+        return addField(fieldName, FieldType.TIMESTAMP);
     }
 
     /**
      * Adds a timestamp with timezone field consisting of
-     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
      * to the class definition
      *
      * @param fieldName name of the field that will be added to this class definition
@@ -258,9 +231,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addTimestampWithTimezoneField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE, version));
-        return this;
+        return addField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
     }
 
     /**
@@ -270,9 +241,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addByteArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BYTE_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.BYTE_ARRAY);
     }
 
     /**
@@ -282,9 +251,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addCharArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.CHAR_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.CHAR_ARRAY);
     }
 
     /**
@@ -294,9 +261,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addIntArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.INT_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.INT_ARRAY);
     }
 
     /**
@@ -306,9 +271,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addLongArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.LONG_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.LONG_ARRAY);
     }
 
     /**
@@ -318,9 +281,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addDoubleArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DOUBLE_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.DOUBLE_ARRAY);
     }
 
     /**
@@ -330,9 +291,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addFloatArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.FLOAT_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.FLOAT_ARRAY);
     }
 
     /**
@@ -342,9 +301,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addShortArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.SHORT_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.SHORT_ARRAY);
     }
 
     /**
@@ -354,9 +311,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addUTFArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.UTF_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.UTF_ARRAY);
     }
 
     /**
@@ -402,9 +357,7 @@ public final class ClassDefinitionBuilder {
      * @see #addDecimalField(String)
      */
     public ClassDefinitionBuilder addDecimalArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DECIMAL_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.DECIMAL_ARRAY);
     }
 
     /**
@@ -417,9 +370,7 @@ public final class ClassDefinitionBuilder {
      * @see #addTimeField(String)
      */
     public ClassDefinitionBuilder addTimeArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIME_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.TIME_ARRAY);
     }
 
     /**
@@ -432,9 +383,7 @@ public final class ClassDefinitionBuilder {
      * @see #addDateField(String)
      */
     public ClassDefinitionBuilder addDateArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DATE_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.DATE_ARRAY);
     }
 
     /**
@@ -447,9 +396,7 @@ public final class ClassDefinitionBuilder {
      * @see #addTimestampField(String)
      */
     public ClassDefinitionBuilder addTimestampArrayField(@Nonnull String fieldName) {
-        check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP_ARRAY, version));
-        return this;
+        return addField(fieldName, FieldType.TIMESTAMP_ARRAY);
     }
 
     /**
@@ -462,8 +409,13 @@ public final class ClassDefinitionBuilder {
      * @see #addTimestampWithTimezoneField(String)
      */
     public ClassDefinitionBuilder addTimestampWithTimezoneArrayField(@Nonnull String fieldName) {
+        return addField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
+    }
+
+    @NotNull
+    private ClassDefinitionBuilder addField(@Nonnull String fieldName, FieldType fieldType) {
         check(fieldName);
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY, version));
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, fieldType, version));
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.impl.portable.ClassDefinitionImpl;
 import com.hazelcast.internal.serialization.impl.portable.FieldDefinitionImpl;
 import com.hazelcast.spi.annotation.PrivateApi;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -75,7 +76,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addIntField(String fieldName) {
+    public ClassDefinitionBuilder addIntField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.INT, version));
         return this;
@@ -87,7 +88,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addLongField(String fieldName) {
+    public ClassDefinitionBuilder addLongField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.LONG, version));
         return this;
@@ -99,7 +100,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addUTFField(String fieldName) {
+    public ClassDefinitionBuilder addUTFField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.UTF, version));
         return this;
@@ -111,7 +112,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addBooleanField(String fieldName) {
+    public ClassDefinitionBuilder addBooleanField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BOOLEAN, version));
         return this;
@@ -123,7 +124,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addByteField(String fieldName) {
+    public ClassDefinitionBuilder addByteField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BYTE, version));
         return this;
@@ -135,7 +136,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addBooleanArrayField(String fieldName) {
+    public ClassDefinitionBuilder addBooleanArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BOOLEAN_ARRAY, version));
         return this;
@@ -147,7 +148,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addCharField(String fieldName) {
+    public ClassDefinitionBuilder addCharField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.CHAR, version));
         return this;
@@ -159,7 +160,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addDoubleField(String fieldName) {
+    public ClassDefinitionBuilder addDoubleField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DOUBLE, version));
         return this;
@@ -171,7 +172,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addFloatField(String fieldName) {
+    public ClassDefinitionBuilder addFloatField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.FLOAT, version));
         return this;
@@ -183,9 +184,82 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addShortField(String fieldName) {
+    public ClassDefinitionBuilder addShortField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.SHORT, version));
+        return this;
+    }
+
+    /**
+     * Adds a decimal which is arbitrary precision and scale floating-point number to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addDecimalField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DECIMAL, version));
+        return this;
+    }
+
+    /**
+     * Adds a time field consisting of hour, minute, seconds and nanos parts to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addTimeField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIME, version));
+        return this;
+    }
+
+    /**
+     * Adds a date field consisting of year , month of the year and day of the month to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addDateField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DATE, version));
+        return this;
+    }
+
+    /**
+     * Adds a timestamp field consisting of
+     * year , month of the year and day of the month, hour, minute, seconds, nanos parts to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addTimestampField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP, version));
+        return this;
+    }
+
+    /**
+     * Adds a timestamp with timezone field consisting of
+     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addTimestampWithTimezoneField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE, version));
         return this;
     }
 
@@ -195,7 +269,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addByteArrayField(String fieldName) {
+    public ClassDefinitionBuilder addByteArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BYTE_ARRAY, version));
         return this;
@@ -207,7 +281,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addCharArrayField(String fieldName) {
+    public ClassDefinitionBuilder addCharArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.CHAR_ARRAY, version));
         return this;
@@ -219,7 +293,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addIntArrayField(String fieldName) {
+    public ClassDefinitionBuilder addIntArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.INT_ARRAY, version));
         return this;
@@ -231,7 +305,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addLongArrayField(String fieldName) {
+    public ClassDefinitionBuilder addLongArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.LONG_ARRAY, version));
         return this;
@@ -243,7 +317,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addDoubleArrayField(String fieldName) {
+    public ClassDefinitionBuilder addDoubleArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DOUBLE_ARRAY, version));
         return this;
@@ -255,7 +329,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addFloatArrayField(String fieldName) {
+    public ClassDefinitionBuilder addFloatArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.FLOAT_ARRAY, version));
         return this;
@@ -267,7 +341,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addShortArrayField(String fieldName) {
+    public ClassDefinitionBuilder addShortArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.SHORT_ARRAY, version));
         return this;
@@ -279,7 +353,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addUTFArrayField(String fieldName) {
+    public ClassDefinitionBuilder addUTFArrayField(@Nonnull String fieldName) {
         check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.UTF_ARRAY, version));
         return this;
@@ -291,7 +365,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addPortableField(String fieldName, ClassDefinition def) {
+    public ClassDefinitionBuilder addPortableField(@Nonnull String fieldName, ClassDefinition def) {
         if (def.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
         }
@@ -308,7 +382,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
-    public ClassDefinitionBuilder addPortableArrayField(String fieldName, ClassDefinition classDefinition) {
+    public ClassDefinitionBuilder addPortableArrayField(@Nonnull String fieldName, ClassDefinition classDefinition) {
         if (classDefinition.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
         }
@@ -318,15 +392,89 @@ public final class ClassDefinitionBuilder {
         return this;
     }
 
+    /**
+     * Adds an array of Decimal's to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @see #addDecimalField(String)
+     */
+    public ClassDefinitionBuilder addDecimalArrayField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DECIMAL_ARRAY, version));
+        return this;
+    }
+
+    /**
+     * Adds an array of Time's to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @see #addTimeField(String)
+     */
+    public ClassDefinitionBuilder addTimeArrayField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIME_ARRAY, version));
+        return this;
+    }
+
+    /**
+     * Adds an array of Date's to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @see #addDateField(String)
+     */
+    public ClassDefinitionBuilder addDateArrayField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DATE_ARRAY, version));
+        return this;
+    }
+
+    /**
+     * Adds an array of Timestamp's to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @see #addTimestampField(String)
+     */
+    public ClassDefinitionBuilder addTimestampArrayField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP_ARRAY, version));
+        return this;
+    }
+
+    /**
+     * Adds an array of TimestampWithTimezone's to the class definition
+     *
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @see #addTimestampWithTimezoneField(String)
+     */
+    public ClassDefinitionBuilder addTimestampWithTimezoneArrayField(@Nonnull String fieldName) {
+        check(fieldName);
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY, version));
+        return this;
+    }
+
     @PrivateApi
-    public ClassDefinitionBuilder addField(FieldDefinitionImpl fieldDefinition) {
+    public void addField(FieldDefinitionImpl fieldDefinition) {
         if (index != fieldDefinition.getIndex()) {
             throw new IllegalArgumentException("Invalid field index");
         }
         check(fieldDefinition.getName());
         index++;
         fieldDefinitions.add(fieldDefinition);
-        return this;
     }
 
     /**
@@ -341,7 +489,7 @@ public final class ClassDefinitionBuilder {
         return cd;
     }
 
-    private void check(String fieldName) {
+    private void check(@Nonnull String fieldName) {
         if (!addedFieldNames.add(fieldName)) {
             throw new HazelcastSerializationException("Field with field name : " + fieldName + " already exists");
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -468,6 +468,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeBoolean(@Nonnull String fieldName, boolean value);
 
         /**
@@ -483,6 +484,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeByte(@Nonnull String fieldName, byte value);
 
         /**
@@ -497,6 +499,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeChar(@Nonnull String fieldName, char value);
 
         /**
@@ -511,6 +514,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeDouble(@Nonnull String fieldName, double value);
 
         /**
@@ -525,6 +529,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeFloat(@Nonnull String fieldName, float value);
 
         /**
@@ -539,6 +544,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeInt(@Nonnull String fieldName, int value);
 
         /**
@@ -553,6 +559,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeLong(@Nonnull String fieldName, long value);
 
         /**
@@ -567,6 +574,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeShort(@Nonnull String fieldName, short value);
 
         /**
@@ -581,6 +589,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeUTF(@Nonnull String fieldName, @Nullable String value);
 
         /**
@@ -596,6 +605,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value);
 
         /**
@@ -611,6 +621,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value);
 
         /**
@@ -626,6 +637,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value);
 
         /**
@@ -641,6 +653,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeDate(@Nonnull String fieldName, @Nullable LocalDate value);
 
         /**
@@ -657,6 +670,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value);
 
         /**
@@ -673,6 +687,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value);
 
         /**
@@ -687,6 +702,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeBooleanArray(@Nonnull String fieldName, @Nullable boolean[] value);
 
         /**
@@ -701,6 +717,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeByteArray(@Nonnull String fieldName, @Nullable byte[] value);
 
         /**
@@ -715,6 +732,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeCharArray(@Nonnull String fieldName, @Nullable char[] value);
 
         /**
@@ -729,6 +747,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeFloatArray(@Nonnull String fieldName, @Nullable float[] value);
 
         /**
@@ -743,6 +762,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeIntArray(@Nonnull String fieldName, @Nullable int[] value);
 
         /**
@@ -757,6 +777,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeDoubleArray(@Nonnull String fieldName, @Nullable double[] value);
 
         /**
@@ -771,6 +792,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeLongArray(@Nonnull String fieldName, @Nullable long[] value);
 
         /**
@@ -785,6 +807,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeShortArray(@Nonnull String fieldName, @Nullable short[] value);
 
         /**
@@ -800,6 +823,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeUTFArray(@Nonnull String fieldName, @Nullable String[] value);
 
         /**
@@ -817,6 +841,7 @@ public interface GenericRecord {
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          * @see #writeDecimal(String, BigDecimal)
          */
+        @Nonnull
         Builder writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] value);
 
         /**
@@ -834,6 +859,7 @@ public interface GenericRecord {
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          * @see #writeTime(String, LocalTime)
          */
+        @Nonnull
         Builder writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] value);
 
         /**
@@ -851,6 +877,7 @@ public interface GenericRecord {
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          * @see #writeDate(String, LocalDate)
          */
+        @Nonnull
         Builder writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] value);
 
         /**
@@ -868,6 +895,7 @@ public interface GenericRecord {
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          * @see #writeTimestamp(String, LocalDateTime)
          */
+        @Nonnull
         Builder writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] value);
 
         /**
@@ -885,6 +913,7 @@ public interface GenericRecord {
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          * @see #writeTimestampWithTimezone(String, OffsetDateTime)
          */
+        @Nonnull
         Builder writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] value);
 
         /**
@@ -902,6 +931,7 @@ public interface GenericRecord {
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
+        @Nonnull
         Builder writeGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -21,6 +21,11 @@ import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 /**
@@ -200,6 +205,64 @@ public interface GenericRecord {
     String readUTF(@Nonnull String fieldName);
 
     /**
+     * Reads a decimal which is arbitrary precision and scale floating-point number to BigDecimal
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    BigDecimal readDecimal(@Nonnull String fieldName);
+
+    /**
+     * Reads a time field consisting of hour, minute, seconds and nanos parts to LocalTime
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalTime readTime(@Nonnull String fieldName);
+
+    /**
+     * Reads a date field consisting of year , month of the year and day of the month to LocalDate
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalDate readDate(@Nonnull String fieldName);
+
+    /**
+     * Reads a timestamp field consisting of
+     * year , month of the year and day of the month, hour, minute, seconds, nanos parts to LocalDateTime
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalDateTime readTimestamp(@Nonnull String fieldName);
+
+    /**
+     * Reads a timestamp with timezone field consisting of
+     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * to OffsetDateTime
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName);
+
+    /**
      * @param fieldName the name of the field
      * @return the value of the field
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
@@ -290,6 +353,66 @@ public interface GenericRecord {
     String[] readUTFArray(@Nonnull String fieldName);
 
     /**
+     * Reads an array of Decimal's to BigDecimal[]
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #readDecimal(String)
+     */
+    @Nullable
+    BigDecimal[] readDecimalArray(@Nonnull String fieldName);
+
+    /**
+     * Reads an array of Time's to LocalTime[]
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #readTime(String)
+     */
+    @Nullable
+    LocalTime[] readTimeArray(@Nonnull String fieldName);
+
+    /**
+     * Reads an array of Date's to LocalDate[]
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #readDate(String)
+     */
+    @Nullable
+    LocalDate[] readDateArray(@Nonnull String fieldName);
+
+    /**
+     * Reads an array of Timestamp's to LocalDateTime[]
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #readTimestamp(String)
+     */
+    @Nullable
+    LocalDateTime[] readTimestampArray(@Nonnull String fieldName);
+
+    /**
+     * Reads an array of TimestampWithTimezone's to OffsetDateTime[]
+     *
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #readTimestampWithTimezone(String)
+     */
+    @Nullable
+    OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName);
+
+    /**
      * @param fieldName the name of the field
      * @return the value of the field
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
@@ -338,7 +461,7 @@ public interface GenericRecord {
          * @param fieldName name of the field as it is defined in its class definition.
          *                  It should be composed of only alpha-numeric characters.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
          * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
@@ -353,7 +476,8 @@ public interface GenericRecord {
          * @param fieldName name of the field as it is defined in its class definition.
          *                  It should be composed of only alpha-numeric characters.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -366,7 +490,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -379,7 +504,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -392,7 +518,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -405,7 +532,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -418,7 +546,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -431,7 +560,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -444,7 +574,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -458,7 +589,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -467,11 +599,89 @@ public interface GenericRecord {
         Builder writeGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value);
 
         /**
+         * Writes a decimal which is arbitrary precision and scale floating-point number
          * It is illegal to write to the same field twice.
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         */
+        Builder writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value);
+
+        /**
+         * Write a time field consisting of hour, minute, seconds and nanos parts
+         * It is illegal to write to the same field twice.
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         */
+        Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value);
+
+        /**
+         * Writes a date field consisting of year , month of the year and day of the month
+         * It is illegal to write to the same field twice.
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         */
+        Builder writeDate(@Nonnull String fieldName, @Nullable LocalDate value);
+
+        /**
+         * Writes a timestamp field consisting of
+         * year , month of the year and day of the month, hour, minute, seconds, nanos parts
+         * It is illegal to write to the same field twice.
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         */
+        Builder writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value);
+
+        /**
+         * Writes a timestamp with timezone field consisting of
+         * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+         * It is illegal to write to the same field twice.
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         */
+        Builder writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value);
+
+        /**
+         * It is illegal to write to the same field twice.
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -484,7 +694,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -497,7 +708,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -510,7 +722,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -523,7 +736,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -536,7 +750,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -549,7 +764,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -562,7 +778,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
@@ -572,18 +789,103 @@ public interface GenericRecord {
 
         /**
          * It is illegal to write to the same field twice.
-         * <p>
          * Array items can not be null
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord String[] to write
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using
          *                                         {@link GenericRecord#cloneWithBuilder()}.
          */
         Builder writeUTFArray(@Nonnull String fieldName, @Nullable String[] value);
+
+        /**
+         * Writes an array of Decimals
+         * It is illegal to write to the same field twice.
+         * Array items can not be null
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         * @see #writeDecimal(String, BigDecimal)
+         */
+        Builder writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] value);
+
+        /**
+         * Writes an array of Time's
+         * It is illegal to write to the same field twice.
+         * Array items can not be null
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         * @see #writeTime(String, LocalTime)
+         */
+        Builder writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] value);
+
+        /**
+         * Writes an array of Date's
+         * It is illegal to write to the same field twice.
+         * Array items can not be null
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         * @see #writeDate(String, LocalDate)
+         */
+        Builder writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] value);
+
+        /**
+         * Writes an array of Timestamp's
+         * It is illegal to write to the same field twice.
+         * Array items can not be null
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         * @see #writeTimestamp(String, LocalDateTime)
+         */
+        Builder writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] value);
+
+        /**
+         * Writes an array of TimestampWithTimezone's
+         * It is illegal to write to the same field twice.
+         * Array items can not be null
+         *
+         * @param fieldName name of the field as it is defined in its class definition.
+         *                  See {@link ClassDefinition} for {@link Portable}
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
+         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+         *                                         the type of the field does not match the one in the class definition or
+         *                                         Same field is trying to be overwritten without using
+         *                                         {@link GenericRecord#cloneWithBuilder()}.
+         * @see #writeTimestampWithTimezone(String, OffsetDateTime)
+         */
+        Builder writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] value);
 
         /**
          * It is illegal to write to the same field twice.
@@ -593,7 +895,8 @@ public interface GenericRecord {
          *
          * @param fieldName name of the field as it is defined in its class definition.
          *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value
+         * @param value     to set to GenericRecord
+         * @return itself for chaining
          * @throws HazelcastSerializationException if the field name does not exist in the class definition or
          *                                         the type of the field does not match the one in the class definition or
          *                                         Same field is trying to be overwritten without using

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -227,7 +227,7 @@ public interface GenericRecord {
     LocalTime readTime(@Nonnull String fieldName);
 
     /**
-     * Reads a date field consisting of year , month of the year and day of the month to LocalDate
+     * Reads a date field consisting of year, month of the year and day of the month to LocalDate
      *
      * @param fieldName the name of the field
      * @return the value of the field
@@ -239,7 +239,7 @@ public interface GenericRecord {
 
     /**
      * Reads a timestamp field consisting of
-     * year , month of the year and day of the month, hour, minute, seconds, nanos parts to LocalDateTime
+     * year, month of the year, day of the month, hour, minute, seconds, nanos parts to LocalDateTime
      *
      * @param fieldName the name of the field
      * @return the value of the field
@@ -251,7 +251,7 @@ public interface GenericRecord {
 
     /**
      * Reads a timestamp with timezone field consisting of
-     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
      * to OffsetDateTime
      *
      * @param fieldName the name of the field
@@ -629,7 +629,7 @@ public interface GenericRecord {
         Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value);
 
         /**
-         * Writes a date field consisting of year , month of the year and day of the month
+         * Writes a date field consisting of year, month of the year and day of the month
          * It is illegal to write to the same field twice.
          *
          * @param fieldName name of the field as it is defined in its class definition.
@@ -645,7 +645,7 @@ public interface GenericRecord {
 
         /**
          * Writes a timestamp field consisting of
-         * year , month of the year and day of the month, hour, minute, seconds, nanos parts
+         * year, month of the year, day of the month, hour, minute, seconds, nanos parts
          * It is illegal to write to the same field twice.
          *
          * @param fieldName name of the field as it is defined in its class definition.
@@ -661,7 +661,7 @@ public interface GenericRecord {
 
         /**
          * Writes a timestamp with timezone field consisting of
-         * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+         * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
          * It is illegal to write to the same field twice.
          *
          * @param fieldName name of the field as it is defined in its class definition.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -157,7 +157,7 @@ public interface PortableReader {
     LocalTime readTime(@Nonnull String fieldName) throws IOException;
 
     /**
-     * Reads a date field consisting of year , month of the year and day of the month to LocalDate
+     * Reads a date field consisting of year, month of the year and day of the month to LocalDate
      *
      * @param fieldName name of the field
      * @return the LocalDate value read
@@ -168,7 +168,7 @@ public interface PortableReader {
 
     /**
      * Reads a timestamp field consisting of
-     * year , month of the year and day of the month, hour, minute, seconds, nanos parts to LocalDateTime
+     * year, month of the year, day of the month, hour, minute, seconds, nanos parts to LocalDateTime
      *
      * @param fieldName name of the field
      * @return the LocalDateTime value read
@@ -179,7 +179,7 @@ public interface PortableReader {
 
     /**
      * Reads a timestamp with timezone field consisting of
-     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
      * to OffsetDateTime
      *
      * @param fieldName name of the field

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -54,7 +54,9 @@ public interface PortableReader {
     /**
      * @param fieldName name of the field
      * @return field type of given fieldName
+     * @throws java.lang.IllegalArgumentException if the field does not exist.
      */
+    @Nonnull
     FieldType getFieldType(@Nonnull String fieldName);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -18,7 +18,14 @@ package com.hazelcast.nio.serialization;
 
 import com.hazelcast.nio.ObjectDataInput;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 /**
@@ -36,87 +43,89 @@ public interface PortableReader {
      * @param fieldName name of the field (does not support nested paths)
      * @return true if field exist in this class.
      */
-    boolean hasField(String fieldName);
+    boolean hasField(@Nonnull String fieldName);
 
     /**
      * @return set of field names on this portable class
      */
+    @Nonnull
     Set<String> getFieldNames();
 
     /**
      * @param fieldName name of the field
      * @return field type of given fieldName
      */
-    FieldType getFieldType(String fieldName);
+    FieldType getFieldType(@Nonnull String fieldName);
 
     /**
      * @param fieldName name of the field
      * @return classId of given field
      */
-    int getFieldClassId(String fieldName);
+    int getFieldClassId(@Nonnull String fieldName);
 
     /**
      * @param fieldName name of the field
      * @return the int value read
      * @throws IOException in case of any exceptional case
      */
-    int readInt(String fieldName) throws IOException;
+    int readInt(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the long value read
      * @throws IOException in case of any exceptional case
      */
-    long readLong(String fieldName) throws IOException;
+    long readLong(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the utf string value read
      * @throws IOException in case of any exceptional case
      */
-    String readUTF(String fieldName) throws IOException;
+    @Nullable
+    String readUTF(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the boolean value read
      * @throws IOException in case of any exceptional case
      */
-    boolean readBoolean(String fieldName) throws IOException;
+    boolean readBoolean(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the byte value read
      * @throws IOException in case of any exceptional case
      */
-    byte readByte(String fieldName) throws IOException;
+    byte readByte(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the char value read
      * @throws IOException in case of any exceptional case
      */
-    char readChar(String fieldName) throws IOException;
+    char readChar(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the double value read
      * @throws IOException in case of any exceptional case
      */
-    double readDouble(String fieldName) throws IOException;
+    double readDouble(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the float value read
      * @throws IOException in case of any exceptional case
      */
-    float readFloat(String fieldName) throws IOException;
+    float readFloat(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the short value read
      * @throws IOException in case of any exceptional case
      */
-    short readShort(String fieldName) throws IOException;
+    short readShort(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
@@ -124,77 +133,195 @@ public interface PortableReader {
      * @return the portable value read
      * @throws IOException in case of any exceptional case
      */
-    <P extends Portable> P readPortable(String fieldName) throws IOException;
+    @Nullable
+    <P extends Portable> P readPortable(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads a decimal which is arbitrary precision and scale floating-point number to BigDecimal
+     *
+     * @param fieldName name of the field
+     * @return the BigDecimal value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    BigDecimal readDecimal(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads a time field consisting of hour, minute, seconds and nanos parts to LocalTime
+     *
+     * @param fieldName name of the field
+     * @return the LocalTime value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    LocalTime readTime(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads a date field consisting of year , month of the year and day of the month to LocalDate
+     *
+     * @param fieldName name of the field
+     * @return the LocalDate value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    LocalDate readDate(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads a timestamp field consisting of
+     * year , month of the year and day of the month, hour, minute, seconds, nanos parts to LocalDateTime
+     *
+     * @param fieldName name of the field
+     * @return the LocalDateTime value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    LocalDateTime readTimestamp(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads a timestamp with timezone field consisting of
+     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * to OffsetDateTime
+     *
+     * @param fieldName name of the field
+     * @return the OffsetDateTime value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the byte array value read
      * @throws IOException in case of any exceptional case
      */
-    byte[] readByteArray(String fieldName) throws IOException;
+    @Nullable
+    byte[] readByteArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the boolean array value read
      * @throws IOException in case of any exceptional case
      */
-    boolean[] readBooleanArray(String fieldName) throws IOException;
+    @Nullable
+    boolean[] readBooleanArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the char array value read
      * @throws IOException in case of any exceptional case
      */
-    char[] readCharArray(String fieldName) throws IOException;
+    @Nullable
+    char[] readCharArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the int array value read
      * @throws IOException in case of any exceptional case
      */
-    int[] readIntArray(String fieldName) throws IOException;
+    @Nullable
+    int[] readIntArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the long array value read
      * @throws IOException in case of any exceptional case
      */
-    long[] readLongArray(String fieldName) throws IOException;
+    @Nullable
+    long[] readLongArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the double array value read
      * @throws IOException in case of any exceptional case
      */
-    double[] readDoubleArray(String fieldName) throws IOException;
+    @Nullable
+    double[] readDoubleArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the float array value read
      * @throws IOException in case of any exceptional case
      */
-    float[] readFloatArray(String fieldName) throws IOException;
+    @Nullable
+    float[] readFloatArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the short array value read
      * @throws IOException in case of any exceptional case
      */
-    short[] readShortArray(String fieldName) throws IOException;
+    short[] readShortArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
      * @return the String array value read
      * @throws IOException in case of any exceptional case
      */
-    String[] readUTFArray(String fieldName) throws IOException;
+    @Nullable
+    String[] readUTFArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
-     * @return the portable value read
+     * @return the portable array read
      * @throws IOException in case of any exceptional case
      */
-    Portable[] readPortableArray(String fieldName) throws IOException;
+    @Nullable
+    Portable[] readPortableArray(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads an array of Decimal's to BigDecimal[]
+     *
+     * @param fieldName name of the field
+     * @return the BigDecimal array read
+     * @throws IOException in case of any exceptional case
+     * @see #readDecimal(String)
+     */
+    @Nullable
+    BigDecimal[] readDecimalArray(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads an array of Time's to LocalTime[]
+     *
+     * @param fieldName name of the field
+     * @return the LocalTime array read
+     * @throws IOException in case of any exceptional case
+     * @see #readTime(String)
+     */
+    @Nullable
+    LocalTime[] readTimeArray(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads an array of Date's to LocalDate[]
+     *
+     * @param fieldName name of the field
+     * @return the LocalDate array read
+     * @throws IOException in case of any exceptional case
+     * @see #readDate(String)
+     */
+    @Nullable
+    LocalDate[] readDateArray(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads an array of Timestamp's to LocalDateTime[]
+     *
+     * @param fieldName name of the field
+     * @return the LocalDateTime array read
+     * @throws IOException in case of any exceptional case
+     * @see #readTimestamp(String)
+     */
+    @Nullable
+    LocalDateTime[] readTimestampArray(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * Reads an array of TimestampWithTimezone's to OffsetDateTime[]
+     *
+     * @param fieldName name of the field
+     * @return the OffsetDateTime array read
+     * @throws IOException in case of any exceptional case
+     * @see #readTimestampWithTimezone(String)
+     */
+    @Nullable
+    OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * {@link PortableWriter#getRawDataOutput()}.
@@ -205,5 +332,6 @@ public interface PortableReader {
      * @return rawDataInput
      * @throws IOException in case of any exceptional case
      */
+    @Nonnull
     ObjectDataInput getRawDataInput() throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
@@ -153,7 +153,7 @@ public interface PortableWriter {
     void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) throws IOException;
 
     /**
-     * Writes a date field consisting of year , month of the year and day of the month
+     * Writes a date field consisting of year, month of the year and day of the month
      *
      * @param fieldName name of the field
      * @param value     LocalDate value to be written
@@ -163,7 +163,7 @@ public interface PortableWriter {
 
     /**
      * Writes a timestamp field consisting of
-     * year , month of the year and day of the month, hour, minute, seconds, nanos parts
+     * year, month of the year, day of the month, hour, minute, seconds, nanos parts
      *
      * @param fieldName name of the field
      * @param value     LocalDateTime value to be written
@@ -173,7 +173,7 @@ public interface PortableWriter {
 
     /**
      * Writes a timestamp with timezone field consisting of
-     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
      *
      * @param fieldName name of the field
      * @param value     OffsetDateTime value to be written

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
@@ -18,7 +18,14 @@ package com.hazelcast.nio.serialization;
 
 import com.hazelcast.nio.ObjectDataOutput;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 /**
  * Provides means for writing portable fields to binary data in the form of java primitives,
@@ -33,7 +40,7 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeInt(String fieldName, int value) throws IOException;
+    void writeInt(@Nonnull String fieldName, int value) throws IOException;
 
     /**
      * Writes a primitive long.
@@ -42,7 +49,7 @@ public interface PortableWriter {
      * @param value     long value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeLong(String fieldName, long value) throws IOException;
+    void writeLong(@Nonnull String fieldName, long value) throws IOException;
 
     /**
      * Writes an UTF string.
@@ -51,7 +58,7 @@ public interface PortableWriter {
      * @param value     utf string value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeUTF(String fieldName, String value) throws IOException;
+    void writeUTF(@Nonnull String fieldName, @Nullable String value) throws IOException;
 
     /**
      * Writes a primitive boolean.
@@ -60,7 +67,7 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeBoolean(String fieldName, boolean value) throws IOException;
+    void writeBoolean(@Nonnull String fieldName, boolean value) throws IOException;
 
     /**
      * Writes a primitive byte.
@@ -69,7 +76,7 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeByte(String fieldName, byte value) throws IOException;
+    void writeByte(@Nonnull String fieldName, byte value) throws IOException;
 
     /**
      * Writes a primitive char.
@@ -78,7 +85,7 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeChar(String fieldName, int value) throws IOException;
+    void writeChar(@Nonnull String fieldName, int value) throws IOException;
 
     /**
      * Writes a primitive double.
@@ -87,7 +94,7 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeDouble(String fieldName, double value) throws IOException;
+    void writeDouble(@Nonnull String fieldName, double value) throws IOException;
 
     /**
      * Writes a primitive float.
@@ -96,7 +103,7 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeFloat(String fieldName, float value) throws IOException;
+    void writeFloat(@Nonnull String fieldName, float value) throws IOException;
 
     /**
      * Writes a primitive short.
@@ -105,16 +112,17 @@ public interface PortableWriter {
      * @param value     int value to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeShort(String fieldName, short value) throws IOException;
+    void writeShort(@Nonnull String fieldName, short value) throws IOException;
 
     /**
      * Writes a Portable.
+     * Use {@link #writeNullPortable(String, int, int)} to write a {@code null} Portable
      *
      * @param fieldName name of the field
      * @param portable  Portable to be written
      * @throws IOException in case of any exceptional case
      */
-    void writePortable(String fieldName, Portable portable) throws IOException;
+    void writePortable(@Nonnull String fieldName, @Nullable Portable portable) throws IOException;
 
     /**
      * To write a null portable value, user needs to provide class and factoryIds of related class.
@@ -124,7 +132,54 @@ public interface PortableWriter {
      * @param classId   class ID of related portable class
      * @throws IOException in case of any exceptional case
      */
-    void writeNullPortable(String fieldName, int factoryId, int classId) throws IOException;
+    void writeNullPortable(@Nonnull String fieldName, int factoryId, int classId) throws IOException;
+
+    /**
+     * Writes a decimal which is arbitrary precision and scale floating-point number
+     *
+     * @param fieldName name of the field
+     * @param value     BigDecimal value to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) throws IOException;
+
+    /**
+     * Write a time field consisting of hour, minute, seconds and nanos parts
+     *
+     * @param fieldName name of the field
+     * @param value     LocalTime value to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) throws IOException;
+
+    /**
+     * Writes a date field consisting of year , month of the year and day of the month
+     *
+     * @param fieldName name of the field
+     * @param value     LocalDate value to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeDate(@Nonnull String fieldName, @Nullable LocalDate value) throws IOException;
+
+    /**
+     * Writes a timestamp field consisting of
+     * year , month of the year and day of the month, hour, minute, seconds, nanos parts
+     *
+     * @param fieldName name of the field
+     * @param value     LocalDateTime value to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) throws IOException;
+
+    /**
+     * Writes a timestamp with timezone field consisting of
+     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     *
+     * @param fieldName name of the field
+     * @param value     OffsetDateTime value to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) throws IOException;
 
     /**
      * Writes a primitive byte-array.
@@ -133,7 +188,7 @@ public interface PortableWriter {
      * @param bytes     byte array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeByteArray(String fieldName, byte[] bytes) throws IOException;
+    void writeByteArray(@Nonnull String fieldName, @Nullable byte[] bytes) throws IOException;
 
     /**
      * Writes a primitive boolean-array.
@@ -142,7 +197,7 @@ public interface PortableWriter {
      * @param booleans  boolean array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeBooleanArray(String fieldName, boolean[] booleans) throws IOException;
+    void writeBooleanArray(@Nonnull String fieldName, @Nullable boolean[] booleans) throws IOException;
 
     /**
      * Writes a primitive char-array.
@@ -151,7 +206,7 @@ public interface PortableWriter {
      * @param chars     char array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeCharArray(String fieldName, char[] chars) throws IOException;
+    void writeCharArray(@Nonnull String fieldName, @Nullable char[] chars) throws IOException;
 
     /**
      * Writes a primitive int-array.
@@ -160,7 +215,7 @@ public interface PortableWriter {
      * @param ints      int array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeIntArray(String fieldName, int[] ints) throws IOException;
+    void writeIntArray(@Nonnull String fieldName, @Nullable int[] ints) throws IOException;
 
     /**
      * Writes a primitive long-array.
@@ -169,7 +224,7 @@ public interface PortableWriter {
      * @param longs     long array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeLongArray(String fieldName, long[] longs) throws IOException;
+    void writeLongArray(@Nonnull String fieldName, @Nullable long[] longs) throws IOException;
 
     /**
      * Writes a primitive double array.
@@ -178,7 +233,7 @@ public interface PortableWriter {
      * @param values    double array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeDoubleArray(String fieldName, double[] values) throws IOException;
+    void writeDoubleArray(@Nonnull String fieldName, @Nullable double[] values) throws IOException;
 
     /**
      * Writes a primitive float array.
@@ -187,7 +242,7 @@ public interface PortableWriter {
      * @param values    float array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeFloatArray(String fieldName, float[] values) throws IOException;
+    void writeFloatArray(@Nonnull String fieldName, @Nullable float[] values) throws IOException;
 
     /**
      * Writes a primitive short-array.
@@ -196,7 +251,7 @@ public interface PortableWriter {
      * @param values    short array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeShortArray(String fieldName, short[] values) throws IOException;
+    void writeShortArray(@Nonnull String fieldName, @Nullable short[] values) throws IOException;
 
     /**
      * Writes a String-array.
@@ -205,16 +260,66 @@ public interface PortableWriter {
      * @param values    String array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeUTFArray(String fieldName, String[] values) throws IOException;
+    void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException;
 
     /**
      * Writes a an array of Portables.
      *
      * @param fieldName name of the field
-     * @param portables portable array to be written
+     * @param values    portable array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writePortableArray(String fieldName, Portable[] portables) throws IOException;
+    void writePortableArray(@Nonnull String fieldName, @Nullable Portable[] values) throws IOException;
+
+    /**
+     * Writes an array of Decimals
+     *
+     * @param fieldName name of the field
+     * @param values    BigDecimal array to be written
+     * @throws IOException in case of any exceptional case
+     * @see #writeDecimal(String, BigDecimal)
+     */
+    void writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] values) throws IOException;
+
+    /**
+     * Writes an array of Time's
+     *
+     * @param fieldName name of the field
+     * @param values    LocalTime array to be written
+     * @throws IOException in case of any exceptional case
+     * @see #writeTime(String, LocalTime)
+     */
+    void writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] values) throws IOException;
+
+    /**
+     * Writes an array of Date's
+     *
+     * @param fieldName name of the field
+     * @param values    LocalDate array to be written
+     * @throws IOException in case of any exceptional case
+     * @see #writeDate(String, LocalDate)
+     */
+    void writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] values) throws IOException;
+
+    /**
+     * Writes an array of Timestamp's
+     *
+     * @param fieldName name of the field
+     * @param values    LocalDateTime array to be written
+     * @throws IOException in case of any exceptional case
+     * @see #writeTimestamp(String, LocalDateTime)
+     */
+    void writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] values) throws IOException;
+
+    /**
+     * Writes an array of TimestampWithTimezone's
+     *
+     * @param fieldName name of the field
+     * @param values    OffsetDateTime array to be written
+     * @throws IOException in case of any exceptional case
+     * @see #writeTimestampWithTimezone(String, OffsetDateTime)
+     */
+    void writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] values) throws IOException;
 
     /**
      * After writing portable fields one can subsequently write remaining fields in the old-fashioned way.
@@ -224,5 +329,7 @@ public interface PortableWriter {
      * @return ObjectDataOutput
      * @throws IOException in case of any exceptional case
      */
+    @Nonnull
     ObjectDataOutput getRawDataOutput() throws IOException;
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/genericrecord/AbstractGenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/genericrecord/AbstractGenericRecordTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.GenericRecord;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.test.HazelcastTestSupport;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -63,115 +64,36 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
 
     @Test
     public void testPutWithoutFactory_readAsPortable() {
+        MainPortable expectedPortable = createMainPortable();
+        GenericRecord expected = createGenericRecord(expectedPortable);
 
-        NamedPortable[] nn = new NamedPortable[2];
-        nn[0] = new NamedPortable("name", 123);
-        nn[1] = new NamedPortable("name", 123);
-        InnerPortable inner = new InnerPortable(new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
-                new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
-                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn,
-                new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
-                new LocalTime[]{LocalTime.now(), LocalTime.now()},
-                new LocalDate[]{LocalDate.now(), LocalDate.now()},
-                new LocalDateTime[]{LocalDateTime.now()},
-                new OffsetDateTime[]{OffsetDateTime.now()});
-
-        MainPortable expectedMain = new MainPortable((byte) 113, true, 'x', (short) -500, 56789, -50992225L, 900.5678f,
-                -897543.3678909d, "this is main portable object created for testing!", inner,
-                new BigDecimal("12312313"), LocalTime.now(), LocalDate.now(), LocalDateTime.now(), OffsetDateTime.now());
-
+        assertEquals(expectedPortable.c, expected.readChar("c"));
+        assertEquals(expectedPortable.f, expected.readFloat("f"), 0.1);
         HazelcastInstance[] instances = createCluster();
-        ClassDefinition namedPortableClassDefinition =
-                new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
-        ClassDefinition innerPortableClassDefinition =
-                new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.INNER_PORTABLE)
-                        .addByteArrayField("b")
-                        .addCharArrayField("c")
-                        .addShortArrayField("s")
-                        .addIntArrayField("i")
-                        .addLongArrayField("l")
-                        .addFloatArrayField("f")
-                        .addDoubleArrayField("d")
-                        .addPortableArrayField("nn", namedPortableClassDefinition)
-                        .addDecimalArrayField("bigDecimals")
-                        .addTimeArrayField("localTimes")
-                        .addDateArrayField("localDates")
-                        .addTimestampArrayField("localDateTimes")
-                        .addTimestampWithTimezoneArrayField("offsetDateTimes")
-                        .build();
-        ClassDefinition mainPortableClassDefinition =
-                new ClassDefinitionBuilder(PortableTest.PORTABLE_FACTORY_ID, TestSerializationConstants.MAIN_PORTABLE)
-                        .addByteField("b")
-                        .addBooleanField("bool")
-                        .addCharField("c")
-                        .addShortField("s")
-                        .addIntField("i")
-                        .addLongField("l")
-                        .addFloatField("f")
-                        .addDoubleField("d")
-                        .addUTFField("str")
-                        .addPortableField("p", innerPortableClassDefinition)
-                        .addDecimalField("bigDecimal")
-                        .addTimeField("localTime")
-                        .addDateField("localDate")
-                        .addTimestampField("localDateTime")
-                        .addTimestampWithTimezoneField("offsetDateTime")
-                        .build();
-
-        GenericRecord namedRecord = GenericRecord.Builder.portable(namedPortableClassDefinition)
-                                                         .writeUTF("name", nn[0].name)
-                                                         .writeInt("myint", nn[0].myint).build();
-        GenericRecord[] namedRecords = new GenericRecord[2];
-        namedRecords[0] = namedRecord;
-        namedRecords[1] = namedRecord;
-
-        GenericRecord innerRecord = GenericRecord.Builder.portable(innerPortableClassDefinition)
-                                                         .writeByteArray("b", inner.bb)
-                                                         .writeCharArray("c", inner.cc)
-                                                         .writeShortArray("s", inner.ss)
-                                                         .writeIntArray("i", inner.ii)
-                                                         .writeLongArray("l", inner.ll)
-                                                         .writeFloatArray("f", inner.ff)
-                                                         .writeDoubleArray("d", inner.dd)
-                                                         .writeGenericRecordArray("nn", namedRecords)
-                                                         .writeDecimalArray("bigDecimals", inner.bigDecimals)
-                                                         .writeTimeArray("localTimes", inner.localTimes)
-                                                         .writeDateArray("localDates", inner.localDates)
-                                                         .writeTimestampArray("localDateTimes", inner.localDateTimes)
-                                                         .writeTimestampWithTimezoneArray("offsetDateTimes", inner.offsetDateTimes)
-                                                         .build();
-
-        GenericRecord expected = GenericRecord.Builder.portable(mainPortableClassDefinition)
-                                                      .writeByte("b", expectedMain.b)
-                                                      .writeBoolean("bool", expectedMain.bool)
-                                                      .writeChar("c", expectedMain.c)
-                                                      .writeShort("s", expectedMain.s)
-                                                      .writeInt("i", expectedMain.i)
-                                                      .writeLong("l", expectedMain.l)
-                                                      .writeFloat("f", expectedMain.f)
-                                                      .writeDouble("d", expectedMain.d)
-                                                      .writeUTF("str", expectedMain.str)
-                                                      .writeGenericRecord("p", innerRecord)
-                                                      .writeDecimal("bigDecimal", expectedMain.bigDecimal)
-                                                      .writeTime("localTime", expectedMain.localTime)
-                                                      .writeDate("localDate", expectedMain.localDate)
-                                                      .writeTimestamp("localDateTime", expectedMain.localDateTime)
-                                                      .writeTimestampWithTimezone("offsetDateTime", expectedMain.offsetDateTime)
-                                                      .build();
-
-        assertEquals(expectedMain.c, expected.readChar("c"));
-        assertEquals(expectedMain.f, expected.readFloat("f"), 0.1);
-
         IMap<Object, Object> clusterMap = instances[0].getMap("test");
         clusterMap.put(1, expected);
-
         HazelcastInstance instance = createAccessorInstance(serializationConfig);
         IMap<Object, Object> map = instance.getMap("test");
 
         MainPortable actual = (MainPortable) map.get(1);
+        assertEquals(expectedPortable, actual);
+    }
 
-        assertEquals(expectedMain, actual);
+    @Test
+    public void testPutWithoutFactory_readAsGenericRecord() {
+        MainPortable expectedPortable = createMainPortable();
+        GenericRecord expected = createGenericRecord(expectedPortable);
+
+        assertEquals(expectedPortable.c, expected.readChar("c"));
+        assertEquals(expectedPortable.f, expected.readFloat("f"), 0.1);
+        HazelcastInstance[] instances = createCluster();
+        IMap<Object, Object> clusterMap = instances[0].getMap("test");
+        clusterMap.put(1, expected);
+        HazelcastInstance instance = createAccessorInstance(new SerializationConfig());
+        IMap<Object, Object> map = instance.getMap("test");
+
+        GenericRecord actual = (GenericRecord) map.get(1);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -344,6 +266,110 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         map.put(1, namedRecord);
 
         map.put(2, inConsistentNamedRecord);
+    }
+
+    @NotNull
+    private MainPortable createMainPortable() {
+        NamedPortable[] nn = new NamedPortable[2];
+        nn[0] = new NamedPortable("name", 123);
+        nn[1] = new NamedPortable("name", 123);
+        InnerPortable inner = new InnerPortable(new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
+                new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
+                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn,
+                new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
+                new LocalTime[]{LocalTime.now(), LocalTime.now()},
+                new LocalDate[]{LocalDate.now(), LocalDate.now()},
+                new LocalDateTime[]{LocalDateTime.now()},
+                new OffsetDateTime[]{OffsetDateTime.now()});
+
+        return new MainPortable((byte) 113, true, 'x', (short) -500, 56789, -50992225L, 900.5678f,
+                -897543.3678909d, "this is main portable object created for testing!", inner,
+                new BigDecimal("12312313"), LocalTime.now(), LocalDate.now(), LocalDateTime.now(), OffsetDateTime.now());
+    }
+
+    @NotNull
+    private GenericRecord createGenericRecord(MainPortable expectedPortable) {
+        InnerPortable inner = expectedPortable.p;
+        ClassDefinition namedPortableClassDefinition =
+                new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
+                        .addUTFField("name").addIntField("myint").build();
+        ClassDefinition innerPortableClassDefinition =
+                new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.INNER_PORTABLE)
+                        .addByteArrayField("b")
+                        .addCharArrayField("c")
+                        .addShortArrayField("s")
+                        .addIntArrayField("i")
+                        .addLongArrayField("l")
+                        .addFloatArrayField("f")
+                        .addDoubleArrayField("d")
+                        .addPortableArrayField("nn", namedPortableClassDefinition)
+                        .addDecimalArrayField("bigDecimals")
+                        .addTimeArrayField("localTimes")
+                        .addDateArrayField("localDates")
+                        .addTimestampArrayField("localDateTimes")
+                        .addTimestampWithTimezoneArrayField("offsetDateTimes")
+                        .build();
+        ClassDefinition mainPortableClassDefinition =
+                new ClassDefinitionBuilder(PortableTest.PORTABLE_FACTORY_ID, TestSerializationConstants.MAIN_PORTABLE)
+                        .addByteField("b")
+                        .addBooleanField("bool")
+                        .addCharField("c")
+                        .addShortField("s")
+                        .addIntField("i")
+                        .addLongField("l")
+                        .addFloatField("f")
+                        .addDoubleField("d")
+                        .addUTFField("str")
+                        .addPortableField("p", innerPortableClassDefinition)
+                        .addDecimalField("bigDecimal")
+                        .addTimeField("localTime")
+                        .addDateField("localDate")
+                        .addTimestampField("localDateTime")
+                        .addTimestampWithTimezoneField("offsetDateTime")
+                        .build();
+
+        GenericRecord[] namedRecords = new GenericRecord[inner.nn.length];
+        int i = 0;
+        for (NamedPortable namedPortable : inner.nn) {
+            GenericRecord namedRecord = GenericRecord.Builder.portable(namedPortableClassDefinition)
+                                                             .writeUTF("name", inner.nn[i].name)
+                                                             .writeInt("myint", inner.nn[i].myint).build();
+            namedRecords[i++] = namedRecord;
+        }
+
+        GenericRecord innerRecord = GenericRecord.Builder.portable(innerPortableClassDefinition)
+                                                         .writeByteArray("b", inner.bb)
+                                                         .writeCharArray("c", inner.cc)
+                                                         .writeShortArray("s", inner.ss)
+                                                         .writeIntArray("i", inner.ii)
+                                                         .writeLongArray("l", inner.ll)
+                                                         .writeFloatArray("f", inner.ff)
+                                                         .writeDoubleArray("d", inner.dd)
+                                                         .writeGenericRecordArray("nn", namedRecords)
+                                                         .writeDecimalArray("bigDecimals", inner.bigDecimals)
+                                                         .writeTimeArray("localTimes", inner.localTimes)
+                                                         .writeDateArray("localDates", inner.localDates)
+                                                         .writeTimestampArray("localDateTimes", inner.localDateTimes)
+                                                         .writeTimestampWithTimezoneArray("offsetDateTimes", inner.offsetDateTimes)
+                                                         .build();
+
+        return GenericRecord.Builder.portable(mainPortableClassDefinition)
+                                    .writeByte("b", expectedPortable.b)
+                                    .writeBoolean("bool", expectedPortable.bool)
+                                    .writeChar("c", expectedPortable.c)
+                                    .writeShort("s", expectedPortable.s)
+                                    .writeInt("i", expectedPortable.i)
+                                    .writeLong("l", expectedPortable.l)
+                                    .writeFloat("f", expectedPortable.f)
+                                    .writeDouble("d", expectedPortable.d)
+                                    .writeUTF("str", expectedPortable.str)
+                                    .writeGenericRecord("p", innerRecord)
+                                    .writeDecimal("bigDecimal", expectedPortable.bigDecimal)
+                                    .writeTime("localTime", expectedPortable.localTime)
+                                    .writeDate("localDate", expectedPortable.localDate)
+                                    .writeTimestamp("localDateTime", expectedPortable.localDateTime)
+                                    .writeTimestampWithTimezone("offsetDateTime", expectedPortable.offsetDateTime)
+                                    .build();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/FieldTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/FieldTypeTest.java
@@ -28,6 +28,10 @@ import static com.hazelcast.nio.serialization.FieldType.BYTE;
 import static com.hazelcast.nio.serialization.FieldType.BYTE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.CHAR;
 import static com.hazelcast.nio.serialization.FieldType.CHAR_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.DATE;
+import static com.hazelcast.nio.serialization.FieldType.DATE_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.DECIMAL;
+import static com.hazelcast.nio.serialization.FieldType.DECIMAL_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.DOUBLE;
 import static com.hazelcast.nio.serialization.FieldType.DOUBLE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.FLOAT;
@@ -40,9 +44,14 @@ import static com.hazelcast.nio.serialization.FieldType.PORTABLE;
 import static com.hazelcast.nio.serialization.FieldType.PORTABLE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.SHORT;
 import static com.hazelcast.nio.serialization.FieldType.SHORT_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIME;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_WITH_TIMEZONE;
+import static com.hazelcast.nio.serialization.FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY;
+import static com.hazelcast.nio.serialization.FieldType.TIME_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.UTF;
 import static com.hazelcast.nio.serialization.FieldType.UTF_ARRAY;
-import static com.hazelcast.nio.serialization.FieldType.values;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -63,6 +72,11 @@ public class FieldTypeTest {
         assertFalse(DOUBLE.isArrayType());
         assertFalse(UTF.isArrayType());
         assertFalse(BYTE.isArrayType());
+        assertFalse(DECIMAL.isArrayType());
+        assertFalse(TIME.isArrayType());
+        assertFalse(DATE.isArrayType());
+        assertFalse(TIMESTAMP.isArrayType());
+        assertFalse(TIMESTAMP_WITH_TIMEZONE.isArrayType());
     }
 
     @Test
@@ -77,6 +91,11 @@ public class FieldTypeTest {
         assertTrue(FLOAT_ARRAY.isArrayType());
         assertTrue(DOUBLE_ARRAY.isArrayType());
         assertTrue(UTF_ARRAY.isArrayType());
+        assertTrue(DECIMAL_ARRAY.isArrayType());
+        assertTrue(TIME_ARRAY.isArrayType());
+        assertTrue(DATE_ARRAY.isArrayType());
+        assertTrue(TIMESTAMP_ARRAY.isArrayType());
+        assertTrue(TIMESTAMP_WITH_TIMEZONE_ARRAY.isArrayType());
     }
 
     @Test
@@ -90,12 +109,11 @@ public class FieldTypeTest {
         assertEquals(LONG, LONG_ARRAY.getSingleType());
         assertEquals(FLOAT, FLOAT_ARRAY.getSingleType());
         assertEquals(DOUBLE, DOUBLE_ARRAY.getSingleType());
-        assertEquals(UTF, UTF_ARRAY.getSingleType());
+        assertEquals(DECIMAL, DECIMAL_ARRAY.getSingleType());
+        assertEquals(TIME, TIME_ARRAY.getSingleType());
+        assertEquals(DATE, DATE_ARRAY.getSingleType());
+        assertEquals(TIMESTAMP, TIMESTAMP_ARRAY.getSingleType());
+        assertEquals(TIMESTAMP_WITH_TIMEZONE, TIMESTAMP_WITH_TIMEZONE_ARRAY.getSingleType());
     }
 
-    @Test
-    public void assertCorrectTypesCount() {
-        assertEquals("Wrong types count! See isArrayType() implementation for details what will break",
-                20, values().length);
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/InnerPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/InnerPortable.java
@@ -22,6 +22,11 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 
 public class InnerPortable implements Portable {
@@ -34,11 +39,18 @@ public class InnerPortable implements Portable {
     public float[] ff;
     public double[] dd;
     public NamedPortable[] nn;
+    public BigDecimal[] bigDecimals;
+    public LocalTime[] localTimes;
+    public LocalDate[] localDates;
+    public LocalDateTime[] localDateTimes;
+    public OffsetDateTime[] offsetDateTimes;
 
     InnerPortable() {
     }
 
-    public InnerPortable(byte[] bb, char[] cc, short[] ss, int[] ii, long[] ll, float[] ff, double[] dd, NamedPortable[] nn) {
+    public InnerPortable(byte[] bb, char[] cc, short[] ss, int[] ii, long[] ll, float[] ff, double[] dd, NamedPortable[] nn,
+                         BigDecimal[] bigDecimals, LocalTime[] localTimes, LocalDate[] localDates,
+                         LocalDateTime[] localDateTimes, OffsetDateTime[] offsetDateTimes) {
         this.bb = bb;
         this.cc = cc;
         this.ss = ss;
@@ -47,6 +59,11 @@ public class InnerPortable implements Portable {
         this.ff = ff;
         this.dd = dd;
         this.nn = nn;
+        this.bigDecimals = bigDecimals;
+        this.localTimes = localTimes;
+        this.localDates = localDates;
+        this.localDateTimes = localDateTimes;
+        this.offsetDateTimes = offsetDateTimes;
     }
 
     @Override
@@ -64,6 +81,11 @@ public class InnerPortable implements Portable {
         writer.writeFloatArray("f", ff);
         writer.writeDoubleArray("d", dd);
         writer.writePortableArray("nn", nn);
+        writer.writeDecimalArray("bigDecimals", bigDecimals);
+        writer.writeTimeArray("localTimes", localTimes);
+        writer.writeDateArray("localDates", localDates);
+        writer.writeTimestampArray("localDateTimes", localDateTimes);
+        writer.writeTimestampWithTimezoneArray("offsetDateTimes", offsetDateTimes);
     }
 
     @Override
@@ -78,6 +100,11 @@ public class InnerPortable implements Portable {
         Portable[] pp = reader.readPortableArray("nn");
         nn = new NamedPortable[pp.length];
         System.arraycopy(pp, 0, nn, 0, nn.length);
+        bigDecimals = reader.readDecimalArray("bigDecimals");
+        localTimes = reader.readTimeArray("localTimes");
+        localDates = reader.readDateArray("localDates");
+        localDateTimes = reader.readTimestampArray("localDateTimes");
+        offsetDateTimes = reader.readTimestampWithTimezoneArray("offsetDateTimes");
     }
 
     @Override
@@ -88,46 +115,37 @@ public class InnerPortable implements Portable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         InnerPortable that = (InnerPortable) o;
-        if (!Arrays.equals(bb, that.bb)) {
-            return false;
-        }
-        if (!Arrays.equals(cc, that.cc)) {
-            return false;
-        }
-        if (!Arrays.equals(dd, that.dd)) {
-            return false;
-        }
-        if (!Arrays.equals(ff, that.ff)) {
-            return false;
-        }
-        if (!Arrays.equals(ii, that.ii)) {
-            return false;
-        }
-        if (!Arrays.equals(ll, that.ll)) {
-            return false;
-        }
-        if (!Arrays.equals(nn, that.nn)) {
-            return false;
-        }
-        if (!Arrays.equals(ss, that.ss)) {
-            return false;
-        }
-
-        return true;
+        return Arrays.equals(bb, that.bb)
+                && Arrays.equals(cc, that.cc)
+                && Arrays.equals(ss, that.ss)
+                && Arrays.equals(ii, that.ii)
+                && Arrays.equals(ll, that.ll)
+                && Arrays.equals(ff, that.ff)
+                && Arrays.equals(dd, that.dd)
+                && Arrays.equals(nn, that.nn)
+                && Arrays.equals(bigDecimals, that.bigDecimals)
+                && Arrays.equals(localTimes, that.localTimes)
+                && Arrays.equals(localDates, that.localDates)
+                && Arrays.equals(localDateTimes, that.localDateTimes)
+                && Arrays.equals(offsetDateTimes, that.offsetDateTimes);
     }
 
     @Override
     public int hashCode() {
-        int result = bb != null ? Arrays.hashCode(bb) : 0;
-        result = 31 * result + (cc != null ? Arrays.hashCode(cc) : 0);
-        result = 31 * result + (ss != null ? Arrays.hashCode(ss) : 0);
-        result = 31 * result + (ii != null ? Arrays.hashCode(ii) : 0);
-        result = 31 * result + (ll != null ? Arrays.hashCode(ll) : 0);
-        result = 31 * result + (ff != null ? Arrays.hashCode(ff) : 0);
-        result = 31 * result + (dd != null ? Arrays.hashCode(dd) : 0);
-        result = 31 * result + (nn != null ? Arrays.hashCode(nn) : 0);
+        int result = Arrays.hashCode(bb);
+        result = 31 * result + Arrays.hashCode(cc);
+        result = 31 * result + Arrays.hashCode(ss);
+        result = 31 * result + Arrays.hashCode(ii);
+        result = 31 * result + Arrays.hashCode(ll);
+        result = 31 * result + Arrays.hashCode(ff);
+        result = 31 * result + Arrays.hashCode(dd);
+        result = 31 * result + Arrays.hashCode(nn);
+        result = 31 * result + Arrays.hashCode(bigDecimals);
+        result = 31 * result + Arrays.hashCode(localTimes);
+        result = 31 * result + Arrays.hashCode(localDates);
+        result = 31 * result + Arrays.hashCode(localDateTimes);
+        result = 31 * result + Arrays.hashCode(offsetDateTimes);
         return result;
     }
 
@@ -148,6 +166,11 @@ public class InnerPortable implements Portable {
         sb.append(", ff=").append(Arrays.toString(ff));
         sb.append(", dd=").append(Arrays.toString(dd));
         sb.append(", nn=").append(Arrays.toString(nn));
+        sb.append(", bigDecimals=").append(Arrays.toString(bigDecimals));
+        sb.append(", localTimes=").append(Arrays.toString(localTimes));
+        sb.append(", localDates=").append(Arrays.toString(localDates));
+        sb.append(", localDateTimes=").append(Arrays.toString(localDateTimes));
+        sb.append(", offsetDateTimes=").append(Arrays.toString(offsetDateTimes));
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MainPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MainPortable.java
@@ -22,6 +22,12 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class MainPortable implements Portable {
 
@@ -35,11 +41,18 @@ public class MainPortable implements Portable {
     public double d;
     public String str;
     public InnerPortable p;
+    public BigDecimal bigDecimal;
+    public LocalTime localTime;
+    public LocalDate localDate;
+    public LocalDateTime localDateTime;
+    public OffsetDateTime offsetDateTime;
 
     MainPortable() {
     }
 
-    public MainPortable(byte b, boolean bool, char c, short s, int i, long l, float f, double d, String str, InnerPortable p) {
+    public MainPortable(byte b, boolean bool, char c, short s, int i, long l, float f, double d, String str, InnerPortable p,
+                        BigDecimal bigDecimal, LocalTime localTime, LocalDate localDate,
+                        LocalDateTime localDateTime, OffsetDateTime offsetDateTime) {
         this.b = b;
         this.bool = bool;
         this.c = c;
@@ -50,6 +63,11 @@ public class MainPortable implements Portable {
         this.d = d;
         this.str = str;
         this.p = p;
+        this.bigDecimal = bigDecimal;
+        this.localTime = localTime;
+        this.localDate = localDate;
+        this.localDateTime = localDateTime;
+        this.offsetDateTime = offsetDateTime;
     }
 
     @Override
@@ -74,6 +92,11 @@ public class MainPortable implements Portable {
             writer.writeNullPortable("p", TestSerializationConstants.PORTABLE_FACTORY_ID,
                     TestSerializationConstants.INNER_PORTABLE);
         }
+        writer.writeDecimal("bigDecimal", bigDecimal);
+        writer.writeTime("localTime", localTime);
+        writer.writeDate("localDate", localDate);
+        writer.writeTimestamp("localDateTime", localDateTime);
+        writer.writeTimestampWithTimezone("offsetDateTime", offsetDateTime);
     }
 
     @Override
@@ -88,6 +111,11 @@ public class MainPortable implements Portable {
         d = reader.readDouble("d");
         str = reader.readUTF("str");
         p = reader.readPortable("p");
+        bigDecimal = reader.readDecimal("bigDecimal");
+        localTime = reader.readTime("localTime");
+        localDate = reader.readDate("localDate");
+        localDateTime = reader.readTimestamp("localDateTime");
+        offsetDateTime = reader.readTimestampWithTimezone("offsetDateTime");
     }
 
     @Override
@@ -98,57 +126,28 @@ public class MainPortable implements Portable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         MainPortable that = (MainPortable) o;
-        if (b != that.b) {
-            return false;
-        }
-        if (bool != that.bool) {
-            return false;
-        }
-        if (c != that.c) {
-            return false;
-        }
-        if (Double.compare(that.d, d) != 0) {
-            return false;
-        }
-        if (Float.compare(that.f, f) != 0) {
-            return false;
-        }
-        if (i != that.i) {
-            return false;
-        }
-        if (l != that.l) {
-            return false;
-        }
-        if (s != that.s) {
-            return false;
-        }
-        if (p != null ? !p.equals(that.p) : that.p != null) {
-            return false;
-        }
-        if (str != null ? !str.equals(that.str) : that.str != null) {
-            return false;
-        }
-        return true;
+        return b == that.b
+                && bool == that.bool
+                && c == that.c
+                && s == that.s
+                && i == that.i
+                && l == that.l
+                && Float.compare(that.f, f) == 0
+                && Double.compare(that.d, d) == 0
+                && Objects.equals(str, that.str)
+                && Objects.equals(p, that.p)
+                && Objects.equals(bigDecimal, that.bigDecimal)
+                && Objects.equals(localTime, that.localTime)
+                && Objects.equals(localDate, that.localDate)
+                && Objects.equals(localDateTime, that.localDateTime)
+                && Objects.equals(offsetDateTime, that.offsetDateTime);
     }
 
     @Override
     public int hashCode() {
-        int result;
-        long temp;
-        result = (int) b;
-        result = 31 * result + (bool ? 1 : 0);
-        result = 31 * result + (int) c;
-        result = 31 * result + (int) s;
-        result = 31 * result + i;
-        result = 31 * result + (int) (l ^ (l >>> 32));
-        result = 31 * result + (f != +0.0f ? Float.floatToIntBits(f) : 0);
-        temp = d != +0.0d ? Double.doubleToLongBits(d) : 0L;
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
-        result = 31 * result + (str != null ? str.hashCode() : 0);
-        result = 31 * result + (p != null ? p.hashCode() : 0);
-        return result;
+        return Objects.hash(b, bool, c, s, i, l, f, d, str, p, bigDecimal, localTime, localDate,
+                localDateTime, offsetDateTime);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableClassVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableClassVersionTest.java
@@ -33,6 +33,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
 import static com.hazelcast.internal.nio.IOUtil.readData;
 import static com.hazelcast.internal.nio.IOUtil.writeData;
 import static com.hazelcast.internal.serialization.impl.portable.PortableTest.createNamedPortableClassDefinition;
@@ -68,18 +74,18 @@ public class PortableClassVersionTest {
     @Test
     public void testDifferentClassAndServiceVersions() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().setPortableVersion(1)
-                .addPortableFactory(FACTORY_ID, new PortableFactory() {
-                    public Portable create(int classId) {
-                        return new NamedPortable();
-                    }
-                }).build();
+                                                                                            .addPortableFactory(FACTORY_ID, new PortableFactory() {
+                                                                                                public Portable create(int classId) {
+                                                                                                    return new NamedPortable();
+                                                                                                }
+                                                                                            }).build();
 
         SerializationService serializationService2 = new DefaultSerializationServiceBuilder().setPortableVersion(2)
-                .addPortableFactory(FACTORY_ID, new PortableFactory() {
-                    public Portable create(int classId) {
-                        return new NamedPortableV2();
-                    }
-                }).build();
+                                                                                             .addPortableFactory(FACTORY_ID, new PortableFactory() {
+                                                                                                 public Portable create(int classId) {
+                                                                                                     return new NamedPortableV2();
+                                                                                                 }
+                                                                                             }).build();
 
         testDifferentClassVersions(serializationService, serializationService2);
     }
@@ -125,18 +131,18 @@ public class PortableClassVersionTest {
     @Test
     public void testDifferentClassAndServiceVersionsUsingDataWriteAndRead() throws Exception {
         InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().setPortableVersion(1)
-                .addPortableFactory(FACTORY_ID, new PortableFactory() {
-                    public Portable create(int classId) {
-                        return new NamedPortable();
-                    }
-                }).build();
+                                                                                                    .addPortableFactory(FACTORY_ID, new PortableFactory() {
+                                                                                                        public Portable create(int classId) {
+                                                                                                            return new NamedPortable();
+                                                                                                        }
+                                                                                                    }).build();
 
         InternalSerializationService serializationService2 = new DefaultSerializationServiceBuilder().setPortableVersion(2)
-                .addPortableFactory(FACTORY_ID, new PortableFactory() {
-                    public Portable create(int classId) {
-                        return new NamedPortableV2();
-                    }
-                }).build();
+                                                                                                     .addPortableFactory(FACTORY_ID, new PortableFactory() {
+                                                                                                         public Portable create(int classId) {
+                                                                                                             return new NamedPortableV2();
+                                                                                                         }
+                                                                                                     }).build();
 
         testDifferentClassVersionsUsingDataWriteAndRead(serializationService, serializationService2);
     }
@@ -182,16 +188,22 @@ public class PortableClassVersionTest {
         nn[0] = new NamedPortable("name", 123);
         InnerPortable inner = new InnerPortable(new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
                 new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
-                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn);
+                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn,
+                new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
+                new LocalTime[]{LocalTime.now(), LocalTime.now()},
+                new LocalDate[]{LocalDate.now(), LocalDate.now()},
+                new LocalDateTime[]{LocalDateTime.now()},
+                new OffsetDateTime[]{OffsetDateTime.now(), OffsetDateTime.now()});
 
         MainPortable mainWithInner = new MainPortable((byte) 113, true, 'x', (short) -500, 56789, -50992225L, 900.5678f,
-                -897543.3678909d, "this is main portable object created for testing!", inner);
+                -897543.3678909d, "this is main portable object created for testing!", inner,
+                new BigDecimal("12312313"), LocalTime.now(), LocalDate.now(), LocalDateTime.now(), OffsetDateTime.now());
 
         testPreDefinedDifferentVersions(serializationService, serializationService2, mainWithInner);
     }
 
     @Test
-    public void testPreDefinedDifferentVersionsWithNullInnerPortable() {
+    public void testPreDefinedDifferentVersionsWithNullInnerPortable_and_nullObjects() {
         InternalSerializationService serializationService = createSerializationService(1);
         serializationService.getPortableContext().registerClassDefinition(createInnerPortableClassDefinition(1));
 
@@ -199,7 +211,8 @@ public class PortableClassVersionTest {
         serializationService2.getPortableContext().registerClassDefinition(createInnerPortableClassDefinition(2));
 
         MainPortable mainWithNullInner = new MainPortable((byte) 113, true, 'x', (short) -500, 56789, -50992225L, 900.5678f,
-                -897543.3678909d, "this is main portable object created for testing!", null);
+                -897543.3678909d, "this is main portable object created for testing!", null, null,
+                null, null, null, null);
 
         testPreDefinedDifferentVersions(serializationService, serializationService2, mainWithNullInner);
     }
@@ -224,6 +237,11 @@ public class PortableClassVersionTest {
         builder.addFloatArrayField("f");
         builder.addDoubleArrayField("d");
         builder.addPortableArrayField("nn", createNamedPortableClassDefinition(portableVersion));
+        builder.addDecimalArrayField("bigDecimals");
+        builder.addTimeArrayField("localTimes");
+        builder.addDateArrayField("localDates");
+        builder.addTimestampArrayField("localDateTimes");
+        builder.addTimestampWithTimezoneArrayField("offsetDateTimes");
         return builder.build();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableTest.java
@@ -45,6 +45,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteOrder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -101,7 +102,7 @@ public class PortableTest {
         InnerPortable inner = new InnerPortable(new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
                 new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
                 new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn,
-                new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
+                new BigDecimal[]{new BigDecimal(new BigInteger("12345"), 10), new BigDecimal("123456")},
                 new LocalTime[]{LocalTime.now(), LocalTime.now()},
                 new LocalDate[]{LocalDate.now(), LocalDate.now()},
                 new LocalDateTime[]{LocalDateTime.now()},
@@ -745,8 +746,9 @@ public class PortableTest {
                 .setImplementation(new CustomSerializationTest.FooXmlSerializer())
                 .setTypeClass(CustomSerializationTest.Foo.class);
         config.addSerializerConfig(sc);
-        SerializationService serializationService = new DefaultSerializationServiceBuilder().setPortableVersion(1)
-                                                                                            .addPortableFactory(PORTABLE_FACTORY_ID, new TestPortableFactory()).setConfig(config).build();
+        SerializationService serializationService = new DefaultSerializationServiceBuilder()
+                .setPortableVersion(1)
+                .addPortableFactory(PORTABLE_FACTORY_ID, new TestPortableFactory()).setConfig(config).build();
 
         CustomSerializationTest.Foo foo = new CustomSerializationTest.Foo("f");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableTest.java
@@ -44,7 +44,12 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteOrder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -95,14 +100,20 @@ public class PortableTest {
 
         InnerPortable inner = new InnerPortable(new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
                 new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
-                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn);
+                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn,
+                new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
+                new LocalTime[]{LocalTime.now(), LocalTime.now()},
+                new LocalDate[]{LocalDate.now(), LocalDate.now()},
+                new LocalDateTime[]{LocalDateTime.now()},
+                new OffsetDateTime[]{OffsetDateTime.now(), OffsetDateTime.now()});
 
         data = serializationService.toData(inner);
         assertEquals(inner, serializationService.toObject(data));
         assertEquals(inner, serializationService2.toObject(data));
 
         MainPortable main = new MainPortable((byte) 113, true, 'x', (short) -500, 56789, -50992225L, 900.5678f,
-                -897543.3678909d, "this is main portable object created for testing!", inner);
+                -897543.3678909d, "this is main portable object created for testing!", inner,
+                new BigDecimal("12312313"), LocalTime.now(), LocalDate.now(), LocalDateTime.now(), OffsetDateTime.now());
 
         data = serializationService.toData(main);
         assertEquals(main, serializationService.toObject(data));
@@ -254,8 +265,15 @@ public class PortableTest {
 
         assertRepeatedSerialisationGivesSameByteArrays(ss, new NamedPortable("issue-1096", 1096));
 
-        assertRepeatedSerialisationGivesSameByteArrays(ss, new InnerPortable(new byte[3], new char[5], new short[2],
-                new int[10], new long[7], new float[9], new double[1], new NamedPortable[]{new NamedPortable("issue-1096", 1096)}));
+        assertRepeatedSerialisationGivesSameByteArrays(ss, new InnerPortable(new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
+                new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
+                new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321},
+                new NamedPortable[]{new NamedPortable("issue-1096", 1096)},
+                new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
+                new LocalTime[]{LocalTime.now(), LocalTime.now()},
+                new LocalDate[]{LocalDate.now(), LocalDate.now()},
+                new LocalDateTime[]{LocalDateTime.now()},
+                new OffsetDateTime[]{OffsetDateTime.now()}));
 
         assertRepeatedSerialisationGivesSameByteArrays(ss,
                 new RawDataPortable(1096L, "issue-1096".toCharArray(), new NamedPortable("issue-1096", 1096), 1096,
@@ -728,7 +746,7 @@ public class PortableTest {
                 .setTypeClass(CustomSerializationTest.Foo.class);
         config.addSerializerConfig(sc);
         SerializationService serializationService = new DefaultSerializationServiceBuilder().setPortableVersion(1)
-                .addPortableFactory(PORTABLE_FACTORY_ID, new TestPortableFactory()).setConfig(config).build();
+                                                                                            .addPortableFactory(PORTABLE_FACTORY_ID, new TestPortableFactory()).setConfig(config).build();
 
         CustomSerializationTest.Foo foo = new CustomSerializationTest.Foo("f");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/portablereader/DefaultPortableReaderTestStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/portablereader/DefaultPortableReaderTestStructure.java
@@ -22,8 +22,17 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+
 import static java.util.Arrays.asList;
 
 public class DefaultPortableReaderTestStructure {
@@ -38,6 +47,11 @@ public class DefaultPortableReaderTestStructure {
         Float("float_"),
         Double("double_"),
         UTF("string_"),
+        BigDecimal("bigDecimal_"),
+        LocalTime("localTime_"),
+        LocalDate("localDate_"),
+        LocalDateTime("localDateTime_"),
+        OffsetDateTime("offsetDateTime_"),
 
         ByteArray("bytes"),
         BooleanArray("booleans"),
@@ -47,7 +61,12 @@ public class DefaultPortableReaderTestStructure {
         LongArray("longs"),
         FloatArray("floats"),
         DoubleArray("doubles"),
-        UTFArray("strings");
+        UTFArray("strings"),
+        BigDecimalArray("bigDecimals"),
+        LocalTimeArray("localTimes"),
+        LocalDateArray("localDates"),
+        LocalDateTimeArray("localDateTimes"),
+        OffsetDateTimeArray("offsetDateTimes");
 
         PrimitiveFields(String field) {
             this.field = field;
@@ -56,11 +75,13 @@ public class DefaultPortableReaderTestStructure {
         final String field;
 
         static List<PrimitiveFields> getPrimitives() {
-            return asList(Byte, Boolean, Char, Short, Int, Long, Float, Double, UTF);
+            return asList(Byte, Boolean, Char, Short, Int, Long, Float, Double, UTF, BigDecimal, LocalTime,
+                    LocalDate, LocalDateTime, OffsetDateTime);
         }
 
         static List<PrimitiveFields> getPrimitiveArrays() {
-            return asList(ByteArray, BooleanArray, CharArray, ShortArray, IntArray, LongArray, FloatArray, DoubleArray, UTFArray);
+            return asList(ByteArray, BooleanArray, CharArray, ShortArray, IntArray, LongArray, FloatArray, DoubleArray, UTFArray,
+                    BigDecimalArray, LocalTimeArray, LocalDateArray, LocalDateTimeArray, OffsetDateTimeArray);
         }
 
     }
@@ -79,6 +100,11 @@ public class DefaultPortableReaderTestStructure {
         boolean boolean_;
         char char_;
         String string_;
+        BigDecimal bigDecimal_;
+        LocalTime localTime_;
+        LocalDate localDate_;
+        LocalDateTime localDateTime_;
+        OffsetDateTime offsetDateTime_;
 
         byte[] bytes;
         short[] shorts;
@@ -89,6 +115,11 @@ public class DefaultPortableReaderTestStructure {
         boolean[] booleans;
         char[] chars;
         String[] strings;
+        BigDecimal[] bigDecimals;
+        LocalTime[] localTimes;
+        LocalDate[] localDates;
+        LocalDateTime[] localDateTimes;
+        OffsetDateTime[] offsetDateTimes;
 
         enum Init {
             FULL, NONE, NULL
@@ -108,6 +139,7 @@ public class DefaultPortableReaderTestStructure {
             boolean_ = seed % 2 == 0;
             char_ = (char) (seed + 'a');
 
+            Random rnd = new Random(seed);
             if (init == Init.FULL) {
                 bytes = new byte[]{(byte) (seed + 11), (byte) (seed + 12), (byte) (seed + 13)};
                 shorts = new short[]{(short) (seed + 21), (short) (seed + 22), (short) (seed + 23)};
@@ -120,6 +152,26 @@ public class DefaultPortableReaderTestStructure {
                 strings = new String[]{seed + 81 + "text", seed + 82 + "text", seed + 83 + "text"};
 
                 string_ = seed + 80 + "text";
+                bigDecimal_ = new BigDecimal(new BigInteger(32, rnd), 2);
+                localTime_ = LocalTime.of(1, seed % 60, 0);
+                localDate_ = LocalDate.of(1990, (seed + 1) % 12, 1);
+                localDateTime_ = LocalDateTime.of(localDate_, localTime_);
+                offsetDateTime_ = OffsetDateTime.of(localDate_, localTime_, ZoneOffset.ofHours(seed % 18));
+
+                bigDecimals = new BigDecimal[]{new BigDecimal(new BigInteger(32, rnd), 2),
+                        new BigDecimal(new BigInteger(32, rnd), 2),
+                        new BigDecimal(new BigInteger(32, rnd), 2)};
+                localTimes = new LocalTime[]{LocalTime.of(1, seed % 60, 0),
+                        LocalTime.of(2, seed % 60, 0), LocalTime.of(3, seed % 60, 0)};
+                localDates = new LocalDate[]{LocalDate.of(1990, (seed + 1) % 12, 1),
+                        LocalDate.of(1990, (seed + 1) % 12, 1),
+                        LocalDate.of(1990, (seed + 1) % 12, 1)};
+                localDateTimes = new LocalDateTime[]{LocalDateTime.of(localDates[0], localTimes[0]),
+                        LocalDateTime.of(localDates[1], localTimes[1]), LocalDateTime.of(localDates[2], localTimes[2])};
+                offsetDateTimes = new OffsetDateTime[]{
+                        OffsetDateTime.of(localDates[0], localTimes[0], ZoneOffset.ofHours(seed % 18)),
+                        OffsetDateTime.of(localDates[1], localTimes[1], ZoneOffset.ofHours(seed % 18)),
+                        OffsetDateTime.of(localDates[2], localTimes[2], ZoneOffset.ofHours(seed % 18))};
             } else if (init == Init.NONE) {
                 bytes = new byte[]{};
                 shorts = new short[]{};
@@ -130,10 +182,18 @@ public class DefaultPortableReaderTestStructure {
                 booleans = new boolean[]{};
                 chars = new char[]{};
                 strings = new String[]{};
+                bigDecimals = new BigDecimal[]{};
+                localTimes = new LocalTime[]{};
+                localDates = new LocalDate[]{};
+                localDateTimes = new LocalDateTime[]{};
+                offsetDateTimes = new OffsetDateTime[]{};
 
+                bigDecimal_ = new BigDecimal(new BigInteger(32, rnd), 2);
+                localTime_ = LocalTime.of(1, seed % 60, 0);
+                localDate_ = LocalDate.of(1990, (seed + 1) % 12, 1);
+                localDateTime_ = LocalDateTime.of(localDate_, localTime_);
+                offsetDateTime_ = OffsetDateTime.of(localDate_, localTime_, ZoneOffset.ofHours(seed % 18));
                 string_ = "";
-            } else {
-                string_ = null;
             }
         }
 
@@ -161,6 +221,11 @@ public class DefaultPortableReaderTestStructure {
             writer.writeBoolean("boolean_", boolean_);
             writer.writeChar("char_", char_);
             writer.writeUTF("string_", string_);
+            writer.writeDecimal("bigDecimal_", bigDecimal_);
+            writer.writeTime("localTime_", localTime_);
+            writer.writeDate("localDate_", localDate_);
+            writer.writeTimestamp("localDateTime_", localDateTime_);
+            writer.writeTimestampWithTimezone("offsetDateTime_", offsetDateTime_);
 
             writer.writeByteArray("bytes", bytes);
             writer.writeShortArray("shorts", shorts);
@@ -171,6 +236,11 @@ public class DefaultPortableReaderTestStructure {
             writer.writeBooleanArray("booleans", booleans);
             writer.writeCharArray("chars", chars);
             writer.writeUTFArray("strings", strings);
+            writer.writeDecimalArray("bigDecimals", bigDecimals);
+            writer.writeTimeArray("localTimes", localTimes);
+            writer.writeDateArray("localDates", localDates);
+            writer.writeTimestampArray("localDateTimes", localDateTimes);
+            writer.writeTimestampWithTimezoneArray("offsetDateTimes", offsetDateTimes);
         }
 
         @Override
@@ -184,6 +254,11 @@ public class DefaultPortableReaderTestStructure {
             boolean_ = reader.readBoolean("boolean_");
             char_ = reader.readChar("char_");
             string_ = reader.readUTF("string_");
+            bigDecimal_ = reader.readDecimal("bigDecimal_");
+            localTime_ = reader.readTime("localTime_");
+            localDate_ = reader.readDate("localDate_");
+            localDateTime_ = reader.readTimestamp("localDateTime_");
+            offsetDateTime_ = reader.readTimestampWithTimezone("offsetDateTime_");
 
             bytes = reader.readByteArray("bytes");
             shorts = reader.readShortArray("shorts");
@@ -194,6 +269,11 @@ public class DefaultPortableReaderTestStructure {
             booleans = reader.readBooleanArray("booleans");
             chars = reader.readCharArray("chars");
             strings = reader.readUTFArray("strings");
+            bigDecimals = reader.readDecimalArray("bigDecimals");
+            localTimes = reader.readTimeArray("localTimes");
+            localDates = reader.readDateArray("localDates");
+            localDateTimes = reader.readTimestampArray("localDateTimes");
+            offsetDateTimes = reader.readTimestampWithTimezoneArray("offsetDateTimes");
         }
 
         @Override
@@ -246,6 +326,16 @@ public class DefaultPortableReaderTestStructure {
                     return double_;
                 case UTF:
                     return string_;
+                case BigDecimal:
+                    return bigDecimal_;
+                case LocalTime:
+                    return localTime_;
+                case LocalDate:
+                    return localDate_;
+                case LocalDateTime:
+                    return localDateTime_;
+                case OffsetDateTime:
+                    return offsetDateTime_;
                 default:
                     throw new RuntimeException("Unsupported method " + primitiveFields);
             }
@@ -271,6 +361,16 @@ public class DefaultPortableReaderTestStructure {
                     return doubles;
                 case UTF:
                     return strings;
+                case BigDecimal:
+                    return bigDecimals;
+                case LocalTime:
+                    return localTimes;
+                case LocalDate:
+                    return localDates;
+                case LocalDateTime:
+                    return localDateTimes;
+                case OffsetDateTime:
+                    return offsetDateTimes;
                 //
                 case ByteArray:
                     return bytes;
@@ -290,6 +390,16 @@ public class DefaultPortableReaderTestStructure {
                     return doubles;
                 case UTFArray:
                     return strings;
+                case BigDecimalArray:
+                    return bigDecimals;
+                case LocalTimeArray:
+                    return localTimes;
+                case LocalDateArray:
+                    return localDates;
+                case LocalDateTimeArray:
+                    return localDateTimes;
+                case OffsetDateTimeArray:
+                    return offsetDateTimes;
                 default:
                     throw new RuntimeException("Unsupported array method " + primitiveFields);
             }

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -64,7 +64,6 @@ import static com.hazelcast.internal.nio.IOUtil.getFileFromResources;
 import static com.hazelcast.internal.nio.IOUtil.getPath;
 import static com.hazelcast.internal.nio.IOUtil.newInputStream;
 import static com.hazelcast.internal.nio.IOUtil.newOutputStream;
-import static com.hazelcast.internal.nio.IOUtil.readAttributeValue;
 import static com.hazelcast.internal.nio.IOUtil.readByteArray;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
 import static com.hazelcast.internal.nio.IOUtil.readFullyOrNothing;
@@ -728,100 +727,6 @@ public class IOUtilTest extends HazelcastTestSupport {
         ByteBuffer dst = ByteBuffer.wrap(new byte[SIZE]);
 
         assertEquals(0, copyToHeapBuffer(null, dst));
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeBoolean() throws Exception {
-        final boolean expected = true;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_BOOLEAN);
-        when(input.readBoolean()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeByte() throws Exception {
-        final byte expected = (byte) 0xFF;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_BYTE).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeShort() throws Exception {
-        final short expected = 42;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_SHORT);
-        when(input.readShort()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeInteger() throws Exception {
-        final int expected = 42;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_INTEGER);
-        when(input.readInt()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeLong() throws Exception {
-        final long expected = 42L;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_LONG);
-        when(input.readLong()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeFloat() throws Exception {
-        final float expected = 0.42f;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_FLOAT);
-        when(input.readFloat()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(Float.floatToIntBits(expected), Float.floatToIntBits((Float) actual));
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeDouble() throws Exception {
-        final double expected = 42.42f;
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_DOUBLE);
-        when(input.readDouble()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(Double.doubleToLongBits(expected), Double.doubleToLongBits((Double) actual));
-    }
-
-    @Test
-    public void testReadAttributeValue_whenTypeUTF() throws Exception {
-        final String expected = "UTF";
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn(IOUtil.PRIMITIVE_TYPE_UTF);
-        when(input.readUTF()).thenReturn(expected);
-
-        Object actual = readAttributeValue(input);
-        assertEquals(expected, actual);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testReadAttributeValue_whenInvalidType() throws Exception {
-        ObjectDataInput input = mock(ObjectDataInput.class);
-        when(input.readByte()).thenReturn((byte) 0xFF);
-        readAttributeValue(input);
     }
 
     @Test


### PR DESCRIPTION
The following types are added to the Portable. The need comes from the SQL work.

BigDecimal,LocalTime,LocalDate,LocalDateTime,OffsetDateTime

Each one has its own method on PortableReader/Writer, GenericRecord/Builder, ClassDefinitionBuilder, etc.. Also, the support for the array of each type is also added. 

We did not add these types to ObjectDataOutput/Input or to root serializers.