### PR TITLE
Don't use complex objects in auditable events.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -385,11 +385,12 @@ public class ClusterJoinManager {
                 throw new SecurityException(format("Authentication has failed for %s @%s, cause: %s",
                         String.valueOf(credentials), endpoint, e.getMessage()));
             } finally {
+                Address remoteAddr = connection == null ? null : connection.getRemoteAddress();
                 nodeEngine.getNode().getNodeExtension().getAuditlogService()
                     .eventBuilder(AuditlogTypeIds.AUTHENTICATION_MEMBER)
                     .message("Member connection authentication.")
                     .addParameter("credentials", credentials)
-                    .addParameter("connection", connection)
+                    .addParameter("remoteAddress", remoteAddr)
                     .addParameter("endpoint", endpoint)
                     .addParameter("passed", passed)
                     .log();

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -293,7 +293,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
                 .eventBuilder(AuditlogTypeIds.NETWORK_CONNECT)
                 .message("New connection accepted.")
                 .addParameter("qualifier", qualifier)
-                .addParameter("socket", socketChannel.socket())
+                .addParameter("remoteAddress", socketChannel.getRemoteAddress())
                 .log();
             if (serverContext.isSocketInterceptorEnabled(qualifier)) {
                 serverContext.executeAsync(() -> newConnection0(connectionManager, channel));


### PR DESCRIPTION
This PR avoids using complex objects as parameters in auditable events.
It should help in cases when a custom auditlog implementation serializes (marshalls) parameters to another representation (JSON/XML).