### PR TITLE
Support for multiple pmem directories in config

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -44,8 +44,10 @@ import com.hazelcast.config.IndexType;
 import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
+import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
@@ -58,6 +60,7 @@ import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.cp.ISemaphore;
 import com.hazelcast.map.IMap;
+import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.test.annotation.QuickTest;
@@ -145,6 +148,9 @@ public class TestClientApplicationContext {
 
     @Resource(name = "client19-instance-tracking")
     private HazelcastClientProxy instanceTrackingClient;
+
+    @Resource(name = "client20-native-memory")
+    private HazelcastClientProxy nativeMemoryClient;
 
     @Resource(name = "instance")
     private HazelcastInstance instance;
@@ -533,5 +539,30 @@ public class TestClientApplicationContext {
         assertEquals("/dummy/file", trackingConfig.getFileName());
         assertEquals("dummy-pattern with $HZ_INSTANCE_TRACKING{placeholder} and $RND{placeholder}",
                 trackingConfig.getFormatPattern());
+    }
+
+    @Test
+    public void testNativeMemory() {
+        NativeMemoryConfig nativeMemoryConfig = nativeMemoryClient.getClientConfig().getNativeMemoryConfig();
+
+        assertFalse(nativeMemoryConfig.isEnabled());
+        assertEquals(MemoryUnit.GIGABYTES, nativeMemoryConfig.getSize().getUnit());
+        assertEquals(256, nativeMemoryConfig.getSize().getValue());
+        assertEquals(20, nativeMemoryConfig.getPageSize());
+        assertEquals(NativeMemoryConfig.MemoryAllocatorType.STANDARD, nativeMemoryConfig.getAllocatorType());
+        assertEquals(10.2, nativeMemoryConfig.getMetadataSpacePercentage(), 0.1);
+        assertEquals(10, nativeMemoryConfig.getMinBlockSize());
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemoryConfig.getPersistentMemoryConfig()
+                                                                                   .getDirectoryConfigs();
+
+        assertEquals(3, directoryConfigs.size());
+        // set with <persistent-memory>
+        assertEquals("/mnt/pmem0", directoryConfigs.get(0).getDirectory());
+        assertEquals(0, directoryConfigs.get(0).getNumaNode());
+        assertEquals("/mnt/pmem1", directoryConfigs.get(1).getDirectory());
+        assertFalse(directoryConfigs.get(1).isNumaNodeSet());
+        // set with <persistent-memory-directory>
+        assertEquals("/mnt/optane", directoryConfigs.get(2).getDirectory());
+        assertFalse(directoryConfigs.get(2).isNumaNodeSet());
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -555,14 +555,10 @@ public class TestClientApplicationContext {
         List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemoryConfig.getPersistentMemoryConfig()
                                                                                    .getDirectoryConfigs();
 
-        assertEquals(3, directoryConfigs.size());
-        // set with <persistent-memory>
+        assertEquals(2, directoryConfigs.size());
         assertEquals("/mnt/pmem0", directoryConfigs.get(0).getDirectory());
         assertEquals(0, directoryConfigs.get(0).getNumaNode());
         assertEquals("/mnt/pmem1", directoryConfigs.get(1).getDirectory());
-        assertFalse(directoryConfigs.get(1).isNumaNodeSet());
-        // set with <persistent-memory-directory>
-        assertEquals("/mnt/optane", directoryConfigs.get(2).getDirectory());
-        assertFalse(directoryConfigs.get(2).isNumaNodeSet());
+        assertEquals(1, directoryConfigs.get(1).getNumaNode());
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -34,10 +34,6 @@ import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConsistencyCheckStrategy;
-import com.hazelcast.config.InstanceTrackingConfig;
-import com.hazelcast.config.SqlConfig;
-import com.hazelcast.config.WanBatchPublisherConfig;
-import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -56,6 +52,7 @@ import com.hazelcast.config.IcmpFailureDetectorConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.KubernetesConfig;
@@ -82,6 +79,7 @@ import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionConfig.PermissionType;
+import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
@@ -99,14 +97,17 @@ import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SplitBrainProtectionConfig;
+import com.hazelcast.config.SqlConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.config.VaultSecureStoreConfig;
 import com.hazelcast.config.WanAcknowledgeType;
-import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.config.WanBatchPublisherConfig;
 import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.WanQueueFullBehavior;
+import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
@@ -149,8 +150,8 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.TopicOverloadPolicy;
-import com.hazelcast.wan.WanPublisherState;
 import com.hazelcast.wan.WanPublisher;
+import com.hazelcast.wan.WanPublisherState;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -1128,13 +1129,24 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     public void testNativeMemoryConfig() {
         NativeMemoryConfig nativeMemoryConfig = config.getNativeMemoryConfig();
         assertFalse(nativeMemoryConfig.isEnabled());
-        assertEquals(MemoryUnit.MEGABYTES, nativeMemoryConfig.getSize().getUnit());
+        assertEquals(MemoryUnit.GIGABYTES, nativeMemoryConfig.getSize().getUnit());
         assertEquals(256, nativeMemoryConfig.getSize().getValue());
         assertEquals(20, nativeMemoryConfig.getPageSize());
-        assertEquals(NativeMemoryConfig.MemoryAllocatorType.POOLED, nativeMemoryConfig.getAllocatorType());
+        assertEquals(NativeMemoryConfig.MemoryAllocatorType.STANDARD, nativeMemoryConfig.getAllocatorType());
         assertEquals(10.2, nativeMemoryConfig.getMetadataSpacePercentage(), 0.1);
         assertEquals(10, nativeMemoryConfig.getMinBlockSize());
-        assertEquals("/mnt/optane", nativeMemoryConfig.getPersistentMemoryDirectory());
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemoryConfig.getPersistentMemoryConfig()
+                                                                                   .getDirectoryConfigs();
+
+        assertEquals(3, directoryConfigs.size());
+        // set with <persistent-memory>
+        assertEquals("/mnt/pmem0", directoryConfigs.get(0).getDirectory());
+        assertEquals(0, directoryConfigs.get(0).getNumaNode());
+        assertEquals("/mnt/pmem1", directoryConfigs.get(1).getDirectory());
+        assertFalse(directoryConfigs.get(1).isNumaNodeSet());
+        // set with <persistent-memory-directory>
+        assertEquals("/mnt/optane", directoryConfigs.get(2).getDirectory());
+        assertFalse(directoryConfigs.get(2).isNumaNodeSet());
     }
 
     @Test

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1138,15 +1138,11 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemoryConfig.getPersistentMemoryConfig()
                                                                                    .getDirectoryConfigs();
 
-        assertEquals(3, directoryConfigs.size());
-        // set with <persistent-memory>
+        assertEquals(2, directoryConfigs.size());
         assertEquals("/mnt/pmem0", directoryConfigs.get(0).getDirectory());
         assertEquals(0, directoryConfigs.get(0).getNumaNode());
         assertEquals("/mnt/pmem1", directoryConfigs.get(1).getDirectory());
-        assertFalse(directoryConfigs.get(1).isNumaNodeSet());
-        // set with <persistent-memory-directory>
-        assertEquals("/mnt/optane", directoryConfigs.get(2).getDirectory());
-        assertFalse(directoryConfigs.get(2).isNumaNodeSet());
+        assertEquals(1, directoryConfigs.get(1).getNumaNode());
     }
 
     @Test

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -17,7 +17,6 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
-       xmlns:s="http://www.hazelcast.com/schema/sample"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
@@ -608,11 +607,17 @@
                 </hz:java-serialization-filter>
             </hz:serialization>
 
-            <hz:native-memory enabled="false" allocator-type="POOLED" metadata-space-percentage="10.2"
+            <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
                               min-block-size="10"
                               page-size="20"
                               persistent-memory-directory="/mnt/optane">
-                <hz:size unit="MEGABYTES" value="256"/>
+                <hz:size unit="GIGABYTES" value="256"/>
+                <hz:persistent-memory>
+                    <hz:directories>
+                        <hz:directory numa-node="0">/mnt/pmem0</hz:directory>
+                        <hz:directory>/mnt/pmem1</hz:directory>
+                    </hz:directories>
+                </hz:persistent-memory>
             </hz:native-memory>
             <hz:security>
                 <hz:realms>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -609,13 +609,12 @@
 
             <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
                               min-block-size="10"
-                              page-size="20"
-                              persistent-memory-directory="/mnt/optane">
+                              page-size="20">
                 <hz:size unit="GIGABYTES" value="256"/>
                 <hz:persistent-memory>
                     <hz:directories>
                         <hz:directory numa-node="0">/mnt/pmem0</hz:directory>
-                        <hz:directory>/mnt/pmem1</hz:directory>
+                        <hz:directory numa-node="1">/mnt/pmem1</hz:directory>
                     </hz:directories>
                 </hz:persistent-memory>
             </hz:native-memory>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -423,6 +423,26 @@
         </hz:instance-tracking>
     </hz:client>
 
+    <hz:client id="client20-native-memory">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
+        <hz:network>
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+        </hz:network>
+        <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
+                          min-block-size="10"
+                          page-size="20"
+                          persistent-memory-directory="/mnt/optane">
+            <hz:size unit="GIGABYTES" value="256"/>
+            <hz:persistent-memory>
+                <hz:directories>
+                    <hz:directory numa-node="0">/mnt/pmem0</hz:directory>
+                    <hz:directory>/mnt/pmem1</hz:directory>
+                </hz:directories>
+            </hz:persistent-memory>
+        </hz:native-memory>
+    </hz:client>
+
     <bean id="credentials" class="com.hazelcast.security.UsernamePasswordCredentials">
         <property name="name" value="spring-cluster"/>
         <property name="password" value="spring-cluster-pass"/>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -431,13 +431,12 @@
         </hz:network>
         <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
                           min-block-size="10"
-                          page-size="20"
-                          persistent-memory-directory="/mnt/optane">
+                          page-size="20">
             <hz:size unit="GIGABYTES" value="256"/>
             <hz:persistent-memory>
                 <hz:directories>
                     <hz:directory numa-node="0">/mnt/pmem0</hz:directory>
-                    <hz:directory>/mnt/pmem1</hz:directory>
+                    <hz:directory numa-node="1">/mnt/pmem1</hz:directory>
                 </hz:directories>
             </hz:persistent-memory>
         </hz:native-memory>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -196,6 +196,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                     handleMetrics(node);
                 } else if ("instance-tracking".equals(nodeName)) {
                     handleInstanceTracking(node);
+                } else if ("native-memory".equals(nodeName)) {
+                    handleNativeMemory(node);
                 }
             }
             return configBuilder.getBeanDefinition();

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -67,7 +67,6 @@ import com.hazelcast.config.MetricsJmxConfig;
 import com.hazelcast.config.MetricsManagementCenterConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.MulticastConfig;
-import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.OnJoinPermissionOperationName;
@@ -129,8 +128,6 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.StringUtil;
-import com.hazelcast.memory.MemorySize;
-import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -1783,29 +1780,6 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
             memberAttributeConfigBuilder.addPropertyValue("attributes", attributes);
             configBuilder.addPropertyValue("memberAttributeConfig", beanDefinition);
-        }
-
-        private void handleNativeMemory(Node node) {
-            BeanDefinitionBuilder nativeMemoryConfigBuilder = createBeanBuilder(NativeMemoryConfig.class);
-            AbstractBeanDefinition beanDefinition = nativeMemoryConfigBuilder.getBeanDefinition();
-            fillAttributeValues(node, nativeMemoryConfigBuilder);
-            for (Node child : childElements(node)) {
-                String nodeName = cleanNodeName(child);
-                if ("size".equals(nodeName)) {
-                    handleMemorySizeConfig(child, nativeMemoryConfigBuilder);
-                }
-            }
-            configBuilder.addPropertyValue("nativeMemoryConfig", beanDefinition);
-        }
-
-        private void handleMemorySizeConfig(Node node, BeanDefinitionBuilder nativeMemoryConfigBuilder) {
-            BeanDefinitionBuilder memorySizeConfigBuilder = createBeanBuilder(MemorySize.class);
-            NamedNodeMap attributes = node.getAttributes();
-            Node value = attributes.getNamedItem("value");
-            Node unit = attributes.getNamedItem("unit");
-            memorySizeConfigBuilder.addConstructorArgValue(getTextContent(value));
-            memorySizeConfigBuilder.addConstructorArgValue(MemoryUnit.valueOf(getTextContent(unit)));
-            nativeMemoryConfigBuilder.addPropertyValue("size", memorySizeConfigBuilder.getBeanDefinition());
         }
 
         private void handleSecurityInterceptors(Node node, BeanDefinitionBuilder securityConfigBuilder) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -1573,8 +1573,9 @@
                     <xs:element name="user-code-deployment" type="user-code-deployment-client" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="flake-id-generator" type="client-flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="reliable-topic" type="client-reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="metrics" type="client-metrics" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="metrics" type="client-metrics" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="instance-tracking" type="instance-tracking" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="native-memory" type="native-memory" minOccurs="0" maxOccurs="1"/>
                 </xs:choice>
             </xs:extension>
         </xs:complexContent>
@@ -3801,6 +3802,7 @@
     <xs:complexType name="native-memory">
         <xs:all>
             <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="persistent-memory" type="persistent-memory" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="min-block-size" use="optional" type="xs:positiveInteger"/>
         <xs:attribute name="page-size" use="optional" type="xs:positiveInteger"/>
@@ -3816,7 +3818,7 @@
         </xs:attribute>
         <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
         <xs:attribute name="enabled" default="true" type="parameterized-boolean"/>
-        <xs:attribute name="persistent-memory-directory" type="xs:string" use="optional"/>
+        <xs:attribute name="persistent-memory-directory" type="xs:string" use="optional" />
     </xs:complexType>
     <xs:complexType name="memory-size">
         <xs:attribute name="value" type="parameterized-non-negative-integer" default="128"/>
@@ -3836,6 +3838,47 @@
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="persistent-memory">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for persistent memory (e.g. Intel Optane) devices.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="directories">
+                <xs:annotation>
+                    <xs:documentation>
+                        List of directories where the persistent memory
+                        is mounted to.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice maxOccurs="unbounded">
+                        <xs:element name="directory" type="persistent-memory-directory"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="persistent-memory-directory">
+        <xs:annotation>
+            <xs:documentation>
+                The directory where persistent memory is mounted to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="numa-node" type="xs:int" default="-1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The NUMA node that the persistent memory mounted
+                            to the given directory is attached to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 
     <xs:complexType name="split-brain-protection">
         <xs:all>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -3802,7 +3802,7 @@
     <xs:complexType name="native-memory">
         <xs:all>
             <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="persistent-memory" type="persistent-memory" maxOccurs="1"/>
+            <xs:element name="persistent-memory" type="persistent-memory" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="min-block-size" use="optional" type="xs:positiveInteger"/>
         <xs:attribute name="page-size" use="optional" type="xs:positiveInteger"/>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -3850,6 +3850,12 @@
                     <xs:documentation>
                         List of directories where the persistent memory
                         is mounted to.
+
+                        If the specified directories are not unique either in the directories
+                        themselves or in the NUMA nodes specified for them,
+                        the configuration is treated as invalid. Setting the NUMA
+                        node on the subset of the configured directories while leaving
+                        not set on others also makes the configuration invalid.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -3864,6 +3870,12 @@
         <xs:annotation>
             <xs:documentation>
                 The directory where persistent memory is mounted to.
+
+                If the specified directory id not unique either in the
+                directory itself or in the NUMA node specified, the
+                configuration will be treated as invalid. Setting the NUMA
+                node on the subset of the configured directories while leaving
+                not set on others also results in invalid configuration.
             </xs:documentation>
         </xs:annotation>
         <xs:simpleContent>
@@ -3873,6 +3885,13 @@
                         <xs:documentation>
                             The NUMA node that the persistent memory mounted
                             to the given directory is attached to.
+
+                            NUMA nodes have to be unique across the entire
+                            persistent memory configuration, otherwise the
+                            configuration will be treated as invalid. Similarly,
+                            setting the NUMA node on the subset of the configured
+                            directories while leaving not set on others also
+                            results in invalid configuration.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -34,6 +34,7 @@ import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
+import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.SSLConfig;
@@ -379,13 +380,30 @@ public final class ClientConfigXmlGenerator {
     private static void nativeMemory(XmlGenerator gen, NativeMemoryConfig nativeMemory) {
         gen.open("native-memory", "enabled", nativeMemory.isEnabled(),
                 "allocator-type", nativeMemory.getAllocatorType())
-                .node("size", null, "value", nativeMemory.getSize().getValue(),
-                        "unit", nativeMemory.getSize().getUnit())
-                .node("min-block-size", nativeMemory.getMinBlockSize())
-                .node("page-size", nativeMemory.getPageSize())
-                .node("metadata-space-percentage", nativeMemory.getMetadataSpacePercentage())
-                .node("persistent-memory-directory", nativeMemory.getPersistentMemoryDirectory())
-                .close();
+           .node("size", null, "value", nativeMemory.getSize().getValue(),
+                   "unit", nativeMemory.getSize().getUnit())
+           .node("min-block-size", nativeMemory.getMinBlockSize())
+           .node("page-size", nativeMemory.getPageSize())
+           .node("metadata-space-percentage", nativeMemory.getMetadataSpacePercentage());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemory.getPersistentMemoryConfig()
+                                                                             .getDirectoryConfigs();
+        if (!directoryConfigs.isEmpty()) {
+            gen.open("persistent-memory")
+               .open("directories");
+            for (PersistentMemoryDirectoryConfig dirConfig : directoryConfigs) {
+                if (dirConfig.isNumaNodeSet()) {
+                    gen.node("directory", dirConfig.getDirectory(),
+                            "numa-node", dirConfig.getNumaNode());
+                } else {
+                    gen.node("directory", dirConfig.getDirectory());
+                }
+            }
+            gen.close()
+               .close();
+        }
+
+        gen.close();
     }
 
     private static void proxyFactory(XmlGenerator gen, List<ProxyFactoryConfig> proxyFactories) {

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1675,14 +1675,31 @@ public class ConfigXmlGenerator {
         gen.open("native-memory",
                 "enabled", nativeMemoryConfig.isEnabled(),
                 "allocator-type", nativeMemoryConfig.getAllocatorType())
-                .node("size", null,
-                        "unit", nativeMemoryConfig.getSize().getUnit(),
-                        "value", nativeMemoryConfig.getSize().getValue())
-                .node("min-block-size", nativeMemoryConfig.getMinBlockSize())
-                .node("page-size", nativeMemoryConfig.getPageSize())
-                .node("metadata-space-percentage", nativeMemoryConfig.getMetadataSpacePercentage())
-                .node("persistent-memory-directory", nativeMemoryConfig.getPersistentMemoryDirectory())
-                .close();
+           .node("size", null,
+                   "unit", nativeMemoryConfig.getSize().getUnit(),
+                   "value", nativeMemoryConfig.getSize().getValue())
+           .node("min-block-size", nativeMemoryConfig.getMinBlockSize())
+           .node("page-size", nativeMemoryConfig.getPageSize())
+           .node("metadata-space-percentage", nativeMemoryConfig.getMetadataSpacePercentage());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemoryConfig.getPersistentMemoryConfig()
+                                                                                   .getDirectoryConfigs();
+        if (!directoryConfigs.isEmpty()) {
+            gen.open("persistent-memory")
+               .open("directories");
+            for (PersistentMemoryDirectoryConfig dirConfig : directoryConfigs) {
+                if (dirConfig.isNumaNodeSet()) {
+                    gen.node("directory", dirConfig.getDirectory(),
+                            "numa-node", dirConfig.getNumaNode());
+                } else {
+                    gen.node("directory", dirConfig.getDirectory());
+                }
+            }
+            gen.close()
+               .close();
+        }
+
+        gen.close();
     }
 
     private static void liteMemberXmlGenerator(XmlGenerator gen, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Configures native memory region.
@@ -239,7 +240,7 @@ public class NativeMemoryConfig {
      * @param persistentMemoryConfig The persistent memory configuration to use
      */
     public void setPersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig) {
-        this.persistentMemoryConfig = persistentMemoryConfig;
+        this.persistentMemoryConfig = requireNonNull(persistentMemoryConfig);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -22,6 +22,8 @@ import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.memory.NativeOutOfMemoryError;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 
@@ -229,6 +231,7 @@ public class NativeMemoryConfig {
      *
      * @return the persistent memory configuration
      */
+    @Nonnull
     public PersistentMemoryConfig getPersistentMemoryConfig() {
         return persistentMemoryConfig;
     }
@@ -239,7 +242,7 @@ public class NativeMemoryConfig {
      *
      * @param persistentMemoryConfig The persistent memory configuration to use
      */
-    public void setPersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig) {
+    public void setPersistentMemoryConfig(@Nonnull PersistentMemoryConfig persistentMemoryConfig) {
         this.persistentMemoryConfig = requireNonNull(persistentMemoryConfig);
     }
 
@@ -256,6 +259,7 @@ public class NativeMemoryConfig {
      * instead.
      */
     @Deprecated
+    @Nullable
     public String getPersistentMemoryDirectory() {
         List<PersistentMemoryDirectoryConfig> directoryConfigs = persistentMemoryConfig.getDirectoryConfigs();
         int directoriesDefined = directoryConfigs.size();
@@ -277,9 +281,19 @@ public class NativeMemoryConfig {
      * @return this {@link NativeMemoryConfig} instance
      * @see #getPersistentMemoryConfig()
      * @see PersistentMemoryConfig#addDirectoryConfig(PersistentMemoryDirectoryConfig)
+     * @deprecated Since 4.1 multiple persistent memory directories are
+     * supported. Please use {@link #setPersistentMemoryConfig(PersistentMemoryConfig)}
+     * or {@link PersistentMemoryConfig#addDirectoryConfig(PersistentMemoryDirectoryConfig)}
+     * instead.
      */
-    public NativeMemoryConfig setPersistentMemoryDirectory(String directory) {
-        this.persistentMemoryConfig.setDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
+    @Nonnull
+    @Deprecated
+    public NativeMemoryConfig setPersistentMemoryDirectory(@Nullable String directory) {
+        if (directory != null) {
+            this.persistentMemoryConfig.setDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
+        } else {
+            this.persistentMemoryConfig.getDirectoryConfigs().clear();
+        }
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -16,10 +16,14 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.map.IMap;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.memory.NativeOutOfMemoryError;
+
+import java.util.List;
+import java.util.Objects;
 
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
@@ -66,11 +70,8 @@ public class NativeMemoryConfig {
     private int minBlockSize = DEFAULT_MIN_BLOCK_SIZE;
     private int pageSize = DEFAULT_PAGE_SIZE;
     private float metadataSpacePercentage = DEFAULT_METADATA_SPACE_PERCENTAGE;
-    /**
-     * Path to the non-volatile memory directory. {@code null} indicates the
-     * standard RAM is used.
-     */
-    private String persistentMemoryDirectory;
+
+    private PersistentMemoryConfig persistentMemoryConfig = new PersistentMemoryConfig();
 
     public NativeMemoryConfig() {
     }
@@ -82,7 +83,7 @@ public class NativeMemoryConfig {
         minBlockSize = nativeMemoryConfig.minBlockSize;
         pageSize = nativeMemoryConfig.pageSize;
         metadataSpacePercentage = nativeMemoryConfig.metadataSpacePercentage;
-        persistentMemoryDirectory = nativeMemoryConfig.persistentMemoryDirectory;
+        persistentMemoryConfig = new PersistentMemoryConfig(nativeMemoryConfig.persistentMemoryConfig);
     }
 
     /**
@@ -222,25 +223,62 @@ public class NativeMemoryConfig {
     }
 
     /**
-     * Returns the persistent memory directory (e.g. Intel Optane) to be used to store memory structures allocated by native
-     * memory manager.
-     * <p>
-     * Default value is {@code null}. It indicates that volatile RAM is being used.
-     * {@code null}
+     * Returns the persistent memory configuration this native memory
+     * configuration uses.
+     *
+     * @return the persistent memory configuration
      */
-    public String getPersistentMemoryDirectory() {
-        return persistentMemoryDirectory;
+    public PersistentMemoryConfig getPersistentMemoryConfig() {
+        return persistentMemoryConfig;
     }
 
     /**
-     * Sets the persistent memory directory (e.g. Intel Optane) to be used to store memory structures allocated by native memory
-     * manager.
+     * Sets the persistent memory configuration this native memory
+     * configuration uses.
+     *
+     * @param persistentMemoryConfig The persistent memory configuration to use
+     */
+    public void setPersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig) {
+        this.persistentMemoryConfig = persistentMemoryConfig;
+    }
+
+    /**
+     * Returns the persistent memory directory (e.g. Intel Optane) to be
+     * used to store memory structures allocated by native memory manager.
+     * If there are multiple persistent memory directories are defined in
+     * {@link #persistentMemoryConfig}, an {@link IllegalStateException}
+     * is thrown.
+     *
+     * @see PersistentMemoryConfig#getDirectoryConfigs()
+     * @deprecated Since 4.1 multiple persistent memory directories are
+     * supported. Please use {@link PersistentMemoryConfig#getDirectoryConfigs()}
+     * instead.
+     */
+    @Deprecated
+    public String getPersistentMemoryDirectory() {
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = persistentMemoryConfig.getDirectoryConfigs();
+        int directoriesDefined = directoryConfigs.size();
+        if (directoriesDefined > 1) {
+            throw new HazelcastException("There are multiple persistent memory directories configured. Please use "
+                    + "PersistentMemoryConfig.getDirectoryConfigs()!");
+        }
+
+        return directoriesDefined == 1 ? directoryConfigs.get(0).getDirectory() : null;
+    }
+
+    /**
+     * Sets the persistent memory directory (e.g. Intel Optane) to be used
+     * to store memory structures allocated by native memory manager. If
+     * the {@link #persistentMemoryConfig} already contains directory
+     * definition, it is overridden with the provided {@code directory}.
      *
      * @param directory the persistent memory directory
      * @return this {@link NativeMemoryConfig} instance
+     * @see #getPersistentMemoryConfig()
+     * @see PersistentMemoryConfig#addDirectoryConfig(PersistentMemoryDirectoryConfig)
      */
     public NativeMemoryConfig setPersistentMemoryDirectory(String directory) {
-        this.persistentMemoryDirectory = directory;
+        this.persistentMemoryConfig.setDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
         return this;
     }
 
@@ -287,11 +325,10 @@ public class NativeMemoryConfig {
         if (Float.compare(that.metadataSpacePercentage, metadataSpacePercentage) != 0) {
             return false;
         }
-        if (size != null ? !size.equals(that.size) : that.size != null) {
+        if (!Objects.equals(size, that.size)) {
             return false;
         }
-        if (persistentMemoryDirectory != null ? !persistentMemoryDirectory.equals(that.persistentMemoryDirectory)
-                : that.persistentMemoryDirectory != null) {
+        if (!persistentMemoryConfig.equals(that.persistentMemoryConfig)) {
             return false;
         }
         return allocatorType == that.allocatorType;
@@ -305,7 +342,7 @@ public class NativeMemoryConfig {
         result = 31 * result + minBlockSize;
         result = 31 * result + pageSize;
         result = 31 * result + (metadataSpacePercentage != +0.0f ? Float.floatToIntBits(metadataSpacePercentage) : 0);
-        result = 31 * result + (persistentMemoryDirectory != null ? persistentMemoryDirectory.hashCode() : 0);
+        result = 31 * result + (persistentMemoryConfig.hashCode());
         return result;
     }
 
@@ -318,7 +355,7 @@ public class NativeMemoryConfig {
                 + ", minBlockSize=" + minBlockSize
                 + ", pageSize=" + pageSize
                 + ", metadataSpacePercentage=" + metadataSpacePercentage
-                + ", persistentMemoryDirectory=" + persistentMemoryDirectory
+                + ", persistentMemoryConfig=" + persistentMemoryConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.config;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Configuration class for persistent memory devices (e.g. Intel Optane).
@@ -38,9 +41,10 @@ public class PersistentMemoryConfig {
      * {@link PersistentMemoryConfig}.
      *
      * @param persistentMemoryConfig The configuration to copy
+     * @throws NullPointerException if {@code persistentMemoryConfig} is {@code null}
      */
-    public PersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig) {
-        persistentMemoryConfig.directoryConfigs
+    public PersistentMemoryConfig(@Nonnull PersistentMemoryConfig persistentMemoryConfig) {
+        requireNonNull(persistentMemoryConfig).directoryConfigs
                 .forEach(directoryConfig -> addDirectoryConfig(new PersistentMemoryDirectoryConfig(directoryConfig)));
     }
 
@@ -50,7 +54,10 @@ public class PersistentMemoryConfig {
      * <p>
      * By default there are no configuration is set indicating that
      * volatile RAM is being used.
+     *
+     * @return the list of the persistent memory directory configurations
      */
+    @Nonnull
     public List<PersistentMemoryDirectoryConfig> getDirectoryConfigs() {
         return directoryConfigs;
     }
@@ -70,9 +77,10 @@ public class PersistentMemoryConfig {
      * @throws InvalidConfigurationException If the configured directories
      *                                       violate consistency or
      *                                       uniqueness checks.
+     * @throws NullPointerException if {@code directoryConfigs} is {@code null}
      */
-    public PersistentMemoryConfig setDirectoryConfigs(List<PersistentMemoryDirectoryConfig> directoryConfigs) {
-        ArrayList<PersistentMemoryDirectoryConfig> checkedConfigs = new ArrayList<>(directoryConfigs.size());
+    public PersistentMemoryConfig setDirectoryConfigs(@Nonnull List<PersistentMemoryDirectoryConfig> directoryConfigs) {
+        ArrayList<PersistentMemoryDirectoryConfig> checkedConfigs = new ArrayList<>(requireNonNull(directoryConfigs).size());
         for (PersistentMemoryDirectoryConfig configToCheck : directoryConfigs) {
             for (PersistentMemoryDirectoryConfig checkedConfig : checkedConfigs) {
                 validateDirectoryConfig(configToCheck, checkedConfig);
@@ -99,8 +107,10 @@ public class PersistentMemoryConfig {
      * @throws InvalidConfigurationException If the configured directories
      *                                       violate consistency or
      *                                       uniqueness checks.
+     * @throws NullPointerException if {@code directoryConfigs} is {@code null}
      */
-    public PersistentMemoryConfig addDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig) {
+    public PersistentMemoryConfig addDirectoryConfig(@Nonnull PersistentMemoryDirectoryConfig directoryConfig) {
+        requireNonNull(directoryConfig);
         for (PersistentMemoryDirectoryConfig existingConfig : this.directoryConfigs) {
             validateDirectoryConfig(directoryConfig, existingConfig);
         }
@@ -130,7 +140,8 @@ public class PersistentMemoryConfig {
         }
     }
 
-    void setDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig) {
+    void setDirectoryConfig(@Nonnull PersistentMemoryDirectoryConfig directoryConfig) {
+        requireNonNull(directoryConfig);
         // method to support 4.0 API of NativeMemoryConfig
         this.directoryConfigs.clear();
         this.directoryConfigs.add(directoryConfig);

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Configuration class for persistent memory devices (e.g. Intel Optane).
+ */
+public class PersistentMemoryConfig {
+    /**
+     * Paths to the non-volatile memory directory.
+     */
+    private List<PersistentMemoryDirectoryConfig> directoryConfigs = new LinkedList<>();
+
+    public PersistentMemoryConfig() {
+    }
+
+    /**
+     * Constructs an instance with copying the fields of the provided
+     * {@link PersistentMemoryConfig}.
+     *
+     * @param persistentMemoryConfig The configuration to copy
+     */
+    public PersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig) {
+        persistentMemoryConfig.directoryConfigs
+                .forEach(directoryConfig -> addDirectoryConfig(new PersistentMemoryDirectoryConfig(directoryConfig)));
+    }
+
+    /**
+     * Returns the persistent memory directory configurations to be used
+     * to store memory structures allocated by native memory manager.
+     * <p>
+     * By default there are no configuration is set indicating that
+     * volatile RAM is being used.
+     */
+    public List<PersistentMemoryDirectoryConfig> getDirectoryConfigs() {
+        return directoryConfigs;
+    }
+
+    /**
+     * Sets the persistent memory directory configuration to the set of
+     * directories provided in the {@code directoryConfigs} argument.
+     * <p/>
+     * If the specified directories are not unique either in the directories
+     * themselves or in the NUMA nodes specified for them,
+     * {@link InvalidConfigurationException} is thrown. Setting the NUMA
+     * node on the subset of the configured directories while leaving
+     * not set on others also results in {@link InvalidConfigurationException}.
+     *
+     * @param directoryConfigs The persistent memory directories to set
+     * @return this {@link PersistentMemoryConfig} instance
+     * @throws InvalidConfigurationException If the configured directories
+     *                                       violate consistency or
+     *                                       uniqueness checks.
+     */
+    public PersistentMemoryConfig setDirectoryConfigs(List<PersistentMemoryDirectoryConfig> directoryConfigs) {
+        ArrayList<PersistentMemoryDirectoryConfig> checkedConfigs = new ArrayList<>(directoryConfigs.size());
+        for (PersistentMemoryDirectoryConfig configToCheck : directoryConfigs) {
+            for (PersistentMemoryDirectoryConfig checkedConfig : checkedConfigs) {
+                validateDirectoryConfig(configToCheck, checkedConfig);
+            }
+            checkedConfigs.add(configToCheck);
+        }
+
+        this.directoryConfigs = directoryConfigs;
+        return this;
+    }
+
+    /**
+     * Adds the persistent memory directory configuration to be used to
+     * store memory structures allocated by native memory manager.
+     * <p/>
+     * If the specified directories are not unique either in the directories
+     * themselves or in the NUMA nodes specified for them,
+     * {@link InvalidConfigurationException} is thrown. Setting the NUMA
+     * node on the subset of the configured directories while leaving
+     * not set on others also results in {@link InvalidConfigurationException}.
+     *
+     * @param directoryConfig the persistent memory directory configuration
+     * @return this {@link PersistentMemoryConfig} instance
+     * @throws InvalidConfigurationException If the configured directories
+     *                                       violate consistency or
+     *                                       uniqueness checks.
+     */
+    public PersistentMemoryConfig addDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig) {
+        for (PersistentMemoryDirectoryConfig existingConfig : this.directoryConfigs) {
+            validateDirectoryConfig(directoryConfig, existingConfig);
+        }
+
+        this.directoryConfigs.add(directoryConfig);
+        return this;
+    }
+
+    private void validateDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig,
+                                         PersistentMemoryDirectoryConfig existingConfig) {
+        if (existingConfig.getDirectory().equals(directoryConfig.getDirectory())) {
+            throw new InvalidConfigurationException(
+                    "Persistent directories must be unique. '" + directoryConfig.getDirectory() + "' is already set.");
+        }
+
+        if (existingConfig.isNumaNodeSet() != directoryConfig.isNumaNodeSet()) {
+            throw new InvalidConfigurationException(
+                    "NUMA node on all persistent memory directories should either be set or left unset. NUMA node settings for"
+                            + " directories '" + directoryConfig.getDirectory() + "' and '" + existingConfig.getDirectory()
+                            + "' are not consistent.");
+        }
+
+        if (directoryConfig.isNumaNodeSet() && existingConfig.getNumaNode() == directoryConfig.getNumaNode()) {
+            throw new InvalidConfigurationException(
+                    "NUMA node must be set uniquely on the persistent memory directories. " + directoryConfig.getDirectory()
+                            + " and " + existingConfig.getDirectory() + " have the same NUMA node set.");
+        }
+    }
+
+    void setDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig) {
+        // method to support 4.0 API of NativeMemoryConfig
+        this.directoryConfigs.clear();
+        this.directoryConfigs.add(directoryConfig);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PersistentMemoryConfig that = (PersistentMemoryConfig) o;
+
+        return Objects.equals(directoryConfigs, that.directoryConfigs);
+    }
+
+    @Override
+    public int hashCode() {
+        return directoryConfigs.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "PersistentMemoryConfig{"
+                + "directoryConfigs=" + directoryConfigs
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryDirectoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryDirectoryConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Objects;
+
+/**
+ * Configuration class for directories that persistent memories are mounted at.
+ */
+public class PersistentMemoryDirectoryConfig {
+    private static final int NUMA_NODE_UNSET = -1;
+
+    private String directory;
+    private int numaNode = NUMA_NODE_UNSET;
+
+    /**
+     * Creates an instance with the {@code directory} specified.
+     *
+     * @param directory The directory where the persistent memory is
+     *                  mounted at
+     */
+    public PersistentMemoryDirectoryConfig(String directory) {
+        this.directory = directory;
+    }
+
+    /**
+     * Creates an instance with the {@code directory} and NUMA node specified.
+     *
+     * @param directory The directory where the persistent memory is
+     *                  mounted at
+     * @param numaNode  The NUMA node that the persistent memory mounted
+     *                  to the given directory is attached to
+     */
+    public PersistentMemoryDirectoryConfig(String directory, int numaNode) {
+        this.directory = directory;
+        this.numaNode = numaNode;
+    }
+
+    /**
+     * Constructs an instance by copying the provided {@link PersistentMemoryDirectoryConfig}.
+     *
+     * @param directoryConfig The configuration to copy
+     */
+    public PersistentMemoryDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig) {
+        this.directory = directoryConfig.directory;
+        this.numaNode = directoryConfig.numaNode;
+    }
+
+    /**
+     * Returns the directory of this {@link PersistentMemoryDirectoryConfig}.
+     *
+     * @return the directory
+     */
+    public String getDirectory() {
+        return directory;
+    }
+
+    /**
+     * Returns the {@code directory} of this {@link PersistentMemoryDirectoryConfig}.
+     *
+     * @param directory the directory to set
+     */
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    /**
+     * Returns the NUMA node the persistent memory mounted to the given
+     * directory is attached to.
+     *
+     * @return the NUMA node of the persistent memory
+     */
+    public int getNumaNode() {
+        return numaNode;
+    }
+
+    /**
+     * Sets the NUMA node the persistent memory mounted to the given
+     * directory is attached to.
+     *
+     * @param numaNode the NUMA node to set
+     */
+    public void setNumaNode(int numaNode) {
+        this.numaNode = numaNode;
+    }
+
+    /**
+     * Returns if the NUMA node for the given persistent memory directory
+     * is set.
+     *
+     * @return {@code true} if the NUMA node is set, {@code false} otherwise
+     */
+    public boolean isNumaNodeSet() {
+        return numaNode != NUMA_NODE_UNSET;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PersistentMemoryDirectoryConfig that = (PersistentMemoryDirectoryConfig) o;
+
+        if (numaNode != that.numaNode) {
+            return false;
+        }
+        return Objects.equals(directory, that.directory);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = directory != null ? directory.hashCode() : 0;
+        result = 31 * result + numaNode;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PersistentMemoryDirectoryConfig{"
+                + "directory='" + directory + '\''
+                + ", numaNode=" + numaNode
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryDirectoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryDirectoryConfig.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.config;
 
+import javax.annotation.Nonnull;
 import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Configuration class for directories that persistent memories are mounted at.
@@ -32,21 +35,27 @@ public class PersistentMemoryDirectoryConfig {
      *
      * @param directory The directory where the persistent memory is
      *                  mounted at
+     * @throws NullPointerException if {@code directory} is {@code null}
      */
-    public PersistentMemoryDirectoryConfig(String directory) {
-        this.directory = directory;
+    public PersistentMemoryDirectoryConfig(@Nonnull String directory) {
+        this.directory = requireNonNull(directory);
     }
 
     /**
      * Creates an instance with the {@code directory} and NUMA node specified.
+     * <p/>
+     * Note that setting {@code numaNode} to -1 on any of the configured
+     * {@link PersistentMemoryDirectoryConfig} instances disables
+     * NUMA-aware persistent memory allocation.
      *
      * @param directory The directory where the persistent memory is
      *                  mounted at
      * @param numaNode  The NUMA node that the persistent memory mounted
-     *                  to the given directory is attached to
+     *                  to the given directory is attached to.
+     * @throws NullPointerException if {@code directory} is {@code null}
      */
-    public PersistentMemoryDirectoryConfig(String directory, int numaNode) {
-        this.directory = directory;
+    public PersistentMemoryDirectoryConfig(@Nonnull String directory, int numaNode) {
+        this.directory = requireNonNull(directory);
         this.numaNode = numaNode;
     }
 
@@ -54,9 +63,10 @@ public class PersistentMemoryDirectoryConfig {
      * Constructs an instance by copying the provided {@link PersistentMemoryDirectoryConfig}.
      *
      * @param directoryConfig The configuration to copy
+     * @throws NullPointerException if {@code directoryConfig} is {@code null}
      */
-    public PersistentMemoryDirectoryConfig(PersistentMemoryDirectoryConfig directoryConfig) {
-        this.directory = directoryConfig.directory;
+    public PersistentMemoryDirectoryConfig(@Nonnull PersistentMemoryDirectoryConfig directoryConfig) {
+        this.directory = requireNonNull(directoryConfig).directory;
         this.numaNode = directoryConfig.numaNode;
     }
 
@@ -65,6 +75,7 @@ public class PersistentMemoryDirectoryConfig {
      *
      * @return the directory
      */
+    @Nonnull
     public String getDirectory() {
         return directory;
     }
@@ -73,9 +84,10 @@ public class PersistentMemoryDirectoryConfig {
      * Returns the {@code directory} of this {@link PersistentMemoryDirectoryConfig}.
      *
      * @param directory the directory to set
+     * @throws NullPointerException if {@code directory} is {@code null}
      */
-    public void setDirectory(String directory) {
-        this.directory = directory;
+    public void setDirectory(@Nonnull String directory) {
+        this.directory = requireNonNull(directory);
     }
 
     /**
@@ -91,6 +103,10 @@ public class PersistentMemoryDirectoryConfig {
     /**
      * Sets the NUMA node the persistent memory mounted to the given
      * directory is attached to.
+     * <p/>
+     * Note that setting {@code numaNode} to -1 on any of the configured
+     * {@link PersistentMemoryDirectoryConfig} instances disables
+     * NUMA-aware persistent memory allocation.
      *
      * @param numaNode the NUMA node to set
      */

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -699,6 +699,7 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element name="persistent-memory-directory" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="persistent-memory" type="persistent-memory" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
         <xs:attribute name="enabled" default="false" type="xs:boolean"/>
@@ -724,6 +725,49 @@
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="persistent-memory">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for persistent memory (e.g. Intel Optane) devices.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="directories">
+                <xs:annotation>
+                    <xs:documentation>
+                        List of directories where the persistent memory
+                        is mounted to.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice maxOccurs="unbounded">
+                        <xs:element name="directory" type="persistent-memory-directory"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="persistent-memory-directory">
+        <xs:annotation>
+            <xs:documentation>
+                The directory where persistent memory is mounted to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="numa-node" type="xs:int" default="-1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The NUMA node that the persistent memory mounted
+                            to the given directory is attached to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 
     <xs:complexType name="property">
         <xs:simpleContent>

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -738,6 +738,12 @@
                     <xs:documentation>
                         List of directories where the persistent memory
                         is mounted to.
+
+                        If the specified directories are not unique either in the directories
+                        themselves or in the NUMA nodes specified for them,
+                        the configuration is treated as invalid. Setting the NUMA
+                        node on the subset of the configured directories while leaving
+                        not set on others also makes the configuration invalid.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -753,6 +759,12 @@
         <xs:annotation>
             <xs:documentation>
                 The directory where persistent memory is mounted to.
+
+                If the specified directory id not unique either in the
+                directory itself or in the NUMA node specified, the
+                configuration will be treated as invalid. Setting the NUMA
+                node on the subset of the configured directories while leaving
+                not set on others also results in invalid configuration.
             </xs:documentation>
         </xs:annotation>
         <xs:simpleContent>
@@ -762,6 +774,13 @@
                         <xs:documentation>
                             The NUMA node that the persistent memory mounted
                             to the given directory is attached to.
+
+                            NUMA nodes have to be unique across the entire
+                            persistent memory configuration, otherwise the
+                            configuration will be treated as invalid. Similarly,
+                            setting the NUMA node on the subset of the configured
+                            directories while leaving not set on others also
+                            results in invalid configuration.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -547,6 +547,15 @@
         <min-block-size>1</min-block-size>
         <page-size>1</page-size>
         <metadata-space-percentage>40.5</metadata-space-percentage>
+        <!-- Simple configuration for single-socket machines with non-volatile memory -->
+        <!-- <persistent-memory-directory>/mnt/optane</persistent-memory-directory> -->
+        <!-- Advanced configuration for non-volatile memory -->
+        <persistent-memory>
+            <directories>
+                <directory numa-node="0">/mnt/pmem0</directory>
+                <directory numa-node="1">/mnt/pmem1</directory>
+            </directories>
+        </persistent-memory>
     </native-memory>
     <!--
         ===== HAZELCAST PROXY FACTORY CONFIGURATION =====

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -493,6 +493,16 @@ hazelcast-client:
     min-block-size: 1
     page-size: 1
     metadata-space-percentage: 40.5
+    # Simple configuration for single-socket machines with non-volatile memory
+    # persistent-memory-directory: /mnt/optane
+    # Advanced configuration for non-volatile memory
+    persistent-memory:
+      directories:
+        - directory: /mnt/pmem0
+          numa-node: 0
+        - directory: /mnt/pmem1
+          numa-node: 1
+
   #
   # ===== HAZELCAST PROXY FACTORY CONFIGURATION =====
   #

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -3162,6 +3162,12 @@
                     <xs:documentation>
                         List of directories where the persistent memory
                         is mounted to.
+
+                        If the specified directories are not unique either in the directories
+                        themselves or in the NUMA nodes specified for them,
+                        the configuration is treated as invalid. Setting the NUMA
+                        node on the subset of the configured directories while leaving
+                        not set on others also makes the configuration invalid.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -3177,6 +3183,12 @@
         <xs:annotation>
             <xs:documentation>
                 The directory where persistent memory is mounted to.
+
+                If the specified directory id not unique either in the
+                directory itself or in the NUMA node specified, the
+                configuration will be treated as invalid. Setting the NUMA
+                node on the subset of the configured directories while leaving
+                not set on others also results in invalid configuration.
             </xs:documentation>
         </xs:annotation>
         <xs:simpleContent>
@@ -3186,6 +3198,13 @@
                         <xs:documentation>
                             The NUMA node that the persistent memory mounted
                             to the given directory is attached to.
+
+                            NUMA nodes have to be unique across the entire
+                            persistent memory configuration, otherwise the
+                            configuration will be treated as invalid. Similarly,
+                            setting the NUMA node on the subset of the configured
+                            directories while leaving not set on others also
+                            results in invalid configuration.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -3101,7 +3101,7 @@
 
     <xs:complexType name="native-memory">
         <xs:all>
-            <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
             <xs:element name="min-block-size" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
             <xs:element name="page-size" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
             <xs:element name="metadata-space-percentage" minOccurs="0" maxOccurs="1">
@@ -3115,6 +3115,7 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element name="persistent-memory-directory" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="persistent-memory" type="persistent-memory" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
         <xs:attribute name="enabled" default="false" type="xs:boolean"/>
@@ -3148,6 +3149,49 @@
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="persistent-memory">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for persistent memory (e.g. Intel Optane) devices.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="directories">
+                <xs:annotation>
+                    <xs:documentation>
+                        List of directories where the persistent memory
+                        is mounted to.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice maxOccurs="unbounded">
+                        <xs:element name="directory" type="persistent-memory-directory"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="persistent-memory-directory">
+        <xs:annotation>
+            <xs:documentation>
+                The directory where persistent memory is mounted to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="numa-node" type="xs:int" default="-1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The NUMA node that the persistent memory mounted
+                            to the given directory is attached to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 
     <xs:complexType name="property">
         <xs:simpleContent>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -109,7 +109,7 @@
         in your cluster. To use it for more members, you need to have either a Management Center,
         Hazelcast Enterprise or Hazelcast Enterprise HD license.
     -->
-    <management-center scripting-enabled="false" />
+    <management-center scripting-enabled="false"/>
     <!--
         The <properties> element lets you add properties to some of the Hazelcast elements used to configure some of
         the Hazelcast modules.
@@ -2103,17 +2103,34 @@
             Percentage of the allocated native memory that is used for the metadata such as indexes, offsets, etc. It is
             used only by the POOLED memory allocator. Its default value is 12.5.
         - <persistent-memory-directory>:
-            Specifies the directory where the non-volatile memory (e.g. Intel Optane) is mounted. If this element is
-            not defined, the RAM is used as a native memory. This directory will be created automatically if it does not
-            exist. To avoid collisions, every member of the cluster will create its own subfolder to work with the
-            non-volatile memory.
+            Simple configuration option for a single directory where the non-volatile memory (e.g. Intel Optane) is mounted.
+            This should be used only on single-socket systems as only one directory can be defined. On multi-socket systems
+            use <persistent-memory> instead.
+            If neither this or <persistent-memory> elements are defined, the RAM is used as native memory. This directory
+            will be created automatically if it does not exist. To avoid collisions, every member of the cluster will create
+            its own subfolder to work with the non-volatile memory.
+        - <persistent-memory>:
+            Specifies the configuration for the non-volatile memory (e.g. Intel Optane) in the system. Under this configuration
+            section multiple directories can be listed with optionally specifying the NUMA node the non-volatile memory mounted
+            in the given directory is attached to for NUMA-aware allocations. If neither this or the
+            <persistent-memory-directory> elements are defined, the RAM is used as native memory. The directories defined under
+            this section will be created automatically if they do not exist. To avoid collisions, every member of the cluster
+            will create its own subfolder to work with the non-volatile memory.
     -->
     <native-memory allocator-type="POOLED" enabled="true">
         <size unit="MEGABYTES" value="256"/>
         <min-block-size>32</min-block-size>
         <page-size>4194304</page-size>
         <metadata-space-percentage>12.5</metadata-space-percentage>
-        <persistent-memory-directory>/mnt/optane</persistent-memory-directory>
+        <!-- Simple configuration for single-socket machines with non-volatile memory -->
+        <!-- <persistent-memory-directory>/mnt/optane</persistent-memory-directory> -->
+        <!-- Advanced configuration for non-volatile memory -->
+        <persistent-memory>
+            <directories>
+                <directory numa-node="0">/mnt/pmem0</directory>
+                <directory numa-node="1">/mnt/pmem1</directory>
+            </directories>
+        </persistent-memory>
     </native-memory>
     <!--
         ===== HAZELCAST SECURITY CONFIGURATION =====
@@ -2242,7 +2259,7 @@
             </realm>
             <realm name="usernamePasswordIdentityRealm">
                 <identity>
-                    <username-password username="user" password="Hazelcast" />
+                    <username-password username="user" password="Hazelcast"/>
                 </identity>
             </realm>
             <realm name="tokenIdentityRealm">

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2080,10 +2080,19 @@ hazelcast:
   #     Percentage of the allocated native memory that is used for the metadata such as indexes, offsets, etc. It is
   #     used only by the POOLED memory allocator. Its default value is 12.5.
   # - "persistent-memory-directory":
-  #     Specifies the directory where the non-volatile memory (e.g. Intel Optane) is mounted. If this element is not defined,
-  #     the RAM is used as a native memory. This directory will be created automatically if it does not exist.
-  #     To avoid collisions, every member of the cluster will create its own subfolder to work with the non-volatile
-  #     memory.
+  #     Simple configuration option for a single directory where the non-volatile memory (e.g. Intel Optane) is mounted.
+  #     This should be used only on single-socket systems as only one directory can be defined. On multi-socket systems
+  #     use <persistent-memory> instead.
+  #     If neither this or <persistent-memory> elements are defined, the RAM is used as native memory. This directory
+  #     will be created automatically if it does not exist. To avoid collisions, every member of the cluster will create
+  #     its own subfolder to work with the non-volatile memory.
+  # - "persistent-memory":
+  #     Specifies the configuration for the non-volatile memory (e.g. Intel Optane) in the system. Under this configuration
+  #     section multiple directories can be listed with optionally specifying the NUMA node the non-volatile memory mounted
+  #     in the given directory is attached to for NUMA-aware allocations. If neither this or the
+  #     <persistent-memory-directory> elements are defined, the RAM is used as native memory. The directories defined under
+  #     this section will be created automatically if they do not exist. To avoid collisions, every member of the cluster
+  #     will create its own subfolder to work with the non-volatile memory.
   #
   native-memory:
     enabled: true
@@ -2094,7 +2103,15 @@ hazelcast:
     min-block-size: 32
     page-size: 4194304
     metadata-space-percentage: 12.5
-    persistent-memory-directory: /mnt/optane
+    # Simple configuration for single-socket machines with non-volatile memory
+    # persistent-memory-directory: /mnt/optane
+    # Advanced configuration for non-volatile memory
+    persistent-memory:
+      directories:
+        - directory: /mnt/pmem0
+          numa-node: 0
+        - directory: /mnt/pmem1
+          numa-node: 1
   #
   # ===== HAZELCAST SECURITY CONFIGURATION =====
   #

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -486,4 +486,21 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     @Test
     public abstract void testMetricsConfigJmxDisabled();
 
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfiguration();
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfigurationSimple();
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfiguration_uniqueDirViolationThrows();
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfiguration_uniqueNumaNodeViolationThrows();
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfiguration_numaNodeConsistencyViolationThrows();
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfiguration_simpleAndAdvancedPasses();
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -37,6 +37,7 @@ import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
+import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.SSLConfig;
@@ -451,6 +452,24 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
                 .setMinBlockSize(randomInt())
                 .setPageSize(randomInt())
                 .setSize(new MemorySize(randomInt(), MemoryUnit.BYTES));
+        clientConfig.setNativeMemoryConfig(expected);
+
+        NativeMemoryConfig actual = newConfigViaGenerator().getNativeMemoryConfig();
+        assertEquals(clientConfig.getNativeMemoryConfig(), actual);
+    }
+
+    @Test
+    public void nativeMemoryWithPersistentMemory() {
+        NativeMemoryConfig expected = new NativeMemoryConfig();
+        expected.setEnabled(true)
+                .setAllocatorType(MemoryAllocatorType.STANDARD)
+                .setMetadataSpacePercentage(70)
+                .setMinBlockSize(randomInt())
+                .setPageSize(randomInt())
+                .setSize(new MemorySize(randomInt(), MemoryUnit.BYTES))
+                .getPersistentMemoryConfig()
+                .addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem0", 0))
+                .addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem1", 1));
         clientConfig.setNativeMemoryConfig(expected);
 
         NativeMemoryConfig actual = newConfigViaGenerator().getNativeMemoryConfig();

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -23,12 +23,15 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.YamlConfigBuilderTest;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.util.RootCauseMatcher;
+import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
@@ -466,6 +469,149 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         ClientMetricsConfig metricsConfig = config.getMetricsConfig();
         assertTrue(metricsConfig.isEnabled());
         assertFalse(metricsConfig.getJmxConfig().isEnabled());
+    }
+
+    @Test
+    public void nativeMemory() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    enabled: true\n"
+                + "    allocator-type: STANDARD\n"
+                + "    min-block-size: 42\n"
+                + "    page-size: 24\n"
+                + "    size:\n"
+                + "      unit: BYTES\n"
+                + "      value: 256\n"
+                + "    metadata-space-percentage: 70";
+
+        ClientConfig config = buildConfig(yaml);
+
+        NativeMemoryConfig nativeMemoryConfig = config.getNativeMemoryConfig();
+        assertTrue(nativeMemoryConfig.isEnabled());
+        assertEquals(NativeMemoryConfig.MemoryAllocatorType.STANDARD, nativeMemoryConfig.getAllocatorType());
+        assertEquals(42, nativeMemoryConfig.getMinBlockSize());
+        assertEquals(24, nativeMemoryConfig.getPageSize());
+        assertEquals(MemoryUnit.BYTES, nativeMemoryConfig.getSize().getUnit());
+        assertEquals(256, nativeMemoryConfig.getSize().getValue());
+        assertEquals(70, nativeMemoryConfig.getMetadataSpacePercentage(), 10E-6);
+    }
+
+    @Test
+    public void testPersistentMemoryDirectoryConfiguration() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n"
+                + "          numa-node: 0\n"
+                + "        - directory: /mnt/pmem1\n"
+                + "          numa-node: 1\n";
+
+        ClientConfig config = buildConfig(yaml);
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig()
+                                                                       .getPersistentMemoryConfig()
+                                                                       .getDirectoryConfigs();
+        assertEquals(2, directoryConfigs.size());
+        PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
+        PersistentMemoryDirectoryConfig dir1Config = directoryConfigs.get(1);
+        assertEquals("/mnt/pmem0", dir0Config.getDirectory());
+        assertEquals(0, dir0Config.getNumaNode());
+        assertEquals("/mnt/pmem1", dir1Config.getDirectory());
+        assertEquals(1, dir1Config.getNumaNode());
+    }
+
+    @Test
+    public void testPersistentMemoryDirectoryConfigurationSimple() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory-directory: /mnt/pmem0";
+
+        ClientConfig config = buildConfig(yaml);
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig().getPersistentMemoryConfig()
+                                                                       .getDirectoryConfigs();
+        assertEquals(1, directoryConfigs.size());
+        PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
+        assertEquals("/mnt/pmem0", dir0Config.getDirectory());
+        assertFalse(dir0Config.isNumaNodeSet());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryDirectoryConfiguration_uniqueDirViolationThrows() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n"
+                + "          numa-node: 0\n"
+                + "        - directory: /mnt/pmem0\n"
+                + "          numa-node: 1\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryDirectoryConfiguration_uniqueNumaNodeViolationThrows() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n"
+                + "          numa-node: 0\n"
+                + "        - directory: /mnt/pmem1\n"
+                + "          numa-node: 0\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryDirectoryConfiguration_numaNodeConsistencyViolationThrows() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n"
+                + "          numa-node: 0\n"
+                + "        - directory: /mnt/pmem1\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test
+    public void testPersistentMemoryDirectoryConfiguration_simpleAndAdvancedPasses() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory-directory: /mnt/optane\n"
+                + "    persistent-memory:\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n"
+                + "        - directory: /mnt/pmem1\n";
+
+        ClientConfig config = buildConfig(yaml);
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig()
+                                                                       .getPersistentMemoryConfig()
+                                                                       .getDirectoryConfigs();
+        assertEquals(3, directoryConfigs.size());
+        PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
+        PersistentMemoryDirectoryConfig dir1Config = directoryConfigs.get(1);
+        PersistentMemoryDirectoryConfig dir2Config = directoryConfigs.get(2);
+        assertEquals("/mnt/optane", dir0Config.getDirectory());
+        assertFalse(dir0Config.isNumaNodeSet());
+        assertEquals("/mnt/pmem0", dir1Config.getDirectory());
+        assertFalse(dir1Config.isNumaNodeSet());
+        assertEquals("/mnt/pmem1", dir2Config.getDirectory());
+        assertFalse(dir2Config.isNumaNodeSet());
     }
 
     public static ClientConfig buildConfig(String yaml) {

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -576,7 +576,23 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(expected.getActions(), configured.getActions());
     }
 
+    @Test
     public abstract void testPersistentMemoryDirectoryConfiguration() throws IOException;
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfigurationSimple();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryDirectoryConfiguration_uniqueDirViolationThrows();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryDirectoryConfiguration_uniqueNumaNodeViolationThrows();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryDirectoryConfiguration_numaNodeConsistencyViolationThrows();
+
+    @Test
+    public abstract void testPersistentMemoryDirectoryConfiguration_simpleAndAdvancedPasses();
 
     protected abstract Config buildAuditlogConfig();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -136,6 +136,8 @@ public class ConfigCompatibilityChecker {
 
         checkCompatibleConfigs("instance-tracking", c1.getInstanceTrackingConfig(), c2.getInstanceTrackingConfig(),
                 new InstanceTrackingConfigChecker());
+        checkCompatibleConfigs("native memory", c1.getNativeMemoryConfig(), c2.getNativeMemoryConfig(),
+                new NativeMemoryConfigChecker());
 
         return true;
     }
@@ -780,6 +782,32 @@ public class ConfigCompatibilityChecker {
         @Override
         MetricsConfig getDefault(Config c) {
             return c.getMetricsConfig();
+        }
+    }
+
+    public static class NativeMemoryConfigChecker extends ConfigChecker<NativeMemoryConfig> {
+
+        @Override
+        boolean check(NativeMemoryConfig c1, NativeMemoryConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+
+            return c1.isEnabled() == c2.isEnabled()
+                    && c1.getAllocatorType() == c2.getAllocatorType()
+                    && c1.getMetadataSpacePercentage() == c2.getMetadataSpacePercentage()
+                    && c1.getMinBlockSize() == c2.getMinBlockSize()
+                    && c1.getPageSize() == c2.getPageSize()
+                    && c1.getPersistentMemoryConfig().getDirectoryConfigs()
+                         .equals(c2.getPersistentMemoryConfig().getDirectoryConfigs());
+        }
+
+        @Override
+        NativeMemoryConfig getDefault(Config c) {
+            return c.getNativeMemoryConfig();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
@@ -35,8 +35,8 @@ public class NativeMemoryConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(NativeMemoryConfig.class)
-                .allFieldsShouldBeUsed()
-                .suppress(Warning.NONFINAL_FIELDS)
-                .verify();
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -31,13 +31,13 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.instance.impl.TestUtil;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
-import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.impl.PartitionServiceState;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -120,7 +120,7 @@ public abstract class HazelcastTestSupport {
 
     public static final int ASSERT_TRUE_EVENTUALLY_TIMEOUT;
     public static final int ASSERT_COMPLETES_STALL_TOLERANCE;
-    public static final String PERSISTENT_MEMORY_DIRECTORY;
+    public static final String PERSISTENT_MEMORY_DIRECTORIES;
 
     private static final String COMPAT_HZ_INSTANCE_FACTORY = "com.hazelcast.test.CompatibilityTestHazelcastInstanceFactory";
     private static final boolean EXPECT_DIFFERENT_HASHCODES = (new Object().hashCode() != new Object().hashCode());
@@ -142,8 +142,8 @@ public abstract class HazelcastTestSupport {
         LOGGER.fine("ASSERT_TRUE_EVENTUALLY_TIMEOUT = " + ASSERT_TRUE_EVENTUALLY_TIMEOUT);
         ASSERT_COMPLETES_STALL_TOLERANCE = getInteger("hazelcast.assertCompletes.stallTolerance", 20);
         LOGGER.fine("ASSERT_COMPLETES_STALL_TOLERANCE = " + ASSERT_COMPLETES_STALL_TOLERANCE);
-        String pmemDirectory = System.getProperty("hazelcast.persistent.memory");
-        PERSISTENT_MEMORY_DIRECTORY =  pmemDirectory != null ? pmemDirectory : "/tmp/pmem";
+        String pmemDirectories = System.getProperty("hazelcast.persistent.memory");
+        PERSISTENT_MEMORY_DIRECTORIES = pmemDirectories != null ? pmemDirectories : "/tmp/pmem0,/tmp/pmem1";
         System.setProperty(ClusterProperty.METRICS_COLLECTION_FREQUENCY.getName(), "1");
         System.setProperty(ClusterProperty.METRICS_DEBUG.getName(), "true");
     }

--- a/hazelcast/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.xml
@@ -234,6 +234,12 @@
         <min-block-size>1</min-block-size>
         <page-size>1</page-size>
         <metadata-space-percentage>40.5</metadata-space-percentage>
+        <persistent-memory>
+            <directories>
+                <directory numa-node="0">/mnt/pmem0</directory>
+                <directory numa-node="1">/mnt/pmem1</directory>
+            </directories>
+        </persistent-memory>
     </native-memory>
 
     <proxy-factories>

--- a/hazelcast/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-full.yaml
@@ -212,6 +212,12 @@ hazelcast-client:
     min-block-size: 1
     page-size: 1
     metadata-space-percentage: 40.5
+    persistent-memory:
+      directories:
+        - directory: /mnt/pmem0
+          numa-node: 0
+        - directory: /mnt/pmem1
+          numa-node: 1
 
   proxy-factories:
     - class-name: com.hazelcast.examples.ProxyXYZ1

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -604,6 +604,12 @@
         <min-block-size>123</min-block-size>
         <page-size>123</page-size>
         <metadata-space-percentage>12.5</metadata-space-percentage>
+        <persistent-memory>
+            <directories>
+                <directory numa-node="0">/mnt/pmem0</directory>
+                <directory numa-node="1">/mnt/pmem1</directory>
+            </directories>
+        </persistent-memory>
     </native-memory>
 
     <security enabled="false">

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -589,6 +589,12 @@ hazelcast:
     min-block-size: 123
     page-size: 123
     metadata-space-percentage: 12.5
+    persistent-memory:
+      directories:
+        - directory: /mnt/pmem0
+          numa-node: 0
+        - directory: /mnt/pmem1
+          numa-node: 1
 
   security:
     enabled: false


### PR DESCRIPTION
This change introduces advanced persistent memory configuration in the following form:
```xml
    <native-memory allocator-type="POOLED" enabled="true">
        <size unit="MEGABYTES" value="256"/>
	<!-- Simple configuration for single-socket machines with non-volatile memory -->
	<!-- <persistent-memory-directory>/mnt/optane</persistent-memory-directory> -->
        <!-- Advanced configuration for non-volatile memory -->
        <persistent-memory>
            <directories>
                <directory numa-node="0">/mnt/pmem0</directory>
                <directory numa-node="1">/mnt/pmem1</directory>
            </directories>
        </persistent-memory>
    </native-memory>
```
YAML configuration follows the same structure.

Besides the configuration support, the following config validations are added:
- Persistent memory directories must be unique
- NUMA node defined for the persistent memory directories must be unique (if set)
- NUMA node must be defined either on all or none of the directories
Therefore, mixing `<persistent-memory-directory>` and `<persistent-memory>` is allowed only if no NUMA nodes are set.

Besides this change, `native-memory` configuration is added to the Spring configuration for clients that was missing entirely.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3703
Closes: https://github.com/hazelcast/hazelcast/issues/17322