### PR TITLE
Enable animal-sniffer for test classes too

### DIFF
--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -52,7 +52,7 @@
                 <executions>
                     <execution>
                         <id>source-java8-check</id>
-                        <phase>compile</phase>
+                        <phase>test-compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -56,7 +56,7 @@
                 <executions>
                     <execution>
                         <id>source-java8-check</id>
-                        <phase>compile</phase>
+                        <phase>test-compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -80,13 +80,14 @@
                         <version>1.0</version>
                     </signature>
                     <ignores>
+                        <ignore>java.lang.invoke.MethodHandle</ignore>
                         <ignore>sun.misc.Unsafe</ignore>
                     </ignores>
                 </configuration>
                 <executions>
                     <execution>
                         <id>source-java8-check</id>
-                        <phase>compile</phase>
+                        <phase>test-compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
Fixes the animal sniffer plugin execution - to be used also for test classes.
Adds the `MethodHandle` class to ignores due to mojohaus/animal-sniffer#67.