### PR TITLE
WAN counter fixes and cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -48,7 +48,6 @@ import com.hazelcast.internal.monitor.LocalMemoryStats;
 import com.hazelcast.internal.monitor.LocalOperationStats;
 import com.hazelcast.internal.monitor.LocalPNCounterStats;
 import com.hazelcast.internal.monitor.LocalWanStats;
-import com.hazelcast.internal.monitor.WanSyncState;
 import com.hazelcast.internal.monitor.impl.HotRestartStateImpl;
 import com.hazelcast.internal.monitor.impl.LocalMemoryStatsImpl;
 import com.hazelcast.internal.monitor.impl.LocalOperationStatsImpl;
@@ -198,7 +197,6 @@ public class TimedMemberStateFactory {
         createNodeState(memberState);
         createHotRestartState(memberState);
         createClusterHotRestartStatus(memberState);
-        createWanSyncState(memberState);
 
         memberState.setClientStats(getClientAttributes(node.getClientEngine().getClientStatistics()));
 
@@ -243,14 +241,6 @@ public class TimedMemberStateFactory {
         NodeStateImpl nodeState = new NodeStateImpl(cluster.getClusterState(), node.getState(),
                 cluster.getClusterVersion(), node.getVersion());
         memberState.setNodeState(nodeState);
-    }
-
-    private void createWanSyncState(MemberStateImpl memberState) {
-        WanReplicationService wanReplicationService = instance.node.nodeEngine.getWanReplicationService();
-        WanSyncState wanSyncState = wanReplicationService.getWanSyncState();
-        if (wanSyncState != null) {
-            memberState.setWanSyncState(wanSyncState);
-        }
     }
 
     private void createMemState(MemberStateImpl memberState,

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/MemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/MemberState.java
@@ -103,6 +103,4 @@ public interface MemberState extends JsonSerializable {
     HotRestartState getHotRestartState();
 
     ClusterHotRestartStatusDTO getClusterHotRestartStatus();
-
-    WanSyncState getWanSyncState();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/WanSyncState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/WanSyncState.java
@@ -26,8 +26,6 @@ public interface WanSyncState extends LocalInstanceStats {
 
     WanSyncStatus getStatus();
 
-    int getSyncedPartitionCount();
-
     String getActiveWanConfigName();
 
     String getActivePublisherName();

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/MemberStateImpl.java
@@ -38,7 +38,6 @@ import com.hazelcast.internal.monitor.LocalWanStats;
 import com.hazelcast.internal.monitor.MemberPartitionState;
 import com.hazelcast.internal.monitor.MemberState;
 import com.hazelcast.internal.monitor.NodeState;
-import com.hazelcast.internal.monitor.WanSyncState;
 import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.multimap.LocalMultiMapStats;
@@ -88,7 +87,6 @@ public class MemberStateImpl implements MemberState {
     private NodeState nodeState = new NodeStateImpl();
     private HotRestartState hotRestartState = new HotRestartStateImpl();
     private ClusterHotRestartStatusDTO clusterHotRestartStatus = new ClusterHotRestartStatusDTO();
-    private WanSyncState wanSyncState = new WanSyncStateImpl();
     private AdvancedNetworkStatsDTO inboundNetworkStats = new AdvancedNetworkStatsDTO();
     private AdvancedNetworkStatsDTO outboundNetworkStats = new AdvancedNetworkStatsDTO();
 
@@ -314,15 +312,6 @@ public class MemberStateImpl implements MemberState {
         this.clusterHotRestartStatus = clusterHotRestartStatus;
     }
 
-    @Override
-    public WanSyncState getWanSyncState() {
-        return wanSyncState;
-    }
-
-    public void setWanSyncState(WanSyncState wanSyncState) {
-        this.wanSyncState = wanSyncState;
-    }
-
     public Map<UUID, String> getClientStats() {
         return clientStats;
     }
@@ -406,7 +395,6 @@ public class MemberStateImpl implements MemberState {
         root.add("nodeState", nodeState.toJson());
         root.add("hotRestartState", hotRestartState.toJson());
         root.add("clusterHotRestartStatus", clusterHotRestartStatus.toJson());
-        addJsonIfSerializable(root, "wanSyncState", wanSyncState);
 
         JsonObject clientStatsObject = new JsonObject();
         for (Map.Entry<UUID, String> entry : clientStats.entrySet()) {
@@ -570,10 +558,6 @@ public class MemberStateImpl implements MemberState {
             clusterHotRestartStatus = new ClusterHotRestartStatusDTO();
             clusterHotRestartStatus.fromJson(jsonClusterHotRestartStatus);
         }
-        JsonObject jsonWanSyncState = getObject(json, "wanSyncState", null);
-        if (jsonWanSyncState != null) {
-            wanSyncState = readJsonIfDeserializable(jsonWanSyncState, new WanSyncStateImpl());
-        }
         for (JsonObject.Member next : getObject(json, "clientStats")) {
             clientStats.put(UUID.fromString(next.getName()), next.getValue().asString());
         }
@@ -612,7 +596,6 @@ public class MemberStateImpl implements MemberState {
                 + ", nodeState=" + nodeState
                 + ", hotRestartState=" + hotRestartState
                 + ", clusterHotRestartStatus=" + clusterHotRestartStatus
-                + ", wanSyncState=" + wanSyncState
                 + ", flakeIdStats=" + flakeIdGeneratorStats
                 + ", clientStats=" + clientStats
                 + ", inboundNetworkStats=" + inboundNetworkStats

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/WanSyncStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/WanSyncStateImpl.java
@@ -16,27 +16,20 @@
 
 package com.hazelcast.internal.monitor.impl;
 
-import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.monitor.WanSyncState;
 import com.hazelcast.internal.util.Clock;
-import com.hazelcast.json.internal.JsonSerializable;
 import com.hazelcast.wan.impl.WanSyncStatus;
 
-public class WanSyncStateImpl implements WanSyncState, JsonSerializable {
+public class WanSyncStateImpl implements WanSyncState {
 
     private long creationTime;
     private WanSyncStatus status = WanSyncStatus.READY;
-    private int syncedPartitionCount;
     private String activeWanConfigName;
     private String activePublisherName;
 
-    public WanSyncStateImpl() { }
-
-    public WanSyncStateImpl(WanSyncStatus status, int syncedPartitionCount,
-                            String activeWanConfigName, String activePublisherName) {
+    public WanSyncStateImpl(WanSyncStatus status, String activeWanConfigName, String activePublisherName) {
         creationTime = Clock.currentTimeMillis();
         this.status = status;
-        this.syncedPartitionCount = syncedPartitionCount;
         this.activeWanConfigName = activeWanConfigName;
         this.activePublisherName = activePublisherName;
     }
@@ -52,11 +45,6 @@ public class WanSyncStateImpl implements WanSyncState, JsonSerializable {
     }
 
     @Override
-    public int getSyncedPartitionCount() {
-        return syncedPartitionCount;
-    }
-
-    @Override
     public String getActiveWanConfigName() {
         return activeWanConfigName;
     }
@@ -67,34 +55,8 @@ public class WanSyncStateImpl implements WanSyncState, JsonSerializable {
     }
 
     @Override
-    public JsonObject toJson() {
-        JsonObject root = new JsonObject();
-        root.add("creationTime", creationTime);
-        root.add("status", status.getStatus());
-        root.add("syncedPartitionCount", syncedPartitionCount);
-        if (activeWanConfigName != null) {
-            root.add("activeWanConfigName", activeWanConfigName);
-        }
-        if (activePublisherName != null) {
-            root.add("activePublisherName", activePublisherName);
-        }
-        return root;
-    }
-
-    @Override
-    public void fromJson(JsonObject json) {
-        this.creationTime = json.getLong("creationTime", -1L);
-        int status = json.getInt("status", WanSyncStatus.READY.getStatus());
-        this.status = WanSyncStatus.getByStatus(status);
-        this.syncedPartitionCount = json.getInt("syncedPartitionCount", 0);
-        this.activeWanConfigName = json.getString("activeWanConfigName", null);
-        this.activePublisherName = json.getString("activePublisherName", null);
-    }
-
-    @Override
     public String toString() {
         return "WanSyncStateImpl{wanSyncStatus=" + status
-                + ", syncedPartitionCount=" + syncedPartitionCount
                 + ", activeWanConfigName=" + activeWanConfigName
                 + ", activePublisherName=" + activePublisherName
                 + '}';

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/MemberStateImplTest.java
@@ -17,12 +17,13 @@
 package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.cache.impl.CacheStatisticsImpl;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hotrestart.BackupTaskState;
 import com.hazelcast.hotrestart.BackupTaskStatus;
-import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.management.TimedMemberState;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.management.dto.AdvancedNetworkStatsDTO;
@@ -30,16 +31,13 @@ import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.monitor.HotRestartState;
 import com.hazelcast.internal.monitor.NodeState;
-import com.hazelcast.internal.monitor.WanSyncState;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.Clock;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
-import com.hazelcast.wan.impl.WanSyncStatus;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -102,7 +100,6 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         final BackupTaskStatus backupTaskStatus = new BackupTaskStatus(BackupTaskState.IN_PROGRESS, 5, 10);
         final String backupDirectory = "/hot/backup/dir";
         final HotRestartStateImpl hotRestartState = new HotRestartStateImpl(backupTaskStatus, true, backupDirectory);
-        final WanSyncState wanSyncState = new WanSyncStateImpl(WanSyncStatus.IN_PROGRESS, 86, "atob", "B");
 
         Map<UUID, String> clientStats = new HashMap<>();
         clientStats.put(clientUuid, "someStats");
@@ -142,7 +139,6 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         memberState.setClients(clients);
         memberState.setNodeState(state);
         memberState.setHotRestartState(hotRestartState);
-        memberState.setWanSyncState(wanSyncState);
         memberState.setClientStats(clientStats);
         memberState.setInboundNetworkStats(inboundNetworkStats);
         memberState.setOutboundNetworkStats(outboundNetworkStats);
@@ -195,12 +191,6 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         assertTrue(deserializedHotRestartState.isHotBackupEnabled());
         assertEquals(backupTaskStatus, deserializedHotRestartState.getBackupTaskStatus());
         assertEquals(backupDirectory, deserializedHotRestartState.getBackupDirectory());
-
-        final WanSyncState deserializedWanSyncState = deserialized.getWanSyncState();
-        assertEquals(WanSyncStatus.IN_PROGRESS, deserializedWanSyncState.getStatus());
-        assertEquals(86, deserializedWanSyncState.getSyncedPartitionCount());
-        assertEquals("atob", deserializedWanSyncState.getActiveWanConfigName());
-        assertEquals("B", deserializedWanSyncState.getActivePublisherName());
 
         ClusterHotRestartStatusDTO clusterHotRestartStatus = deserialized.getClusterHotRestartStatus();
         assertEquals(FULL_RECOVERY_ONLY, clusterHotRestartStatus.getDataRecoveryPolicy());


### PR DESCRIPTION
- removed WanSyncManager#syncedPartitionCount as it was superseded by
the https://github.com/hazelcast/hazelcast-enterprise/pull/3058. The
syncedPartitionCount also fails to track concurrent sync requests which
caused the test failure
- removed WanSyncState from MC code and thus removed it from being
JsonSerializable
- fixed statistics counting for merkle tree sync. Sync statistics on
members which didn't need to sync anything had a synced partition count
of zero, which then causes the sum of the synced partition counts on
all members after sync completes to be less than the total partition
count

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/3145
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3711