### PR TITLE
SQL math expressions (#17339)

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -24,6 +24,7 @@ import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastSqlMonotonicBi
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes;
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastReturnTypes;
+import com.hazelcast.sql.impl.calcite.validate.types.ReplaceUnknownOperandTypeInference;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
@@ -34,11 +35,15 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
 
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes.NULLABLE_OBJECT;
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAllNull;
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
+import static org.apache.calcite.sql.type.SqlTypeName.BIGINT;
+import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
+import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
 
 /**
  * Custom functions and operators.
@@ -273,7 +278,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         "ABS",
         SqlKind.OTHER_FUNCTION,
         HazelcastReturnTypes.UNARY_MINUS,
-        HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+        new ReplaceUnknownOperandTypeInference(DECIMAL),
         notAny(OperandTypes.NUMERIC_OR_INTERVAL),
         SqlFunctionCategory.NUMERIC
     );
@@ -282,7 +287,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         "SIGN",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.ARG0,
-        HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+        new ReplaceUnknownOperandTypeInference(DECIMAL),
         notAny(OperandTypes.NUMERIC),
         SqlFunctionCategory.NUMERIC
     );
@@ -291,7 +296,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         "RAND",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.DOUBLE,
-        HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+        new ReplaceUnknownOperandTypeInference(BIGINT),
         OperandTypes.or(OperandTypes.NILADIC, notAny(OperandTypes.NUMERIC)),
         SqlFunctionCategory.NUMERIC
     );
@@ -316,7 +321,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         "ROUND",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.ARG0_NULLABLE,
-        HazelcastInferTypes.ROUND,
+        new ReplaceUnknownOperandTypeInference(new SqlTypeName[] { DECIMAL, INTEGER }),
         notAny(OperandTypes.NUMERIC_OPTIONAL_INTEGER),
         SqlFunctionCategory.NUMERIC
     );
@@ -325,7 +330,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         "TRUNCATE",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.ARG0_NULLABLE,
-        HazelcastInferTypes.ROUND,
+        new ReplaceUnknownOperandTypeInference(new SqlTypeName[] { DECIMAL, INTEGER }),
         notAny(OperandTypes.NUMERIC_OPTIONAL_INTEGER),
         SqlFunctionCategory.NUMERIC
     );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -16,14 +16,17 @@
 
 package com.hazelcast.sql.impl.calcite.validate;
 
+import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastDoubleFunction;
 import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastSqlBinaryOperator;
 import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastSqlCastFunction;
+import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastSqlFloorFunction;
 import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastSqlMonotonicBinaryOperator;
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes;
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastReturnTypes;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlPostfixOperator;
 import org.apache.calcite.sql.SqlPrefixOperator;
@@ -40,6 +43,7 @@ import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandType
 /**
  * Custom functions and operators.
  */
+@SuppressWarnings("unused")
 public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
     //@formatter:off
@@ -259,6 +263,71 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         ReturnTypes.BOOLEAN_NOT_NULL,
         NULLABLE_OBJECT,
         OperandTypes.ANY
+    );
+
+    //#endregion
+
+    //#region Math functions.
+
+    public static final SqlFunction ABS = new SqlFunction(
+        "ABS",
+        SqlKind.OTHER_FUNCTION,
+        HazelcastReturnTypes.UNARY_MINUS,
+        HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+        notAny(OperandTypes.NUMERIC_OR_INTERVAL),
+        SqlFunctionCategory.NUMERIC
+    );
+
+    public static final SqlFunction SIGN = new SqlFunction(
+        "SIGN",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG0,
+        HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+        notAny(OperandTypes.NUMERIC),
+        SqlFunctionCategory.NUMERIC
+    );
+
+    public static final SqlFunction RAND = new SqlFunction(
+        "RAND",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.DOUBLE,
+        HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+        OperandTypes.or(OperandTypes.NILADIC, notAny(OperandTypes.NUMERIC)),
+        SqlFunctionCategory.NUMERIC
+    );
+
+    public static final SqlFunction COS = new HazelcastDoubleFunction("COS");
+    public static final SqlFunction SIN = new HazelcastDoubleFunction("SIN");
+    public static final SqlFunction TAN = new HazelcastDoubleFunction("TAN");
+    public static final SqlFunction COT = new HazelcastDoubleFunction("COT");
+    public static final SqlFunction ACOS = new HazelcastDoubleFunction("ACOS");
+    public static final SqlFunction ASIN = new HazelcastDoubleFunction("ASIN");
+    public static final SqlFunction ATAN = new HazelcastDoubleFunction("ATAN");
+    public static final SqlFunction EXP = new HazelcastDoubleFunction("EXP");
+    public static final SqlFunction LN = new HazelcastDoubleFunction("LN");
+    public static final SqlFunction LOG10 = new HazelcastDoubleFunction("LOG10");
+    public static final SqlFunction DEGREES = new HazelcastDoubleFunction("DEGREES");
+    public static final SqlFunction RADIANS = new HazelcastDoubleFunction("RADIANS");
+
+    public static final SqlFunction FLOOR = new HazelcastSqlFloorFunction(SqlKind.FLOOR);
+    public static final SqlFunction CEIL = new HazelcastSqlFloorFunction(SqlKind.CEIL);
+
+    public static final SqlFunction ROUND = new SqlFunction(
+        "ROUND",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG0_NULLABLE,
+        HazelcastInferTypes.ROUND,
+        OperandTypes.NUMERIC_OPTIONAL_INTEGER,
+        SqlFunctionCategory.NUMERIC
+    );
+
+    public static final SqlFunction TRUNCATE = new SqlFunction(
+        "TRUNCATE",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG0_NULLABLE,
+        HazelcastInferTypes.ROUND,
+        OperandTypes.NUMERIC_OPTIONAL_INTEGER,
+        SqlFunctionCategory.NUMERIC
     );
 
     //#endregion

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -296,7 +296,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         "RAND",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.DOUBLE,
-        new ReplaceUnknownOperandTypeInference(BIGINT),
+        HazelcastInferTypes.explicit(BIGINT),
         OperandTypes.or(OperandTypes.NILADIC, notAny(OperandTypes.NUMERIC)),
         SqlFunctionCategory.NUMERIC
     );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -317,7 +317,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.ARG0_NULLABLE,
         HazelcastInferTypes.ROUND,
-        OperandTypes.NUMERIC_OPTIONAL_INTEGER,
+        notAny(OperandTypes.NUMERIC_OPTIONAL_INTEGER),
         SqlFunctionCategory.NUMERIC
     );
 
@@ -326,7 +326,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.ARG0_NULLABLE,
         HazelcastInferTypes.ROUND,
-        OperandTypes.NUMERIC_OPTIONAL_INTEGER,
+        notAny(OperandTypes.NUMERIC_OPTIONAL_INTEGER),
         SqlFunctionCategory.NUMERIC
     );
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
@@ -16,13 +16,16 @@
 
 package com.hazelcast.sql.impl.calcite.validate.operators;
 
-import com.hazelcast.sql.impl.calcite.validate.types.ReplaceUnknownOperandTypeInference;
+import com.hazelcast.sql.impl.calcite.validate.types.HazelcastTypeFactory;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Collections;
 
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
 
@@ -35,7 +38,7 @@ public class HazelcastDoubleFunction extends SqlFunction {
             name,
             SqlKind.OTHER_FUNCTION,
             ReturnTypes.DOUBLE_NULLABLE,
-            new ReplaceUnknownOperandTypeInference(SqlTypeName.DOUBLE),
+            InferTypes.explicit(Collections.singletonList(HazelcastTypeFactory.INSTANCE.createSqlType(SqlTypeName.DOUBLE))),
             notAny(OperandTypes.NUMERIC),
             SqlFunctionCategory.NUMERIC
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate.operators;
+
+import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+
+import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
+
+/**
+ * Function that accepts a DOUBLE argument and produces a DOUBLE result.
+ */
+public class HazelcastDoubleFunction extends SqlFunction {
+    public HazelcastDoubleFunction(String name) {
+        super(
+            name,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.DOUBLE_NULLABLE,
+            HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+            notAny(OperandTypes.NUMERIC),
+            SqlFunctionCategory.NUMERIC
+        );
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
@@ -16,16 +16,13 @@
 
 package com.hazelcast.sql.impl.calcite.validate.operators;
 
-import com.hazelcast.sql.impl.calcite.validate.types.HazelcastTypeFactory;
+import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
-
-import java.util.Collections;
 
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
 
@@ -38,7 +35,7 @@ public class HazelcastDoubleFunction extends SqlFunction {
             name,
             SqlKind.OTHER_FUNCTION,
             ReturnTypes.DOUBLE_NULLABLE,
-            InferTypes.explicit(Collections.singletonList(HazelcastTypeFactory.INSTANCE.createSqlType(SqlTypeName.DOUBLE))),
+            HazelcastInferTypes.explicit(SqlTypeName.DOUBLE),
             notAny(OperandTypes.NUMERIC),
             SqlFunctionCategory.NUMERIC
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastDoubleFunction.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.sql.impl.calcite.validate.operators;
 
-import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
+import com.hazelcast.sql.impl.calcite.validate.types.ReplaceUnknownOperandTypeInference;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
 
@@ -34,7 +35,7 @@ public class HazelcastDoubleFunction extends SqlFunction {
             name,
             SqlKind.OTHER_FUNCTION,
             ReturnTypes.DOUBLE_NULLABLE,
-            HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+            new ReplaceUnknownOperandTypeInference(SqlTypeName.DOUBLE),
             notAny(OperandTypes.NUMERIC),
             SqlFunctionCategory.NUMERIC
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastSqlFloorFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastSqlFloorFunction.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate.operators;
+
+import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlMonotonicUnaryFunction;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.validate.SqlMonotonicity;
+
+import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
+
+public class HazelcastSqlFloorFunction extends SqlMonotonicUnaryFunction {
+    public HazelcastSqlFloorFunction(SqlKind kind) {
+        super(
+            kind.name(),
+            kind,
+            ReturnTypes.ARG0_OR_EXACT_NO_SCALE,
+            HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+            notAny(OperandTypes.NUMERIC),
+            SqlFunctionCategory.NUMERIC
+        );
+    }
+
+    @Override public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
+        return call.getOperandMonotonicity(0).unstrict();
+    }
+
+    @SuppressWarnings("checkstyle:MagicNumber")
+    @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+        SqlWriter.Frame frame = writer.startFunCall(getName());
+
+        if (call.operandCount() == 2) {
+            call.operand(0).unparse(writer, 0, 100);
+            writer.sep("TO");
+            call.operand(1).unparse(writer, 100, 0);
+        } else {
+            call.operand(0).unparse(writer, 0, 0);
+        }
+        writer.endFunCall(frame);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastSqlFloorFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/HazelcastSqlFloorFunction.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.validate.operators;
 
-import com.hazelcast.sql.impl.calcite.validate.types.HazelcastInferTypes;
+import com.hazelcast.sql.impl.calcite.validate.types.ReplaceUnknownOperandTypeInference;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
 
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastOperandTypes.notAny;
+import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
 
 public class HazelcastSqlFloorFunction extends SqlMonotonicUnaryFunction {
     public HazelcastSqlFloorFunction(SqlKind kind) {
@@ -35,7 +36,7 @@ public class HazelcastSqlFloorFunction extends SqlMonotonicUnaryFunction {
             kind.name(),
             kind,
             ReturnTypes.ARG0_OR_EXACT_NO_SCALE,
-            HazelcastInferTypes.DECIMAL_IF_UNKNOWN,
+            new ReplaceUnknownOperandTypeInference(DECIMAL),
             notAny(OperandTypes.NUMERIC),
             SqlFunctionCategory.NUMERIC
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
@@ -19,6 +19,7 @@ package com.hazelcast.sql.impl.calcite.validate.types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.Arrays;
 
@@ -79,7 +80,36 @@ public final class HazelcastInferTypes {
         }
     };
 
+    public static final SqlOperandTypeInference DECIMAL_IF_UNKNOWN = (callBinding, returnType, operandTypes) -> {
+        RelDataType unknownType = callBinding.getTypeFactory().createUnknownType();
+
+        for (int i = 0; i < operandTypes.length; i++) {
+            RelDataType operandType = operandTypes[i];
+
+            if (operandType == unknownType) {
+                operandTypes[i] = callBinding.getTypeFactory().createSqlType(SqlTypeName.DECIMAL);
+            }
+        }
+    };
+
+    public static final SqlOperandTypeInference ROUND = (callBinding, returnType, operandTypes) -> {
+        RelDataType unknownType = callBinding.getTypeFactory().createUnknownType();
+
+        for (int i = 0; i < operandTypes.length; i++) {
+            RelDataType operandType = operandTypes[i];
+
+            if (operandType == unknownType) {
+                if (i == 0) {
+                    operandTypes[i] = callBinding.getTypeFactory().createSqlType(SqlTypeName.DECIMAL);
+                } else {
+                    assert i == 1;
+
+                    operandTypes[i] = callBinding.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
+                }
+            }
+        }
+    };
+
     private HazelcastInferTypes() {
     }
-
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
@@ -81,11 +81,11 @@ public final class HazelcastInferTypes {
         }
     };
 
-    public static SqlOperandTypeInference explicit(SqlTypeName typeName) {
-        return InferTypes.explicit(Collections.singletonList(HazelcastTypeFactory.INSTANCE.createSqlType(typeName)));
-    }
-
     private HazelcastInferTypes() {
         // No-op.
+    }
+
+    public static SqlOperandTypeInference explicit(SqlTypeName typeName) {
+        return InferTypes.explicit(Collections.singletonList(HazelcastTypeFactory.INSTANCE.createSqlType(typeName)));
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
@@ -19,7 +19,6 @@ package com.hazelcast.sql.impl.calcite.validate.types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
-import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.Arrays;
 
@@ -80,36 +79,7 @@ public final class HazelcastInferTypes {
         }
     };
 
-    public static final SqlOperandTypeInference DECIMAL_IF_UNKNOWN = (callBinding, returnType, operandTypes) -> {
-        RelDataType unknownType = callBinding.getTypeFactory().createUnknownType();
-
-        for (int i = 0; i < operandTypes.length; i++) {
-            RelDataType operandType = operandTypes[i];
-
-            if (operandType == unknownType) {
-                operandTypes[i] = callBinding.getTypeFactory().createSqlType(SqlTypeName.DECIMAL);
-            }
-        }
-    };
-
-    public static final SqlOperandTypeInference ROUND = (callBinding, returnType, operandTypes) -> {
-        RelDataType unknownType = callBinding.getTypeFactory().createUnknownType();
-
-        for (int i = 0; i < operandTypes.length; i++) {
-            RelDataType operandType = operandTypes[i];
-
-            if (operandType == unknownType) {
-                if (i == 0) {
-                    operandTypes[i] = callBinding.getTypeFactory().createSqlType(SqlTypeName.DECIMAL);
-                } else {
-                    assert i == 1;
-
-                    operandTypes[i] = callBinding.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
-                }
-            }
-        }
-    };
-
     private HazelcastInferTypes() {
+        // No-op.
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastInferTypes.java
@@ -19,8 +19,10 @@ package com.hazelcast.sql.impl.calcite.validate.types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static com.hazelcast.sql.impl.calcite.validate.SqlNodeUtil.isParameter;
 import static com.hazelcast.sql.impl.calcite.validate.types.HazelcastTypeSystem.typeName;
@@ -78,6 +80,10 @@ public final class HazelcastInferTypes {
             }
         }
     };
+
+    public static SqlOperandTypeInference explicit(SqlTypeName typeName) {
+        return InferTypes.explicit(Collections.singletonList(HazelcastTypeFactory.INSTANCE.createSqlType(typeName)));
+    }
 
     private HazelcastInferTypes() {
         // No-op.

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/ReplaceUnknownOperandTypeInference.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/ReplaceUnknownOperandTypeInference.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.validate.types;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlCallBinding;
@@ -40,6 +41,7 @@ public class ReplaceUnknownOperandTypeInference implements SqlOperandTypeInferen
         this(null, defaultTypeName);
     }
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public ReplaceUnknownOperandTypeInference(SqlTypeName[] typeNames, SqlTypeName defaultTypeName) {
         this.typeNames = typeNames;
         this.defaultTypeName = defaultTypeName;

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/ReplaceUnknownOperandTypeInference.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/ReplaceUnknownOperandTypeInference.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate.types;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Type inference, that replaces unknown operands with the given types.
+ */
+public class ReplaceUnknownOperandTypeInference implements SqlOperandTypeInference {
+
+    private final SqlTypeName[] typeNames;
+
+    /** Type name to be applied to operands that do not have a concrete types defined in "typeNames" */
+    private final SqlTypeName defaultTypeName;
+
+    public ReplaceUnknownOperandTypeInference(SqlTypeName[] typeNames) {
+        this(typeNames, null);
+    }
+
+    public ReplaceUnknownOperandTypeInference(SqlTypeName defaultTypeName) {
+        this(null, defaultTypeName);
+    }
+
+    public ReplaceUnknownOperandTypeInference(SqlTypeName[] typeNames, SqlTypeName defaultTypeName) {
+        this.typeNames = typeNames;
+        this.defaultTypeName = defaultTypeName;
+    }
+
+    @Override
+    public void inferOperandTypes(SqlCallBinding callBinding, RelDataType returnType, RelDataType[] operandTypes) {
+        RelDataType unknownType = callBinding.getTypeFactory().createUnknownType();
+
+        for (int i = 0; i < operandTypes.length; i++) {
+            RelDataType operandType = operandTypes[i];
+
+            if (operandType == unknownType) {
+                RelDataType newOperandType = operandType(i, callBinding.getTypeFactory());
+
+                if (newOperandType != null) {
+                    operandTypes[i] = newOperandType;
+                }
+            }
+        }
+    }
+
+    private RelDataType operandType(int index, RelDataTypeFactory typeFactory) {
+        SqlTypeName typeName = null;
+
+        if (typeNames != null && index < typeNames.length) {
+            typeName = typeNames[index];
+        }
+
+        if (typeName == null) {
+            typeName = defaultTypeName;
+        }
+
+        if (typeName != null) {
+            return typeFactory.createSqlType(typeName);
+        }
+
+        return null;
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
@@ -148,7 +148,7 @@ public class ParserOperationsTest {
 
     @Test
     public void testUnsupportedFunction() {
-        checkFailure("select sin(0) from t", "SIN is not supported");
+        checkFailure("select atan2(0, 0) from t", "ATAN2 is not supported");
     }
 
     private static void checkSuccess(String sql) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
@@ -37,9 +37,9 @@ import static org.junit.Assert.fail;
 public abstract class SqlExpressionIntegrationTestSupport extends SqlTestSupport {
 
     protected static final Object SKIP_VALUE_CHECK = new Object();
+    protected HazelcastInstance member;
 
     private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
-    private HazelcastInstance member;
     private IMap map;
 
     @Before
@@ -57,6 +57,20 @@ public abstract class SqlExpressionIntegrationTestSupport extends SqlTestSupport
     protected void put(Object value) {
         map.clear();
         map.put(0, value);
+
+        clearPlanCache(member);
+    }
+
+    protected void putAll(Object... values) {
+        map.clear();
+
+        if (values != null) {
+            int i = 0;
+
+            for (Object value : values) {
+                map.put(i++, value);
+            }
+        }
 
         clearPlanCache(member);
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public abstract class SqlExpressionIntegrationTestSupport extends SqlTestSupport {
+
+    protected static final Object SKIP_VALUE_CHECK = new Object();
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    protected void put(Object value) {
+        map.clear();
+        map.put(0, value);
+
+        clearPlanCache(member);
+    }
+
+    protected Object checkValueInternal(
+        String sql,
+        SqlColumnType expectedType,
+        Object expectedValue,
+        Object... params
+    ) {
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+
+        Object value = row.getObject(0);
+
+        if (expectedValue != SKIP_VALUE_CHECK) {
+            assertEquals(expectedValue, value);
+        }
+
+        return value;
+    }
+
+    protected void checkFailureInternal(
+        String sql,
+        int expectedErrorCode,
+        String expectedErrorMessage,
+        Object... params
+    ) {
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -16,54 +16,23 @@
 
 package com.hazelcast.sql.impl.expression.math;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
-import com.hazelcast.sql.SqlRow;
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-@SuppressWarnings({"rawtypes", "unchecked"})
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class AbsFunctionIntegrationTest extends SqlTestSupport {
-
-    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
-    private HazelcastInstance member;
-    private IMap map;
-
-    @Before
-    public void before() {
-        member = factory.newHazelcastInstance();
-
-        map = member.getMap("map");
-    }
-
-    @After
-    public void after() {
-        factory.shutdownAll();
-    }
-
+public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupport {
     @Test
     public void testColumn() {
         checkColumn((byte) 0, SqlColumnType.SMALLINT, (short) 0);
@@ -126,22 +95,20 @@ public class AbsFunctionIntegrationTest extends SqlTestSupport {
     }
 
     private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
-        map.clear();
-        map.put(0, value);
+        put(value);
 
         check("this", expectedType, expectedResult);
     }
 
     private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
-        map.clear();
-        map.put(0, value);
+        put(value);
 
         checkFailure("this", expectedErrorCode, expectedErrorMessage);
     }
 
     @Test
     public void testParameter() {
-        map.put(0, 0);
+        put(0);
 
         checkParameter((byte) 0, BigDecimal.ZERO);
         checkParameter((byte) 1, BigDecimal.ONE);
@@ -215,7 +182,7 @@ public class AbsFunctionIntegrationTest extends SqlTestSupport {
 
     @Test
     public void testLiteral() {
-        map.put(0, 0);
+        put(0);
 
         checkExactLiteral(1, SqlColumnType.TINYINT, (byte) 1);
         checkExactLiteral(0, SqlColumnType.TINYINT, (byte) 0);
@@ -268,28 +235,12 @@ public class AbsFunctionIntegrationTest extends SqlTestSupport {
     private void check(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
         String sql = "SELECT ABS(" + operand + ") FROM map";
 
-        List<SqlRow> rows = execute(member, sql, params);
-        assertEquals(1, rows.size());
-
-        SqlRow row = rows.get(0);
-        assertEquals(1, row.getMetadata().getColumnCount());
-        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
-        assertEquals(expectedValue, row.getObject(0));
+        checkValueInternal(sql, expectedType, expectedValue, params);
     }
 
     private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
         String sql = "SELECT ABS(" + operand + ") FROM map";
 
-        try {
-            execute(member, sql, params);
-
-            fail("Must fail");
-        } catch (SqlException e) {
-            assertTrue(expectedErrorMessage.length() != 0);
-            assertNotNull(e.getMessage());
-            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
-
-            assertEquals(expectedErrorCode, e.getCode());
-        }
+        checkFailureInternal(sql, expectedErrorCode, expectedErrorMessage, params);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class AbsFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn((byte) 0, SqlColumnType.SMALLINT, (short) 0);
+        checkColumn((byte) 1, SqlColumnType.SMALLINT, (short) 1);
+        checkColumn((byte) -1, SqlColumnType.SMALLINT, (short) 1);
+        checkColumn(Byte.MAX_VALUE, SqlColumnType.SMALLINT, (short) Byte.MAX_VALUE);
+        checkColumn(Byte.MIN_VALUE, SqlColumnType.SMALLINT, (short) (Byte.MAX_VALUE + 1));
+
+        checkColumn((short) 0, SqlColumnType.INTEGER, 0);
+        checkColumn((short) 1, SqlColumnType.INTEGER, 1);
+        checkColumn((short) -1, SqlColumnType.INTEGER, 1);
+        checkColumn(Short.MAX_VALUE, SqlColumnType.INTEGER, (int) Short.MAX_VALUE);
+        checkColumn(Short.MIN_VALUE, SqlColumnType.INTEGER, Short.MAX_VALUE + 1);
+
+        checkColumn(0, SqlColumnType.BIGINT, (long) 0);
+        checkColumn(1, SqlColumnType.BIGINT, (long) 1);
+        checkColumn(-1, SqlColumnType.BIGINT, (long) 1);
+        checkColumn(Integer.MAX_VALUE, SqlColumnType.BIGINT, (long) Integer.MAX_VALUE);
+        checkColumn(Integer.MIN_VALUE, SqlColumnType.BIGINT, (long) Integer.MAX_VALUE + 1);
+
+        checkColumn((long) 0, SqlColumnType.BIGINT, (long) 0);
+        checkColumn((long) 1, SqlColumnType.BIGINT, (long) 1);
+        checkColumn((long) -1, SqlColumnType.BIGINT, (long) 1);
+        checkColumn(Long.MAX_VALUE, SqlColumnType.BIGINT, Long.MAX_VALUE);
+        checkColumnFailure(Long.MIN_VALUE, SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ABS function (consider adding an explicit CAST to DECIMAL)");
+
+        checkColumn(BigInteger.ZERO, SqlColumnType.DECIMAL, BigDecimal.ZERO);
+        checkColumn(BigInteger.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn(BigInteger.ONE.negate(), SqlColumnType.DECIMAL, BigDecimal.ONE);
+
+        checkColumn(BigDecimal.ZERO, SqlColumnType.DECIMAL, BigDecimal.ZERO);
+        checkColumn(BigDecimal.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn(BigDecimal.ONE.negate(), SqlColumnType.DECIMAL, BigDecimal.ONE);
+
+        checkColumn((float) 0, SqlColumnType.REAL, (float) 0);
+        checkColumn((float) 1.1, SqlColumnType.REAL, (float) 1.1);
+        checkColumn((float) -1.1, SqlColumnType.REAL, (float) 1.1);
+        checkColumn(Float.MAX_VALUE, SqlColumnType.REAL, Float.MAX_VALUE);
+        checkColumn(Float.MIN_VALUE, SqlColumnType.REAL, Math.abs(Float.MIN_VALUE));
+        checkColumn(Float.POSITIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
+        checkColumn(Float.NEGATIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
+        checkColumn(Float.NaN, SqlColumnType.REAL, Float.NaN);
+
+        checkColumn(0d, SqlColumnType.DOUBLE, 0d);
+        checkColumn(1.1d, SqlColumnType.DOUBLE, 1.1d);
+        checkColumn(-1.1d, SqlColumnType.DOUBLE, 1.1d);
+        checkColumn(Double.MAX_VALUE, SqlColumnType.DOUBLE, Double.MAX_VALUE);
+        checkColumn(Double.MIN_VALUE, SqlColumnType.DOUBLE, Math.abs(Double.MIN_VALUE));
+        checkColumn(Double.POSITIVE_INFINITY, SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
+        checkColumn(Double.NEGATIVE_INFINITY, SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
+        checkColumn(Double.NaN, SqlColumnType.DOUBLE, Double.NaN);
+
+        checkColumn("0", SqlColumnType.DECIMAL, BigDecimal.ZERO);
+        checkColumn("1.1", SqlColumnType.DECIMAL, new BigDecimal("1.1"));
+        checkColumn("-1.1", SqlColumnType.DECIMAL, new BigDecimal("1.1"));
+        checkColumnFailure("a", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure('a', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+
+        checkColumnFailure(new ExpressionValue.ObjectVal(), SqlErrorCode.PARSING, "Cannot apply 'ABS' to arguments of type 'ABS(<OBJECT>)'");
+    }
+
+    private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
+        map.clear();
+        map.put(0, value);
+
+        check("this", expectedType, expectedResult);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        map.clear();
+        map.put(0, value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    @Test
+    public void testParameter() {
+        map.put(0, 0);
+
+        checkParameter((byte) 0, BigDecimal.ZERO);
+        checkParameter((byte) 1, BigDecimal.ONE);
+        checkParameter((byte) -1, BigDecimal.ONE);
+        checkParameter(Byte.MAX_VALUE, new BigDecimal(Byte.MAX_VALUE));
+        checkParameter(Byte.MIN_VALUE, new BigDecimal(Byte.MIN_VALUE).negate());
+        checkParameter(Byte.toString(Byte.MAX_VALUE), new BigDecimal(Byte.MAX_VALUE));
+        checkParameter(Byte.toString(Byte.MIN_VALUE), new BigDecimal(Byte.MIN_VALUE).negate());
+
+        checkParameter((short) 0, BigDecimal.ZERO);
+        checkParameter((short) 1, BigDecimal.ONE);
+        checkParameter((short) -1, BigDecimal.ONE);
+        checkParameter(Short.MAX_VALUE, new BigDecimal(Short.MAX_VALUE));
+        checkParameter(Short.MIN_VALUE, new BigDecimal(Short.MIN_VALUE).negate());
+        checkParameter(Short.toString(Short.MAX_VALUE), new BigDecimal(Short.MAX_VALUE));
+        checkParameter(Short.toString(Short.MIN_VALUE), new BigDecimal(Short.MIN_VALUE).negate());
+
+        checkParameter(0, BigDecimal.ZERO);
+        checkParameter(1, BigDecimal.ONE);
+        checkParameter(-1, BigDecimal.ONE);
+        checkParameter(Integer.MAX_VALUE, new BigDecimal(Integer.MAX_VALUE));
+        checkParameter(Integer.MIN_VALUE, new BigDecimal(Integer.MIN_VALUE).negate());
+        checkParameter(Integer.toString(Integer.MAX_VALUE), new BigDecimal(Integer.MAX_VALUE));
+        checkParameter(Integer.toString(Integer.MIN_VALUE), new BigDecimal(Integer.MIN_VALUE).negate());
+
+        checkParameter(0L, BigDecimal.ZERO);
+        checkParameter(1L, BigDecimal.ONE);
+        checkParameter(-1L, BigDecimal.ONE);
+        checkParameter(Long.MAX_VALUE, new BigDecimal(Long.MAX_VALUE));
+        checkParameter(Long.MIN_VALUE, new BigDecimal(Long.MIN_VALUE).negate());
+        checkParameter(Long.toString(Long.MAX_VALUE), new BigDecimal(Long.MAX_VALUE));
+        checkParameter(Long.toString(Long.MIN_VALUE), new BigDecimal(Long.MIN_VALUE).negate());
+
+        checkParameter(BigInteger.ZERO, BigDecimal.ZERO);
+        checkParameter(BigInteger.ONE, BigDecimal.ONE);
+        checkParameter(BigInteger.ONE.negate(), BigDecimal.ONE);
+
+        checkParameter(BigDecimal.ZERO, BigDecimal.ZERO);
+        checkParameter(BigDecimal.ONE, BigDecimal.ONE);
+        checkParameter(BigDecimal.ONE.negate(), BigDecimal.ONE);
+        checkParameter(new BigDecimal("1.1"), new BigDecimal("1.1"));
+        checkParameter(new BigDecimal("-1.1"), new BigDecimal("1.1"));
+        checkParameter("1.1", new BigDecimal("1.1"));
+        checkParameter("-1.1", new BigDecimal("1.1"));
+
+        checkParameter(0f, BigDecimal.ZERO);
+        checkParameter(1f, BigDecimal.ONE);
+        checkParameter(-1f, BigDecimal.ONE);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.POSITIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.NEGATIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN REAL value to DECIMAL", Float.NaN);
+
+        checkParameter(0d, BigDecimal.ZERO);
+        checkParameter(1d, BigDecimal.ONE);
+        checkParameter(-1d, BigDecimal.ONE);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.POSITIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.NEGATIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN DOUBLE value to DECIMAL", Double.NaN);
+
+        checkParameter('0', BigDecimal.ZERO);
+        checkParameter('1', BigDecimal.ONE);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+    }
+
+    private void checkParameter(Object parameterValue, Object expectedValue) {
+        check("?", SqlColumnType.DECIMAL, expectedValue, parameterValue);
+    }
+
+    @Test
+    public void testLiteral() {
+        map.put(0, 0);
+
+        checkExactLiteral(1, SqlColumnType.TINYINT, (byte) 1);
+        checkExactLiteral(0, SqlColumnType.TINYINT, (byte) 0);
+        checkExactLiteral(-1, SqlColumnType.TINYINT, (byte) 1);
+
+        checkExactLiteral(Byte.MAX_VALUE - 1, SqlColumnType.SMALLINT, (short) (Byte.MAX_VALUE - 1));
+        checkExactLiteral(Byte.MAX_VALUE, SqlColumnType.SMALLINT, (short) Byte.MAX_VALUE);
+        checkExactLiteral(Byte.MIN_VALUE, SqlColumnType.SMALLINT, (short) (Byte.MAX_VALUE + 1));
+
+        checkExactLiteral(Short.MAX_VALUE - 1, SqlColumnType.INTEGER, Short.MAX_VALUE - 1);
+        checkExactLiteral(Short.MAX_VALUE, SqlColumnType.INTEGER, (int) Short.MAX_VALUE);
+        checkExactLiteral(Short.MIN_VALUE, SqlColumnType.INTEGER, Short.MAX_VALUE + 1);
+
+        checkExactLiteral(Integer.MAX_VALUE - 1, SqlColumnType.BIGINT, (long) (Integer.MAX_VALUE - 1));
+        checkExactLiteral(Integer.MAX_VALUE, SqlColumnType.BIGINT, (long) Integer.MAX_VALUE);
+        checkExactLiteral(Integer.MIN_VALUE, SqlColumnType.BIGINT, (long) Integer.MAX_VALUE + 1);
+
+        checkExactLiteral(Long.MAX_VALUE - 1, SqlColumnType.BIGINT, Long.MAX_VALUE - 1);
+        checkExactLiteral(Long.MAX_VALUE, SqlColumnType.BIGINT, Long.MAX_VALUE);
+
+        check("null", SqlColumnType.DECIMAL, null);
+        checkExactLiteral("1.1", SqlColumnType.DECIMAL, new BigDecimal("1.1"));
+        checkExactLiteral("0.0", SqlColumnType.DECIMAL, new BigDecimal("0.0"));
+        checkExactLiteral("-1.1", SqlColumnType.DECIMAL, new BigDecimal("1.1"));
+
+        checkInexactLiteral("1.1E0", SqlColumnType.DOUBLE, 1.1d);
+        checkInexactLiteral("0.0E0", SqlColumnType.DOUBLE, 0d);
+        checkInexactLiteral("-1.1E0", SqlColumnType.DOUBLE, 1.1d);
+
+        checkFailure(Long.MIN_VALUE, SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ABS function (consider adding an explicit CAST to DECIMAL)");
+
+        checkFailure("'a'", SqlErrorCode.PARSING, "Literal ''a'' can not be parsed to type 'DECIMAL'");
+        checkFailure("true", SqlErrorCode.PARSING, "Cannot apply 'ABS' to arguments of type 'ABS(<BOOLEAN>)'");
+        checkFailure("false", SqlErrorCode.PARSING, "Cannot apply 'ABS' to arguments of type 'ABS(<BOOLEAN>)'");
+    }
+
+    private void checkExactLiteral(Object literal, SqlColumnType expectedType, Object expectedValue) {
+        String literalString = literal.toString();
+
+        check(literalString, expectedType, expectedValue);
+        check("'" + literalString + "'", SqlColumnType.DECIMAL, new BigDecimal(expectedValue.toString()));
+    }
+
+    private void checkInexactLiteral(Object literal, SqlColumnType expectedType, double expectedValue) {
+        String literalString = literal.toString();
+
+        check(literalString, expectedType, expectedValue);
+    }
+
+    private void check(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        String sql = "SELECT ABS(" + operand + ") FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+        assertEquals(expectedValue, row.getObject(0));
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT ABS(" + operand + ") FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -67,16 +67,18 @@ public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupp
         checkColumn(BigDecimal.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
         checkColumn(BigDecimal.ONE.negate(), SqlColumnType.DECIMAL, BigDecimal.ONE);
 
-        checkColumn((float) 0, SqlColumnType.REAL, (float) 0);
-        checkColumn((float) 1.1, SqlColumnType.REAL, (float) 1.1);
-        checkColumn((float) -1.1, SqlColumnType.REAL, (float) 1.1);
+        checkColumn(0.0f, SqlColumnType.REAL, 0.0f);
+        checkColumn(-0.0f, SqlColumnType.REAL, 0.0f);
+        checkColumn(1.1f, SqlColumnType.REAL, 1.1f);
+        checkColumn(-1.1f, SqlColumnType.REAL, 1.1f);
         checkColumn(Float.MAX_VALUE, SqlColumnType.REAL, Float.MAX_VALUE);
         checkColumn(Float.MIN_VALUE, SqlColumnType.REAL, Math.abs(Float.MIN_VALUE));
         checkColumn(Float.POSITIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
         checkColumn(Float.NEGATIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
         checkColumn(Float.NaN, SqlColumnType.REAL, Float.NaN);
 
-        checkColumn(0d, SqlColumnType.DOUBLE, 0d);
+        checkColumn(0.0d, SqlColumnType.DOUBLE, 0.0d);
+        checkColumn(-0.0d, SqlColumnType.DOUBLE, 0.0d);
         checkColumn(1.1d, SqlColumnType.DOUBLE, 1.1d);
         checkColumn(-1.1d, SqlColumnType.DOUBLE, 1.1d);
         checkColumn(Double.MAX_VALUE, SqlColumnType.DOUBLE, Double.MAX_VALUE);
@@ -154,14 +156,16 @@ public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupp
         checkParameter("1.1", new BigDecimal("1.1"));
         checkParameter("-1.1", new BigDecimal("1.1"));
 
-        checkParameter(0f, BigDecimal.ZERO);
+        checkParameter(0.0f, BigDecimal.ZERO);
+        checkParameter(-0.0f, BigDecimal.ZERO);
         checkParameter(1f, BigDecimal.ONE);
         checkParameter(-1f, BigDecimal.ONE);
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.POSITIVE_INFINITY);
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.NEGATIVE_INFINITY);
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN REAL value to DECIMAL", Float.NaN);
 
-        checkParameter(0d, BigDecimal.ZERO);
+        checkParameter(0.0d, BigDecimal.ZERO);
+        checkParameter(-0.0d, BigDecimal.ZERO);
         checkParameter(1d, BigDecimal.ONE);
         checkParameter(-1d, BigDecimal.ONE);
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.POSITIVE_INFINITY);
@@ -208,8 +212,9 @@ public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupp
         checkExactLiteral("0.0", SqlColumnType.DECIMAL, new BigDecimal("0.0"));
         checkExactLiteral("-1.1", SqlColumnType.DECIMAL, new BigDecimal("1.1"));
 
+        checkInexactLiteral("0.0E0", SqlColumnType.DOUBLE, 0.0d);
+        checkInexactLiteral("-0.0E0", SqlColumnType.DOUBLE, 0.0d);
         checkInexactLiteral("1.1E0", SqlColumnType.DOUBLE, 1.1d);
-        checkInexactLiteral("0.0E0", SqlColumnType.DOUBLE, 0d);
         checkInexactLiteral("-1.1E0", SqlColumnType.DOUBLE, 1.1d);
 
         checkFailure(Long.MIN_VALUE, SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ABS function (consider adding an explicit CAST to DECIMAL)");

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -72,7 +72,6 @@ public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupp
         checkColumn(1.1f, SqlColumnType.REAL, 1.1f);
         checkColumn(-1.1f, SqlColumnType.REAL, 1.1f);
         checkColumn(Float.MAX_VALUE, SqlColumnType.REAL, Float.MAX_VALUE);
-        checkColumn(Float.MIN_VALUE, SqlColumnType.REAL, Math.abs(Float.MIN_VALUE));
         checkColumn(Float.POSITIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
         checkColumn(Float.NEGATIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
         checkColumn(Float.NaN, SqlColumnType.REAL, Float.NaN);
@@ -82,7 +81,6 @@ public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupp
         checkColumn(1.1d, SqlColumnType.DOUBLE, 1.1d);
         checkColumn(-1.1d, SqlColumnType.DOUBLE, 1.1d);
         checkColumn(Double.MAX_VALUE, SqlColumnType.DOUBLE, Double.MAX_VALUE);
-        checkColumn(Double.MIN_VALUE, SqlColumnType.DOUBLE, Math.abs(Double.MIN_VALUE));
         checkColumn(Double.POSITIVE_INFINITY, SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
         checkColumn(Double.NEGATIVE_INFINITY, SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
         checkColumn(Double.NaN, SqlColumnType.DOUBLE, Double.NaN);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class AbsFunctionTest extends SqlTestSupport {
+    @Test
+    public void testEquals() {
+        AbsFunction<?> function = AbsFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.BIGINT);
+
+        checkEquals(function, AbsFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.BIGINT), true);
+        checkEquals(function, AbsFunction.create(ConstantExpression.create(2, QueryDataType.INT), QueryDataType.BIGINT), false);
+        checkEquals(function, AbsFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.VARCHAR), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        AbsFunction<?> original = AbsFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.BIGINT);
+        AbsFunction<?> restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_ABS);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
@@ -110,6 +110,7 @@ public class CeilFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
 
         checkLiteral("null", SqlColumnType.DECIMAL, null);
         checkLiteral("1.1", SqlColumnType.DECIMAL, new BigDecimal("2"));
+        checkLiteral("'1.1'", SqlColumnType.DECIMAL, new BigDecimal("2"));
         checkLiteral("1.1E0", SqlColumnType.DOUBLE, 2d);
 
         checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CeilFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn((byte) 1, SqlColumnType.TINYINT, (byte) 1);
+        checkColumn((short) 1, SqlColumnType.SMALLINT, (short) 1);
+        checkColumn(1, SqlColumnType.INTEGER, 1);
+        checkColumn(1L, SqlColumnType.BIGINT, 1L);
+        checkColumn(0.9f, SqlColumnType.REAL, 1f);
+        checkColumn(0.9d, SqlColumnType.DOUBLE, 1d);
+        checkColumn(BigInteger.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn(new BigDecimal("0.9"), SqlColumnType.DECIMAL, BigDecimal.ONE);
+
+        checkColumn("0.9", SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn('1', SqlColumnType.DECIMAL, BigDecimal.ONE);
+
+        checkColumn(Float.POSITIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
+        checkColumn(Float.NEGATIVE_INFINITY, SqlColumnType.REAL, Float.NEGATIVE_INFINITY);
+        checkColumn(Float.NaN, SqlColumnType.REAL, Float.NaN);
+
+        checkColumn(Double.POSITIVE_INFINITY, SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
+        checkColumn(Double.NEGATIVE_INFINITY, SqlColumnType.DOUBLE, Double.NEGATIVE_INFINITY);
+        checkColumn(Double.NaN, SqlColumnType.DOUBLE, Double.NaN);
+
+        map.clear();
+        map.put(0, new ExpressionValue.IntegerVal());
+        assertNull(execute("field1", SqlColumnType.INTEGER));
+
+        checkColumnFailure("bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure('b', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure(new ExpressionValue.ObjectVal(), SqlErrorCode.PARSING, "Cannot apply 'CEIL' to arguments of type 'CEIL(<OBJECT>)'");
+    }
+
+    private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
+        map.clear();
+        map.put(0, value);
+
+        Object res = execute("this", expectedType);
+        assertEquals(expectedResult, res);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        map.clear();
+        map.put(0, value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    @Test
+    public void testParameter() {
+        map.put(0, 0);
+
+        checkParameter((byte) 1, BigDecimal.ONE);
+        checkParameter((short) 1, BigDecimal.ONE);
+        checkParameter(1, BigDecimal.ONE);
+        checkParameter(1L, BigDecimal.ONE);
+        checkParameter(0.9f, BigDecimal.ONE);
+        checkParameter(0.9d, BigDecimal.ONE);
+        checkParameter(BigInteger.ONE, BigDecimal.ONE);
+        checkParameter(new BigDecimal("0.9"), BigDecimal.ONE);
+
+        checkParameter("0.9", BigDecimal.ONE);
+        checkParameter('1', BigDecimal.ONE);
+
+        assertNull(execute("?", SqlColumnType.DECIMAL, new Object[] { null }));
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+    }
+
+    private void checkParameter(Object param, Object expectedResult) {
+        Object res = execute("?", SqlColumnType.DECIMAL, param);
+        assertEquals(res, expectedResult);
+    }
+
+    @Test
+    public void testLiteral() {
+        map.put(0, 0);
+
+        checkLiteral(1, SqlColumnType.TINYINT, (byte) 1);
+
+        checkLiteral("null", SqlColumnType.DECIMAL, null);
+        checkLiteral("1.1", SqlColumnType.DECIMAL, new BigDecimal("2"));
+        checkLiteral("1.1E0", SqlColumnType.DOUBLE, 2d);
+
+        checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    private void checkLiteral(Object literal, SqlColumnType expectedType, Object expectedResult) {
+        String literalString = literal.toString();
+
+        Object res = execute(literalString, expectedType);
+        assertEquals(expectedResult, res);
+    }
+
+    private Object execute(Object operand, SqlColumnType expectedType, Object... params) {
+        String sql = "SELECT CEIL(" + operand + ") FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+
+        return row.getObject(0);
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT CEIL(" + operand + ") FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
@@ -111,9 +111,9 @@ public class DoubleFunctionIntegrationTest extends SqlExpressionIntegrationTestS
 
         checkValue("?", null, new Object[] { null });
 
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DOUBLE", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DOUBLE", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DOUBLE", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object param, double expectedArgument) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DoubleFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Parameterized.Parameter
+    public Mode mode;
+
+    @Parameterized.Parameters(name = "mode: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+            { new Mode("COS") },
+            { new Mode("SIN") },
+            { new Mode("TAN") },
+            { new Mode("COT") },
+            { new Mode("ACOS") },
+            { new Mode("ASIN") },
+            { new Mode("ATAN") },
+            { new Mode("EXP") },
+            { new Mode("LN") },
+            { new Mode("LOG10") },
+            { new Mode("DEGREES") },
+            { new Mode("RADIANS") },
+        });
+    }
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn((byte) 1, 1d);
+        checkColumn((short) 1, 1d);
+        checkColumn(1, 1d);
+        checkColumn(1L, 1d);
+        checkColumn(1f, 1d);
+        checkColumn(1d, 1d);
+        checkColumn(BigInteger.ONE, 1d);
+        checkColumn(new BigDecimal("1.1"), 1.1d);
+
+        checkColumn("1", 1d);
+        checkColumn('1', 1d);
+
+        map.clear();
+        map.put(0, new ExpressionValue.IntegerVal());
+        assertNull(execute("field1"));
+
+        checkColumnFailure("bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure('b', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure(new ExpressionValue.ObjectVal(), SqlErrorCode.PARSING, "Cannot apply '" + mode.mode + "' to arguments of type '" + mode.mode + "(<OBJECT>)'");
+    }
+
+    private void checkColumn(Object value, double expectedArgument) {
+        map.clear();
+        map.put(0, value);
+
+        double res = execute("this");
+        assertEquals(res, mode.process(expectedArgument), 0.0d);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        map.clear();
+        map.put(0, value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    @Test
+    public void testParameter() {
+        map.put(0, 0);
+
+        checkParameter((byte) 1, 1d);
+        checkParameter((short) 1, 1d);
+        checkParameter(1, 1d);
+        checkParameter(1L, 1d);
+        checkParameter(1f, 1d);
+        checkParameter(1d, 1d);
+        checkParameter(BigInteger.ONE, 1d);
+        checkParameter(new BigDecimal("1.1"), 1.1d);
+
+        checkParameter("1.1", 1.1d);
+        checkParameter('1', 1d);
+
+        assertNull(execute("?", new Object[] { null }));
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+    }
+
+    private void checkParameter(Object param, double expectedArgument) {
+        double res = execute("?", param);
+        assertEquals(res, mode.process(expectedArgument), 0.0d);
+    }
+
+    @Test
+    public void testLiteral() {
+        map.put(0, 0);
+
+        checkLiteral(0, 0d);
+        checkLiteral("1.1", 1.1d);
+        checkLiteral("'1.1'", 1.1d);
+
+        checkLiteral("null", null);
+
+        checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    private void checkLiteral(Object literal, Double expectedArg) {
+        String literalString = literal.toString();
+
+        Double res1 = execute(literalString);
+        assertEquals(res1, mode.process(expectedArg));
+    }
+
+    private Double execute(Object operand, Object... params) {
+        String sql = "SELECT " + mode.mode + "(" + operand + ") FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(SqlColumnType.DOUBLE, row.getMetadata().getColumn(0).getType());
+
+        return row.getObject(0);
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT " + mode.mode + "(" + operand + ") FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private static final class Mode {
+
+        private final String mode;
+
+        private Mode(String mode) {
+            this.mode = mode;
+        }
+
+        public Double process(Double arg) {
+            if (arg == null) {
+                return null;
+            }
+
+            switch (mode) {
+                case "COS":
+                    return Math.cos(arg);
+
+                case "SIN":
+                    return Math.sin(arg);
+
+                case "TAN":
+                    return Math.tan(arg);
+
+                case "COT":
+                    return 1.0d / Math.tan(arg);
+
+                case "ACOS":
+                    return Math.acos(arg);
+
+                case "ASIN":
+                    return Math.asin(arg);
+
+                case "ATAN":
+                    return Math.atan(arg);
+
+                case "EXP":
+                    return Math.exp(arg);
+
+                case "LN":
+                    return Math.log(arg);
+
+                case "LOG10":
+                    return Math.log10(arg);
+
+                case "DEGREES":
+                    return Math.toDegrees(arg);
+
+                case "RADIANS":
+                    return Math.toRadians(arg);
+
+                default:
+                    throw new UnsupportedOperationException("Unsupported mode: " + mode);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return mode;
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.sql.impl.SqlTestSupport.checkEquals;
+import static com.hazelcast.sql.impl.SqlTestSupport.serializeAndCheck;
+import static com.hazelcast.sql.impl.expression.math.DoubleFunction.COS;
+import static com.hazelcast.sql.impl.expression.math.DoubleFunction.SIN;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DoubleFunctionTest {
+    @Test
+    public void testEquals() {
+        DoubleFunction function = DoubleFunction.create(ConstantExpression.create(1, QueryDataType.INT), COS);
+
+        checkEquals(function, DoubleFunction.create(ConstantExpression.create(1, QueryDataType.INT), COS), true);
+        checkEquals(function, DoubleFunction.create(ConstantExpression.create(2, QueryDataType.INT), COS), false);
+        checkEquals(function, DoubleFunction.create(ConstantExpression.create(1, QueryDataType.INT), SIN), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        DoubleFunction original = DoubleFunction.create(ConstantExpression.create(1, QueryDataType.INT), COS);
+        DoubleFunction restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_DOUBLE);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorCeilFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorCeilFunctionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.sql.impl.type.QueryDataType.BIGINT;
+import static com.hazelcast.sql.impl.type.QueryDataType.DECIMAL;
+import static com.hazelcast.sql.impl.type.QueryDataType.DECIMAL_BIG_INTEGER;
+import static com.hazelcast.sql.impl.type.QueryDataType.DOUBLE;
+import static com.hazelcast.sql.impl.type.QueryDataType.INT;
+import static com.hazelcast.sql.impl.type.QueryDataType.REAL;
+import static com.hazelcast.sql.impl.type.QueryDataType.SMALLINT;
+import static com.hazelcast.sql.impl.type.QueryDataType.TINYINT;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class FloorCeilFunctionTest extends SqlTestSupport {
+    @Test
+    public void testEquals() {
+        Expression<?> function = FloorCeilFunction.create(ConstantExpression.create(1, DECIMAL), DECIMAL, true);
+
+        checkEquals(function, FloorCeilFunction.create(ConstantExpression.create(1, DECIMAL), DECIMAL, true), true);
+        checkEquals(function, FloorCeilFunction.create(ConstantExpression.create(2, DECIMAL), DECIMAL, true), false);
+        checkEquals(function, FloorCeilFunction.create(ConstantExpression.create(1, DECIMAL), DECIMAL, false), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        Expression<?> original = FloorCeilFunction.create(ConstantExpression.create(1, DECIMAL), DECIMAL, true);
+        Expression<?> restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_FLOOR_CEIL);
+
+        checkEquals(original, restored, true);
+    }
+
+    @Test
+    public void testSimplification() {
+        checkSimplified(FloorCeilFunction.create(ConstantExpression.create(null, TINYINT), TINYINT, true));
+        checkSimplified(FloorCeilFunction.create(ConstantExpression.create(null, SMALLINT), SMALLINT, true));
+        checkSimplified(FloorCeilFunction.create(ConstantExpression.create(null, INT), INT, true));
+        checkSimplified(FloorCeilFunction.create(ConstantExpression.create(null, BIGINT), BIGINT, true));
+
+        checkNotSimplified(FloorCeilFunction.create(ConstantExpression.create(null, DECIMAL_BIG_INTEGER), DECIMAL_BIG_INTEGER, true));
+        checkNotSimplified(FloorCeilFunction.create(ConstantExpression.create(null, DECIMAL), DECIMAL, true));
+
+        checkNotSimplified(FloorCeilFunction.create(ConstantExpression.create(null, REAL), REAL, true));
+        checkNotSimplified(FloorCeilFunction.create(ConstantExpression.create(null, DOUBLE), DOUBLE, true));
+
+        checkNotSimplified(FloorCeilFunction.create(ConstantExpression.create(null, TINYINT), DECIMAL, true));
+    }
+
+    private void checkNotSimplified(Expression<?> expression) {
+        assertEquals(FloorCeilFunction.class, expression.getClass());
+    }
+
+    private void checkSimplified(Expression<?> expression) {
+        assertEquals(ConstantExpression.class, expression.getClass());
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
@@ -110,6 +110,7 @@ public class FloorFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
 
         checkLiteral("null", SqlColumnType.DECIMAL, null);
         checkLiteral("1.1", SqlColumnType.DECIMAL, new BigDecimal("1"));
+        checkLiteral("'1.1'", SqlColumnType.DECIMAL, new BigDecimal("1"));
         checkLiteral("1.1E0", SqlColumnType.DOUBLE, 1d);
 
         checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class FloorFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn((byte) 1, SqlColumnType.TINYINT, (byte) 1);
+        checkColumn((short) 1, SqlColumnType.SMALLINT, (short) 1);
+        checkColumn(1, SqlColumnType.INTEGER, 1);
+        checkColumn(1L, SqlColumnType.BIGINT, 1L);
+        checkColumn(1.1f, SqlColumnType.REAL, 1f);
+        checkColumn(1.1d, SqlColumnType.DOUBLE, 1d);
+        checkColumn(BigInteger.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn(new BigDecimal("1.1"), SqlColumnType.DECIMAL, BigDecimal.ONE);
+
+        checkColumn("1.1", SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn('1', SqlColumnType.DECIMAL, BigDecimal.ONE);
+
+        checkColumn(Float.POSITIVE_INFINITY, SqlColumnType.REAL, Float.POSITIVE_INFINITY);
+        checkColumn(Float.NEGATIVE_INFINITY, SqlColumnType.REAL, Float.NEGATIVE_INFINITY);
+        checkColumn(Float.NaN, SqlColumnType.REAL, Float.NaN);
+
+        checkColumn(Double.POSITIVE_INFINITY, SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
+        checkColumn(Double.NEGATIVE_INFINITY, SqlColumnType.DOUBLE, Double.NEGATIVE_INFINITY);
+        checkColumn(Double.NaN, SqlColumnType.DOUBLE, Double.NaN);
+
+        map.clear();
+        map.put(0, new ExpressionValue.IntegerVal());
+        assertNull(execute("field1", SqlColumnType.INTEGER));
+
+        checkColumnFailure("bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure('b', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure(new ExpressionValue.ObjectVal(), SqlErrorCode.PARSING, "Cannot apply 'FLOOR' to arguments of type 'FLOOR(<OBJECT>)'");
+    }
+
+    private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
+        map.clear();
+        map.put(0, value);
+
+        Object res = execute("this", expectedType);
+        assertEquals(expectedResult, res);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        map.clear();
+        map.put(0, value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    @Test
+    public void testParameter() {
+        map.put(0, 0);
+
+        checkParameter((byte) 1, BigDecimal.ONE);
+        checkParameter((short) 1, BigDecimal.ONE);
+        checkParameter(1, BigDecimal.ONE);
+        checkParameter(1L, BigDecimal.ONE);
+        checkParameter(1.1f, BigDecimal.ONE);
+        checkParameter(1.1d, BigDecimal.ONE);
+        checkParameter(BigInteger.ONE, BigDecimal.ONE);
+        checkParameter(new BigDecimal("1.1"), BigDecimal.ONE);
+
+        checkParameter("1.1", BigDecimal.ONE);
+        checkParameter('1', BigDecimal.ONE);
+
+        assertNull(execute("?", SqlColumnType.DECIMAL, new Object[] { null }));
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+    }
+
+    private void checkParameter(Object param, Object expectedResult) {
+        Object res = execute("?", SqlColumnType.DECIMAL, param);
+        assertEquals(res, expectedResult);
+    }
+
+    @Test
+    public void testLiteral() {
+        map.put(0, 0);
+
+        checkLiteral(1, SqlColumnType.TINYINT, (byte) 1);
+
+        checkLiteral("null", SqlColumnType.DECIMAL, null);
+        checkLiteral("1.1", SqlColumnType.DECIMAL, new BigDecimal("1"));
+        checkLiteral("1.1E0", SqlColumnType.DOUBLE, 1d);
+
+        checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    private void checkLiteral(Object literal, SqlColumnType expectedType, Object expectedResult) {
+        String literalString = literal.toString();
+
+        Object res1 = execute(literalString, expectedType);
+        assertEquals(res1, expectedResult);
+    }
+
+    private Object execute(Object operand, SqlColumnType expectedType, Object... params) {
+        String sql = "SELECT FLOOR(" + operand + ") FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+
+        return row.getObject(0);
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT FLOOR(" + operand + ") FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
@@ -16,55 +16,23 @@
 
 package com.hazelcast.sql.impl.expression.math;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
-import com.hazelcast.sql.SqlRow;
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-@SuppressWarnings({"unchecked", "rawtypes"})
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class FloorFunctionIntegrationTest extends SqlTestSupport {
-
-    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
-    private HazelcastInstance member;
-    private IMap map;
-
-    @Before
-    public void before() {
-        member = factory.newHazelcastInstance();
-
-        map = member.getMap("map");
-    }
-
-    @After
-    public void after() {
-        factory.shutdownAll();
-    }
-
+public class FloorFunctionIntegrationTest extends SqlExpressionIntegrationTestSupport {
     @Test
     public void testColumn() {
         checkColumn((byte) 1, SqlColumnType.TINYINT, (byte) 1);
@@ -87,9 +55,8 @@ public class FloorFunctionIntegrationTest extends SqlTestSupport {
         checkColumn(Double.NEGATIVE_INFINITY, SqlColumnType.DOUBLE, Double.NEGATIVE_INFINITY);
         checkColumn(Double.NaN, SqlColumnType.DOUBLE, Double.NaN);
 
-        map.clear();
-        map.put(0, new ExpressionValue.IntegerVal());
-        assertNull(execute("field1", SqlColumnType.INTEGER));
+        put(new ExpressionValue.IntegerVal());
+        checkValue("field1", SqlColumnType.INTEGER, null);
 
         checkColumnFailure("bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
         checkColumnFailure('b', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
@@ -97,23 +64,20 @@ public class FloorFunctionIntegrationTest extends SqlTestSupport {
     }
 
     private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
-        map.clear();
-        map.put(0, value);
+        put(value);
 
-        Object res = execute("this", expectedType);
-        assertEquals(expectedResult, res);
+        checkValue("this", expectedType, expectedResult);
     }
 
     private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
-        map.clear();
-        map.put(0, value);
+        put(value);
 
         checkFailure("this", expectedErrorCode, expectedErrorMessage);
     }
 
     @Test
     public void testParameter() {
-        map.put(0, 0);
+        put(0);
 
         checkParameter((byte) 1, BigDecimal.ONE);
         checkParameter((short) 1, BigDecimal.ONE);
@@ -127,7 +91,7 @@ public class FloorFunctionIntegrationTest extends SqlTestSupport {
         checkParameter("1.1", BigDecimal.ONE);
         checkParameter('1', BigDecimal.ONE);
 
-        assertNull(execute("?", SqlColumnType.DECIMAL, new Object[] { null }));
+        checkValue("?", SqlColumnType.DECIMAL, null, new Object[] { null });
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
@@ -135,13 +99,12 @@ public class FloorFunctionIntegrationTest extends SqlTestSupport {
     }
 
     private void checkParameter(Object param, Object expectedResult) {
-        Object res = execute("?", SqlColumnType.DECIMAL, param);
-        assertEquals(res, expectedResult);
+        checkValue("?", SqlColumnType.DECIMAL, expectedResult, param);
     }
 
     @Test
     public void testLiteral() {
-        map.put(0, 0);
+        put(0);
 
         checkLiteral(1, SqlColumnType.TINYINT, (byte) 1);
 
@@ -155,36 +118,18 @@ public class FloorFunctionIntegrationTest extends SqlTestSupport {
     private void checkLiteral(Object literal, SqlColumnType expectedType, Object expectedResult) {
         String literalString = literal.toString();
 
-        Object res1 = execute(literalString, expectedType);
-        assertEquals(res1, expectedResult);
+        checkValue(literalString, expectedType, expectedResult);
     }
 
-    private Object execute(Object operand, SqlColumnType expectedType, Object... params) {
+    private void checkValue(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
         String sql = "SELECT FLOOR(" + operand + ") FROM map";
 
-        List<SqlRow> rows = execute(member, sql, params);
-        assertEquals(1, rows.size());
-
-        SqlRow row = rows.get(0);
-        assertEquals(1, row.getMetadata().getColumnCount());
-        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
-
-        return row.getObject(0);
+        checkValueInternal(sql, expectedType, expectedValue, params);
     }
 
     private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
         String sql = "SELECT FLOOR(" + operand + ") FROM map";
 
-        try {
-            execute(member, sql, params);
-
-            fail("Must fail");
-        } catch (SqlException e) {
-            assertTrue(expectedErrorMessage.length() != 0);
-            assertNotNull(e.getMessage());
-            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
-
-            assertEquals(expectedErrorCode, e.getCode());
-        }
+        checkFailureInternal(sql, expectedErrorCode, expectedErrorMessage, params);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -126,9 +126,9 @@ public class RandFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
         double nullRes2 = checkValue("?", SKIP_VALUE_CHECK, new Object[] { null });
         assertNotEquals(nullRes1, nullRes2);
 
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BIGINT", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BIGINT", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to BIGINT", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object param, long expectedSeed) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RandFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testNoArg() {
+        map.put(0, 0);
+
+        double res1 = execute("");
+        double res2 = execute("");
+
+        assertNotEquals(res1, res2);
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn((byte) 1, 1L);
+        checkColumn((short) 1, 1L);
+        checkColumn(1, 1L);
+        checkColumn(1L, 1L);
+        checkColumn(1f, 1L);
+        checkColumn(1d, 1L);
+        checkColumn(BigInteger.ONE, 1L);
+        checkColumn(BigDecimal.ONE, 1L);
+
+        checkColumn("1", 1L);
+        checkColumn('1', 1L);
+
+        map.clear();
+        map.put(0, new ExpressionValue.IntegerVal());
+        double nullRes1 = execute("field1");
+        double nullRes2 = execute("field1");
+        assertNotEquals(nullRes1, nullRes2);
+
+        checkColumnFailure("bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure('b', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure(new ExpressionValue.ObjectVal(), SqlErrorCode.PARSING, "Cannot apply 'RAND' to arguments of type 'RAND(<OBJECT>)'");
+    }
+
+    private void checkColumn(Object value, long expectedSeed) {
+        map.clear();
+        map.put(0, value);
+
+        double res1 = execute("this");
+        assertEquals(res1, new Random(expectedSeed).nextDouble(), 0.0d);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        map.clear();
+        map.put(0, value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    @Test
+    public void testParameter() {
+        map.put(0, 0);
+
+        checkParameter((byte) 1, 1L);
+        checkParameter((short) 1, 1L);
+        checkParameter(1, 1L);
+        checkParameter(1L, 1L);
+        checkParameter(1f, 1L);
+        checkParameter(1d, 1L);
+        checkParameter(BigInteger.ONE, 1L);
+        checkParameter(BigDecimal.ONE, 1L);
+
+        checkParameter("1", 1L);
+        checkParameter('1', 1L);
+
+        double nullRes1 = execute("?", new Object[] { null });
+        double nullRes2 = execute("?", new Object[] { null });
+        assertNotEquals(nullRes1, nullRes2);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+    }
+
+    private void checkParameter(Object param, long expectedSeed) {
+        double res = execute("?", param);
+        assertEquals(res, new Random(expectedSeed).nextDouble(), 0.0d);
+    }
+
+    @Test
+    public void testLiteral() {
+        map.put(0, 0);
+
+        checkNumericLiteral(0, 0L);
+        checkNumericLiteral(Long.MAX_VALUE, Long.MAX_VALUE);
+        checkNumericLiteral("1.1", 1L);
+
+        double nullRes1 = execute("null");
+        double nullRes2 = execute("null");
+        assertNotEquals(nullRes1, nullRes2);
+
+        checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    private void checkNumericLiteral(Object literal, long expectedSeed) {
+        String literalString = literal.toString();
+
+        double res1 = execute(literalString);
+        assertEquals(res1, new Random(expectedSeed).nextDouble(), 0.0d);
+
+        double res2 = execute("'" +  literalString + "'");
+        assertEquals(res2, new Random(expectedSeed).nextDouble(), 0.0d);
+    }
+
+    private Double execute(Object operand, Object... params) {
+        String sql = "SELECT RAND(" + operand + ") FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(SqlColumnType.DOUBLE, row.getMetadata().getColumn(0).getType());
+
+        return row.getObject(0);
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT RAND(" + operand + ") FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -53,18 +53,21 @@ public class RandFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
     }
 
     @Test
-    public void testSeveralRows() {
+    public void testMultipleCallsInSingleQuery() {
         putAll(0, 1, 2, 3);
 
-        List<SqlRow> rows = execute(member, "SELECT RAND() FROM map");
+        List<SqlRow> rows = execute(member, "SELECT RAND(), RAND() FROM map");
         assertEquals(4, rows.size());
 
         Set<Double> values = new HashSet<>();
 
         for (SqlRow row : rows) {
-            double value = row.getObject(0);
+            double value1 = row.getObject(0);
+            double value2 = row.getObject(1);
 
-            values.add(value);
+            assertNotEquals(value1, value2);
+
+            values.add(value1);
         }
 
         assertTrue(values.size() > 1);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -29,9 +30,14 @@ import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -44,6 +50,24 @@ public class RandFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
         double res2 = checkValue("", SKIP_VALUE_CHECK);
 
         assertNotEquals(res1, res2);
+    }
+
+    @Test
+    public void testSeveralRows() {
+        putAll(0, 1, 2, 3);
+
+        List<SqlRow> rows = execute(member, "SELECT RAND() FROM map");
+        assertEquals(4, rows.size());
+
+        Set<Double> values = new HashSet<>();
+
+        for (SqlRow row : rows) {
+            double value = row.getObject(0);
+
+            values.add(value);
+        }
+
+        assertTrue(values.size() > 1);
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RandFunctionTest extends SqlTestSupport {
+    @Test
+    public void testEquals() {
+        RandFunction function = RandFunction.create(ConstantExpression.create(1, QueryDataType.INT));
+
+        checkEquals(function, RandFunction.create(ConstantExpression.create(1, QueryDataType.INT)), true);
+        checkEquals(function, RandFunction.create(ConstantExpression.create(2, QueryDataType.INT)), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        RandFunction original = RandFunction.create(ConstantExpression.create(1, QueryDataType.INT));
+        RandFunction restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_RAND);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.LongIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.ShortIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.sql.support.expressions.ExpressionValue.BigIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.ByteVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.IntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.LongVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.ShortVal;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigDecimalVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.DoubleIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.DoubleVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatVal;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RoundFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap<Integer, ExpressionValue> map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void test_byte() {
+        checkColumn_1(new ByteVal().field1((byte) 127), SqlColumnType.TINYINT, (byte) 127);
+        checkColumn_1(new ByteVal().field1((byte) -128), SqlColumnType.TINYINT, (byte) -128);
+
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, 1), SqlColumnType.TINYINT, (byte) 127);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, 0), SqlColumnType.TINYINT, (byte) 127);
+        checkColumnFailure_2(new ByteIntegerVal().fields((byte) 127, -1), SqlErrorCode.DATA_EXCEPTION, "TINYINT overflow in ROUND function (consider adding an explicit CAST to SMALLINT)");
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -2), SqlColumnType.TINYINT, (byte) 100);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -3), SqlColumnType.TINYINT, (byte) 0);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -4), SqlColumnType.TINYINT, (byte) 0);
+
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, 1), SqlColumnType.TINYINT, (byte) -128);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, 0), SqlColumnType.TINYINT, (byte) -128);
+        checkColumnFailure_2(new ByteIntegerVal().fields((byte) -128, -1), SqlErrorCode.DATA_EXCEPTION, "TINYINT overflow in ROUND function (consider adding an explicit CAST to SMALLINT)");
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -2), SqlColumnType.TINYINT, (byte) -100);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -3), SqlColumnType.TINYINT, (byte) 0);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -4), SqlColumnType.TINYINT, (byte) 0);
+    }
+
+    @Test
+    public void test_short() {
+        checkColumn_1(new ShortVal().field1((short) 32767), SqlColumnType.SMALLINT, (short) 32767);
+        checkColumn_1(new ShortVal().field1((short) -32768), SqlColumnType.SMALLINT, (short) -32768);
+
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, 1), SqlColumnType.SMALLINT, (short) 32767);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, 0), SqlColumnType.SMALLINT, (short) 32767);
+        checkColumnFailure_2(new ShortIntegerVal().fields((short) 32767, -1), SqlErrorCode.DATA_EXCEPTION, "SMALLINT overflow in ROUND function (consider adding an explicit CAST to INT)");
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, -4), SqlColumnType.SMALLINT, (short) 30000);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, -5), SqlColumnType.SMALLINT, (short) 0);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, -6), SqlColumnType.SMALLINT, (short) 0);
+
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, 1), SqlColumnType.SMALLINT, (short) -32768);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, 0), SqlColumnType.SMALLINT, (short) -32768);
+        checkColumnFailure_2(new ShortIntegerVal().fields((short) -32768, -1), SqlErrorCode.DATA_EXCEPTION, "SMALLINT overflow in ROUND function (consider adding an explicit CAST to INT)");
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, -4), SqlColumnType.SMALLINT, (short) -30000);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, -5), SqlColumnType.SMALLINT, (short) 0);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, -6), SqlColumnType.SMALLINT, (short) 0);
+    }
+
+    @Test
+    public void test_int() {
+        checkColumn_1(new IntegerVal().field1(2_147_483_647), SqlColumnType.INTEGER, 2_147_483_647);
+        checkColumn_1(new IntegerVal().field1(-2_147_483_648), SqlColumnType.INTEGER, -2_147_483_648);
+
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, 1), SqlColumnType.INTEGER, 2_147_483_647);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, 0), SqlColumnType.INTEGER, 2_147_483_647);
+        checkColumnFailure_2(new IntegerIntegerVal().fields(2_147_483_647, -1), SqlErrorCode.DATA_EXCEPTION, "INT overflow in ROUND function (consider adding an explicit CAST to BIGINT)");
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -2), SqlColumnType.INTEGER, 2_147_483_600);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -10), SqlColumnType.INTEGER, 0);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -11), SqlColumnType.INTEGER, 0);
+
+        checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, 1), SqlColumnType.INTEGER, -2_147_483_648);
+        checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, 0), SqlColumnType.INTEGER, -2_147_483_648);
+        checkColumnFailure_2(new IntegerIntegerVal().fields(-2_147_483_648, -1), SqlErrorCode.DATA_EXCEPTION, "INT overflow in ROUND function (consider adding an explicit CAST to BIGINT)");
+        checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, -2), SqlColumnType.INTEGER, -2_147_483_600);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -10), SqlColumnType.INTEGER, 0);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -11), SqlColumnType.INTEGER, 0);
+    }
+
+    @Test
+    public void test_long() {
+        checkColumn_1(new LongVal().field1(9_223_372_036_854_775_807L), SqlColumnType.BIGINT, 9_223_372_036_854_775_807L);
+        checkColumn_1(new LongVal().field1(-9_223_372_036_854_775_808L), SqlColumnType.BIGINT, -9_223_372_036_854_775_808L);
+
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, 1), SqlColumnType.BIGINT, 9_223_372_036_854_775_807L);
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, 0), SqlColumnType.BIGINT, 9_223_372_036_854_775_807L);
+        checkColumnFailure_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -1), SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ROUND function (consider adding an explicit CAST to DECIMAL)");
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -2), SqlColumnType.BIGINT, 9_223_372_036_854_775_800L);
+        checkColumnFailure_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -19), SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ROUND function (consider adding an explicit CAST to DECIMAL)");
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -20), SqlColumnType.BIGINT, 0L);
+
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, 1), SqlColumnType.BIGINT, -9_223_372_036_854_775_808L);
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, 0), SqlColumnType.BIGINT, -9_223_372_036_854_775_808L);
+        checkColumnFailure_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -1), SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ROUND function (consider adding an explicit CAST to DECIMAL)");
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -2), SqlColumnType.BIGINT, -9_223_372_036_854_775_800L);
+        checkColumnFailure_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -19), SqlErrorCode.DATA_EXCEPTION, "BIGINT overflow in ROUND function (consider adding an explicit CAST to DECIMAL)");
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -20), SqlColumnType.BIGINT, 0L);
+    }
+
+    @Test
+    public void test_BigInteger() {
+        checkColumn_1(new BigIntegerVal().field1(new BigInteger("15")), SqlColumnType.DECIMAL, new BigDecimal("15"));
+        checkColumn_1(new BigIntegerVal().field1(new BigInteger("-15")), SqlColumnType.DECIMAL, new BigDecimal("-15"));
+
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("15"), -1), SqlColumnType.DECIMAL, new BigDecimal("20"));
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("15"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("-15"), -1), SqlColumnType.DECIMAL, new BigDecimal("-20"));
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("-15"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+    }
+
+    @Test
+    public void test_BigDecimal() {
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("15.4")), SqlColumnType.DECIMAL, new BigDecimal("15"));
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("15.5")), SqlColumnType.DECIMAL, new BigDecimal("16"));
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("-15.4")), SqlColumnType.DECIMAL, new BigDecimal("-15"));
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("-15.5")), SqlColumnType.DECIMAL, new BigDecimal("-16"));
+
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("15.5"), -1), SqlColumnType.DECIMAL, new BigDecimal("20"));
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("15.5"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("-15.5"), -1), SqlColumnType.DECIMAL, new BigDecimal("-20"));
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("-15.5"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+    }
+
+    @Test
+    public void test_float() {
+        checkColumn_1(new FloatVal().field1(15.4f), SqlColumnType.REAL, 15f);
+        checkColumn_1(new FloatVal().field1(15.5f), SqlColumnType.REAL, 16f);
+        checkColumn_1(new FloatVal().field1(-15.4f), SqlColumnType.REAL, -15f);
+        checkColumn_1(new FloatVal().field1(-15.5f), SqlColumnType.REAL, -16f);
+
+        checkColumn_2(new FloatIntegerVal().fields(15.5f, -1), SqlColumnType.REAL, 20f);
+        checkColumn_2(new FloatIntegerVal().fields(15.5f, -2), SqlColumnType.REAL, 0f);
+
+        checkColumn_2(new FloatIntegerVal().fields(-15.5f, -1), SqlColumnType.REAL, -20f);
+        checkColumn_2(new FloatIntegerVal().fields(-15.5f, -2), SqlColumnType.REAL, 0f);
+
+        checkColumn_2(new FloatIntegerVal().fields(Float.POSITIVE_INFINITY, -1), SqlColumnType.REAL, Float.POSITIVE_INFINITY);
+        checkColumn_2(new FloatIntegerVal().fields(Float.NEGATIVE_INFINITY, -1), SqlColumnType.REAL, Float.NEGATIVE_INFINITY);
+        checkColumn_2(new FloatIntegerVal().fields(Float.NaN, -1), SqlColumnType.REAL, Float.NaN);
+    }
+
+    @Test
+    public void test_double() {
+        checkColumn_1(new DoubleVal().field1(15.4d), SqlColumnType.DOUBLE, 15d);
+        checkColumn_1(new DoubleVal().field1(15.5d), SqlColumnType.DOUBLE, 16d);
+        checkColumn_1(new DoubleVal().field1(-15.4d), SqlColumnType.DOUBLE, -15d);
+        checkColumn_1(new DoubleVal().field1(-15.5d), SqlColumnType.DOUBLE, -16d);
+
+        checkColumn_2(new DoubleIntegerVal().fields(15.5d, -1), SqlColumnType.DOUBLE, 20d);
+        checkColumn_2(new DoubleIntegerVal().fields(15.5d, -2), SqlColumnType.DOUBLE, 0d);
+
+        checkColumn_2(new DoubleIntegerVal().fields(-15.5d, -1), SqlColumnType.DOUBLE, -20d);
+        checkColumn_2(new DoubleIntegerVal().fields(-15.5d, -2), SqlColumnType.DOUBLE, 0d);
+
+        checkColumn_2(new DoubleIntegerVal().fields(Double.POSITIVE_INFINITY, -1), SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
+        checkColumn_2(new DoubleIntegerVal().fields(Double.NEGATIVE_INFINITY, -1), SqlColumnType.DOUBLE, Double.NEGATIVE_INFINITY);
+        checkColumn_2(new DoubleIntegerVal().fields(Double.NaN, -1), SqlColumnType.DOUBLE, Double.NaN);
+    }
+
+    @Test
+    public void testParameters() {
+        // One operand
+        putValue(new IntegerVal().field1(0));
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), (byte) 10);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), (short) 10);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("9.5"));
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5f);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5d);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), "9.5");
+        checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
+
+        // Two operands, first operand
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), (byte) 10);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), (short) 10);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("9.5"));
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5f);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5d);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), "9.5");
+        checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
+
+        // Two operands, second operand
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, (byte) -1);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, (short) -1);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, -1);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, -1L);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, new BigInteger("-1"));
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, new BigDecimal("-1"));
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, "-1");
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to INT", "bad");
+
+        // Two operands, both
+        check_2("?", "?", SqlColumnType.DECIMAL, new BigDecimal("20"), 15, -1);
+    }
+
+    @Test
+    public void testLiterals() {
+        // Single operand
+        putValue(new IntegerVal().field1(0));
+
+        check_1("null", SqlColumnType.DECIMAL, null);
+
+        check_1("15.1", SqlColumnType.DECIMAL, new BigDecimal("15"));
+        check_1("15.5", SqlColumnType.DECIMAL, new BigDecimal("16"));
+        check_1("-15.1", SqlColumnType.DECIMAL, new BigDecimal("-15"));
+        check_1("-15.5", SqlColumnType.DECIMAL, new BigDecimal("-16"));
+
+        check_1("15.1E0", SqlColumnType.DOUBLE, 15d);
+        check_1("15.5E0", SqlColumnType.DOUBLE, 16d);
+        check_1("-15.1E0", SqlColumnType.DOUBLE, -15d);
+        check_1("-15.5E0", SqlColumnType.DOUBLE, -16d);
+
+        // First operand
+        putValue(new IntegerVal().field1(-1));
+        check_2("15", "field1", SqlColumnType.TINYINT, (byte) 20);
+        check_2("'15'", "field1", SqlColumnType.DECIMAL, new BigDecimal("20"));
+        check_2("15.1", "field1", SqlColumnType.DECIMAL, new BigDecimal("20"));
+        check_2("'15.1'", "field1", SqlColumnType.DECIMAL, new BigDecimal("20"));
+        checkFailure_2("'bad'", "field1", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+
+        // Second operand
+        putValue(new IntegerVal().field1(15));
+        check_2("field1", "-1", SqlColumnType.INTEGER, 20);
+        check_2("field1", "'-1'", SqlColumnType.INTEGER, 20);
+        checkFailure_2("field1", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    private void checkColumn_1(ExpressionValue value, SqlColumnType expectedType, Object expectedValue) {
+        putValue(value);
+
+        check_1("field1", expectedType, expectedValue);
+    }
+
+    private void checkColumn_2(ExpressionBiValue value, SqlColumnType expectedType, Object expectedValue) {
+        putValue(value);
+
+        check_2("field1", "field2", expectedType, expectedValue);
+    }
+
+    private void checkColumnFailure_2(ExpressionBiValue value, int expectedErrorCode, String expectedErrorMessage) {
+        try {
+            checkColumn_2(value, null, null);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void checkFailure_1(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        try {
+            check_1(operand, null, null, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void checkFailure_2(Object operand1, Object operand2, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        try {
+            check_2(operand1, operand2, null, null, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void putValue(ExpressionValue value) {
+        map.clear();
+        map.put(0, value);
+    }
+
+    private void check_1(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        check(sql(operand), expectedType, expectedValue, params);
+    }
+
+    private void check_2(Object operand1, Object operand2, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        check(sql(operand1, operand2), expectedType, expectedValue, params);
+    }
+
+    private void check(String sql, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+
+        if (expectedType != null) {
+            assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+            assertEquals(expectedValue, row.getObject(0));
+        }
+    }
+
+    private static String sql(Object operand1, Object... operand2) {
+        assert operand2 == null || operand2.length <= 1;
+
+        if (operand2 != null && operand2.length == 1) {
+            return "SELECT ROUND(" + operand1 + ", " + operand2[0] + ") FROM map";
+        } else {
+            return "SELECT ROUND(" + operand1 + ") FROM map";
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -53,6 +53,12 @@ import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatVal;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSupport {
     @Test
+    public void testLengthOverflow() {
+        put(new ExpressionBiValue.IntegerLongVal().fields(1, Long.MAX_VALUE));
+        checkFailure_2("field1", "field2", SqlErrorCode.DATA_EXCEPTION, "Cannot convert the second operand of ROUND function to INT");
+    }
+
+    @Test
     public void test_byte() {
         checkColumn_1(new ByteVal().field1((byte) 127), SqlColumnType.TINYINT, (byte) 127);
         checkColumn_1(new ByteVal().field1((byte) -128), SqlColumnType.TINYINT, (byte) -128);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerObjectVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.LongIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ShortIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
@@ -191,6 +192,11 @@ public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
         checkColumn_2(new DoubleIntegerVal().fields(Double.POSITIVE_INFINITY, -1), SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
         checkColumn_2(new DoubleIntegerVal().fields(Double.NEGATIVE_INFINITY, -1), SqlColumnType.DOUBLE, Double.NEGATIVE_INFINITY);
         checkColumn_2(new DoubleIntegerVal().fields(Double.NaN, -1), SqlColumnType.DOUBLE, Double.NaN);
+    }
+
+    @Test
+    public void test_object() {
+        checkColumnFailure_2(new IntegerObjectVal().fields(127, "bad"), SqlErrorCode.PARSING, "Cannot apply 'ROUND' to arguments of type 'ROUND(<INTEGER>, <OBJECT>)'");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunctionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.sql.impl.type.QueryDataType.BIGINT;
+import static com.hazelcast.sql.impl.type.QueryDataType.DECIMAL;
+import static com.hazelcast.sql.impl.type.QueryDataType.DOUBLE;
+import static com.hazelcast.sql.impl.type.QueryDataType.INT;
+import static com.hazelcast.sql.impl.type.QueryDataType.REAL;
+import static com.hazelcast.sql.impl.type.QueryDataType.SMALLINT;
+import static com.hazelcast.sql.impl.type.QueryDataType.TINYINT;
+import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RoundTruncateFunctionTest extends SqlTestSupport {
+    @Test
+    public void testEquals() {
+        ConstantExpression<?> const1 = ConstantExpression.create(1, INT);
+        ConstantExpression<?> const2 = ConstantExpression.create(2, INT);
+        ConstantExpression<?> constOther = ConstantExpression.create(3, INT);
+
+        Expression<?> function = RoundTruncateFunction.create(const1, const2, INT, true);
+
+        checkEquals(function, RoundTruncateFunction.create(const1, const2, INT, true), true);
+        checkEquals(function, RoundTruncateFunction.create(constOther, const2, INT, true), false);
+        checkEquals(function, RoundTruncateFunction.create(const1, constOther, INT, true), false);
+        checkEquals(function, RoundTruncateFunction.create(const1, const2, BIGINT, true), false);
+        checkEquals(function, RoundTruncateFunction.create(const1, const2, INT, false), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        ConstantExpression<?> const1 = ConstantExpression.create(1, INT);
+        ConstantExpression<?> const2 = ConstantExpression.create(2, INT);
+
+        Expression<?> original = RoundTruncateFunction.create(const1, const2, DECIMAL, true);
+        RoundTruncateFunction<?> restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_ROUND_TRUNCATE);
+
+        checkEquals(original, restored, true);
+    }
+
+    @Test
+    public void testSimplification() {
+        // Without the second operand
+        checkSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, TINYINT), null, TINYINT, true));
+        checkSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, SMALLINT), null, SMALLINT, true));
+        checkSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, INT), null, INT, true));
+        checkSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, BIGINT), null, BIGINT, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DECIMAL), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, REAL), null, REAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DOUBLE), null, DOUBLE, true));
+
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, TINYINT), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, SMALLINT), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, INT), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, BIGINT), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DECIMAL), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, REAL), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DOUBLE), null, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, VARCHAR), null, DECIMAL, true));
+
+        // With second operand
+        ConstantExpression<?> len = ConstantExpression.create(1, INT);
+
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, TINYINT), len, TINYINT, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, SMALLINT), len, SMALLINT, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, INT), len, INT, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, BIGINT), len, BIGINT, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DECIMAL), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, REAL), len, REAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DOUBLE), len, DOUBLE, true));
+
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, TINYINT), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, SMALLINT), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, INT), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, BIGINT), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DECIMAL), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, REAL), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DOUBLE), len, DECIMAL, true));
+        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, VARCHAR), len, DECIMAL, true));
+    }
+
+    private void checkNotSimplified(Expression<?> expression) {
+        assertEquals(RoundTruncateFunction.class, expression.getClass());
+    }
+
+    private void checkSimplified(Expression<?> expression) {
+        assertEquals(ConstantExpression.class, expression.getClass());
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunctionTest.java
@@ -77,15 +77,6 @@ public class RoundTruncateFunctionTest extends SqlTestSupport {
         checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, REAL), null, REAL, true));
         checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DOUBLE), null, DOUBLE, true));
 
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, TINYINT), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, SMALLINT), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, INT), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, BIGINT), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DECIMAL), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, REAL), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, DOUBLE), null, DECIMAL, true));
-        checkNotSimplified(RoundTruncateFunction.create(ConstantExpression.create(null, VARCHAR), null, DECIMAL, true));
-
         // With second operand
         ConstantExpression<?> len = ConstantExpression.create(1, INT);
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SignFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn((byte) 0, SqlColumnType.TINYINT, (byte) 0);
+        checkColumn((byte) 1, SqlColumnType.TINYINT, (byte) 1);
+        checkColumn((byte) -1, SqlColumnType.TINYINT, (byte) -1);
+        checkColumn(Byte.MAX_VALUE, SqlColumnType.TINYINT, (byte) 1);
+        checkColumn(Byte.MIN_VALUE, SqlColumnType.TINYINT, (byte) -1);
+
+        checkColumn((short) 0, SqlColumnType.SMALLINT, (short) 0);
+        checkColumn((short) 1, SqlColumnType.SMALLINT, (short) 1);
+        checkColumn((short) -1, SqlColumnType.SMALLINT, (short) -1);
+        checkColumn(Short.MAX_VALUE, SqlColumnType.SMALLINT, (short) 1);
+        checkColumn(Short.MIN_VALUE, SqlColumnType.SMALLINT, (short) -1);
+
+        checkColumn(0, SqlColumnType.INTEGER, 0);
+        checkColumn(1, SqlColumnType.INTEGER, 1);
+        checkColumn(-1, SqlColumnType.INTEGER, -1);
+        checkColumn(Integer.MAX_VALUE, SqlColumnType.INTEGER, 1);
+        checkColumn(Integer.MIN_VALUE, SqlColumnType.INTEGER, -1);
+
+        checkColumn(0L, SqlColumnType.BIGINT, 0L);
+        checkColumn(1L, SqlColumnType.BIGINT, 1L);
+        checkColumn(-1L, SqlColumnType.BIGINT, -1L);
+        checkColumn(Long.MAX_VALUE, SqlColumnType.BIGINT, 1L);
+        checkColumn(Long.MIN_VALUE, SqlColumnType.BIGINT, -1L);
+
+        checkColumn(BigInteger.ZERO, SqlColumnType.DECIMAL, BigDecimal.ZERO);
+        checkColumn(BigInteger.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn(BigInteger.ONE.negate(), SqlColumnType.DECIMAL, BigDecimal.ONE.negate());
+
+        checkColumn(BigDecimal.ZERO, SqlColumnType.DECIMAL, BigDecimal.ZERO);
+        checkColumn(BigDecimal.ONE, SqlColumnType.DECIMAL, BigDecimal.ONE);
+        checkColumn(BigDecimal.ONE.negate(), SqlColumnType.DECIMAL, BigDecimal.ONE.negate());
+
+        checkColumn(0f, SqlColumnType.REAL, 0f);
+        checkColumn(1.1f, SqlColumnType.REAL, 1f);
+        checkColumn(-1.1f, SqlColumnType.REAL, -1f);
+        checkColumn(Float.POSITIVE_INFINITY, SqlColumnType.REAL, 1f);
+        checkColumn(Float.NEGATIVE_INFINITY, SqlColumnType.REAL, -1f);
+        checkColumn(Float.NaN, SqlColumnType.REAL, Float.NaN);
+
+        checkColumn(0d, SqlColumnType.DOUBLE, 0d);
+        checkColumn(1.1d, SqlColumnType.DOUBLE, 1d);
+        checkColumn(-1.1d, SqlColumnType.DOUBLE, -1d);
+        checkColumn(Double.POSITIVE_INFINITY, SqlColumnType.DOUBLE, 1d);
+        checkColumn(Double.NEGATIVE_INFINITY, SqlColumnType.DOUBLE, -1d);
+        checkColumn(Double.NaN, SqlColumnType.DOUBLE, Double.NaN);
+
+        checkColumn("0", SqlColumnType.DECIMAL, BigDecimal.ZERO);
+        checkColumn("1.1", SqlColumnType.DECIMAL, new BigDecimal("1"));
+        checkColumn("-1.1", SqlColumnType.DECIMAL, new BigDecimal("-1"));
+        checkColumnFailure("a", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+        checkColumnFailure('a', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+
+        checkColumnFailure(new ExpressionValue.ObjectVal(), SqlErrorCode.PARSING, "Cannot apply 'SIGN' to arguments of type 'SIGN(<OBJECT>)'");
+    }
+
+    private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
+        map.clear();
+        map.put(0, value);
+
+        check("this", expectedType, expectedResult);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        map.clear();
+        map.put(0, value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    @Test
+    public void testParameter() {
+        map.put(0, 0);
+
+        BigDecimal zero = BigDecimal.ZERO;
+        BigDecimal positive = BigDecimal.ONE;
+        BigDecimal negative = BigDecimal.ONE.negate();
+
+        checkParameter((byte) 0, zero);
+        checkParameter((byte) 1, positive);
+        checkParameter((byte) -1, negative);
+        checkParameter(Byte.MAX_VALUE, positive);
+        checkParameter(Byte.MIN_VALUE, negative);
+        checkParameter(Byte.toString(Byte.MAX_VALUE), positive);
+        checkParameter(Byte.toString(Byte.MIN_VALUE), negative);
+
+        checkParameter((short) 0, zero);
+        checkParameter((short) 1, positive);
+        checkParameter((short) -1, negative);
+        checkParameter(Short.MAX_VALUE, positive);
+        checkParameter(Short.MIN_VALUE, negative);
+        checkParameter(Short.toString(Short.MAX_VALUE), positive);
+        checkParameter(Short.toString(Short.MIN_VALUE), negative);
+
+        checkParameter(0, zero);
+        checkParameter(1, positive);
+        checkParameter(-1, negative);
+        checkParameter(Integer.MAX_VALUE, positive);
+        checkParameter(Integer.MIN_VALUE, negative);
+        checkParameter(Integer.toString(Integer.MAX_VALUE), positive);
+        checkParameter(Integer.toString(Integer.MIN_VALUE), negative);
+
+        checkParameter(0L, zero);
+        checkParameter(1L, positive);
+        checkParameter(-1L, negative);
+        checkParameter(Long.MAX_VALUE, positive);
+        checkParameter(Long.MIN_VALUE, negative);
+        checkParameter(Long.toString(Long.MAX_VALUE), positive);
+        checkParameter(Long.toString(Long.MIN_VALUE), negative);
+
+        checkParameter(BigInteger.ZERO, zero);
+        checkParameter(BigInteger.ONE, positive);
+        checkParameter(BigInteger.ONE.negate(), negative);
+
+        checkParameter(BigDecimal.ZERO, zero);
+        checkParameter(BigDecimal.ONE, positive);
+        checkParameter(BigDecimal.ONE.negate(), negative);
+        checkParameter(new BigDecimal("1.1"), positive);
+        checkParameter(new BigDecimal("-1.1"), negative);
+        checkParameter("1.1", positive);
+        checkParameter("-1.1", negative);
+
+        checkParameter(0f, zero);
+        checkParameter(1f, positive);
+        checkParameter(-1f, negative);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.POSITIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.NEGATIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN REAL value to DECIMAL", Float.NaN);
+
+        checkParameter(0d, zero);
+        checkParameter(1d, positive);
+        checkParameter(-1d, negative);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.POSITIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.NEGATIVE_INFINITY);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN DOUBLE value to DECIMAL", Double.NaN);
+
+        checkParameter('0', zero);
+        checkParameter('1', positive);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+    }
+
+    private void checkParameter(Object parameterValue, Object expectedValue) {
+        check("?", SqlColumnType.DECIMAL, expectedValue, parameterValue);
+    }
+
+    @Test
+    public void testLiteral() {
+        map.put(0, 0);
+
+        checkExactLiteral(0, SqlColumnType.TINYINT, (byte) 0);
+        checkExactLiteral(1, SqlColumnType.TINYINT, (byte) 1);
+        checkExactLiteral(-1, SqlColumnType.TINYINT, (byte) -1);
+        checkExactLiteral(Byte.MAX_VALUE, SqlColumnType.TINYINT, (byte) 1);
+        checkExactLiteral(Byte.MIN_VALUE, SqlColumnType.TINYINT, (byte) -1);
+        checkExactLiteral(Short.MAX_VALUE, SqlColumnType.SMALLINT, (short) 1);
+        checkExactLiteral(Short.MIN_VALUE, SqlColumnType.SMALLINT, (short) -1);
+        checkExactLiteral(Integer.MAX_VALUE, SqlColumnType.INTEGER, 1);
+        checkExactLiteral(Integer.MIN_VALUE, SqlColumnType.INTEGER, -1);
+        checkExactLiteral(Long.MAX_VALUE, SqlColumnType.BIGINT, 1L);
+        checkExactLiteral(Long.MIN_VALUE, SqlColumnType.BIGINT, -1L);
+
+        check("null", SqlColumnType.DECIMAL, null);
+        checkExactLiteral("1.1", SqlColumnType.DECIMAL, new BigDecimal("1"));
+        checkExactLiteral("0.0", SqlColumnType.DECIMAL, new BigDecimal("0"));
+        checkExactLiteral("-1.1", SqlColumnType.DECIMAL, new BigDecimal("-1"));
+
+        checkInexactLiteral("1.1E0", SqlColumnType.DOUBLE, 1.0d);
+        checkInexactLiteral("0.0E0", SqlColumnType.DOUBLE, 0d);
+        checkInexactLiteral("-1.1E0", SqlColumnType.DOUBLE, -1.0d);
+
+        checkFailure("'a'", SqlErrorCode.PARSING, "Literal ''a'' can not be parsed to type 'DECIMAL'");
+        checkFailure("true", SqlErrorCode.PARSING, "Cannot apply 'SIGN' to arguments of type 'SIGN(<BOOLEAN>)'");
+        checkFailure("false", SqlErrorCode.PARSING, "Cannot apply 'SIGN' to arguments of type 'SIGN(<BOOLEAN>)'");
+    }
+
+    private void checkExactLiteral(Object literal, SqlColumnType expectedType, Object expectedValue) {
+        String literalString = literal.toString();
+
+        check(literalString, expectedType, expectedValue);
+        check("'" + literalString + "'", SqlColumnType.DECIMAL, new BigDecimal(expectedValue.toString()));
+    }
+
+    private void checkInexactLiteral(Object literal, SqlColumnType expectedType, double expectedValue) {
+        String literalString = literal.toString();
+
+        check(literalString, expectedType, expectedValue);
+    }
+
+    private void check(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        String sql = "SELECT SIGN(" + operand + ") FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+        assertEquals(expectedValue, row.getObject(0));
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT SIGN(" + operand + ") FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage.length() != 0);
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
+
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SignFunctionTest extends SqlTestSupport {
+    @Test
+    public void testEquals() {
+        SignFunction<?> function = SignFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.INT);
+
+        checkEquals(function, SignFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.INT), true);
+        checkEquals(function, SignFunction.create(ConstantExpression.create(2, QueryDataType.INT), QueryDataType.INT), false);
+        checkEquals(function, SignFunction.create(ConstantExpression.create(1, QueryDataType.BIGINT), QueryDataType.BIGINT), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        SignFunction<?> original = SignFunction.create(ConstantExpression.create(1, QueryDataType.INT), QueryDataType.INT);
+        SignFunction<?> restored = serializeAndCheck(original, SqlDataSerializerHook.EXPRESSION_SIGN);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerObjectVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.LongIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ShortIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
@@ -229,6 +230,11 @@ public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTes
     }
 
     @Test
+    public void test_object() {
+        checkColumnFailure_2(new IntegerObjectVal().fields(127, "bad"), SqlErrorCode.PARSING, "Cannot apply 'TRUNCATE' to arguments of type 'TRUNCATE(<INTEGER>, <OBJECT>)'");
+    }
+
+    @Test
     public void testLiterals() {
         // Single operand
         put(new IntegerVal().field1(0));
@@ -270,6 +276,14 @@ public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTes
         put(value);
 
         check_2("field1", "field2", expectedType, expectedValue);
+    }
+
+    private void checkColumnFailure_2(ExpressionBiValue value, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+
+        String sql = sql("field1", "field2");
+
+        checkFailureInternal(sql, expectedErrorCode, expectedErrorMessage);
     }
 
     private void checkFailure_1(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -53,6 +53,12 @@ import static com.hazelcast.sql.support.expressions.ExpressionValue.FloatVal;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTestSupport {
     @Test
+    public void testLengthOverflow() {
+        put(new ExpressionBiValue.IntegerLongVal().fields(1, Long.MAX_VALUE));
+        checkFailure_2("field1", "field2", SqlErrorCode.DATA_EXCEPTION, "Cannot convert the second operand of TRUNCATE function to INT");
+    }
+
+    @Test
     public void test_byte() {
         checkColumn_1(new ByteVal().field1((byte) 127), SqlColumnType.TINYINT, (byte) 127);
         checkColumn_1(new ByteVal().field1((byte) -128), SqlColumnType.TINYINT, (byte) -128);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.LongIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.ShortIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.sql.support.expressions.ExpressionValue.BigIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.ByteVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.IntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.LongVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue.ShortVal;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.DoubleIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatIntegerVal;
+import static com.hazelcast.sql.support.expressions.ExpressionValue.BigDecimalVal;
+import static com.hazelcast.sql.support.expressions.ExpressionValue.DoubleVal;
+import static com.hazelcast.sql.support.expressions.ExpressionValue.FloatVal;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class TruncateFunctionIntegrationTest extends SqlTestSupport {
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+    private HazelcastInstance member;
+    private IMap<Integer, ExpressionValue> map;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+
+        map = member.getMap("map");
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void test_byte() {
+        checkColumn_1(new ByteVal().field1((byte) 127), SqlColumnType.TINYINT, (byte) 127);
+        checkColumn_1(new ByteVal().field1((byte) -128), SqlColumnType.TINYINT, (byte) -128);
+
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, 1), SqlColumnType.TINYINT, (byte) 127);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, 0), SqlColumnType.TINYINT, (byte) 127);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -1), SqlColumnType.TINYINT, (byte) 120);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -2), SqlColumnType.TINYINT, (byte) 100);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -3), SqlColumnType.TINYINT, (byte) 0);
+        checkColumn_2(new ByteIntegerVal().fields((byte) 127, -4), SqlColumnType.TINYINT, (byte) 0);
+
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, 1), SqlColumnType.TINYINT, (byte) -128);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, 0), SqlColumnType.TINYINT, (byte) -128);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -1), SqlColumnType.TINYINT, (byte) -120);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -2), SqlColumnType.TINYINT, (byte) -100);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -3), SqlColumnType.TINYINT, (byte) 0);
+        checkColumn_2(new ByteIntegerVal().fields((byte) -128, -4), SqlColumnType.TINYINT, (byte) 0);
+    }
+
+    @Test
+    public void test_short() {
+        checkColumn_1(new ShortVal().field1((short) 32767), SqlColumnType.SMALLINT, (short) 32767);
+        checkColumn_1(new ShortVal().field1((short) -32768), SqlColumnType.SMALLINT, (short) -32768);
+
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, 1), SqlColumnType.SMALLINT, (short) 32767);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, 0), SqlColumnType.SMALLINT, (short) 32767);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, -1), SqlColumnType.SMALLINT, (short) 32760);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, -5), SqlColumnType.SMALLINT, (short) 0);
+        checkColumn_2(new ShortIntegerVal().fields((short) 32767, -6), SqlColumnType.SMALLINT, (short) 0);
+
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, 1), SqlColumnType.SMALLINT, (short) -32768);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, 0), SqlColumnType.SMALLINT, (short) -32768);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, -1), SqlColumnType.SMALLINT, (short) -32760);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, -5), SqlColumnType.SMALLINT, (short) 0);
+        checkColumn_2(new ShortIntegerVal().fields((short) -32768, -6), SqlColumnType.SMALLINT, (short) 0);
+    }
+
+    @Test
+    public void test_int() {
+        checkColumn_1(new IntegerVal().field1(2_147_483_647), SqlColumnType.INTEGER, 2_147_483_647);
+        checkColumn_1(new IntegerVal().field1(-2_147_483_648), SqlColumnType.INTEGER, -2_147_483_648);
+
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, 1), SqlColumnType.INTEGER, 2_147_483_647);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, 0), SqlColumnType.INTEGER, 2_147_483_647);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -1), SqlColumnType.INTEGER, 2_147_483_640);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -10), SqlColumnType.INTEGER, 0);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -11), SqlColumnType.INTEGER, 0);
+
+        checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, 1), SqlColumnType.INTEGER, -2_147_483_648);
+        checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, 0), SqlColumnType.INTEGER, -2_147_483_648);
+        checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, -1), SqlColumnType.INTEGER, -2_147_483_640);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -10), SqlColumnType.INTEGER, 0);
+        checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -11), SqlColumnType.INTEGER, 0);
+    }
+
+    @Test
+    public void test_long() {
+        checkColumn_1(new LongVal().field1(9_223_372_036_854_775_807L), SqlColumnType.BIGINT, 9_223_372_036_854_775_807L);
+        checkColumn_1(new LongVal().field1(-9_223_372_036_854_775_808L), SqlColumnType.BIGINT, -9_223_372_036_854_775_808L);
+
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, 1), SqlColumnType.BIGINT, 9_223_372_036_854_775_807L);
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, 0), SqlColumnType.BIGINT, 9_223_372_036_854_775_807L);
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -1), SqlColumnType.BIGINT, 9_223_372_036_854_775_800L);
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -19), SqlColumnType.BIGINT, 0L);
+        checkColumn_2(new LongIntegerVal().fields(9_223_372_036_854_775_807L, -20), SqlColumnType.BIGINT, 0L);
+
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, 1), SqlColumnType.BIGINT, -9_223_372_036_854_775_808L);
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, 0), SqlColumnType.BIGINT, -9_223_372_036_854_775_808L);
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -1), SqlColumnType.BIGINT, -9_223_372_036_854_775_800L);
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -19), SqlColumnType.BIGINT, 0L);
+        checkColumn_2(new LongIntegerVal().fields(-9_223_372_036_854_775_808L, -20), SqlColumnType.BIGINT, 0L);
+    }
+
+    @Test
+    public void test_BigInteger() {
+        checkColumn_1(new BigIntegerVal().field1(new BigInteger("15")), SqlColumnType.DECIMAL, new BigDecimal("15"));
+        checkColumn_1(new BigIntegerVal().field1(new BigInteger("-15")), SqlColumnType.DECIMAL, new BigDecimal("-15"));
+
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("15"), -1), SqlColumnType.DECIMAL, new BigDecimal("10"));
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("15"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("-15"), -1), SqlColumnType.DECIMAL, new BigDecimal("-10"));
+        checkColumn_2(new BigIntegerIntegerVal().fields(new BigInteger("-15"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+    }
+
+    @Test
+    public void test_BigDecimal() {
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("15.4")), SqlColumnType.DECIMAL, new BigDecimal("15"));
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("15.5")), SqlColumnType.DECIMAL, new BigDecimal("15"));
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("-15.4")), SqlColumnType.DECIMAL, new BigDecimal("-15"));
+        checkColumn_1(new BigDecimalVal().field1(new BigDecimal("-15.5")), SqlColumnType.DECIMAL, new BigDecimal("-15"));
+
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("15.5"), -1), SqlColumnType.DECIMAL, new BigDecimal("10"));
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("15.5"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("-15.5"), -1), SqlColumnType.DECIMAL, new BigDecimal("-10"));
+        checkColumn_2(new BigDecimalIntegerVal().fields(new BigDecimal("-15.5"), -2), SqlColumnType.DECIMAL, new BigDecimal("0"));
+    }
+
+    @Test
+    public void test_float() {
+        checkColumn_1(new FloatVal().field1(15.4f), SqlColumnType.REAL, 15f);
+        checkColumn_1(new FloatVal().field1(15.5f), SqlColumnType.REAL, 15f);
+        checkColumn_1(new FloatVal().field1(-15.4f), SqlColumnType.REAL, -15f);
+        checkColumn_1(new FloatVal().field1(-15.5f), SqlColumnType.REAL, -15f);
+
+        checkColumn_2(new FloatIntegerVal().fields(15.5f, -1), SqlColumnType.REAL, 10f);
+        checkColumn_2(new FloatIntegerVal().fields(15.5f, -2), SqlColumnType.REAL, 0f);
+
+        checkColumn_2(new FloatIntegerVal().fields(-15.5f, -1), SqlColumnType.REAL, -10f);
+        checkColumn_2(new FloatIntegerVal().fields(-15.5f, -2), SqlColumnType.REAL, 0f);
+
+        checkColumn_2(new FloatIntegerVal().fields(Float.POSITIVE_INFINITY, -1), SqlColumnType.REAL, Float.POSITIVE_INFINITY);
+        checkColumn_2(new FloatIntegerVal().fields(Float.NEGATIVE_INFINITY, -1), SqlColumnType.REAL, Float.NEGATIVE_INFINITY);
+        checkColumn_2(new FloatIntegerVal().fields(Float.NaN, -1), SqlColumnType.REAL, Float.NaN);
+    }
+
+    @Test
+    public void test_double() {
+        checkColumn_1(new DoubleVal().field1(15.4d), SqlColumnType.DOUBLE, 15d);
+        checkColumn_1(new DoubleVal().field1(15.5d), SqlColumnType.DOUBLE, 15d);
+        checkColumn_1(new DoubleVal().field1(-15.4d), SqlColumnType.DOUBLE, -15d);
+        checkColumn_1(new DoubleVal().field1(-15.5d), SqlColumnType.DOUBLE, -15d);
+
+        checkColumn_2(new DoubleIntegerVal().fields(15.5d, -1), SqlColumnType.DOUBLE, 10d);
+        checkColumn_2(new DoubleIntegerVal().fields(15.5d, -2), SqlColumnType.DOUBLE, 0d);
+
+        checkColumn_2(new DoubleIntegerVal().fields(-15.5d, -1), SqlColumnType.DOUBLE, -10d);
+        checkColumn_2(new DoubleIntegerVal().fields(-15.5d, -2), SqlColumnType.DOUBLE, 0d);
+
+        checkColumn_2(new DoubleIntegerVal().fields(Double.POSITIVE_INFINITY, -1), SqlColumnType.DOUBLE, Double.POSITIVE_INFINITY);
+        checkColumn_2(new DoubleIntegerVal().fields(Double.NEGATIVE_INFINITY, -1), SqlColumnType.DOUBLE, Double.NEGATIVE_INFINITY);
+        checkColumn_2(new DoubleIntegerVal().fields(Double.NaN, -1), SqlColumnType.DOUBLE, Double.NaN);
+    }
+
+    @Test
+    public void testParameters() {
+        // One operand
+        putValue(new IntegerVal().field1(0));
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), (byte) 10);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), (short) 10);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("10.5"));
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5f);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5d);
+        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), "10.5");
+        checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
+
+        // Two operands, first operand
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), (byte) 10);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), (short) 10);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("10.5"));
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5f);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5d);
+        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), "10.5");
+        checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
+
+        // Two operands, second operand
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, (byte) -1);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, (short) -1);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, -1);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, -1L);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, new BigInteger("-1"));
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, new BigDecimal("-1"));
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, "-1");
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to INT", "bad");
+
+        // Two operands, both
+        check_2("?", "?", SqlColumnType.DECIMAL, new BigDecimal("10"), 15, -1);
+    }
+
+    @Test
+    public void testLiterals() {
+        // Single operand
+        putValue(new IntegerVal().field1(0));
+
+        check_1("null", SqlColumnType.DECIMAL, null);
+
+        check_1("15.1", SqlColumnType.DECIMAL, new BigDecimal("15"));
+        check_1("15.5", SqlColumnType.DECIMAL, new BigDecimal("15"));
+        check_1("-15.1", SqlColumnType.DECIMAL, new BigDecimal("-15"));
+        check_1("-15.5", SqlColumnType.DECIMAL, new BigDecimal("-15"));
+
+        check_1("15.1E0", SqlColumnType.DOUBLE, 15d);
+        check_1("15.5E0", SqlColumnType.DOUBLE, 15d);
+        check_1("-15.1E0", SqlColumnType.DOUBLE, -15d);
+        check_1("-15.5E0", SqlColumnType.DOUBLE, -15d);
+
+        // First operand
+        putValue(new IntegerVal().field1(-1));
+        check_2("15", "field1", SqlColumnType.TINYINT, (byte) 10);
+        check_2("'15'", "field1", SqlColumnType.DECIMAL, new BigDecimal("10"));
+        check_2("15.1", "field1", SqlColumnType.DECIMAL, new BigDecimal("10"));
+        check_2("'15.1'", "field1", SqlColumnType.DECIMAL, new BigDecimal("10"));
+        checkFailure_2("'bad'", "field1", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+
+        // Second operand
+        putValue(new IntegerVal().field1(15));
+        check_2("field1", "-1", SqlColumnType.INTEGER, 10);
+        check_2("field1", "'-1'", SqlColumnType.INTEGER, 10);
+        checkFailure_2("field1", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    private void checkColumn_1(ExpressionValue value, SqlColumnType expectedType, Object expectedValue) {
+        putValue(value);
+
+        check_1("field1", expectedType, expectedValue);
+    }
+
+    private void checkColumn_2(ExpressionBiValue value, SqlColumnType expectedType, Object expectedValue) {
+        putValue(value);
+
+        check_2("field1", "field2", expectedType, expectedValue);
+    }
+
+    private void checkColumnFailure_2(ExpressionBiValue value, int expectedErrorCode, String expectedErrorMessage) {
+        try {
+            checkColumn_2(value, null, null);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void checkFailure_1(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        try {
+            check_1(operand, null, null, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void checkFailure_2(Object operand1, Object operand2, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        try {
+            check_2(operand1, operand2, null, null, params);
+
+            fail("Must fail");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void putValue(ExpressionValue value) {
+        map.clear();
+        map.put(0, value);
+    }
+
+    private void check_1(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        check(sql(operand), expectedType, expectedValue, params);
+    }
+
+    private void check_2(Object operand1, Object operand2, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        check(sql(operand1, operand2), expectedType, expectedValue, params);
+    }
+
+    private void check(String sql, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+
+        if (expectedType != null) {
+            assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
+            assertEquals(expectedValue, row.getObject(0));
+        }
+    }
+
+    private static String sql(Object operand1, Object... operand2) {
+        assert operand2 == null || operand2.length <= 1;
+
+        if (operand2 != null && operand2.length == 1) {
+            return "SELECT TRUNCATE(" + operand1 + ", " + operand2[0] + ") FROM map";
+        } else {
+            return "SELECT TRUNCATE(" + operand1 + ") FROM map";
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -16,13 +16,9 @@
 
 package com.hazelcast.sql.impl.expression.math;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
-import com.hazelcast.sql.SqlRow;
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.IntegerIntegerVal;
@@ -35,18 +31,14 @@ import com.hazelcast.sql.support.expressions.ExpressionValue.IntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.LongVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.ShortVal;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.List;
 
 import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
 import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
@@ -55,30 +47,10 @@ import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatInteg
 import static com.hazelcast.sql.support.expressions.ExpressionValue.BigDecimalVal;
 import static com.hazelcast.sql.support.expressions.ExpressionValue.DoubleVal;
 import static com.hazelcast.sql.support.expressions.ExpressionValue.FloatVal;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class TruncateFunctionIntegrationTest extends SqlTestSupport {
-
-    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
-    private HazelcastInstance member;
-    private IMap<Integer, ExpressionValue> map;
-
-    @Before
-    public void before() {
-        member = factory.newHazelcastInstance();
-
-        map = member.getMap("map");
-    }
-
-    @After
-    public void after() {
-        factory.shutdownAll();
-    }
-
+public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTestSupport {
     @Test
     public void test_byte() {
         checkColumn_1(new ByteVal().field1((byte) 127), SqlColumnType.TINYINT, (byte) 127);
@@ -218,7 +190,7 @@ public class TruncateFunctionIntegrationTest extends SqlTestSupport {
     @Test
     public void testParameters() {
         // One operand
-        putValue(new IntegerVal().field1(0));
+        put(new IntegerVal().field1(0));
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), (byte) 10);
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), (short) 10);
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10);
@@ -259,7 +231,7 @@ public class TruncateFunctionIntegrationTest extends SqlTestSupport {
     @Test
     public void testLiterals() {
         // Single operand
-        putValue(new IntegerVal().field1(0));
+        put(new IntegerVal().field1(0));
 
         check_1("null", SqlColumnType.DECIMAL, null);
 
@@ -274,7 +246,7 @@ public class TruncateFunctionIntegrationTest extends SqlTestSupport {
         check_1("-15.5E0", SqlColumnType.DOUBLE, -15d);
 
         // First operand
-        putValue(new IntegerVal().field1(-1));
+        put(new IntegerVal().field1(-1));
         check_2("15", "field1", SqlColumnType.TINYINT, (byte) 10);
         check_2("'15'", "field1", SqlColumnType.DECIMAL, new BigDecimal("10"));
         check_2("15.1", "field1", SqlColumnType.DECIMAL, new BigDecimal("10"));
@@ -282,87 +254,42 @@ public class TruncateFunctionIntegrationTest extends SqlTestSupport {
         checkFailure_2("'bad'", "field1", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
 
         // Second operand
-        putValue(new IntegerVal().field1(15));
+        put(new IntegerVal().field1(15));
         check_2("field1", "-1", SqlColumnType.INTEGER, 10);
         check_2("field1", "'-1'", SqlColumnType.INTEGER, 10);
         checkFailure_2("field1", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
     }
 
     private void checkColumn_1(ExpressionValue value, SqlColumnType expectedType, Object expectedValue) {
-        putValue(value);
+        put(value);
 
         check_1("field1", expectedType, expectedValue);
     }
 
     private void checkColumn_2(ExpressionBiValue value, SqlColumnType expectedType, Object expectedValue) {
-        putValue(value);
+        put(value);
 
         check_2("field1", "field2", expectedType, expectedValue);
     }
 
-    private void checkColumnFailure_2(ExpressionBiValue value, int expectedErrorCode, String expectedErrorMessage) {
-        try {
-            checkColumn_2(value, null, null);
-
-            fail("Must fail");
-        } catch (SqlException e) {
-            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
-
-            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
-            assertEquals(expectedErrorCode, e.getCode());
-        }
-    }
-
     private void checkFailure_1(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
-        try {
-            check_1(operand, null, null, params);
+        String sql = sql(operand);
 
-            fail("Must fail");
-        } catch (SqlException e) {
-            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
-
-            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
-            assertEquals(expectedErrorCode, e.getCode());
-        }
+        checkFailureInternal(sql, expectedErrorCode, expectedErrorMessage, params);
     }
 
     private void checkFailure_2(Object operand1, Object operand2, int expectedErrorCode, String expectedErrorMessage, Object... params) {
-        try {
-            check_2(operand1, operand2, null, null, params);
+        String sql = sql(operand1, operand2);
 
-            fail("Must fail");
-        } catch (SqlException e) {
-            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
-
-            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
-            assertEquals(expectedErrorCode, e.getCode());
-        }
-    }
-
-    private void putValue(ExpressionValue value) {
-        map.clear();
-        map.put(0, value);
+        checkFailureInternal(sql, expectedErrorCode, expectedErrorMessage, params);
     }
 
     private void check_1(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
-        check(sql(operand), expectedType, expectedValue, params);
+        checkValueInternal(sql(operand), expectedType, expectedValue, params);
     }
 
     private void check_2(Object operand1, Object operand2, SqlColumnType expectedType, Object expectedValue, Object... params) {
-        check(sql(operand1, operand2), expectedType, expectedValue, params);
-    }
-
-    private void check(String sql, SqlColumnType expectedType, Object expectedValue, Object... params) {
-        List<SqlRow> rows = execute(member, sql, params);
-        assertEquals(1, rows.size());
-
-        SqlRow row = rows.get(0);
-        assertEquals(1, row.getMetadata().getColumnCount());
-
-        if (expectedType != null) {
-            assertEquals(expectedType, row.getMetadata().getColumn(0).getType());
-            assertEquals(expectedValue, row.getObject(0));
-        }
+        checkValueInternal(sql(operand1, operand2), expectedType, expectedValue, params);
     }
 
     private static String sql(Object operand1, Object... operand2) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionBiValue.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionBiValue.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.support.expressions;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@SuppressWarnings({"unused", "unchecked", "checkstyle:MultipleVariableDeclarations"})
+public abstract class ExpressionBiValue extends ExpressionValue {
+    public static Class<? extends ExpressionBiValue> createBiClass(ExpressionType<?> type1, ExpressionType<?> type2) {
+        return createBiClass(type1.typeName(), type2.typeName());
+    }
+
+    public static Class<? extends ExpressionBiValue> createBiClass(String type1, String type2) {
+        try {
+            String className = ExpressionBiValue.class.getName() + "$" + type1 + type2 + "Val";
+
+            return (Class<? extends ExpressionBiValue>) Class.forName(className);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Cannot create " + ExpressionBiValue.class.getSimpleName() + " for types \""
+                + type1 + "\" and \"" + type2 + "\"", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends ExpressionBiValue> T createBiValue(Class<? extends ExpressionBiValue> clazz) {
+        try {
+            return (T) clazz.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to create an instance of " + clazz.getSimpleName());
+        }
+    }
+
+    public static <T extends ExpressionBiValue> T createBiValue(
+        Class<? extends ExpressionBiValue> clazz,
+        int key,
+        Object field1,
+        Object field2
+    ) {
+        T res = create(clazz);
+
+        res.key = key;
+        res.field1(field1);
+        res.field2(field2);
+
+        return res;
+    }
+
+    public Object field2() {
+        return getField("field2");
+    }
+
+    public ExpressionBiValue field2(Object value) {
+        setField("field2", value);
+
+        return this;
+    }
+
+    public ExpressionBiValue fields(Object value1, Object value2) {
+        field1(value1);
+        field2(value2);
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + field1() + ", " + field2() + "]";
+    }
+
+    public static class BooleanBooleanVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Boolean field2; }
+    public static class BooleanByteVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Byte field2; }
+    public static class BooleanShortVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Short field2; }
+    public static class BooleanIntegerVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Integer field2; }
+    public static class BooleanLongVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Long field2; }
+    public static class BooleanBigDecimalVal extends ExpressionBiValue implements Serializable { public Boolean field1; public BigDecimal field2; }
+    public static class BooleanBigIntegerVal extends ExpressionBiValue implements Serializable { public Boolean field1; public BigInteger field2; }
+    public static class BooleanFloatVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Float field2; }
+    public static class BooleanDoubleVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Double field2; }
+    public static class BooleanStringVal extends ExpressionBiValue implements Serializable { public Boolean field1; public String field2; }
+    public static class BooleanCharacterVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Character field2; }
+    public static class BooleanObjectVal extends ExpressionBiValue implements Serializable { public Boolean field1; public Object field2; }
+
+    public static class ByteBooleanVal extends ExpressionBiValue implements Serializable { public Byte field1; public Boolean field2; }
+    public static class ByteByteVal extends ExpressionBiValue implements Serializable { public Byte field1; public Byte field2; }
+    public static class ByteShortVal extends ExpressionBiValue implements Serializable { public Byte field1; public Short field2; }
+    public static class ByteIntegerVal extends ExpressionBiValue implements Serializable { public Byte field1; public Integer field2; }
+    public static class ByteLongVal extends ExpressionBiValue implements Serializable { public Byte field1; public Long field2; }
+    public static class ByteBigDecimalVal extends ExpressionBiValue implements Serializable { public Byte field1; public BigDecimal field2; }
+    public static class ByteBigIntegerVal extends ExpressionBiValue implements Serializable { public Byte field1; public BigInteger field2; }
+    public static class ByteFloatVal extends ExpressionBiValue implements Serializable { public Byte field1; public Float field2; }
+    public static class ByteDoubleVal extends ExpressionBiValue implements Serializable { public Byte field1; public Double field2; }
+    public static class ByteStringVal extends ExpressionBiValue implements Serializable { public Byte field1; public String field2; }
+    public static class ByteCharacterVal extends ExpressionBiValue implements Serializable { public Byte field1; public Character field2; }
+    public static class ByteObjectVal extends ExpressionBiValue implements Serializable { public Byte field1; public Object field2; }
+
+    public static class ShortBooleanVal extends ExpressionBiValue implements Serializable { public Short field1; public Boolean field2; }
+    public static class ShortByteVal extends ExpressionBiValue implements Serializable { public Short field1; public Byte field2; }
+    public static class ShortShortVal extends ExpressionBiValue implements Serializable { public Short field1; public Short field2; }
+    public static class ShortIntegerVal extends ExpressionBiValue implements Serializable { public Short field1; public Integer field2; }
+    public static class ShortLongVal extends ExpressionBiValue implements Serializable { public Short field1; public Long field2; }
+    public static class ShortBigDecimalVal extends ExpressionBiValue implements Serializable { public Short field1; public BigDecimal field2; }
+    public static class ShortBigIntegerVal extends ExpressionBiValue implements Serializable { public Short field1; public BigInteger field2; }
+    public static class ShortFloatVal extends ExpressionBiValue implements Serializable { public Short field1; public Float field2; }
+    public static class ShortDoubleVal extends ExpressionBiValue implements Serializable { public Short field1; public Double field2; }
+    public static class ShortStringVal extends ExpressionBiValue implements Serializable { public Short field1; public String field2; }
+    public static class ShortCharacterVal extends ExpressionBiValue implements Serializable { public Short field1; public Character field2; }
+    public static class ShortObjectVal extends ExpressionBiValue implements Serializable { public Short field1; public Object field2; }
+
+    public static class IntegerBooleanVal extends ExpressionBiValue implements Serializable { public Integer field1; public Boolean field2; }
+    public static class IntegerByteVal extends ExpressionBiValue implements Serializable { public Integer field1; public Byte field2; }
+    public static class IntegerShortVal extends ExpressionBiValue implements Serializable { public Integer field1; public Short field2; }
+    public static class IntegerIntegerVal extends ExpressionBiValue implements Serializable { public Integer field1; public Integer field2; }
+    public static class IntegerLongVal extends ExpressionBiValue implements Serializable { public Integer field1; public Long field2; }
+    public static class IntegerBigDecimalVal extends ExpressionBiValue implements Serializable { public Integer field1; public BigDecimal field2; }
+    public static class IntegerBigIntegerVal extends ExpressionBiValue implements Serializable { public Integer field1; public BigInteger field2; }
+    public static class IntegerFloatVal extends ExpressionBiValue implements Serializable { public Integer field1; public Float field2; }
+    public static class IntegerDoubleVal extends ExpressionBiValue implements Serializable { public Integer field1; public Double field2; }
+    public static class IntegerStringVal extends ExpressionBiValue implements Serializable { public Integer field1; public String field2; }
+    public static class IntegerCharacterVal extends ExpressionBiValue implements Serializable { public Integer field1; public Character field2; }
+    public static class IntegerObjectVal extends ExpressionBiValue implements Serializable { public Integer field1; public Object field2; }
+
+    public static class LongBooleanVal extends ExpressionBiValue implements Serializable { public Long field1; public Boolean field2; }
+    public static class LongByteVal extends ExpressionBiValue implements Serializable { public Long field1; public Byte field2; }
+    public static class LongShortVal extends ExpressionBiValue implements Serializable { public Long field1; public Short field2; }
+    public static class LongIntegerVal extends ExpressionBiValue implements Serializable { public Long field1; public Integer field2; }
+    public static class LongLongVal extends ExpressionBiValue implements Serializable { public Long field1; public Long field2; }
+    public static class LongBigDecimalVal extends ExpressionBiValue implements Serializable { public Long field1; public BigDecimal field2; }
+    public static class LongBigIntegerVal extends ExpressionBiValue implements Serializable { public Long field1; public BigInteger field2; }
+    public static class LongFloatVal extends ExpressionBiValue implements Serializable { public Long field1; public Float field2; }
+    public static class LongDoubleVal extends ExpressionBiValue implements Serializable { public Long field1; public Double field2; }
+    public static class LongStringVal extends ExpressionBiValue implements Serializable { public Long field1; public String field2; }
+    public static class LongCharacterVal extends ExpressionBiValue implements Serializable { public Long field1; public Character field2; }
+    public static class LongObjectVal extends ExpressionBiValue implements Serializable { public Long field1; public Object field2; }
+
+    public static class BigDecimalBooleanVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Boolean field2; }
+    public static class BigDecimalByteVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Byte field2; }
+    public static class BigDecimalShortVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Short field2; }
+    public static class BigDecimalIntegerVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Integer field2; }
+    public static class BigDecimalLongVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Long field2; }
+    public static class BigDecimalBigDecimalVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public BigDecimal field2; }
+    public static class BigDecimalBigIntegerVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public BigInteger field2; }
+    public static class BigDecimalFloatVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Float field2; }
+    public static class BigDecimalDoubleVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Double field2; }
+    public static class BigDecimalStringVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public String field2; }
+    public static class BigDecimalCharacterVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Character field2; }
+    public static class BigDecimalObjectVal extends ExpressionBiValue implements Serializable { public BigDecimal field1; public Object field2; }
+
+    public static class BigIntegerBooleanVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Boolean field2; }
+    public static class BigIntegerByteVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Byte field2; }
+    public static class BigIntegerShortVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Short field2; }
+    public static class BigIntegerIntegerVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Integer field2; }
+    public static class BigIntegerLongVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Long field2; }
+    public static class BigIntegerBigDecimalVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public BigDecimal field2; }
+    public static class BigIntegerBigIntegerVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public BigInteger field2; }
+    public static class BigIntegerFloatVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Float field2; }
+    public static class BigIntegerDoubleVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Double field2; }
+    public static class BigIntegerStringVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public String field2; }
+    public static class BigIntegerCharacterVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Character field2; }
+    public static class BigIntegerObjectVal extends ExpressionBiValue implements Serializable { public BigInteger field1; public Object field2; }
+
+    public static class FloatBooleanVal extends ExpressionBiValue implements Serializable { public Float field1; public Boolean field2; }
+    public static class FloatByteVal extends ExpressionBiValue implements Serializable { public Float field1; public Byte field2; }
+    public static class FloatShortVal extends ExpressionBiValue implements Serializable { public Float field1; public Short field2; }
+    public static class FloatIntegerVal extends ExpressionBiValue implements Serializable { public Float field1; public Integer field2; }
+    public static class FloatLongVal extends ExpressionBiValue implements Serializable { public Float field1; public Long field2; }
+    public static class FloatBigDecimalVal extends ExpressionBiValue implements Serializable { public Float field1; public BigDecimal field2; }
+    public static class FloatBigIntegerVal extends ExpressionBiValue implements Serializable { public Float field1; public BigInteger field2; }
+    public static class FloatFloatVal extends ExpressionBiValue implements Serializable { public Float field1; public Float field2; }
+    public static class FloatDoubleVal extends ExpressionBiValue implements Serializable { public Float field1; public Double field2; }
+    public static class FloatStringVal extends ExpressionBiValue implements Serializable { public Float field1; public String field2; }
+    public static class FloatCharacterVal extends ExpressionBiValue implements Serializable { public Float field1; public Character field2; }
+    public static class FloatObjectVal extends ExpressionBiValue implements Serializable { public Float field1; public Object field2; }
+
+    public static class DoubleBooleanVal extends ExpressionBiValue implements Serializable { public Double field1; public Boolean field2; }
+    public static class DoubleByteVal extends ExpressionBiValue implements Serializable { public Double field1; public Byte field2; }
+    public static class DoubleShortVal extends ExpressionBiValue implements Serializable { public Double field1; public Short field2; }
+    public static class DoubleIntegerVal extends ExpressionBiValue implements Serializable { public Double field1; public Integer field2; }
+    public static class DoubleLongVal extends ExpressionBiValue implements Serializable { public Double field1; public Long field2; }
+    public static class DoubleBigDecimalVal extends ExpressionBiValue implements Serializable { public Double field1; public BigDecimal field2; }
+    public static class DoubleBigIntegerVal extends ExpressionBiValue implements Serializable { public Double field1; public BigInteger field2; }
+    public static class DoubleFloatVal extends ExpressionBiValue implements Serializable { public Double field1; public Float field2; }
+    public static class DoubleDoubleVal extends ExpressionBiValue implements Serializable { public Double field1; public Double field2; }
+    public static class DoubleStringVal extends ExpressionBiValue implements Serializable { public Double field1; public String field2; }
+    public static class DoubleCharacterVal extends ExpressionBiValue implements Serializable { public Double field1; public Character field2; }
+    public static class DoubleObjectVal extends ExpressionBiValue implements Serializable { public Double field1; public Object field2; }
+
+    public static class StringBooleanVal extends ExpressionBiValue implements Serializable { public String field1; public Boolean field2; }
+    public static class StringByteVal extends ExpressionBiValue implements Serializable { public String field1; public Byte field2; }
+    public static class StringShortVal extends ExpressionBiValue implements Serializable { public String field1; public Short field2; }
+    public static class StringIntegerVal extends ExpressionBiValue implements Serializable { public String field1; public Integer field2; }
+    public static class StringLongVal extends ExpressionBiValue implements Serializable { public String field1; public Long field2; }
+    public static class StringBigDecimalVal extends ExpressionBiValue implements Serializable { public String field1; public BigDecimal field2; }
+    public static class StringBigIntegerVal extends ExpressionBiValue implements Serializable { public String field1; public BigInteger field2; }
+    public static class StringFloatVal extends ExpressionBiValue implements Serializable { public String field1; public Float field2; }
+    public static class StringDoubleVal extends ExpressionBiValue implements Serializable { public String field1; public Double field2; }
+    public static class StringStringVal extends ExpressionBiValue implements Serializable { public String field1; public String field2; }
+    public static class StringCharacterVal extends ExpressionBiValue implements Serializable { public String field1; public Character field2; }
+    public static class StringObjectVal extends ExpressionBiValue implements Serializable { public String field1; public Object field2; }
+
+    public static class CharacterBooleanVal extends ExpressionBiValue implements Serializable { public Character field1; public Boolean field2; }
+    public static class CharacterByteVal extends ExpressionBiValue implements Serializable { public Character field1; public Byte field2; }
+    public static class CharacterShortVal extends ExpressionBiValue implements Serializable { public Character field1; public Short field2; }
+    public static class CharacterIntegerVal extends ExpressionBiValue implements Serializable { public Character field1; public Integer field2; }
+    public static class CharacterLongVal extends ExpressionBiValue implements Serializable { public Character field1; public Long field2; }
+    public static class CharacterBigDecimalVal extends ExpressionBiValue implements Serializable { public Character field1; public BigDecimal field2; }
+    public static class CharacterBigIntegerVal extends ExpressionBiValue implements Serializable { public Character field1; public BigInteger field2; }
+    public static class CharacterFloatVal extends ExpressionBiValue implements Serializable { public Character field1; public Float field2; }
+    public static class CharacterDoubleVal extends ExpressionBiValue implements Serializable { public Character field1; public Double field2; }
+    public static class CharacterStringVal extends ExpressionBiValue implements Serializable { public Character field1; public String field2; }
+    public static class CharacterCharacterVal extends ExpressionBiValue implements Serializable { public Character field1; public Character field2; }
+    public static class CharacterObjectVal extends ExpressionBiValue implements Serializable { public Character field1; public Object field2; }
+
+    public static class ObjectBooleanVal extends ExpressionBiValue implements Serializable { public Object field1; public Boolean field2; }
+    public static class ObjectByteVal extends ExpressionBiValue implements Serializable { public Object field1; public Byte field2; }
+    public static class ObjectShortVal extends ExpressionBiValue implements Serializable { public Object field1; public Short field2; }
+    public static class ObjectIntegerVal extends ExpressionBiValue implements Serializable { public Object field1; public Integer field2; }
+    public static class ObjectLongVal extends ExpressionBiValue implements Serializable { public Object field1; public Long field2; }
+    public static class ObjectBigDecimalVal extends ExpressionBiValue implements Serializable { public Object field1; public BigDecimal field2; }
+    public static class ObjectBigIntegerVal extends ExpressionBiValue implements Serializable { public Object field1; public BigInteger field2; }
+    public static class ObjectFloatVal extends ExpressionBiValue implements Serializable { public Object field1; public Float field2; }
+    public static class ObjectDoubleVal extends ExpressionBiValue implements Serializable { public Object field1; public Double field2; }
+    public static class ObjectStringVal extends ExpressionBiValue implements Serializable { public Object field1; public String field2; }
+    public static class ObjectCharacterVal extends ExpressionBiValue implements Serializable { public Object field1; public Character field2; }
+    public static class ObjectObjectVal extends ExpressionBiValue implements Serializable { public Object field1; public Object field2; }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionPredicates.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionPredicates.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.support.expressions;
+
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertNotNull;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public final class ExpressionPredicates {
+    private ExpressionPredicates() {
+        // No-op.
+    }
+
+    public static Predicate<ExpressionValue> eq(Object operand) {
+        return new ComparePredicate(Comparison.EQ, operand, true);
+    }
+
+    public static Predicate<ExpressionValue> eq_2(Object operand) {
+        return new ComparePredicate(Comparison.EQ, operand, false);
+    }
+
+    public static Predicate<ExpressionValue> gt(Object operand) {
+        return new ComparePredicate(Comparison.GT, operand, true);
+    }
+
+    public static Predicate<ExpressionValue> gt_2(Object operand) {
+        return new ComparePredicate(Comparison.GT, operand, false);
+    }
+
+    public static Predicate<ExpressionValue> gte(Object operand) {
+        return new ComparePredicate(Comparison.GTE, operand, true);
+    }
+
+    public static Predicate<ExpressionValue> gte_2(Object operand) {
+        return new ComparePredicate(Comparison.GTE, operand, false);
+    }
+
+    public static Predicate<ExpressionValue> lt(Object operand) {
+        return new ComparePredicate(Comparison.LT, operand, true);
+    }
+
+    public static Predicate<ExpressionValue> lt_2(Object operand) {
+        return new ComparePredicate(Comparison.LT, operand, false);
+    }
+
+    public static Predicate<ExpressionValue> lte(Object operand) {
+        return new ComparePredicate(Comparison.LTE, operand, true);
+    }
+
+    public static Predicate<ExpressionValue> lte_2(Object operand) {
+        return new ComparePredicate(Comparison.LTE, operand, false);
+    }
+
+    public static Predicate<ExpressionValue> isNull() {
+        return new NullPredicate(true);
+    }
+
+    public static Predicate<ExpressionValue> isNull_2() {
+        return new NullPredicate(false);
+    }
+
+    public static Predicate<ExpressionValue> or(Predicate<ExpressionValue>... predicates) {
+        return new OrPredicate(predicates);
+    }
+
+    public static Predicate<ExpressionValue> and(Predicate<ExpressionValue>... predicates) {
+        return new AndPredicate(predicates);
+    }
+
+    private enum Comparison {
+        EQ, GT, GTE, LT, LTE
+    }
+
+    public static class ComparePredicate implements Predicate<ExpressionValue> {
+
+        private final Comparison comparison;
+        private final Object operand;
+        private final boolean firstField;
+
+        public ComparePredicate(Comparison comparison, Object operand, boolean firstField) {
+            assertNotNull("Use IsNullPredicate to compare with null", operand);
+
+            this.comparison = comparison;
+            this.operand = operand;
+            this.firstField = firstField;
+        }
+
+        @Override
+        public boolean test(ExpressionValue value) {
+            Object field = firstField ? value.field1() : ((ExpressionBiValue) value).field2();
+
+            if (field == null) {
+                return false;
+            }
+
+            int res = ((Comparable) field).compareTo(operand);
+
+            switch (comparison) {
+                case GT:
+                    return res > 0;
+
+                case GTE:
+                    return res >= 0;
+
+                case LT:
+                    return res < 0;
+
+                case LTE:
+                    return res <= 0;
+
+                default:
+                    return res == 0;
+            }
+        }
+    }
+
+    public static class NullPredicate implements Predicate<ExpressionValue> {
+
+        private final boolean firstField;
+
+        public NullPredicate(boolean firstField) {
+            this.firstField = firstField;
+        }
+
+        @Override
+        public boolean test(ExpressionValue value) {
+            Object field = firstField ? value.field1() : ((ExpressionBiValue) value).field2();
+
+            return field == null;
+        }
+    }
+
+    public static class OrPredicate implements Predicate<ExpressionValue> {
+
+        private final Predicate[] predicates;
+
+        public OrPredicate(Predicate... predicates) {
+            this.predicates = predicates;
+        }
+
+        @Override
+        public boolean test(ExpressionValue value) {
+            for (Predicate predicate : predicates) {
+                if (predicate.test(value)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static class AndPredicate implements Predicate<ExpressionValue> {
+
+        private final Predicate[] predicates;
+
+        public AndPredicate(Predicate... predicates) {
+            this.predicates = predicates;
+        }
+
+        @Override
+        public boolean test(ExpressionValue value) {
+            for (Predicate predicate : predicates) {
+                if (!predicate.test(value)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionType.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionType.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.support.expressions;
+
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class ExpressionType<T> {
+
+    public abstract String typeName();
+    public abstract List<T> values();
+    public abstract T valueFrom();
+    public abstract T valueTo();
+    public abstract QueryDataType getFieldConverterType();
+
+    @Override
+    public String toString() {
+        return typeName();
+    }
+
+    public static class BooleanType extends ExpressionType<Boolean>  {
+        @Override
+        public String typeName() {
+            return "Boolean";
+        }
+
+        @Override
+        public List<Boolean> values() {
+            return Arrays.asList(true, false, null);
+        }
+
+        @Override
+        public Boolean valueFrom() {
+            return false;
+        }
+
+        @Override
+        public Boolean valueTo() {
+            return true;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.BOOLEAN;
+        }
+    }
+
+    public static class ByteType extends ExpressionType<Byte> {
+        @Override
+        public String typeName() {
+            return "Byte";
+        }
+
+        @Override
+        public List<Byte> values() {
+            return Arrays.asList((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, null);
+        }
+
+        @Override
+        public Byte valueFrom() {
+            return (byte) 2;
+        }
+
+        @Override
+        public Byte valueTo() {
+            return (byte) 4;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.TINYINT;
+        }
+    }
+
+    public static class ShortType extends ExpressionType<Short> {
+        @Override
+        public String typeName() {
+            return "Short";
+        }
+
+        @Override
+        public List<Short> values() {
+            return Arrays.asList((short) 1, (short) 2, (short) 3, (short) 4, (short) 5, null);
+        }
+
+        @Override
+        public Short valueFrom() {
+            return (short) 2;
+        }
+
+        @Override
+        public Short valueTo() {
+            return (short) 4;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.SMALLINT;
+        }
+    }
+
+    public static class IntegerType extends ExpressionType<Integer> {
+        @Override
+        public String typeName() {
+            return "Integer";
+        }
+
+        @Override
+        public List<Integer> values() {
+            return Arrays.asList(1, 2, 3, 4, 5, null);
+        }
+
+        @Override
+        public Integer valueFrom() {
+            return 2;
+        }
+
+        @Override
+        public Integer valueTo() {
+            return 4;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.INT;
+        }
+    }
+
+    public static class LongType extends ExpressionType<Long> {
+        @Override
+        public String typeName() {
+            return "Long";
+        }
+
+        @Override
+        public List<Long> values() {
+            return Arrays.asList(1L, 2L, 3L, 4L, 5L, null);
+        }
+
+        @Override
+        public Long valueFrom() {
+            return 2L;
+        }
+
+        @Override
+        public Long valueTo() {
+            return 4L;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.BIGINT;
+        }
+    }
+
+    public static class BigDecimalType extends ExpressionType<BigDecimal> {
+        @Override
+        public String typeName() {
+            return "BigDecimal";
+        }
+
+        @Override
+        public List<BigDecimal> values() {
+            return Arrays.asList(
+                new BigDecimal("1"),
+                new BigDecimal("2"),
+                new BigDecimal("3"),
+                new BigDecimal("4"),
+                new BigDecimal("5"),
+                null
+            );
+        }
+
+        @Override
+        public BigDecimal valueFrom() {
+            return new BigDecimal("2");
+        }
+
+        @Override
+        public BigDecimal valueTo() {
+            return new BigDecimal("4");
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.DECIMAL;
+        }
+    }
+
+    public static class BigIntegerType extends ExpressionType<BigInteger> {
+        @Override
+        public String typeName() {
+            return "BigInteger";
+        }
+
+        @Override
+        public List<BigInteger> values() {
+            return Arrays.asList(
+                new BigInteger("1"),
+                new BigInteger("2"),
+                new BigInteger("3"),
+                new BigInteger("4"),
+                new BigInteger("5"),
+                null
+            );
+        }
+
+        @Override
+        public BigInteger valueFrom() {
+            return new BigInteger("2");
+        }
+
+        @Override
+        public BigInteger valueTo() {
+            return new BigInteger("4");
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.DECIMAL_BIG_INTEGER;
+        }
+    }
+
+    public static class FloatType extends ExpressionType<Float> {
+        @Override
+        public String typeName() {
+            return "Float";
+        }
+
+        @Override
+        public List<Float> values() {
+            return Arrays.asList(1f, 2f, 3f, 4f, 5f, null);
+        }
+
+        @Override
+        public Float valueFrom() {
+            return 2f;
+        }
+
+        @Override
+        public Float valueTo() {
+            return 4f;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.REAL;
+        }
+    }
+
+    public static class DoubleType extends ExpressionType<Double> {
+        @Override
+        public String typeName() {
+            return "Double";
+        }
+
+        @Override
+        public List<Double> values() {
+            return Arrays.asList(1d, 2d, 3d, 4d, 5d, null);
+        }
+
+        @Override
+        public Double valueFrom() {
+            return 2d;
+        }
+
+        @Override
+        public Double valueTo() {
+            return 4d;
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.DOUBLE;
+        }
+    }
+
+    public static class StringType extends ExpressionType<String> {
+        @Override
+        public String typeName() {
+            return "String";
+        }
+
+        @Override
+        public List<String> values() {
+            return Arrays.asList("a", "b", "c", "d", "e", null);
+        }
+
+        @Override
+        public String valueFrom() {
+            return "b";
+        }
+
+        @Override
+        public String valueTo() {
+            return "d";
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.VARCHAR;
+        }
+    }
+
+    public static class CharacterType extends ExpressionType<Character> {
+        @Override
+        public String typeName() {
+            return "Character";
+        }
+
+        @Override
+        public List<Character> values() {
+            return Arrays.asList('a', 'b', 'c', 'd', 'e', null);
+        }
+
+        @Override
+        public Character valueFrom() {
+            return 'b';
+        }
+
+        @Override
+        public Character valueTo() {
+            return 'd';
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.VARCHAR_CHARACTER;
+        }
+    }
+
+    public static class ObjectType extends ExpressionType<Object> {
+        @Override
+        public String typeName() {
+            return "Object";
+        }
+
+        @Override
+        public List<Object> values() {
+            return Arrays.asList(
+                new ObjectHolder(1),
+                new ObjectHolder(2),
+                new ObjectHolder(3),
+                new ObjectHolder(4),
+                new ObjectHolder(5),
+                null);
+        }
+
+        @Override
+        public Object valueFrom() {
+            return new ObjectHolder(2);
+        }
+
+        @Override
+        public Object valueTo() {
+            return new ObjectHolder(4);
+        }
+
+        @Override
+        public QueryDataType getFieldConverterType() {
+            return QueryDataType.OBJECT;
+        }
+    }
+
+    public static final class ObjectHolder implements Comparable<ObjectHolder>, Serializable {
+
+        private final int value;
+
+        public ObjectHolder(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(ObjectHolder o) {
+            return Integer.compare(value, o.value);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ObjectHolder that = (ObjectHolder) o;
+
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + value + "]";
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionTypes.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionTypes.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.support.expressions;
+
+public final class ExpressionTypes {
+
+    public static final ExpressionType<?> BOOLEAN = new ExpressionType.BooleanType();
+    public static final ExpressionType<?> BYTE = new ExpressionType.ByteType();
+    public static final ExpressionType<?> SHORT = new ExpressionType.ShortType();
+    public static final ExpressionType<?> INTEGER = new ExpressionType.IntegerType();
+    public static final ExpressionType<?> LONG = new ExpressionType.LongType();
+    public static final ExpressionType<?> BIG_DECIMAL = new ExpressionType.BigDecimalType();
+    public static final ExpressionType<?> BIG_INTEGER = new ExpressionType.BigIntegerType();
+    public static final ExpressionType<?> FLOAT = new ExpressionType.FloatType();
+    public static final ExpressionType<?> DOUBLE = new ExpressionType.DoubleType();
+    public static final ExpressionType<?> STRING = new ExpressionType.StringType();
+    public static final ExpressionType<?> CHARACTER = new ExpressionType.CharacterType();
+    public static final ExpressionType<?> OBJECT = new ExpressionType.ObjectType();
+
+    private ExpressionTypes() {
+        // No-op.
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionValue.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionValue.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.support.expressions;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@SuppressWarnings({"unused", "unchecked, checkstyle:MultipleVariableDeclarations"})
+public abstract class ExpressionValue implements Serializable {
+
+    public int key;
+
+    public static Class<? extends ExpressionValue> createClass(ExpressionType<?> type) {
+        return createClass(type.typeName());
+    }
+
+    public static Class<? extends ExpressionValue> createClass(String type) {
+        try {
+            String className = ExpressionValue.class.getName() + "$" + type + "Val";
+
+            return (Class<? extends ExpressionValue>) Class.forName(className);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Cannot create " + ExpressionValue.class.getSimpleName() + " for type \""
+                + type + "\"", e);
+        }
+    }
+
+    public static <T extends ExpressionValue> T create(Class<? extends ExpressionValue> clazz) {
+        try {
+            return (T) clazz.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to create an instance of " + clazz.getSimpleName());
+        }
+    }
+
+    public static <T extends ExpressionValue> T create(Class<? extends ExpressionValue> clazz, int key, Object field) {
+        T res = create(clazz);
+
+        res.key = key;
+        res.field1(field);
+
+        return res;
+    }
+
+    public Object field1() {
+        return getField("field1");
+    }
+
+    public ExpressionValue field1(Object value) {
+        setField("field1", value);
+
+        return this;
+    }
+
+    protected Object getField(String name) {
+        try {
+            return getClass().getDeclaredField(name).get(this);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void setField(String name, Object value) {
+        try {
+            getClass().getDeclaredField(name).set(this, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "[" + field1() + "]";
+    }
+
+    public static class BooleanVal extends ExpressionValue implements Serializable { public Boolean field1; }
+    public static class ByteVal extends ExpressionValue implements Serializable { public Byte field1; }
+    public static class ShortVal extends ExpressionValue implements Serializable { public Short field1; }
+    public static class IntegerVal extends ExpressionValue implements Serializable { public Integer field1; }
+    public static class LongVal extends ExpressionValue implements Serializable { public Long field1; }
+    public static class BigDecimalVal extends ExpressionValue implements Serializable { public BigDecimal field1; }
+    public static class BigIntegerVal extends ExpressionValue implements Serializable { public BigInteger field1; }
+    public static class FloatVal extends ExpressionValue implements Serializable { public Float field1; }
+    public static class DoubleVal extends ExpressionValue implements Serializable { public Double field1; }
+    public static class StringVal extends ExpressionValue implements Serializable { public String field1; }
+    public static class CharacterVal extends ExpressionValue implements Serializable { public Character field1; }
+    public static class ObjectVal extends ExpressionValue implements Serializable { public Object field1; }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
@@ -26,10 +26,16 @@ import com.hazelcast.sql.impl.expression.CastExpression;
 import com.hazelcast.sql.impl.expression.ColumnExpression;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ParameterExpression;
+import com.hazelcast.sql.impl.expression.math.AbsFunction;
 import com.hazelcast.sql.impl.expression.math.DivideFunction;
+import com.hazelcast.sql.impl.expression.math.DoubleFunction;
+import com.hazelcast.sql.impl.expression.math.FloorCeilFunction;
 import com.hazelcast.sql.impl.expression.math.MinusFunction;
 import com.hazelcast.sql.impl.expression.math.MultiplyFunction;
 import com.hazelcast.sql.impl.expression.math.PlusFunction;
+import com.hazelcast.sql.impl.expression.math.RandFunction;
+import com.hazelcast.sql.impl.expression.math.RoundTruncateFunction;
+import com.hazelcast.sql.impl.expression.math.SignFunction;
 import com.hazelcast.sql.impl.expression.math.UnaryMinusFunction;
 import com.hazelcast.sql.impl.expression.predicate.AndPredicate;
 import com.hazelcast.sql.impl.expression.predicate.ComparisonPredicate;
@@ -123,7 +129,14 @@ public class SqlDataSerializerHook implements DataSerializerHook {
     public static final int EXPRESSION_IS_NOT_FALSE = 39;
     public static final int EXPRESSION_IS_NOT_NULL = 40;
 
-    public static final int LEN = EXPRESSION_IS_NOT_NULL + 1;
+    public static final int EXPRESSION_ABS = 41;
+    public static final int EXPRESSION_SIGN = 42;
+    public static final int EXPRESSION_RAND = 43;
+    public static final int EXPRESSION_DOUBLE = 44;
+    public static final int EXPRESSION_FLOOR_CEIL = 45;
+    public static final int EXPRESSION_ROUND_TRUNCATE = 46;
+
+    public static final int LEN = EXPRESSION_ROUND_TRUNCATE + 1;
 
     @Override
     public int getFactoryId() {
@@ -184,6 +197,13 @@ public class SqlDataSerializerHook implements DataSerializerHook {
         constructors[EXPRESSION_IS_FALSE] = arg -> new IsFalsePredicate();
         constructors[EXPRESSION_IS_NOT_FALSE] = arg -> new IsNotFalsePredicate();
         constructors[EXPRESSION_IS_NOT_NULL] = arg -> new IsNotNullPredicate();
+
+        constructors[EXPRESSION_ABS] = arg -> new AbsFunction<>();
+        constructors[EXPRESSION_SIGN] = arg -> new SignFunction<>();
+        constructors[EXPRESSION_RAND] = arg -> new RandFunction();
+        constructors[EXPRESSION_DOUBLE] = arg -> new DoubleFunction();
+        constructors[EXPRESSION_FLOOR_CEIL] = arg -> new FloorCeilFunction<>();
+        constructors[EXPRESSION_ROUND_TRUNCATE] = arg -> new RoundTruncateFunction<>();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/AbsFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/AbsFunction.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UniExpressionWithType;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.converter.Converter;
+
+import static com.hazelcast.sql.impl.expression.math.ExpressionMath.DECIMAL_MATH_CONTEXT;
+
+public class AbsFunction<T> extends UniExpressionWithType<T> implements IdentifiedDataSerializable {
+    @SuppressWarnings("unused")
+    public AbsFunction() {
+        // No-op.
+    }
+
+    private AbsFunction(Expression<?> operand, QueryDataType resultType) {
+        super(operand, resultType);
+    }
+
+    public static AbsFunction<?> create(Expression<?> operand, QueryDataType resultType) {
+        return new AbsFunction<>(operand, resultType);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T eval(Row row, ExpressionEvalContext context) {
+        Object operandValue = operand.eval(row, context);
+
+        if (operandValue == null) {
+            return null;
+        }
+
+        return (T) abs(operandValue, operand.getType(), resultType);
+    }
+
+    private static Object abs(Object operand, QueryDataType operandType, QueryDataType resultType) {
+        Converter operandConverter = operandType.getConverter();
+
+        switch (resultType.getTypeFamily()) {
+            case TINYINT:
+                return (byte) Math.abs(operandConverter.asTinyint(operand));
+
+            case SMALLINT:
+                return (short) Math.abs(operandConverter.asSmallint(operand));
+
+            case INT:
+                return Math.abs(operandConverter.asInt(operand));
+
+            case BIGINT:
+                long res = Math.abs(operandConverter.asBigint(operand));
+
+                if (res < 0) {
+                    throw QueryException.error(SqlErrorCode.DATA_EXCEPTION,
+                        "BIGINT overflow in ABS function (consider adding an explicit CAST to DECIMAL)");
+                }
+
+                return res;
+
+            case DECIMAL:
+                return operandConverter.asDecimal(operand).abs(DECIMAL_MATH_CONTEXT);
+
+            case REAL:
+                return Math.abs(operandConverter.asReal(operand));
+
+            case DOUBLE:
+                return Math.abs(operandConverter.asDouble(operand));
+
+            default:
+                throw QueryException.error("Unexpected result type: " + resultType);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_ABS;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DoubleFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DoubleFunction.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UniExpression;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.IOException;
+
+/**
+ * Family of functions which accept a single double operand and return double result:
+ *     COS, SIN, TAN, COT, ACOS, ASIN, ATAN, SQRT, EXP, LN, LOG10, DEGREES, RADIANS
+ */
+public class DoubleFunction extends UniExpression<Double> implements IdentifiedDataSerializable {
+
+    public static final int COS = 0;
+    public static final int SIN = 1;
+    public static final int TAN = 2;
+    public static final int COT = 3;
+    public static final int ACOS = 4;
+    public static final int ASIN = 5;
+    public static final int ATAN = 6;
+    public static final int EXP = 7;
+    public static final int LN = 8;
+    public static final int LOG10 = 9;
+    public static final int DEGREES = 10;
+    public static final int RADIANS = 11;
+
+    private int type;
+
+    public DoubleFunction() {
+        // No-op.
+    }
+
+    public DoubleFunction(Expression<?> operand, int type) {
+        super(operand);
+
+        this.type = type;
+    }
+
+    public static DoubleFunction create(Expression<?> operand, int type) {
+        return new DoubleFunction(operand, type);
+    }
+
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:ReturnCount"})
+    @Override
+    public Double eval(Row row, ExpressionEvalContext context) {
+        Object value = operand.eval(row, context);
+
+        if (value == null) {
+            return null;
+        }
+
+        double valueDouble = operand.getType().getConverter().asDouble(value);
+
+        switch (type) {
+            case COS:
+                return Math.cos(valueDouble);
+
+            case SIN:
+                return Math.sin(valueDouble);
+
+            case TAN:
+                return Math.tan(valueDouble);
+
+            case COT:
+                return 1.0d / Math.tan(valueDouble);
+
+            case ACOS:
+                return Math.acos(valueDouble);
+
+            case ASIN:
+                return Math.asin(valueDouble);
+
+            case ATAN:
+                return Math.atan(valueDouble);
+
+            case EXP:
+                return Math.exp(valueDouble);
+
+            case LN:
+                return Math.log(valueDouble);
+
+            case LOG10:
+                return Math.log10(valueDouble);
+
+            case DEGREES:
+                return Math.toDegrees(valueDouble);
+
+            case RADIANS:
+                return Math.toRadians(valueDouble);
+
+            default:
+                throw QueryException.error("Unsupported function type: " + type);
+        }
+    }
+
+    @Override
+    public QueryDataType getType() {
+        return QueryDataType.DOUBLE;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_DOUBLE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+
+        out.writeInt(type);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        super.readData(in);
+
+        type = in.readInt();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DoubleFunction that = (DoubleFunction) o;
+
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+
+        result = 31 * result + type;
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{type=" + type + ", operand=" + operand + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DoubleFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DoubleFunction.java
@@ -73,7 +73,9 @@ public class DoubleFunction extends UniExpression<Double> implements IdentifiedD
             return null;
         }
 
-        double valueDouble = operand.getType().getConverter().asDouble(value);
+        assert value instanceof Number;
+
+        double valueDouble = ((Number) value).doubleValue();
 
         switch (type) {
             case COS:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DoubleFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DoubleFunction.java
@@ -30,8 +30,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import java.io.IOException;
 
 /**
- * Family of functions which accept a single double operand and return double result:
- *     COS, SIN, TAN, COT, ACOS, ASIN, ATAN, SQRT, EXP, LN, LOG10, DEGREES, RADIANS
+ * Family of functions which accept a single double operand and return double result.
  */
 public class DoubleFunction extends UniExpression<Double> implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/FloorCeilFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/FloorCeilFunction.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UniExpressionWithType;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.converter.Converter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Implementation of FLOOR/CEIL functions.
+ */
+public class FloorCeilFunction<T> extends UniExpressionWithType<T> implements IdentifiedDataSerializable {
+
+    private boolean ceil;
+
+    public FloorCeilFunction() {
+        // No-op.
+    }
+
+    private FloorCeilFunction(Expression<?> operand, QueryDataType resultType, boolean ceil) {
+        super(operand, resultType);
+
+        this.ceil = ceil;
+    }
+
+    public static Expression<?> create(Expression<?> operand, QueryDataType resultType, boolean ceil) {
+        QueryDataType operandType = operand.getType();
+
+        // Non-fractional operand will not be changed.
+        if (MathFunctionUtils.notFractional(operandType) && operandType == resultType) {
+            return operand;
+        }
+
+        return new FloorCeilFunction<>(operand, resultType, ceil);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T eval(Row row, ExpressionEvalContext context) {
+        Object value = operand.eval(row, context);
+
+        if (value == null) {
+            return null;
+        }
+
+        return (T) floorCeil(value, operand.getType(), resultType, ceil);
+    }
+
+    @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+    private static Object floorCeil(Object operandValue, QueryDataType operandType, QueryDataType resultType, boolean ceil) {
+        Converter operandConverter = operandType.getConverter();
+
+        switch (resultType.getTypeFamily()) {
+            case DECIMAL: {
+                BigDecimal operand0 = operandConverter.asDecimal(operandValue);
+
+                RoundingMode roundingMode = ceil ? RoundingMode.CEILING : RoundingMode.FLOOR;
+
+                return operand0.setScale(0, roundingMode);
+            }
+
+            case REAL: {
+                float operand0 = operandConverter.asReal(operandValue);
+
+                return (float) (ceil ? Math.ceil(operand0) : Math.floor(operand0));
+            }
+
+            case DOUBLE: {
+                double operand0 = operandConverter.asDouble(operandValue);
+
+                return ceil ? Math.ceil(operand0) : Math.floor(operand0);
+            }
+
+            default:
+                throw QueryException.error("Unexpected type: " + resultType);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_FLOOR_CEIL;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+
+        out.writeBoolean(ceil);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        super.readData(in);
+
+        ceil = in.readBoolean();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        FloorCeilFunction<?> that = (FloorCeilFunction<?>) o;
+
+        return ceil == that.ceil;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+
+        result = 31 * result + (ceil ? 1 : 0);
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{operand=" + operand + ", ceil=" + ceil + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MathFunctionUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MathFunctionUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+public final class MathFunctionUtils {
+    private MathFunctionUtils() {
+        // No-op.
+    }
+
+    public static boolean notFractional(QueryDataType type) {
+        switch (type.getTypeFamily()) {
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    public static Integer asInt(Expression<?> expression, Row row, ExpressionEvalContext context) {
+        Object res = expression.eval(row, context);
+
+        if (res == null) {
+            return null;
+        }
+
+        return expression.getType().getConverter().asInt(res);
+    }
+
+    public static Long asBigint(Expression<?> expression, Row row, ExpressionEvalContext context) {
+        Object res = expression.eval(row, context);
+
+        if (res == null) {
+            return null;
+        }
+
+        return expression.getType().getConverter().asBigint(res);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RandFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RandFunction.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UniExpression;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Random function implementation.
+ */
+public class RandFunction extends UniExpression<Double> implements IdentifiedDataSerializable {
+    public RandFunction() {
+        // No-op.
+    }
+
+    public RandFunction(Expression<?> seedExp) {
+        super(seedExp);
+    }
+
+    public static RandFunction create(Expression<?> seedExp) {
+        return new RandFunction(seedExp);
+    }
+
+    @Override
+    public Double eval(Row row, ExpressionEvalContext context) {
+        Long seed = operand != null ? MathFunctionUtils.asBigint(operand, row, context) : null;
+
+        Random random = seed != null ? new Random(seed) : ThreadLocalRandom.current();
+
+        return random.nextDouble();
+    }
+
+    @Override
+    public QueryDataType getType() {
+        return QueryDataType.DOUBLE;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_RAND;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunction.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.BiExpressionWithType;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Implementation of ROUND/TRUNCATE functions.
+ */
+public class RoundTruncateFunction<T> extends BiExpressionWithType<T> implements IdentifiedDataSerializable {
+
+    private boolean truncate;
+
+    public RoundTruncateFunction() {
+        // No-op.
+    }
+
+    private RoundTruncateFunction(Expression<?> operand1, Expression<?> operand2, QueryDataType resultType, boolean truncate) {
+        super(operand1, operand2, resultType);
+
+        this.truncate = truncate;
+    }
+
+    public static Expression<?> create(
+        Expression<?> operand1,
+        Expression<?> operand2,
+        QueryDataType resultType,
+        boolean truncate
+    ) {
+        if (operand2 == null) {
+            QueryDataType operand1Type = operand1.getType();
+
+            // No conversion is expected for non-fractional types when the length operand is not defined.
+            if (MathFunctionUtils.notFractional(operand1Type) && operand1Type == resultType) {
+                return operand1;
+            }
+        }
+
+        return new RoundTruncateFunction<>(operand1, operand2, resultType, truncate);
+    }
+
+    @SuppressWarnings({"unchecked", "checkstyle:CyclomaticComplexity", "checkstyle:ReturnCount"})
+    @Override
+    public T eval(Row row, ExpressionEvalContext context) {
+        // Get base operand.
+        Object operand1Value = operand1.eval(row, context);
+
+        // NULL always yields NULL
+        if (operand1Value == null) {
+            return null;
+        }
+
+        // Get length.
+        Integer operand2Value = operand2 != null ? MathFunctionUtils.asInt(operand2, row, context) : null;
+
+        int len = operand2Value != null ? operand2Value : 0;
+
+        // Cast to expected type.
+        switch (resultType.getTypeFamily()) {
+            case TINYINT:
+                try {
+                    return (T) (Byte) execute(operand1Value, len).byteValueExact();
+                } catch (ArithmeticException e) {
+                    throw overflow(QueryDataTypeFamily.TINYINT, QueryDataTypeFamily.SMALLINT, e);
+                }
+
+            case SMALLINT:
+                try {
+                    return (T) (Short) execute(operand1Value, len).shortValueExact();
+                } catch (ArithmeticException e) {
+                    throw overflow(QueryDataTypeFamily.SMALLINT, QueryDataTypeFamily.INT, e);
+                }
+
+            case INT:
+                try {
+                    return (T) (Integer) execute(operand1Value, len).intValueExact();
+                } catch (ArithmeticException e) {
+                    throw overflow(QueryDataTypeFamily.INT, QueryDataTypeFamily.BIGINT, e);
+                }
+
+            case BIGINT:
+                try {
+                    return (T) (Long) execute(operand1Value, len).longValueExact();
+                } catch (ArithmeticException e) {
+                    throw overflow(QueryDataTypeFamily.BIGINT, QueryDataTypeFamily.DECIMAL, e);
+                }
+
+            case DECIMAL:
+                return (T) execute(operand1Value, len);
+
+            case REAL:
+                float floatValue = (float) operand1Value;
+
+                if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+                    return (T) (Float) floatValue;
+                }
+
+                return (T) (Float) execute(operand1Value, len).floatValue();
+
+            case DOUBLE:
+                double doubleValue = (double) operand1Value;
+
+                if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+                    return (T) (Double) doubleValue;
+                }
+
+                return (T) (Double) execute(operand1Value, len).doubleValue();
+
+            default:
+                throw QueryException.error("Unsupported result type for ROUND/TRUNCATE function: " + resultType);
+        }
+    }
+
+    private BigDecimal execute(Object operand1Value, int len) {
+        BigDecimal value = operand1.getType().getConverter().asDecimal(operand1Value);
+
+        RoundingMode roundingMode = truncate ? RoundingMode.DOWN : RoundingMode.HALF_UP;
+
+        if (len == 0) {
+            return value.setScale(0, roundingMode);
+        } else {
+            return value.movePointRight(len).setScale(0, roundingMode).movePointLeft(len);
+        }
+    }
+
+    private QueryException overflow(
+        QueryDataTypeFamily resultTypeFamily,
+        QueryDataTypeFamily proposedTypeFamily,
+        ArithmeticException cause
+    ) {
+        return QueryException.dataException(resultTypeFamily + " overflow in " + (truncate ? "TRUNCATE" : "ROUND")
+            + " function (consider adding an explicit CAST to " + proposedTypeFamily + ")", cause);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_ROUND_TRUNCATE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+
+        out.writeBoolean(truncate);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        super.readData(in);
+
+        truncate = in.readBoolean();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        RoundTruncateFunction<?> that = (RoundTruncateFunction<?>) o;
+
+        return truncate == that.truncate;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (truncate ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " {operand1=" + operand1 + ", operand2=" + operand2 + ", truncate=" + truncate + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunction.java
@@ -59,7 +59,9 @@ public class RoundTruncateFunction<T> extends BiExpressionWithType<T> implements
             QueryDataType operand1Type = operand1.getType();
 
             // No conversion is expected for non-fractional types when the length operand is not defined.
-            if (MathFunctionUtils.notFractional(operand1Type) && operand1Type == resultType) {
+            if (MathFunctionUtils.notFractional(operand1Type)) {
+                assert operand1Type == resultType;
+
                 return operand1;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/SignFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/SignFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.math;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UniExpressionWithType;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.converter.Converter;
+
+import java.math.BigDecimal;
+
+public class SignFunction<T> extends UniExpressionWithType<T> implements IdentifiedDataSerializable {
+
+    private static final BigDecimal DECIMAL_NEGATIVE = BigDecimal.ONE.negate();
+
+    public SignFunction() {
+        // No-op.
+    }
+
+    private SignFunction(Expression<?> operand, QueryDataType resultType) {
+        super(operand, resultType);
+    }
+
+    public static SignFunction<?> create(Expression<?> operand, QueryDataType returnType) {
+        return new SignFunction<>(operand, returnType);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T eval(Row row, ExpressionEvalContext context) {
+        Object operandValue = operand.eval(row, context);
+
+        if (operandValue == null) {
+            return null;
+        }
+
+        return (T) doSign(operandValue, operand.getType(), resultType);
+    }
+
+    private static Number doSign(Object operandValue, QueryDataType operandType, QueryDataType resultType) {
+        Converter operandConverter = operandType.getConverter();
+
+        switch (resultType.getTypeFamily()) {
+            case TINYINT:
+                return (byte) Integer.signum(operandConverter.asInt(operandValue));
+
+            case SMALLINT:
+                return (short) Integer.signum(operandConverter.asInt(operandValue));
+
+            case INT:
+                return Integer.signum(operandConverter.asInt(operandValue));
+
+            case BIGINT:
+                return (long) Long.signum(operandConverter.asBigint(operandValue));
+
+            case DECIMAL:
+                int res = operandConverter.asDecimal(operandValue).signum();
+
+                return res == 0 ? BigDecimal.ZERO : res == 1 ? BigDecimal.ONE : DECIMAL_NEGATIVE;
+
+            case REAL:
+                return Math.signum(operandConverter.asReal(operandValue));
+
+            case DOUBLE:
+                return Math.signum(operandConverter.asDouble(operandValue));
+
+            default:
+                throw QueryException.error("Unexpected type: " + resultType);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_SIGN;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
@@ -17,8 +17,8 @@
 package com.hazelcast.sql.impl.type.converter;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 
 import java.lang.reflect.Method;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/DoubleConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/DoubleConverter.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.sql.impl.type.converter;
 
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 
 import java.math.BigDecimal;
 
 import static com.hazelcast.sql.impl.expression.math.ExpressionMath.DECIMAL_MATH_CONTEXT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DOUBLE;
 
 /**
  * Converter for {@link java.lang.Double} type.
@@ -109,10 +112,19 @@ public final class DoubleConverter extends Converter {
         return converted;
     }
 
-    @SuppressWarnings("UnpredictableBigDecimalConstructorCall")
     @Override
     public BigDecimal asDecimal(Object val) {
-        return new BigDecimal(cast(val), DECIMAL_MATH_CONTEXT);
+        double val0 = cast(val);
+
+        if (Double.isInfinite(val0)) {
+            throw QueryException.dataException("Cannot convert infinite " + DOUBLE + " value to " + DECIMAL);
+        }
+
+        if (Double.isNaN(val0)) {
+            throw QueryException.dataException("Cannot convert NaN " + DOUBLE + " value to " + DECIMAL);
+        }
+
+        return new BigDecimal(val0, DECIMAL_MATH_CONTEXT);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/FloatConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/FloatConverter.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.sql.impl.type.converter;
 
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 
 import java.math.BigDecimal;
 
 import static com.hazelcast.sql.impl.expression.math.ExpressionMath.DECIMAL_MATH_CONTEXT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.REAL;
 
 /**
  * Converter for {@link java.lang.Float} type.
@@ -30,7 +33,7 @@ public final class FloatConverter extends Converter {
     public static final FloatConverter INSTANCE = new FloatConverter();
 
     private FloatConverter() {
-        super(ID_FLOAT, QueryDataTypeFamily.REAL);
+        super(ID_FLOAT, REAL);
     }
 
     @Override
@@ -110,10 +113,19 @@ public final class FloatConverter extends Converter {
         return converted;
     }
 
-    @SuppressWarnings("UnpredictableBigDecimalConstructorCall")
     @Override
     public BigDecimal asDecimal(Object val) {
-        return new BigDecimal(cast(val), DECIMAL_MATH_CONTEXT);
+        float val0 = cast(val);
+
+        if (Float.isInfinite(val0)) {
+            throw QueryException.dataException("Cannot convert infinite " + REAL + " value to " + DECIMAL);
+        }
+
+        if (Float.isNaN(val0)) {
+            throw QueryException.dataException("Cannot convert NaN " + REAL + " value to " + DECIMAL);
+        }
+
+        return new BigDecimal(val0, DECIMAL_MATH_CONTEXT);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
@@ -215,4 +215,8 @@ public class SqlTestSupport extends HazelcastTestSupport {
 
         return rows;
     }
+
+    public static void clearPlanCache(HazelcastInstance member) {
+        ((SqlServiceImpl) member.getSql()).getPlanCache().clear();
+    }
 }


### PR DESCRIPTION
This PR introduces base SQL math functions.

Out of scope due to additional complexity: `ATAN2`, `POWER`/`SQRT`, `RAND_INTEGER`

Closes #17339