### PR TITLE
Test stabilization - Ignore failures in n.s.m.MemcachedClient.shutdown()

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static com.hazelcast.instance.EndpointQualifier.REST;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
+import static com.hazelcast.test.MemcacheTestUtil.shutdownQuietly;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -114,7 +115,7 @@ public class InvalidEndpointTest {
             ignore(e);
         }
 
-        client.shutdown();
+        shutdownQuietly(client);
     }
 
     protected Config createRestEndpointConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.ConcurrentModificationException;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
+import static com.hazelcast.test.MemcacheTestUtil.shutdownQuietly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -78,9 +79,7 @@ public class MemcachedTest extends HazelcastTestSupport {
     @After
     public void tearDown() {
         try {
-            if (client != null) {
-                client.shutdown();
-            }
+            shutdownQuietly(client);
         } catch (ConcurrentModificationException e) {
             // See https://github.com/hazelcast/hazelcast/issues/14204
             // Due to a MemcachedClient bug, we swallow this exception

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkingCommunicationIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkingCommunicationIntegrationTest.java
@@ -36,6 +36,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.Collections;
 
+import static com.hazelcast.test.MemcacheTestUtil.shutdownQuietly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -82,9 +83,7 @@ public class AdvancedNetworkingCommunicationIntegrationTest extends AbstractAdva
             client = getMemcachedClient(hz, MEMCACHE_PORT);
             client.get("whatever");
         } finally {
-            if (client != null) {
-                client.shutdown();
-            }
+            shutdownQuietly(client);
         }
 
         testMemcacheCallFailsOnPort(hz, MEMBER_PORT);
@@ -143,9 +142,7 @@ public class AdvancedNetworkingCommunicationIntegrationTest extends AbstractAdva
                 // expected
             }
         } finally {
-            if (client != null) {
-                client.shutdown();
-            }
+            shutdownQuietly(client);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/MemcacheTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/MemcacheTestUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import javax.annotation.Nullable;
+
+import com.hazelcast.logging.Logger;
+
+import net.spy.memcached.MemcachedClient;
+
+public final class MemcacheTestUtil {
+
+    private MemcacheTestUtil() {
+    }
+
+    /**
+     * Shutdowns {@link MemcachedClient} ignoring exceptions. Problems are just logged on FINE level. Workaround a
+     * {@link java.util.ConcurrentModificationException} issue in Selector.shutdown() on IBM JDK.
+     *
+     * @param client a {@link MemcachedClient} to be shut down
+     */
+    public static void shutdownQuietly(@Nullable MemcachedClient client) {
+        if (client == null) {
+            return;
+        }
+        try {
+            client.shutdown();
+        } catch (Exception e) {
+            Logger.getLogger(MemcacheTestUtil.class).fine("MemcachedClient.shutdown() failed. Ignoring.", e);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #13152
Fixes: #14048

Related to EE intermittent test-failure: hazelcast/hazelcast-enterprise#3534

Sometimes we see a `ConcurrentModificationException`  thrown from the `net.spy.memcached.MemcachedClient.shutdown()` on IBM Java runtimes. IMO it's a bug in Java itself. In either case, the client shutdown failures can be ignored in the tests.

Related stack trace:
```
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1453)
	at java.util.HashMap$KeyIterator.next(HashMap.java:1477)
	at sun.nio.ch.SelectorImpl.implCloseSelector(SelectorImpl.java:124)
	at java.nio.channels.spi.AbstractSelector.close(AbstractSelector.java:122)
	at net.spy.memcached.MemcachedConnection.shutdown(MemcachedConnection.java:1339)
	at net.spy.memcached.MemcachedClient.shutdown(MemcachedClient.java:2512)
	at net.spy.memcached.MemcachedClient.shutdown(MemcachedClient.java:2474)
```