### PR TITLE
[FORWARD-PORT] Fix WanAddConfigTest#testConfigAddingWithLiteMembersAdded

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventContainerReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventContainerReplicationOperation.java
@@ -69,7 +69,7 @@ public class WanEventContainerReplicationOperation extends Operation implements 
         int partitionId = getPartitionId();
 
         for (WanReplicationConfig wanReplicationConfig : wanReplicationConfigs) {
-            service.appendWanReplicationConfig(wanReplicationConfig);
+            service.addWanReplicationConfigLocally(wanReplicationConfig);
         }
 
         // first ensure all publishers have configuration


### PR DESCRIPTION
WAN config is added as a partition operation. Lite members don't own any
partitions which is why they don't get the WAN config added. In 3.12.z
and 4.0.z we applied a best-effort fix where we add the config locally
in case the member adding the config is a lite member while in 4.1 we
add a new operation which adds the config on lite members specifically.
This test fails randomly when the member adding the config is a data
member and passes when the member adding the config is a lite member.

Since 4.1 adds the config to lite members, we don't need to adapt the
test as we needed to do in 3.12.z and 4.0.z.

We apply an additional fix because the WAN queue migration operation
would add dynamically added WAN config even to a promoted lite member
but wouldn't initialize it, causing the rest of the migration operation
to fail.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/3612
Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/3598
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3717
Forward-port of: https://github.com/hazelcast/hazelcast/pull/17331