### PR TITLE
Ensure members are started before test completes

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefIsolatedServersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefIsolatedServersTest.java
@@ -76,13 +76,13 @@ public class AtomicRefIsolatedServersTest extends HazelcastRaftTestSupport {
         assertNotNull(result);
     }
 
-    private void startServers(int count, Config config) {
+    private void startServers(int count, Config config) throws Exception {
         spawn(() -> {
             FilteringClassLoader cl = new FilteringClassLoader(singletonList("classloading"), null);
             Thread.currentThread().setContextClassLoader(cl);
 
             config.setClassLoader(cl);
             factory.newInstances(config, count);
-        });
+        }).get();
     }
 }


### PR DESCRIPTION
Members were being started async, which one of them might leak after test completes.

Fixes #17188