### PR TITLE
[FORWARD-PORT] WAN counter fixes and cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/WanSyncState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/WanSyncState.java
@@ -26,8 +26,6 @@ public interface WanSyncState extends LocalInstanceStats {
 
     WanSyncStatus getStatus();
 
-    int getSyncedPartitionCount();
-
     String getActiveWanConfigName();
 
     String getActivePublisherName();

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/WanSyncStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/WanSyncStateImpl.java
@@ -25,17 +25,12 @@ public class WanSyncStateImpl implements WanSyncState {
 
     private long creationTime;
     private WanSyncStatus status = WanSyncStatus.READY;
-    private int syncedPartitionCount;
     private String activeWanConfigName;
     private String activePublisherName;
 
-    public WanSyncStateImpl() { }
-
-    public WanSyncStateImpl(WanSyncStatus status, int syncedPartitionCount,
-                            String activeWanConfigName, String activePublisherName) {
+    public WanSyncStateImpl(WanSyncStatus status, String activeWanConfigName, String activePublisherName) {
         creationTime = Clock.currentTimeMillis();
         this.status = status;
-        this.syncedPartitionCount = syncedPartitionCount;
         this.activeWanConfigName = activeWanConfigName;
         this.activePublisherName = activePublisherName;
     }
@@ -51,11 +46,6 @@ public class WanSyncStateImpl implements WanSyncState {
     }
 
     @Override
-    public int getSyncedPartitionCount() {
-        return syncedPartitionCount;
-    }
-
-    @Override
     public String getActiveWanConfigName() {
         return activeWanConfigName;
     }
@@ -68,7 +58,6 @@ public class WanSyncStateImpl implements WanSyncState {
     @Override
     public String toString() {
         return "WanSyncStateImpl{wanSyncStatus=" + status
-                + ", syncedPartitionCount=" + syncedPartitionCount
                 + ", activeWanConfigName=" + activeWanConfigName
                 + ", activePublisherName=" + activePublisherName
                 + '}';


### PR DESCRIPTION
- removed WanSyncManager#syncedPartitionCount as it was superseded by
the https://github.com/hazelcast/hazelcast-enterprise/pull/3058. The
syncedPartitionCount also fails to track concurrent sync requests which
caused the test failure
- removed WanSyncState from MC code and thus removed it from being
JsonSerializable
- fixed statistics counting for merkle tree sync. Sync statistics on
members which didn't need to sync anything had a synced partition count
of zero, which then causes the sum of the synced partition counts on
all members after sync completes to be less than the total partition
count

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/3145
Forward-port of: https://github.com/hazelcast/hazelcast/pull/17328
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/3719