### PR TITLE
Fix RingBufferPermission.ALL action mask

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
@@ -20,7 +20,7 @@ public class RingBufferPermission extends InstancePermission {
 
     private static final int PUT = 4;
     private static final int READ = 8;
-    private static final int ALL = PUT | READ;
+    private static final int ALL = PUT | READ | CREATE | DESTROY;
 
     public RingBufferPermission(String name, String... actions) {
         super(name, actions);


### PR DESCRIPTION
Fixes behavior of `RingBufferPermission` for the `"all"` action.