### PR TITLE
Fixed dangling pointers in global indexes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -224,8 +224,8 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     @Override
     public void clear() {
-        recordStore.clear();
         indexes.destroyIndexes();
+        recordStore.clear();
     }
 
     protected IndexConfig getNormalizedIndexConfig(IndexConfig originalConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1270,10 +1270,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public void reset() {
-        mutationObserver.onReset();
-        mapDataStore.reset();
-        storage.clear(false);
-        stats.reset();
+        try {
+            mutationObserver.onReset();
+        } finally {
+            mapDataStore.reset();
+            storage.clear(false);
+            stats.reset();
+        }
     }
 
     @Override
@@ -1327,8 +1330,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     private void clearStorage(boolean isDuringShutdown) {
-        mutationObserver.onClear();
-        storage.clear(isDuringShutdown);
+        try {
+            mutationObserver.onClear();
+        } finally {
+            storage.clear(isDuringShutdown);
+        }
     }
 
     private void clearLockStore() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -834,8 +834,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             newValue = persistenceEnabledFor(provenance)
                     ? mapDataStore.add(key, newValue, record.getExpirationTime(), now, null) : newValue;
             onStore(record);
-            mutationObserver.onUpdateRecord(key, record, oldValue, newValue, false);
             storage.updateRecordValue(key, record, newValue);
+            mutationObserver.onUpdateRecord(key, record, oldValue, newValue, false);
         }
 
         return newValue != null;
@@ -1270,10 +1270,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public void reset() {
+        mutationObserver.onReset();
         mapDataStore.reset();
         storage.clear(false);
         stats.reset();
-        mutationObserver.onReset();
     }
 
     @Override
@@ -1327,8 +1327,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     private void clearStorage(boolean isDuringShutdown) {
-        storage.clear(isDuringShutdown);
         mutationObserver.onClear();
+        storage.clear(isDuringShutdown);
     }
 
     private void clearLockStore() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -272,8 +273,19 @@ public class Indexes {
      */
     public void putEntry(QueryableEntry queryableEntry, Object oldValue, Index.OperationSource operationSource) {
         InternalIndex[] indexes = getIndexes();
+        Throwable exception = null;
         for (InternalIndex index : indexes) {
-            index.putEntry(queryableEntry, oldValue, operationSource);
+            try {
+                index.putEntry(queryableEntry, oldValue, operationSource);
+            } catch (Throwable t) {
+                if (exception == null) {
+                    exception = t;
+                }
+            }
+        }
+
+        if (exception != null) {
+            rethrow(exception);
         }
     }
 


### PR DESCRIPTION
Revised the storage/indexes calls and make sure the indexes never
contain dangling pointers. However, in case of NativeOutOfMemory or
ClassCastException the storage still may contain more entries than
indexes and that is not going come to the consistent state eventually.

Closes https://github.com/hazelcast/hazelcast/issues/17205