### PR TITLE
Default implementation of a backup EP is nop for readonly EPs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.serialization.BinaryInterface;
 
 import javax.annotation.Nullable;
@@ -143,6 +144,9 @@ public interface EntryProcessor<K, V, R> extends Serializable {
      * @return the backup entry processor
      */
     default @Nullable EntryProcessor<K, V, R> getBackupProcessor() {
+        if (this instanceof ReadOnly) {
+            return null;
+        }
         return this;
     }
 }


### PR DESCRIPTION
Not executing a read-only processors on backups seems like a sensible
default choice to me. This is a behaviour change, I believe acceptable
in a minor release.