### PR TITLE
Throw HazelcastInstanceNotActiveException when session manager is shu…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/AbstractProxySessionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/AbstractProxySessionManager.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cp.internal.session;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
 import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.internal.util.BiTuple;
@@ -37,7 +38,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
-import static com.hazelcast.internal.util.Preconditions.checkState;
 import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
 
 /**
@@ -191,7 +191,9 @@ public abstract class AbstractProxySessionManager {
     private SessionState getOrCreateSession(RaftGroupId groupId) {
         lock.readLock().lock();
         try {
-            checkState(running, "Session manager is already shut down!");
+            if (!running) {
+                throw new HazelcastInstanceNotActiveException("Session manager is already shut down!");
+            }
 
             SessionState session = sessions.get(groupId);
             if (session == null || !session.isValid()) {


### PR DESCRIPTION
An `IllegalStateException` was being thrown before but it's too generic.

This is a small behavior change but `HazelcastInstanceNotActiveException` is already an expected
exception when a member/client is shutting down. So the change won't cause a significant issue.

Fixes #17120