### PR TITLE
Add a constructor with a name into CacheSimpleConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -141,6 +141,15 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
         this.disablePerEntryInvalidationEvents = cacheSimpleConfig.disablePerEntryInvalidationEvents;
     }
 
+    /**
+     * Create a Cache Simple Config for a cache with a specific name.
+     *
+     * @param name cache name
+     */
+    public CacheSimpleConfig(String name) {
+        setName(name);
+    }
+
     public CacheSimpleConfig() {
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -28,12 +28,22 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CacheSimpleConfigTest extends HazelcastTestSupport {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testNameInConstructor() {
+        String name = randomMapName();
+        CacheSimpleConfig config = new CacheSimpleConfig(name);
+
+        assertEquals(name, config.getName());
+    }
 
     @Test
     public void givenCacheLoaderIsConfigured_whenConfigureCacheLoaderFactory_thenThrowIllegalStateException() {


### PR DESCRIPTION
Fixes #17287
It makes it consistent with other data structure configuration objects.