### PR TITLE
Fixed failures in SqlErrorAbstractTest.testMapMigration (#17347)

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -144,7 +144,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
         // Start query
         SqlException error = assertSqlException(useClient ? client : instance1, query());
-        assertEquals(SqlErrorCode.PARTITION_NOT_OWNED, error.getCode());
+        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, error.getCode());
     }
 
     protected void checkMapDestroy(boolean useClient, boolean firstMember) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlErrorCode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlErrorCode.java
@@ -32,8 +32,8 @@ public final class SqlErrorCode {
     /** Query was cancelled due to timeout. */
     public static final int TIMEOUT = 1004;
 
-    /** An error caused by concurrent migration of partition to other member. */
-    public static final int PARTITION_MIGRATED = 1005;
+    /** Partition distribution has changed. */
+    public static final int PARTITION_DISTRIBUTION_CHANGED = 1005;
 
     /** An error caused by a concurrent destroy of a map. */
     public static final int MAP_DESTROYED = 1006;
@@ -43,9 +43,6 @@ public final class SqlErrorCode {
 
     /** Generic parsing error. */
     public static final int PARSING = 1008;
-
-    /** Partition is not owned by a member. */
-    public static final int PARTITION_NOT_OWNED = 1009;
 
     /** An error with data conversion or transformation. */
     public static final int DATA_EXCEPTION = 2000;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -130,7 +130,7 @@ public abstract class AbstractMapScanExec extends AbstractExec {
         // Check for concurrent migration
         if (!validateMigrationStamp(migrationStamp)) {
             throw QueryException.error(
-                SqlErrorCode.PARTITION_MIGRATED, "Map scan failed due to concurrent partition migration "
+                SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, "Map scan failed due to concurrent partition migration "
                 + "(result consistency cannot be guaranteed)"
             ).withInvalidate();
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -92,7 +92,7 @@ public class MapScanExecIterator implements KeyValueIterator {
 
                     if (!isOwned) {
                         throw QueryException.error(
-                            SqlErrorCode.PARTITION_NOT_OWNED,
+                            SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED,
                             "Partition is not owned by member: " + nextPart
                         ).withInvalidate();
                     }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
@@ -423,7 +423,7 @@ public class MapScanExecTest extends SqlTestSupport {
         );
 
         QueryException exception = assertThrows(QueryException.class, () -> exec.setup(emptyFragmentContext()));
-        assertEquals(SqlErrorCode.PARTITION_NOT_OWNED, exception.getCode());
+        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, exception.getCode());
         assertTrue(exception.isInvalidatePlan());
     }
 
@@ -502,7 +502,7 @@ public class MapScanExecTest extends SqlTestSupport {
 
             // Try advance, should fail.
             QueryException exception = assertThrows(QueryException.class, exec::advance);
-            assertEquals(SqlErrorCode.PARTITION_MIGRATED, exception.getCode());
+            assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, exception.getCode());
             assertTrue(exception.isInvalidatePlan());
         } finally {
             instance3.shutdown();


### PR DESCRIPTION
This PR fixes a failure in the `SqlErrorAbstractTest.testMapMigration`. Earlier we had two separate error codes for partition change error conditions - "partition migration" and "partition not owned". 

First, the difference between these events is not very important to users, provided that the error message is clear since users will have to re-execute the query anyway.
Second, it is not very easy to write tests that distinguish these conditions - this was the root cause of the test failure.
Third, originally we had only one event. I added the second one later, but it seems that there was no real reason for this.

This PR ensures that there is only one error code for the partition distribution change error condition. 

Closes https://github.com/hazelcast/hazelcast/issues/17347