### PR TITLE
Force BouncingMembers to set driver type explicitly

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class AggregationMemberBounceTest extends HazelcastTestSupport {
     @Rule
     public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig())
             .clusterSize(MEMBER_COUNT)
-            .driverCount(DRIVER_COUNT).build();
+            .driverCount(DRIVER_COUNT).driverType(BounceTestConfiguration.DriverType.MEMBER).build();
 
     protected Config getConfig() {
         return new Config();

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,6 +88,7 @@ public class ClientBackpressureBouncingTest extends HazelcastTestSupport {
         this.backoff = backoffTimeoutMillis;
         this.bounceMemberRule = BounceMemberRule
                 .with(new Config())
+                .driverType(BounceTestConfiguration.DriverType.CLIENT)
                 .driverFactory(new MultiSocketClientDriverFactory(
                         new ClientConfig()
                                 .setProperty(MAX_CONCURRENT_INVOCATIONS.getName(), valueOf(MAX_CONCURRENT_INVOCATION_CONFIG))

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientPutAllRemoveBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientPutAllRemoveBounceTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import com.hazelcast.test.jitter.JitterRule;
 import org.junit.After;
 import org.junit.Before;
@@ -52,7 +53,8 @@ public class ClientPutAllRemoveBounceTest extends HazelcastTestSupport {
     private static final int CONCURRENCY = 1;
 
     @Rule
-    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig()).clusterSize(4).driverCount(4).build();
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig()).clusterSize(4).driverCount(4)
+            .driverType(BounceTestConfiguration.DriverType.CLIENT).build();
 
     @Rule
     public JitterRule jitterRule = new JitterRule();

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
@@ -45,6 +45,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -63,6 +64,7 @@ public class DynamicConfigBouncingTest extends HazelcastTestSupport {
             .clusterSize(4)
             .driverCount(1)
             .useTerminate(true)
+            .driverType(BounceTestConfiguration.DriverType.MEMBER)
             .build();
 
     public Config getConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBounceTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.internal.journal.EventJournalReader;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import com.hazelcast.test.jitter.JitterRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,11 +30,11 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.spi.properties.ClusterProperty.EVENT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.GENERIC_OPERATION_THREAD_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_OPERATION_THREAD_COUNT;
-import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
@@ -50,8 +51,10 @@ public abstract class AbstractEventJournalBounceTest {
 
     @Rule
     public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig())
-                                                               .clusterSize(4)
-                                                               .driverCount(4).build();
+            .clusterSize(4)
+            .driverCount(4)
+            .driverType(BounceTestConfiguration.DriverType.MEMBER)
+            .build();
 
     @Rule
     public JitterRule jitterRule = new JitterRule();

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,7 +47,8 @@ public class EntryProcessorOffloadableBouncingNodesTest extends HazelcastTestSup
     private static final int CONCURRENCY = RuntimeAvailableProcessors.get();
 
     @Rule
-    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getBouncingTestConfig()).build();
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getBouncingTestConfig())
+            .driverType(BounceTestConfiguration.DriverType.MEMBER).build();
 
     private void populateMap(IMap<Integer, SimpleValue> map) {
         for (int i = 0; i < COUNT_ENTRIES; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,7 @@ public class MapPutAllWithBouncingMemberTest extends HazelcastTestSupport {
     @Rule
     public BounceMemberRule bounceMemberRule =
             BounceMemberRule.with(getConfig())
+                    .driverType(BounceTestConfiguration.DriverType.MEMBER)
                     .clusterSize(2)
                     .build();
 

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.query.SampleTestObjects;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import com.hazelcast.test.jitter.JitterRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,6 +55,7 @@ public class QueryBounceTest {
             BounceMemberRule.with(getConfig())
                     .clusterSize(4)
                     .driverCount(4)
+                    .driverType(BounceTestConfiguration.DriverType.MEMBER)
                     .useTerminate(useTerminate())
                     .build();
 

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -18,9 +18,9 @@ package com.hazelcast.test.bounce;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.bounce.BounceTestConfiguration.DriverType;
 import org.junit.rules.TestRule;
@@ -41,13 +41,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import static com.hazelcast.internal.nio.ClassLoaderUtil.isClassAvailable;
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.StringUtil.timeToString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
 import static com.hazelcast.test.bounce.BounceTestConfiguration.DriverType.ALWAYS_UP_MEMBER;
 import static com.hazelcast.test.bounce.BounceTestConfiguration.DriverType.CLIENT;
-import static com.hazelcast.test.bounce.BounceTestConfiguration.DriverType.MEMBER;
-import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.StringUtil.timeToString;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -461,13 +459,7 @@ public class BounceMemberRule implements TestRule {
         public BounceMemberRule build() {
 
             if (testDriverType == null) {
-                // guess driver: if HazelcastTestFactory class is available, then use the client driver,
-                // otherwise use member driver as default
-                if (isClassAvailable(null, "com.hazelcast.client.test.TestHazelcastFactory")) {
-                    testDriverType = CLIENT;
-                } else {
-                    testDriverType = MEMBER;
-                }
+                throw new AssertionError("testDriverType must be set");
             }
 
             if (testDriverType == ALWAYS_UP_MEMBER) {

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleStalenessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleStalenessTest.java
@@ -44,6 +44,7 @@ public class BounceMemberRuleStalenessTest extends HazelcastTestSupport {
             .clusterSize(2)
             .maximumStalenessSeconds(MAXIMUM_STALENESS_SECONDS)
             .bouncingIntervalSeconds(BOUNCING_INTERVAL_SECONDS)
+            .driverType(BounceTestConfiguration.DriverType.MEMBER)
             .build();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleTest.java
@@ -43,7 +43,8 @@ public class BounceMemberRuleTest {
     private String mapName = randomMapName();
 
     @Rule
-    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(new Config()).clusterSize(3).build();
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(new Config()).clusterSize(3)
+            .driverType(BounceTestConfiguration.DriverType.MEMBER).build();
 
     @Before
     public void setup() {


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/15393

(cherry picked from commit 2e3787529010814b5ad12a2c0968d135884725da)