### PR TITLE
SQL predicates integration tests (#17356)

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/SqlToQueryType.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/SqlToQueryType.java
@@ -46,7 +46,7 @@ public final class SqlToQueryType {
 
         HZ_TO_CALCITE.put(QueryDataTypeFamily.TINYINT, SqlTypeName.TINYINT);
         HZ_TO_CALCITE.put(QueryDataTypeFamily.SMALLINT, SqlTypeName.SMALLINT);
-        HZ_TO_CALCITE.put(QueryDataTypeFamily.INT, SqlTypeName.INTEGER);
+        HZ_TO_CALCITE.put(QueryDataTypeFamily.INTEGER, SqlTypeName.INTEGER);
         HZ_TO_CALCITE.put(QueryDataTypeFamily.BIGINT, SqlTypeName.BIGINT);
         CALCITE_TO_HZ.put(SqlTypeName.TINYINT, QueryDataType.TINYINT);
         CALCITE_TO_HZ.put(SqlTypeName.SMALLINT, QueryDataType.SMALLINT);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/distribution/DistributionTrait.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/distribution/DistributionTrait.java
@@ -21,6 +21,8 @@ import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
 
 import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.ANY;
+import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.REPLICATED;
+import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.ROOT;
 
 /**
  * Defines how the given relation is distributed in the cluster.
@@ -58,10 +60,15 @@ public class DistributionTrait implements RelTrait {
             return true;
         }
 
-        DistributionType targetType = ((DistributionTrait) targetTrait).getType();
+        DistributionTrait targetTrait0 = (DistributionTrait) targetTrait;
 
         // Any type satisfies ANY.
-        if (targetType == ANY) {
+        if (targetTrait0.getType() == ANY) {
+            return true;
+        }
+
+        // Converting from REPLICATED to ROOT is always OK.
+        if (type == REPLICATED && targetTrait0.getType() == ROOT) {
             return true;
         }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/distribution/DistributionTraitDef.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/distribution/DistributionTraitDef.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.RelNode;
 
 import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.ANY;
 import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.PARTITIONED;
+import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.REPLICATED;
 import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.ROOT;
 
 /**
@@ -34,6 +35,9 @@ import static com.hazelcast.sql.impl.calcite.opt.distribution.DistributionType.R
 public class DistributionTraitDef extends RelTraitDef<DistributionTrait> {
     /** Partitioned trait with unknown partitioning columns. */
     private final DistributionTrait traitPartitionedUnknown;
+
+    /** Every node has the same data set locally. */
+    private final DistributionTrait traitReplicated;
 
     /** Consume the whole stream on a single node. */
     private final DistributionTrait traitRoot;
@@ -48,6 +52,7 @@ public class DistributionTraitDef extends RelTraitDef<DistributionTrait> {
         this.memberCount = memberCount;
 
         traitPartitionedUnknown = createTrait(PARTITIONED);
+        traitReplicated = createTrait(REPLICATED);
         traitRoot = createTrait(ROOT);
         traitAny = createTrait(ANY);
     }
@@ -58,6 +63,10 @@ public class DistributionTraitDef extends RelTraitDef<DistributionTrait> {
 
     public DistributionTrait getTraitPartitionedUnknown() {
         return traitPartitionedUnknown;
+    }
+
+    public DistributionTrait getTraitReplicated() {
+        return traitReplicated;
     }
 
     public DistributionTrait getTraitRoot() {
@@ -123,7 +132,7 @@ public class DistributionTraitDef extends RelTraitDef<DistributionTrait> {
      * @return Converted node.
      */
     private RelNode convertToRoot(RelOptPlanner planner, RelNode rel, DistributionTrait currentTrait) {
-        // ANY already handler before, ROOT and REPLICATED do not require further conversions.
+        // ANY already handled before, ROOT and REPLICATED do not require further conversions.
         assert currentTrait.getType() == PARTITIONED;
 
         RelTraitSet traitSet = OptUtils.traitPlus(planner.emptyTraitSet(), getTraitRoot());

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/distribution/DistributionType.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/distribution/DistributionType.java
@@ -32,6 +32,12 @@ public enum DistributionType {
     PARTITIONED,
 
     /**
+     * The whole data set is located on all nodes. That is, if there are N nodes, there will be N copies of the
+     * data set.
+     */
+    REPLICATED,
+
+    /**
      * Data set is located on the root node.
      */
     ROOT

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/LogicalRules.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
 import org.apache.calcite.rel.rules.ProjectJoinTransposeRule;
 import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
+import org.apache.calcite.rel.rules.PruneEmptyRules;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
 
@@ -47,10 +48,15 @@ public final class LogicalRules {
             ProjectJoinTransposeRule.INSTANCE,
             ProjectIntoScanLogicalRule.INSTANCE,
 
+            // Values rules
+            PruneEmptyRules.PROJECT_INSTANCE,
+            PruneEmptyRules.FILTER_INSTANCE,
+
             // Converter rules
             MapScanLogicalRule.INSTANCE,
             FilterLogicalRule.INSTANCE,
-            ProjectLogicalRule.INSTANCE
+            ProjectLogicalRule.INSTANCE,
+            ValuesLogicalRule.INSTANCE
         );
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ValuesLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ValuesLogicalRel.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.logical;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+
+public class ValuesLogicalRel extends Values implements LogicalRel {
+    public ValuesLogicalRel(
+        RelOptCluster cluster,
+        RelDataType rowType,
+        ImmutableList<ImmutableList<RexLiteral>> tuples,
+        RelTraitSet traits
+    ) {
+        super(cluster, rowType, tuples, traits);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ValuesLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/logical/ValuesLogicalRule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.logical;
+
+import com.hazelcast.sql.impl.calcite.opt.HazelcastConventions;
+import com.hazelcast.sql.impl.calcite.opt.OptUtils;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.logical.LogicalValues;
+
+/**
+ * Converts abstract filter to logical filter.
+ */
+public final class ValuesLogicalRule extends ConverterRule {
+    public static final RelOptRule INSTANCE = new ValuesLogicalRule();
+
+    private ValuesLogicalRule() {
+        super(LogicalValues.class, Convention.NONE, HazelcastConventions.LOGICAL, ValuesLogicalRule.class.getSimpleName());
+    }
+
+    @Override
+    public RelNode convert(RelNode rel) {
+        LogicalValues values = (LogicalValues) rel;
+
+        return new ValuesLogicalRel(
+            values.getCluster(),
+            values.getRowType(),
+            values.getTuples(),
+            OptUtils.toLogicalConvention(values.getTraitSet())
+        );
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/PhysicalRules.java
@@ -35,6 +35,7 @@ public final class PhysicalRules {
             FilterPhysicalRule.INSTANCE,
             ProjectPhysicalRule.INSTANCE,
             MapScanPhysicalRule.INSTANCE,
+            ValuesPhysicalRule.INSTANCE,
 
             new AbstractConverter.ExpandConversionRule(RelFactories.LOGICAL_BUILDER)
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/ProjectPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/ProjectPhysicalRule.java
@@ -115,6 +115,10 @@ public final class ProjectPhysicalRule extends RelOptRule {
                 // Singleton remains singleton.
                 return physicalInputDist;
 
+            case REPLICATED:
+                // Replicated remains replicated.
+                return physicalInputDist;
+
             default:
                 assert type == PARTITIONED;
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/ValuesPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/ValuesPhysicalRel.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.physical;
+
+import com.google.common.collect.ImmutableList;
+import com.hazelcast.sql.impl.calcite.opt.physical.visitor.PhysicalRelVisitor;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+
+public class ValuesPhysicalRel extends Values implements PhysicalRel  {
+    public ValuesPhysicalRel(
+        RelOptCluster cluster,
+        RelDataType rowType,
+        ImmutableList<ImmutableList<RexLiteral>> tuples,
+        RelTraitSet traits
+    ) {
+        super(cluster, rowType, tuples, traits);
+    }
+
+    @Override
+    public void visit(PhysicalRelVisitor visitor) {
+        visitor.onValues(this);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/ValuesPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/ValuesPhysicalRule.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.opt.physical;
+
+import com.hazelcast.sql.impl.calcite.opt.HazelcastConventions;
+import com.hazelcast.sql.impl.calcite.opt.OptUtils;
+import com.hazelcast.sql.impl.calcite.opt.distribution.DistributionTrait;
+import com.hazelcast.sql.impl.calcite.opt.logical.ValuesLogicalRel;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+
+/**
+ * Rule to convert the logical values node to physical values node.
+ */
+public final class ValuesPhysicalRule extends RelOptRule {
+    public static final RelOptRule INSTANCE = new ValuesPhysicalRule();
+
+    private ValuesPhysicalRule() {
+        super(
+            OptUtils.single(ValuesLogicalRel.class, HazelcastConventions.LOGICAL),
+            ValuesPhysicalRule.class.getSimpleName()
+        );
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        ValuesLogicalRel logicalValues = call.rel(0);
+
+        DistributionTrait distribution = logicalValues.getHazelcastCluster().getDistributionTraitDef().getTraitReplicated();
+
+        ValuesPhysicalRel transformedValues = new ValuesPhysicalRel(
+            logicalValues.getCluster(),
+            logicalValues.getRowType(),
+            logicalValues.getTuples(),
+            OptUtils.toPhysicalConvention(logicalValues.getTraitSet(), distribution)
+        );
+
+        call.transformTo(transformedValues);
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/EdgeCollectorPlanNodeVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/EdgeCollectorPlanNodeVisitor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.opt.physical.visitor;
 
+import com.hazelcast.sql.impl.plan.node.EmptyPlanNode;
 import com.hazelcast.sql.impl.plan.node.FilterPlanNode;
 import com.hazelcast.sql.impl.plan.node.MapScanPlanNode;
 import com.hazelcast.sql.impl.plan.node.PlanNode;
@@ -74,6 +75,11 @@ public class EdgeCollectorPlanNodeVisitor implements PlanNodeVisitor {
 
     @Override
     public void onFilterNode(FilterPlanNode node) {
+        onNode(node);
+    }
+
+    @Override
+    public void onEmptyNode(EmptyPlanNode node) {
         onNode(node);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PhysicalRelVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PhysicalRelVisitor.java
@@ -20,6 +20,7 @@ import com.hazelcast.sql.impl.calcite.opt.physical.FilterPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.MapScanPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.ProjectPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.RootPhysicalRel;
+import com.hazelcast.sql.impl.calcite.opt.physical.ValuesPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.exchange.RootExchangePhysicalRel;
 
 /**
@@ -31,4 +32,5 @@ public interface PhysicalRelVisitor {
     void onRootExchange(RootExchangePhysicalRel rel);
     void onProject(ProjectPhysicalRel rel);
     void onFilter(FilterPhysicalRel rel);
+    void onValues(ValuesPhysicalRel rel);
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PhysicalRelVisitorAdapter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PhysicalRelVisitorAdapter.java
@@ -21,6 +21,7 @@ import com.hazelcast.sql.impl.calcite.opt.physical.MapScanPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.PhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.ProjectPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.RootPhysicalRel;
+import com.hazelcast.sql.impl.calcite.opt.physical.ValuesPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.exchange.RootExchangePhysicalRel;
 
 /**
@@ -49,6 +50,11 @@ public abstract class PhysicalRelVisitorAdapter implements PhysicalRelVisitor {
 
     @Override
     public void onFilter(FilterPhysicalRel rel) {
+        onNode(rel);
+    }
+
+    @Override
+    public void onValues(ValuesPhysicalRel rel) {
         onNode(rel);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PlanCreateVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/PlanCreateVisitor.java
@@ -19,13 +19,16 @@ package com.hazelcast.sql.impl.calcite.opt.physical.visitor;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.sql.SqlColumnMetadata;
 import com.hazelcast.sql.SqlRowMetadata;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.calcite.SqlToQueryType;
 import com.hazelcast.sql.impl.calcite.opt.physical.FilterPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.MapScanPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.PhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.ProjectPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.RootPhysicalRel;
+import com.hazelcast.sql.impl.calcite.opt.physical.ValuesPhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.exchange.AbstractExchangePhysicalRel;
 import com.hazelcast.sql.impl.calcite.opt.physical.exchange.RootExchangePhysicalRel;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
@@ -35,6 +38,7 @@ import com.hazelcast.sql.impl.plan.Plan;
 import com.hazelcast.sql.impl.plan.PlanFragmentMapping;
 import com.hazelcast.sql.impl.plan.cache.PlanCacheKey;
 import com.hazelcast.sql.impl.plan.cache.PlanObjectKey;
+import com.hazelcast.sql.impl.plan.node.EmptyPlanNode;
 import com.hazelcast.sql.impl.plan.node.FilterPlanNode;
 import com.hazelcast.sql.impl.plan.node.MapScanPlanNode;
 import com.hazelcast.sql.impl.plan.node.PlanNode;
@@ -51,6 +55,7 @@ import org.apache.calcite.rex.RexNode;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
@@ -300,6 +305,22 @@ public class PlanCreateVisitor implements PhysicalRelVisitor {
         );
 
         pushUpstream(filterNode);
+    }
+
+    @Override
+    public void onValues(ValuesPhysicalRel rel) {
+        if (!rel.getTuples().isEmpty()) {
+            throw QueryException.error("Non-empty VALUES are not supported");
+        }
+
+        QueryDataType[] fieldTypes = SqlToQueryType.mapRowType(rel.getRowType());
+
+        EmptyPlanNode planNode = new EmptyPlanNode(
+            pollId(rel),
+            Arrays.asList(fieldTypes)
+        );
+
+        pushUpstream(planNode);
     }
 
     /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeSystem.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeSystem.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.sql.impl.calcite.validate.types;
 
-import com.hazelcast.internal.util.collection.Object2LongHashMap;
 import com.hazelcast.sql.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.calcite.SqlToQueryType;
@@ -34,31 +33,19 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import java.math.BigDecimal;
 import java.util.Calendar;
 
-import static org.apache.calcite.sql.type.SqlTypeName.ANY;
 import static org.apache.calcite.sql.type.SqlTypeName.APPROX_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.BIGINT;
-import static org.apache.calcite.sql.type.SqlTypeName.BOOLEAN;
 import static org.apache.calcite.sql.type.SqlTypeName.CHAR_TYPES;
-import static org.apache.calcite.sql.type.SqlTypeName.DATE;
 import static org.apache.calcite.sql.type.SqlTypeName.DATETIME_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.DAY_INTERVAL_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
 import static org.apache.calcite.sql.type.SqlTypeName.DOUBLE;
 import static org.apache.calcite.sql.type.SqlTypeName.FRACTIONAL_TYPES;
-import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
 import static org.apache.calcite.sql.type.SqlTypeName.INTERVAL_DAY_SECOND;
 import static org.apache.calcite.sql.type.SqlTypeName.INTERVAL_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.INTERVAL_YEAR_MONTH;
 import static org.apache.calcite.sql.type.SqlTypeName.INT_TYPES;
-import static org.apache.calcite.sql.type.SqlTypeName.NULL;
 import static org.apache.calcite.sql.type.SqlTypeName.NUMERIC_TYPES;
-import static org.apache.calcite.sql.type.SqlTypeName.REAL;
-import static org.apache.calcite.sql.type.SqlTypeName.SMALLINT;
-import static org.apache.calcite.sql.type.SqlTypeName.TIME;
-import static org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP;
-import static org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
-import static org.apache.calcite.sql.type.SqlTypeName.TINYINT;
-import static org.apache.calcite.sql.type.SqlTypeName.VARCHAR;
 import static org.apache.calcite.sql.type.SqlTypeName.YEAR_INTERVAL_TYPES;
 
 /**
@@ -90,25 +77,8 @@ public final class HazelcastTypeSystem extends RelDataTypeSystemImpl {
      */
     public static final String OBJECT_TYPE_NAME = "OBJECT";
 
-    /**
-     * Defines the set of supported types. Order is important for precedence
-     * determination: types at the end of the array have higher precedence.
-     * Types in this array have one-to-one relation with the types defined by
-     * {@link com.hazelcast.sql.impl.type.QueryDataTypeFamily}.
-     */
-    private static final SqlTypeName[] TYPE_NAMES =
-            {NULL, VARCHAR, BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP,
-                    TIMESTAMP_WITH_LOCAL_TIME_ZONE, ANY};
-
-    private static final Object2LongHashMap<SqlTypeName> TYPE_TO_PRECEDENCE = new Object2LongHashMap<>(-1);
-
-    static {
-        for (int i = 0; i < TYPE_NAMES.length; ++i) {
-            TYPE_TO_PRECEDENCE.put(TYPE_NAMES[i], i);
-        }
-    }
-
     private HazelcastTypeSystem() {
+        // No-op
     }
 
     /**
@@ -339,11 +309,9 @@ public final class HazelcastTypeSystem extends RelDataTypeSystemImpl {
             typeName = INTERVAL_DAY_SECOND;
         }
 
-        long value = TYPE_TO_PRECEDENCE.getValue(typeName);
-        if (value == -1) {
-            throw new IllegalArgumentException("unexpected type name: " + typeName);
-        }
-        return (int) value;
+        QueryDataType hzType = SqlToQueryType.map(typeName);
+
+        return hzType.getTypeFamily().getPrecedence();
     }
 
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:ReturnCount"})

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/SqlToQueryTypeTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/SqlToQueryTypeTest.java
@@ -42,7 +42,7 @@ public class SqlToQueryTypeTest {
 
         assertSame(SqlTypeName.TINYINT, SqlToQueryType.map(QueryDataTypeFamily.TINYINT));
         assertSame(SqlTypeName.SMALLINT, SqlToQueryType.map(QueryDataTypeFamily.SMALLINT));
-        assertSame(SqlTypeName.INTEGER, SqlToQueryType.map(QueryDataTypeFamily.INT));
+        assertSame(SqlTypeName.INTEGER, SqlToQueryType.map(QueryDataTypeFamily.INTEGER));
         assertSame(SqlTypeName.BIGINT, SqlToQueryType.map(QueryDataTypeFamily.BIGINT));
 
         assertSame(SqlTypeName.DECIMAL, SqlToQueryType.map(QueryDataTypeFamily.DECIMAL));

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastEndToEndTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastEndToEndTest.java
@@ -65,7 +65,7 @@ public class CastEndToEndTest extends ExpressionEndToEndTestBase {
         assertRow("cast(objectBooleanTrue as boolean)", EXPR0, BOOLEAN, true);
         assertDataError("cast(objectByte1 as boolean)", "Cannot convert TINYINT to BOOLEAN");
         assertDataError("cast(objectShort1 as boolean)", "Cannot convert SMALLINT to BOOLEAN");
-        assertDataError("cast(objectInt1 as boolean)", "Cannot convert INT to BOOLEAN");
+        assertDataError("cast(objectInt1 as boolean)", "Cannot convert INTEGER to BOOLEAN");
         assertDataError("cast(objectLong1 as boolean)", "Cannot convert BIGINT to BOOLEAN");
         assertDataError("cast(objectFloat1 as boolean)", "Cannot convert REAL to BOOLEAN");
         assertDataError("cast(objectDouble1 as boolean)", "Cannot convert DOUBLE to BOOLEAN");
@@ -86,7 +86,7 @@ public class CastEndToEndTest extends ExpressionEndToEndTestBase {
         assertRow("cast(short1 as tinyint)", EXPR0, TINYINT, (byte) 1);
         assertDataError("cast(shortMax as tinyint)", "Numeric overflow while converting SMALLINT to TINYINT");
         assertRow("cast(int1 as tinyint)", EXPR0, TINYINT, (byte) 1);
-        assertDataError("cast(intMax as tinyint)", "Numeric overflow while converting INT to TINYINT");
+        assertDataError("cast(intMax as tinyint)", "Numeric overflow while converting INTEGER to TINYINT");
         assertRow("cast(long1 as tinyint)", EXPR0, TINYINT, (byte) 1);
         assertDataError("cast(longMax as tinyint)", "Numeric overflow while converting BIGINT to TINYINT");
 
@@ -131,7 +131,7 @@ public class CastEndToEndTest extends ExpressionEndToEndTestBase {
         assertRow("cast(short1 as smallint)", EXPR0, SMALLINT, (short) 1);
         assertRow("cast(shortMax as smallint)", EXPR0, SMALLINT, Short.MAX_VALUE);
         assertRow("cast(int1 as smallint)", EXPR0, SMALLINT, (short) 1);
-        assertDataError("cast(intMax as smallint)", "Numeric overflow while converting INT to SMALLINT");
+        assertDataError("cast(intMax as smallint)", "Numeric overflow while converting INTEGER to SMALLINT");
         assertRow("cast(long1 as smallint)", EXPR0, SMALLINT, (short) 1);
         assertDataError("cast(longMax as smallint)", "Numeric overflow while converting BIGINT to SMALLINT");
 
@@ -206,7 +206,7 @@ public class CastEndToEndTest extends ExpressionEndToEndTestBase {
         assertRow("cast(objectBigInteger1 as integer)", EXPR0, INTEGER, 1);
         assertRow("cast(objectString1 as integer)", EXPR0, INTEGER, 1);
         assertRow("cast(objectChar1 as integer)", EXPR0, INTEGER, 1);
-        assertDataError("cast(object as integer)", "Cannot convert OBJECT to INT: com.hazelcast.sql.impl.expression"
+        assertDataError("cast(object as integer)", "Cannot convert OBJECT to INTEGER: com.hazelcast.sql.impl.expression"
                 + ".ExpressionEndToEndTestBase$SerializableObject");
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ParameterEndToEndTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ParameterEndToEndTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.sql.impl.expression;
 
 import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.impl.expression.math.ExpressionMath;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -33,7 +32,6 @@ import static com.hazelcast.sql.SqlColumnType.BOOLEAN;
 import static com.hazelcast.sql.SqlColumnType.DECIMAL;
 import static com.hazelcast.sql.SqlColumnType.DOUBLE;
 import static com.hazelcast.sql.SqlColumnType.REAL;
-import static com.hazelcast.sql.SqlColumnType.SMALLINT;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -47,15 +45,15 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
         assertRow("booleanTrue and ? and ?", EXPR0, BOOLEAN, false, "tRuE", false);
         assertRow("? and ? and ?", EXPR0, BOOLEAN, true, "tRuE", true, "true");
         assertDataError("booleanTrue and ?", "failed to convert parameter", "foo");
-        assertDataError("booleanTrue and ?", "failed to convert parameter", 1);
+        assertDataError("booleanTrue and ?", "Cannot implicitly convert parameter at position 0 from INTEGER to BOOLEAN", 1);
     }
 
     @Test
     public void testByte() {
         assertRow("byte1 + ?", EXPR0, BIGINT, 1L, 0);
-        assertRow("byte1 + ?", EXPR0, BIGINT, 2L, 1.0d);
-        assertRow("byte1 + ?", EXPR0, BIGINT, 2L, 1.1d);
         assertRow("byte1 + ?", EXPR0, BIGINT, 2L, "1");
+
+        assertDataError("byte1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to BIGINT", 1d);
         assertDataError("byte1 + ?", "failed to convert parameter", "1.1");
         assertDataError("byte1 + ?", "failed to convert parameter", "foo");
     }
@@ -63,9 +61,9 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
     @Test
     public void testShort() {
         assertRow("short1 + ?", EXPR0, BIGINT, 1L, 0);
-        assertRow("short1 + ?", EXPR0, BIGINT, 2L, 1.0d);
-        assertRow("short1 + ?", EXPR0, BIGINT, 2L, 1.1d);
         assertRow("short1 + ?", EXPR0, BIGINT, 2L, "1");
+
+        assertDataError("byte1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to BIGINT", 1d);
         assertDataError("short1 + ?", "failed to convert parameter", "1.1");
         assertDataError("short1 + ?", "failed to convert parameter", "foo");
     }
@@ -73,9 +71,9 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
     @Test
     public void testInt() {
         assertRow("int1 + ?", EXPR0, BIGINT, 1L, 0);
-        assertRow("int1 + ?", EXPR0, BIGINT, 2L, 1.0d);
-        assertRow("int1 + ?", EXPR0, BIGINT, 2L, 1.1d);
         assertRow("int1 + ?", EXPR0, BIGINT, 2L, "1");
+
+        assertDataError("int1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to BIGINT", 1d);
         assertDataError("int1 + ?", "failed to convert parameter", "1.1");
         assertDataError("int1 + ?", "failed to convert parameter", "foo");
     }
@@ -83,9 +81,9 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
     @Test
     public void testLong() {
         assertRow("long1 + ?", EXPR0, BIGINT, 1L, 0);
-        assertRow("long1 + ?", EXPR0, BIGINT, 2L, 1.0d);
-        assertRow("long1 + ?", EXPR0, BIGINT, 2L, 1.1d);
         assertRow("long1 + ?", EXPR0, BIGINT, 2L, "1");
+
+        assertDataError("long1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to BIGINT", 1d);
         assertDataError("long1 + ?", "failed to convert parameter", "1.1");
         assertDataError("long1 + ?", "failed to convert parameter", "foo");
     }
@@ -93,10 +91,10 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
     @Test
     public void testFloat() {
         assertRow("float1 + ?", EXPR0, REAL, 1.0f, 0);
-        assertRow("float1 + ?", EXPR0, REAL, 2.0f, 1d);
-        assertRow("float1 + ?", EXPR0, REAL, 2.1f, 1.1d);
         assertRow("float1 + ?", EXPR0, REAL, 2.0f, "1");
         assertRow("float1 + ?", EXPR0, REAL, 2.1f, "1.1");
+
+        assertDataError("float1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to REAL", 1d);
         assertDataError("float1 + ?", "failed to convert parameter", "foo");
     }
 
@@ -110,30 +108,26 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
         assertDataError("double1 + ?", "failed to convert parameter", "foo");
     }
 
-    @SuppressWarnings("UnpredictableBigDecimalConstructorCall")
     @Test
     public void testDecimal() {
         assertRow("decimal1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(1), 0);
-        assertRow("decimal1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2), 1d);
-        assertRow("decimal1 + ?", EXPR0, DECIMAL, new BigDecimal(1, ExpressionMath.DECIMAL_MATH_CONTEXT).add(
-                new BigDecimal(1.1, ExpressionMath.DECIMAL_MATH_CONTEXT)), 1.1d);
         assertRow("decimal1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2), "1");
         assertRow("decimal1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2.1), "1.1");
         assertRow("decimal1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2.1), BigDecimal.valueOf(1.1));
+
+        assertDataError("decimal1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 1d);
         assertDataError("decimal1 + ?", "failed to convert parameter", "foo");
     }
 
-    @SuppressWarnings("UnpredictableBigDecimalConstructorCall")
     @Test
     public void testBigInteger() {
         assertRow("bigInteger1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(1), 0);
-        assertRow("bigInteger1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2), 1d);
-        assertRow("bigInteger1 + ?", EXPR0, DECIMAL, new BigDecimal(1, ExpressionMath.DECIMAL_MATH_CONTEXT).add(
-                new BigDecimal(1.1, ExpressionMath.DECIMAL_MATH_CONTEXT)), 1.1d);
         assertRow("bigInteger1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2), "1");
         assertRow("bigInteger1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2.1), "1.1");
         assertRow("bigInteger1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(2.1), BigDecimal.valueOf(1.1));
         assertRow("bigInteger1 + ?", EXPR0, DECIMAL, BigDecimal.valueOf(3), BigInteger.valueOf(2));
+
+        assertDataError("bigInteger1 + ?", "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 1d);
         assertDataError("bigInteger1 + ?", "failed to convert parameter", "foo");
     }
 
@@ -170,12 +164,10 @@ public class ParameterEndToEndTest extends ExpressionEndToEndTestBase {
     public void testVarious() {
         assertParsingError("?", "illegal use of dynamic parameter");
         assertParsingError("? + ?", "illegal use of dynamic parameter");
-        assertRow("? + cast(? as tinyint)", EXPR0, BIGINT, 3L, 1, 2);
-        assertRow("cast(? as tinyint) + cast(? as tinyint)", EXPR0, SMALLINT, (short) 3, 1, 2);
         assertRow("? + cast(? as double)", EXPR0, DOUBLE, 3.0, 1, 2);
+
         assertDataError("? + 1", "unexpected parameter count");
         assertDataError("? and ? and ?", "unexpected parameter count", 0, 1);
         assertDataError("? + 1", "Failed to convert parameter at position 0 from VARCHAR to BIGINT", "foo");
     }
-
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
@@ -26,7 +26,9 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -55,22 +57,35 @@ public abstract class SqlExpressionIntegrationTestSupport extends SqlTestSupport
     }
 
     protected void put(Object value) {
+        put(0, value);
+    }
+
+    protected void put(int key, Object value) {
         map.clear();
-        map.put(0, value);
+        map.put(key, value);
 
         clearPlanCache(member);
     }
 
     protected void putAll(Object... values) {
-        map.clear();
-
-        if (values != null) {
-            int i = 0;
-
-            for (Object value : values) {
-                map.put(i++, value);
-            }
+        if (values == null || values.length == 0) {
+            return;
         }
+
+        Map<Integer, Object> entries = new HashMap<>();
+
+        int key = 0;
+
+        for (Object value : values) {
+            entries.put(key++, value);
+        }
+
+        putAll(entries);
+    }
+
+    protected void putAll(Map<Integer, Object> entries) {
+        map.clear();
+        map.putAll(entries);
 
         clearPlanCache(member);
     }
@@ -112,7 +127,7 @@ public abstract class SqlExpressionIntegrationTestSupport extends SqlTestSupport
             assertNotNull(e.getMessage());
             assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));
 
-            assertEquals(expectedErrorCode, e.getCode());
+            assertEquals(e.getCode() + ": " + e.getMessage(), expectedErrorCode, e.getCode());
         }
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -154,28 +154,16 @@ public class AbsFunctionIntegrationTest extends SqlExpressionIntegrationTestSupp
         checkParameter("1.1", new BigDecimal("1.1"));
         checkParameter("-1.1", new BigDecimal("1.1"));
 
-        checkParameter(0.0f, BigDecimal.ZERO);
-        checkParameter(-0.0f, BigDecimal.ZERO);
-        checkParameter(1f, BigDecimal.ONE);
-        checkParameter(-1f, BigDecimal.ONE);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.POSITIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.NEGATIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN REAL value to DECIMAL", Float.NaN);
-
-        checkParameter(0.0d, BigDecimal.ZERO);
-        checkParameter(-0.0d, BigDecimal.ZERO);
-        checkParameter(1d, BigDecimal.ONE);
-        checkParameter(-1d, BigDecimal.ONE);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.POSITIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.NEGATIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN DOUBLE value to DECIMAL", Double.NaN);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 0.0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 0.0d);
 
         checkParameter('0', BigDecimal.ZERO);
         checkParameter('1', BigDecimal.ONE);
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object parameterValue, Object expectedValue) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
@@ -83,10 +83,11 @@ public class CeilFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
         checkParameter((short) 1, BigDecimal.ONE);
         checkParameter(1, BigDecimal.ONE);
         checkParameter(1L, BigDecimal.ONE);
-        checkParameter(0.9f, BigDecimal.ONE);
-        checkParameter(0.9d, BigDecimal.ONE);
         checkParameter(BigInteger.ONE, BigDecimal.ONE);
         checkParameter(new BigDecimal("0.9"), BigDecimal.ONE);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 0.0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 0.0d);
 
         checkParameter("0.9", BigDecimal.ONE);
         checkParameter('1', BigDecimal.ONE);
@@ -95,7 +96,8 @@ public class CeilFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object param, Object expectedResult) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
@@ -113,7 +113,8 @@ public class DoubleFunctionIntegrationTest extends SqlExpressionIntegrationTestS
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DOUBLE", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DOUBLE", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DOUBLE", new ExpressionValue.ObjectVal());
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to DOUBLE", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object param, double expectedArgument) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
@@ -83,10 +83,11 @@ public class FloorFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
         checkParameter((short) 1, BigDecimal.ONE);
         checkParameter(1, BigDecimal.ONE);
         checkParameter(1L, BigDecimal.ONE);
-        checkParameter(1.1f, BigDecimal.ONE);
-        checkParameter(1.1d, BigDecimal.ONE);
         checkParameter(BigInteger.ONE, BigDecimal.ONE);
         checkParameter(new BigDecimal("1.1"), BigDecimal.ONE);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 0.0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 0.0d);
 
         checkParameter("1.1", BigDecimal.ONE);
         checkParameter('1', BigDecimal.ONE);
@@ -95,7 +96,8 @@ public class FloorFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object param, Object expectedResult) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -117,10 +117,11 @@ public class RandFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
         checkParameter((short) 1, 1L);
         checkParameter(1, 1L);
         checkParameter(1L, 1L);
-        checkParameter(1f, 1L);
-        checkParameter(1d, 1L);
-        checkParameter(BigInteger.ONE, 1L);
-        checkParameter(BigDecimal.ONE, 1L);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BIGINT", BigInteger.ONE);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BIGINT", BigDecimal.ONE);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to BIGINT", 0.0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to BIGINT", 0.0d);
 
         checkParameter("1", 1L);
         checkParameter('1', 1L);
@@ -131,7 +132,7 @@ public class RandFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BIGINT", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BIGINT", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to BIGINT", new ExpressionValue.ObjectVal());
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to BIGINT", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object param, long expectedSeed) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -85,14 +85,14 @@ public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
 
         checkColumn_2(new ShortIntegerVal().fields((short) 32767, 1), SqlColumnType.SMALLINT, (short) 32767);
         checkColumn_2(new ShortIntegerVal().fields((short) 32767, 0), SqlColumnType.SMALLINT, (short) 32767);
-        checkColumnFailure_2(new ShortIntegerVal().fields((short) 32767, -1), SqlErrorCode.DATA_EXCEPTION, "SMALLINT overflow in ROUND function (consider adding an explicit CAST to INT)");
+        checkColumnFailure_2(new ShortIntegerVal().fields((short) 32767, -1), SqlErrorCode.DATA_EXCEPTION, "SMALLINT overflow in ROUND function (consider adding an explicit CAST to INTEGER)");
         checkColumn_2(new ShortIntegerVal().fields((short) 32767, -4), SqlColumnType.SMALLINT, (short) 30000);
         checkColumn_2(new ShortIntegerVal().fields((short) 32767, -5), SqlColumnType.SMALLINT, (short) 0);
         checkColumn_2(new ShortIntegerVal().fields((short) 32767, -6), SqlColumnType.SMALLINT, (short) 0);
 
         checkColumn_2(new ShortIntegerVal().fields((short) -32768, 1), SqlColumnType.SMALLINT, (short) -32768);
         checkColumn_2(new ShortIntegerVal().fields((short) -32768, 0), SqlColumnType.SMALLINT, (short) -32768);
-        checkColumnFailure_2(new ShortIntegerVal().fields((short) -32768, -1), SqlErrorCode.DATA_EXCEPTION, "SMALLINT overflow in ROUND function (consider adding an explicit CAST to INT)");
+        checkColumnFailure_2(new ShortIntegerVal().fields((short) -32768, -1), SqlErrorCode.DATA_EXCEPTION, "SMALLINT overflow in ROUND function (consider adding an explicit CAST to INTEGER)");
         checkColumn_2(new ShortIntegerVal().fields((short) -32768, -4), SqlColumnType.SMALLINT, (short) -30000);
         checkColumn_2(new ShortIntegerVal().fields((short) -32768, -5), SqlColumnType.SMALLINT, (short) 0);
         checkColumn_2(new ShortIntegerVal().fields((short) -32768, -6), SqlColumnType.SMALLINT, (short) 0);
@@ -105,14 +105,14 @@ public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
 
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, 1), SqlColumnType.INTEGER, 2_147_483_647);
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, 0), SqlColumnType.INTEGER, 2_147_483_647);
-        checkColumnFailure_2(new IntegerIntegerVal().fields(2_147_483_647, -1), SqlErrorCode.DATA_EXCEPTION, "INT overflow in ROUND function (consider adding an explicit CAST to BIGINT)");
+        checkColumnFailure_2(new IntegerIntegerVal().fields(2_147_483_647, -1), SqlErrorCode.DATA_EXCEPTION, "INTEGER overflow in ROUND function (consider adding an explicit CAST to BIGINT)");
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -2), SqlColumnType.INTEGER, 2_147_483_600);
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -10), SqlColumnType.INTEGER, 0);
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -11), SqlColumnType.INTEGER, 0);
 
         checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, 1), SqlColumnType.INTEGER, -2_147_483_648);
         checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, 0), SqlColumnType.INTEGER, -2_147_483_648);
-        checkColumnFailure_2(new IntegerIntegerVal().fields(-2_147_483_648, -1), SqlErrorCode.DATA_EXCEPTION, "INT overflow in ROUND function (consider adding an explicit CAST to BIGINT)");
+        checkColumnFailure_2(new IntegerIntegerVal().fields(-2_147_483_648, -1), SqlErrorCode.DATA_EXCEPTION, "INTEGER overflow in ROUND function (consider adding an explicit CAST to BIGINT)");
         checkColumn_2(new IntegerIntegerVal().fields(-2_147_483_648, -2), SqlColumnType.INTEGER, -2_147_483_600);
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -10), SqlColumnType.INTEGER, 0);
         checkColumn_2(new IntegerIntegerVal().fields(2_147_483_647, -11), SqlColumnType.INTEGER, 0);
@@ -215,8 +215,8 @@ public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("9.5"));
-        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5f);
-        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5d);
+        checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 9.5f);
+        checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 9.5d);
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), "9.5");
         checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
 
@@ -227,8 +227,8 @@ public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("9.5"));
-        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5f);
-        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 9.5d);
+        checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 9.5f);
+        checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 9.5d);
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), "9.5");
         checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
 
@@ -236,9 +236,9 @@ public class RoundFunctionIntegrationTest extends SqlExpressionIntegrationTestSu
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, (byte) -1);
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, (short) -1);
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, -1);
-        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, -1L);
-        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, new BigInteger("-1"));
-        check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, new BigDecimal("-1"));
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from BIGINT to INTEGER", -1L);
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to INTEGER", BigInteger.ONE.negate());
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to INTEGER", BigDecimal.ONE.negate());
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 20, "-1");
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to INT", "bad");
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
@@ -154,26 +154,16 @@ public class SignFunctionIntegrationTest extends SqlExpressionIntegrationTestSup
         checkParameter("1.1", positive);
         checkParameter("-1.1", negative);
 
-        checkParameter(0f, zero);
-        checkParameter(1f, positive);
-        checkParameter(-1f, negative);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.POSITIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite REAL value to DECIMAL", Float.NEGATIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN REAL value to DECIMAL", Float.NaN);
-
-        checkParameter(0d, zero);
-        checkParameter(1d, positive);
-        checkParameter(-1d, negative);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.POSITIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert infinite DOUBLE value to DECIMAL", Double.NEGATIVE_INFINITY);
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert NaN DOUBLE value to DECIMAL", Double.NaN);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 0.0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 0.0d);
 
         checkParameter('0', zero);
         checkParameter('1', positive);
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", "bad");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to DECIMAL", 'b');
-        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to DECIMAL", new ExpressionValue.ObjectVal());
     }
 
     private void checkParameter(Object parameterValue, Object expectedValue) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -204,8 +204,8 @@ public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTes
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("10.5"));
-        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5f);
-        check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5d);
+        checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 10.5f);
+        checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 10.5d);
         check_1("?", SqlColumnType.DECIMAL, new BigDecimal("10"), "10.5");
         checkFailure_1("?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
 
@@ -216,8 +216,8 @@ public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTes
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10L);
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigInteger("10"));
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), new BigDecimal("10.5"));
-        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5f);
-        check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), 10.5d);
+        checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to DECIMAL", 10.5f);
+        checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to DECIMAL", 10.5d);
         check_2("?", "0", SqlColumnType.DECIMAL, new BigDecimal("10"), "10.5");
         checkFailure_2("?", "0", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL", "bad");
 
@@ -225,9 +225,9 @@ public class TruncateFunctionIntegrationTest extends SqlExpressionIntegrationTes
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, (byte) -1);
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, (short) -1);
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, -1);
-        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, -1L);
-        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, new BigInteger("-1"));
-        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, new BigDecimal("-1"));
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from BIGINT to INTEGER", 1L);
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to INTEGER", BigInteger.ONE.negate());
+        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to INTEGER", BigDecimal.ONE.negate());
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, "-1");
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to INT", "bad");
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/AndPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/AndPredicateIntegrationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.predicate;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBigDecimalVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBigIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBooleanVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanByteVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanDoubleVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanLongVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanObjectVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanShortVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.CharacterBooleanVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringBigDecimalVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringBigIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringBooleanVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringByteVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringDoubleVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringFloatVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringLongVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringObjectVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringShortVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringStringVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanFloatVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanIntegerVal;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class AndPredicateIntegrationTest extends SqlExpressionIntegrationTestSupport {
+
+    private static final Boolean RES_TRUE = true;
+    private static final Boolean RES_FALSE = false;
+    private static final Boolean RES_NULL = null;
+
+    @Test
+    public void test_three_operands() {
+        put(0);
+
+        String sql = sql("?", "?", "?");
+
+        checkValue(sql, RES_FALSE, null, true, false);
+    }
+
+    @Test
+    public void test_column() {
+        // BOOLEAN/BOOLEAN
+        checkColumnColumn(new BooleanBooleanVal().fields(true, true), RES_TRUE);
+        checkColumnColumn(new BooleanBooleanVal().fields(true, false), RES_FALSE);
+        checkColumnColumn(new BooleanBooleanVal().fields(true, null), RES_NULL);
+        checkColumnColumn(new BooleanBooleanVal().fields(false, false), RES_FALSE);
+        checkColumnColumn(new BooleanBooleanVal().fields(false, null), RES_FALSE);
+        checkColumnColumn(new BooleanBooleanVal().fields(null, null), RES_NULL);
+
+        // BOOLEAN/VARCHAR
+        checkColumnColumn(new StringBooleanVal().fields("true", true), RES_TRUE);
+        checkColumnColumn(new StringBooleanVal().fields("false", true), RES_FALSE);
+        checkColumnColumn(new StringBooleanVal().fields("false", false), RES_FALSE);
+        checkColumnColumnFailure(new StringBooleanVal().fields("bad", null), SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+        checkColumnColumnFailure(new CharacterBooleanVal().fields('b', null), SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+
+        // VARCHAR/VARCHAR
+        checkColumnColumn(new StringStringVal().fields("true", "true"), RES_TRUE);
+        checkColumnColumn(new StringStringVal().fields("false", "true"), RES_FALSE);
+        checkColumnColumn(new StringStringVal().fields("false", "false"), RES_FALSE);
+        checkColumnColumnFailure(new StringStringVal().fields("bad", null), SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+
+        // BOOLEAN/unsupported
+        checkColumnColumnFailure(new BooleanByteVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <TINYINT>'");
+        checkColumnColumnFailure(new BooleanShortVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <SMALLINT>'");
+        checkColumnColumnFailure(new BooleanIntegerVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <INTEGER>'");
+        checkColumnColumnFailure(new BooleanLongVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <BIGINT>'");
+        checkColumnColumnFailure(new BooleanBigIntegerVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new BooleanBigDecimalVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new BooleanFloatVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <REAL>'");
+        checkColumnColumnFailure(new BooleanDoubleVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <DOUBLE>'");
+        checkColumnColumnFailure(new BooleanObjectVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <OBJECT>'");
+
+        // VARCHAR/unsupported
+        checkColumnColumnFailure(new StringByteVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <TINYINT>'");
+        checkColumnColumnFailure(new StringShortVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <SMALLINT>'");
+        checkColumnColumnFailure(new StringIntegerVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <INTEGER>'");
+        checkColumnColumnFailure(new StringLongVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <BIGINT>'");
+        checkColumnColumnFailure(new StringBigIntegerVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new StringBigDecimalVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new StringFloatVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <REAL>'");
+        checkColumnColumnFailure(new StringDoubleVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <DOUBLE>'");
+        checkColumnColumnFailure(new StringObjectVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<VARCHAR> AND <OBJECT>'");
+
+        // COLUMN/PARAMETER
+        put(true);
+        checkValue("this", "?", RES_TRUE, true);
+        checkValue("this", "?", RES_FALSE, false);
+        checkValue("this", "?", RES_NULL, new Object[] { null });
+        checkFailure("this", "?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BOOLEAN", "bad");
+
+        // COLUMN/LITERAL
+        checkValue("this", "true", RES_TRUE);
+        checkValue("this", "false", RES_FALSE);
+        checkValue("this", "null", RES_NULL);
+        checkValue("this", "'true'", RES_TRUE);
+        checkValue("this", "'false'", RES_FALSE);
+        checkFailure("this", "1", SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <TINYINT>'");
+        checkFailure("this", "1E0", SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <DOUBLE>'");
+        checkFailure("this", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+    }
+
+    @Test
+    public void test_parameter() {
+        put(1);
+
+        checkValue("?", "?", RES_TRUE, true, true);
+        checkValue("?", "?", RES_FALSE, true, false);
+        checkValue("?", "?", RES_NULL, true, null);
+        checkValue("?", "?", RES_FALSE, false, false);
+        checkValue("?", "?", RES_FALSE, false, null);
+        checkValue("?", "?", RES_NULL, null, null);
+
+        checkValue("?", "?", RES_TRUE, true, "true");
+        checkValue("?", "?", RES_FALSE, true, "false");
+        checkValue("?", "?", RES_TRUE, "true", "true");
+        checkValue("?", "?", RES_FALSE, "true", "false");
+
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 1 from VARCHAR to BOOLEAN", true, "bad");
+
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from TINYINT to BOOLEAN", true, (byte) 1);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from SMALLINT to BOOLEAN", true, (short) 1);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from INTEGER to BOOLEAN", true, 1);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from BIGINT to BOOLEAN", true, 1L);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from DECIMAL to BOOLEAN", true, BigInteger.ONE);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from DECIMAL to BOOLEAN", true, BigDecimal.ONE);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from REAL to BOOLEAN", true, 1f);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from DOUBLE to BOOLEAN", true, 1d);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from OBJECT to BOOLEAN", true, new ExpressionValue.ObjectVal());
+
+        checkValue("?", "true", RES_TRUE, true);
+        checkValue("?", "true", RES_FALSE, false);
+        checkValue("?", "false", RES_FALSE, true);
+        checkValue("?", "false", RES_FALSE, false);
+        checkValue("?", "null", RES_NULL, true);
+        checkValue("?", "null", RES_FALSE, false);
+
+        checkValue("?", "'true'", RES_TRUE, true);
+        checkValue("?", "'true'", RES_FALSE, false);
+        checkValue("?", "'false'", RES_FALSE, true);
+        checkValue("?", "'false'", RES_FALSE, false);
+
+        checkFailure("?", "1", SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <TINYINT>'", true);
+        checkFailure("?", "1E0", SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <DOUBLE>'", true);
+        checkFailure("?", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'", true);
+    }
+
+    @Test
+    public void test_literal() {
+        put(1);
+
+        checkValue("true", "true", RES_TRUE);
+        checkValue("true", "false", RES_FALSE);
+        checkValue("true", "null", RES_NULL);
+        checkValue("false", "false", RES_FALSE);
+        checkValue("false", "null", RES_FALSE);
+        checkValue("null", "null", RES_NULL);
+
+        checkValue("true", "'false'", RES_FALSE);
+
+        checkFailure("true", "1", SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <TINYINT>'");
+        checkFailure("true", "1E0", SqlErrorCode.PARSING, "Cannot apply 'AND' to arguments of type '<BOOLEAN> AND <DOUBLE>'");
+        checkFailure("true", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+    }
+
+    private void checkColumnColumn(ExpressionBiValue value, Boolean expectedValue) {
+        put(value);
+
+        checkValue("field1", "field2", expectedValue);
+    }
+
+    private void checkColumnColumnFailure(ExpressionBiValue value, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+
+        checkFailure("field1", "field2", expectedErrorCode, expectedErrorMessage);
+    }
+
+    private void checkValue(String operand1, String operand2, Boolean expectedResult, Object... params) {
+        checkValue(sql(operand1, operand2), expectedResult, params);
+        checkValue(sql(operand2, operand1), expectedResult, params);
+    }
+
+    private void checkValue(String sql, Boolean expectedValue, Object... params) {
+        checkValueInternal(sql, SqlColumnType.BOOLEAN, expectedValue, params);
+    }
+
+    private void checkFailure(
+        String operand1,
+        String operand2,
+        int expectedErrorCode,
+        String expectedErrorMessage,
+        Object... params
+    ) {
+        checkFailureInternal(sql(operand1, operand2), expectedErrorCode, expectedErrorMessage, params);
+    }
+
+    private String sql(Object... operands) {
+        assert operands != null;
+        assert operands.length > 1;
+
+        StringBuilder condition = new StringBuilder();
+        condition.append(operands[0]);
+
+        for (int i = 1; i < operands.length; i++) {
+            condition.append(" AND ");
+            condition.append(operands[i]);
+        }
+
+        return "SELECT " + condition.toString() + " FROM map";
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -1,0 +1,698 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.predicate;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue;
+import com.hazelcast.sql.support.expressions.ExpressionTypes;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.createBiClass;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.createBiValue;
+
+@SuppressWarnings("rawtypes")
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ComparisonPredicateIntegrationTest extends SqlExpressionIntegrationTestSupport {
+
+    private static final int RES_EQ = 0;
+    private static final int RES_LT = -1;
+    private static final int RES_GT = 1;
+    private static final Integer RES_NULL = null;
+
+    @Parameterized.Parameter
+    public Mode mode;
+
+    @Parameterized.Parameters(name = "mode:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+            { Mode.EQ },
+            { Mode.NEQ },
+            { Mode.LT },
+            { Mode.LTE },
+            { Mode.GT },
+            { Mode.GTE },
+        });
+    }
+
+    @Test
+    public void test_column_column() {
+        // TINYINT/TINYINT
+        Class<? extends ExpressionBiValue> clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.BYTE);
+        checkColumnColumn(clazz, (byte) 0, (byte) 0, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, Byte.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, Byte.MIN_VALUE, RES_GT);
+        checkColumnColumn(clazz, (byte) 0, null, RES_NULL);
+
+        // TINYINT/SMALLINT
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.SHORT);
+        checkColumnColumn(clazz, (byte) 0, (short) 0, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, Short.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, Short.MIN_VALUE, RES_GT);
+
+        // TINYINT/INTEGER
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.INTEGER);
+        checkColumnColumn(clazz, (byte) 0, 0, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, Integer.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, Integer.MIN_VALUE, RES_GT);
+
+        // TINYINT/BIGINT
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.LONG);
+        checkColumnColumn(clazz, (byte) 0, 0L, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, Long.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, Long.MIN_VALUE, RES_GT);
+
+        // TINYINT/DECIMAL
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.BIG_INTEGER);
+        checkColumnColumn(clazz, (byte) 0, BigInteger.ZERO, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, BigInteger.ONE, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, BigInteger.ONE.negate(), RES_GT);
+
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.BIG_DECIMAL);
+        checkColumnColumn(clazz, (byte) 0, BigDecimal.ZERO, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, BigDecimal.ONE, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, BigDecimal.ONE.negate(), RES_GT);
+
+        // TINYINT/REAL
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, (byte) 0, 0f, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, 1f, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, -1f, RES_GT);
+
+        // TINYINT/DOUBLE
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, (byte) 0, 0d, RES_EQ);
+        checkColumnColumn(clazz, (byte) 0, 1d, RES_LT);
+        checkColumnColumn(clazz, (byte) 0, -1d, RES_GT);
+
+        // TINYINT/VARCHAR
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, (byte) 0, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, (byte) 0, "1", RES_LT);
+        checkColumnColumnFailure(clazz, (byte) 0, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BIGINT");
+
+        // TINYINT/OBJECT
+        clazz = createBiClass(ExpressionTypes.BYTE, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, (byte) 0, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // SMALLINT/SMALLINT
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.SHORT);
+        checkColumnColumn(clazz, (short) 0, (short) 0, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, Short.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (short) 0, Short.MIN_VALUE, RES_GT);
+
+        // SMALLINT/INTEGER
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.INTEGER);
+        checkColumnColumn(clazz, (short) 0, 0, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, Integer.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (short) 0, Integer.MIN_VALUE, RES_GT);
+
+        // SMALLINT/BIGINT
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.LONG);
+        checkColumnColumn(clazz, (short) 0, 0L, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, Long.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, (short) 0, Long.MIN_VALUE, RES_GT);
+
+        // SMALLINT/DECIMAL
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.BIG_INTEGER);
+        checkColumnColumn(clazz, (short) 0, BigInteger.ZERO, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, BigInteger.ONE, RES_LT);
+        checkColumnColumn(clazz, (short) 0, BigInteger.ONE.negate(), RES_GT);
+
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.BIG_DECIMAL);
+        checkColumnColumn(clazz, (short) 0, BigDecimal.ZERO, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, BigDecimal.ONE, RES_LT);
+        checkColumnColumn(clazz, (short) 0, BigDecimal.ONE.negate(), RES_GT);
+
+        // SMALLINT/REAL
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, (short) 0, 0f, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, 1f, RES_LT);
+        checkColumnColumn(clazz, (short) 0, -1f, RES_GT);
+
+        // SMALLINT/DOUBLE
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, (short) 0, 0d, RES_EQ);
+        checkColumnColumn(clazz, (short) 0, 1d, RES_LT);
+        checkColumnColumn(clazz, (short) 0, -1d, RES_GT);
+
+        // SMALLINT/VARCHAR
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, (short) 0, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, (short) 0, "1", RES_LT);
+        checkColumnColumnFailure(clazz, (short) 0, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BIGINT");
+
+        // SMALLINT/OBJECT
+        clazz = createBiClass(ExpressionTypes.SHORT, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, (short) 0, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // INTEGER/INTEGER
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.INTEGER);
+        checkColumnColumn(clazz, 0, 0, RES_EQ);
+        checkColumnColumn(clazz, 0, Integer.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, 0, Integer.MIN_VALUE, RES_GT);
+
+        // INTEGER/BIGINT
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.LONG);
+        checkColumnColumn(clazz, 0, 0L, RES_EQ);
+        checkColumnColumn(clazz, 0, Long.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, 0, Long.MIN_VALUE, RES_GT);
+
+        // INTEGER/DECIMAL
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.BIG_INTEGER);
+        checkColumnColumn(clazz, 0, BigInteger.ZERO, RES_EQ);
+        checkColumnColumn(clazz, 0, BigInteger.ONE, RES_LT);
+        checkColumnColumn(clazz, 0, BigInteger.ONE.negate(), RES_GT);
+
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.BIG_DECIMAL);
+        checkColumnColumn(clazz, 0, BigDecimal.ZERO, RES_EQ);
+        checkColumnColumn(clazz, 0, BigDecimal.ONE, RES_LT);
+        checkColumnColumn(clazz, 0, BigDecimal.ONE.negate(), RES_GT);
+
+        // INTEGER/REAL
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, 0, 0f, RES_EQ);
+        checkColumnColumn(clazz, 0, 1f, RES_LT);
+        checkColumnColumn(clazz, 0, -1f, RES_GT);
+
+        // INTEGER/DOUBLE
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, 0, 0d, RES_EQ);
+        checkColumnColumn(clazz, 0, 1d, RES_LT);
+        checkColumnColumn(clazz, 0, -1d, RES_GT);
+
+        // INTEGER/VARCHAR
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, 0, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, 0, "1", RES_LT);
+        checkColumnColumnFailure(clazz, 0, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BIGINT");
+
+        // INTEGER/OBJECT
+        clazz = createBiClass(ExpressionTypes.INTEGER, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, 0, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // BIGINT/BIGINT
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.LONG);
+        checkColumnColumn(clazz, 0L, 0L, RES_EQ);
+        checkColumnColumn(clazz, 0L, Long.MAX_VALUE, RES_LT);
+        checkColumnColumn(clazz, 0L, Long.MIN_VALUE, RES_GT);
+
+        // BIGINT/DECIMAL
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.BIG_INTEGER);
+        checkColumnColumn(clazz, 0L, BigInteger.ZERO, RES_EQ);
+        checkColumnColumn(clazz, 0L, BigInteger.ONE, RES_LT);
+        checkColumnColumn(clazz, 0L, BigInteger.ONE.negate(), RES_GT);
+
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.BIG_DECIMAL);
+        checkColumnColumn(clazz, 0L, BigDecimal.ZERO, RES_EQ);
+        checkColumnColumn(clazz, 0L, BigDecimal.ONE, RES_LT);
+        checkColumnColumn(clazz, 0L, BigDecimal.ONE.negate(), RES_GT);
+
+        // BIGINT/REAL
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, 0L, 0f, RES_EQ);
+        checkColumnColumn(clazz, 0L, 1f, RES_LT);
+        checkColumnColumn(clazz, 0L, -1f, RES_GT);
+
+        // BIGINT/DOUBLE
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, 0L, 0d, RES_EQ);
+        checkColumnColumn(clazz, 0L, 1d, RES_LT);
+        checkColumnColumn(clazz, 0L, -1d, RES_GT);
+
+        // BIGINT/VARCHAR
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, 0L, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, 0L, "1", RES_LT);
+        checkColumnColumnFailure(clazz, 0L, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BIGINT");
+
+        // BIGINT/OBJECT
+        clazz = createBiClass(ExpressionTypes.LONG, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, 0L, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // DECIMAL(BigInteger)/DECIMAL
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.BIG_INTEGER);
+        checkColumnColumn(clazz, BigInteger.ZERO, BigInteger.ZERO, RES_EQ);
+        checkColumnColumn(clazz, BigInteger.ZERO, BigInteger.ONE, RES_LT);
+        checkColumnColumn(clazz, BigInteger.ZERO, BigInteger.ONE.negate(), RES_GT);
+
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.BIG_DECIMAL);
+        checkColumnColumn(clazz, BigInteger.ZERO, BigDecimal.ZERO, RES_EQ);
+        checkColumnColumn(clazz, BigInteger.ZERO, BigDecimal.ONE, RES_LT);
+        checkColumnColumn(clazz, BigInteger.ZERO, BigDecimal.ONE.negate(), RES_GT);
+
+        // DECIMAL(BigInteger)/REAL
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, BigInteger.ZERO, 0f, RES_EQ);
+        checkColumnColumn(clazz, BigInteger.ZERO, 1f, RES_LT);
+        checkColumnColumn(clazz, BigInteger.ZERO, -1f, RES_GT);
+
+        // DECIMAL(BigInteger)/DOUBLE
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, BigInteger.ZERO, 0d, RES_EQ);
+        checkColumnColumn(clazz, BigInteger.ZERO, 1d, RES_LT);
+        checkColumnColumn(clazz, BigInteger.ZERO, -1d, RES_GT);
+
+        // DECIMAL(BigInteger)/VARCHAR
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, BigInteger.ZERO, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, BigInteger.ZERO, "1", RES_LT);
+        checkColumnColumnFailure(clazz, BigInteger.ZERO, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+
+        // DECIMAL(BigInteger)/OBJECT
+        clazz = createBiClass(ExpressionTypes.BIG_INTEGER, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, BigInteger.ZERO, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // BIGINT(BigDecimal)/DECIMAL
+        clazz = createBiClass(ExpressionTypes.BIG_DECIMAL, ExpressionTypes.BIG_DECIMAL);
+        checkColumnColumn(clazz, BigDecimal.ZERO, BigDecimal.ZERO, RES_EQ);
+        checkColumnColumn(clazz, new BigDecimal("0"), new BigDecimal("0.0"), RES_EQ);
+        checkColumnColumn(clazz, BigDecimal.ZERO, BigDecimal.ONE, RES_LT);
+        checkColumnColumn(clazz, BigDecimal.ZERO, BigDecimal.ONE.negate(), RES_GT);
+
+        // DECIMAL(BigDecimal)/REAL
+        clazz = createBiClass(ExpressionTypes.BIG_DECIMAL, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, BigDecimal.ZERO, 0f, RES_EQ);
+        checkColumnColumn(clazz, BigDecimal.ZERO, 1f, RES_LT);
+        checkColumnColumn(clazz, BigDecimal.ZERO, -1f, RES_GT);
+
+        // DECIMAL(BigDecimal)/DOUBLE
+        clazz = createBiClass(ExpressionTypes.BIG_DECIMAL, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, BigDecimal.ZERO, 0d, RES_EQ);
+        checkColumnColumn(clazz, BigDecimal.ZERO, 1d, RES_LT);
+        checkColumnColumn(clazz, BigDecimal.ZERO, -1d, RES_GT);
+
+        // DECIMAL(BigDecimal)/VARCHAR
+        clazz = createBiClass(ExpressionTypes.BIG_DECIMAL, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, BigDecimal.ZERO, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.BIG_DECIMAL, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, BigDecimal.ZERO, "1", RES_LT);
+        checkColumnColumnFailure(clazz, BigDecimal.ZERO, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DECIMAL");
+
+        // DECIMAL(BigDecimal)/OBJECT
+        clazz = createBiClass(ExpressionTypes.BIG_DECIMAL, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, BigDecimal.ZERO, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // REAL/REAL
+        clazz = createBiClass(ExpressionTypes.FLOAT, ExpressionTypes.FLOAT);
+        checkColumnColumn(clazz, 0f, 0f, RES_EQ);
+        checkColumnColumn(clazz, 0f, 1f, RES_LT);
+        checkColumnColumn(clazz, 0f, -1f, RES_GT);
+
+        // REAL/DOUBLE
+        clazz = createBiClass(ExpressionTypes.FLOAT, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, 0f, 0d, RES_EQ);
+        checkColumnColumn(clazz, 0f, 1d, RES_LT);
+        checkColumnColumn(clazz, 0f, -1d, RES_GT);
+
+        // REAL/VARCHAR
+        clazz = createBiClass(ExpressionTypes.FLOAT, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, 0f, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.FLOAT, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, 0f, "1", RES_LT);
+        checkColumnColumnFailure(clazz, 0f, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to REAL");
+
+        // REAL/OBJECT
+        clazz = createBiClass(ExpressionTypes.FLOAT, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, 0f, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // DOUBLE/DOUBLE
+        clazz = createBiClass(ExpressionTypes.DOUBLE, ExpressionTypes.DOUBLE);
+        checkColumnColumn(clazz, 0d, 0d, RES_EQ);
+        checkColumnColumn(clazz, 0d, 1d, RES_LT);
+        checkColumnColumn(clazz, 0d, -1d, RES_GT);
+
+        // DOUBLE/VARCHAR
+        clazz = createBiClass(ExpressionTypes.DOUBLE, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, 0d, '1', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.DOUBLE, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, 0d, "1", RES_LT);
+        checkColumnColumnFailure(clazz, 0d, "bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to DOUBLE");
+
+        // DOUBLE/OBJECT
+        clazz = createBiClass(ExpressionTypes.DOUBLE, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, 0d, 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // VARCHAR(char)/VARCHAR
+        clazz = createBiClass(ExpressionTypes.CHARACTER, ExpressionTypes.CHARACTER);
+        checkColumnColumn(clazz, 'b', 'a', RES_GT);
+        checkColumnColumn(clazz, 'b', 'b', RES_EQ);
+        checkColumnColumn(clazz, 'b', 'c', RES_LT);
+
+        clazz = createBiClass(ExpressionTypes.CHARACTER, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, 'b', "a", RES_GT);
+
+        // VARCHAR(char)/OBJECT
+        clazz = createBiClass(ExpressionTypes.CHARACTER, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, '0', 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // VARCHAR(char)/VARCHAR
+        clazz = createBiClass(ExpressionTypes.STRING, ExpressionTypes.STRING);
+        checkColumnColumn(clazz, "abc", "ab", RES_GT);
+        checkColumnColumn(clazz, "abc", "abc", RES_EQ);
+        checkColumnColumn(clazz, "abc", "abcd", RES_LT);
+
+        // VARCHAR(char)/OBJECT
+        clazz = createBiClass(ExpressionTypes.STRING, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, "abc", 1, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+
+        // OBJECT/OBJECT
+        clazz = createBiClass(ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
+        checkColumnColumnFailure(clazz, 1, 2, SqlErrorCode.PARSING, "to arguments of type '<OBJECT>");
+    }
+
+    @Test
+    public void test_column_parameter() {
+        checkColumnParameter(0, 0, RES_EQ);
+        checkColumnParameter(0, Integer.MAX_VALUE, RES_LT);
+        checkColumnParameter(0, Integer.MIN_VALUE, RES_GT);
+
+        checkColumnParameter(0, null, RES_NULL);
+
+        checkColumnParameterFailure(1, new BigDecimal("1.1"), SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BIGINT");
+    }
+
+    @Test
+    public void test_column_literal() {
+        checkColumnLiteral(1, "1", RES_EQ);
+
+        checkColumnLiteral(1, "1.1", RES_LT);
+        checkColumnLiteral(1, "0.9", RES_GT);
+
+        checkColumnLiteral(1, "1.1E0", RES_LT);
+        checkColumnLiteral(1, "0.9E0", RES_GT);
+
+        checkColumnLiteral(1, "null", RES_NULL);
+
+        checkColumnLiteralFailure(1, "true", SqlErrorCode.PARSING, "Literal 'TRUE' can not be parsed to type 'INTEGER'");
+        checkColumnLiteralFailure(1, "false", SqlErrorCode.PARSING, "Literal 'FALSE' can not be parsed to type 'INTEGER'");
+
+        checkColumnLiteralFailure(1, "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+    }
+
+    @Test
+    public void test_parameter_parameter() {
+        put(1);
+
+        checkFailure("?", "?", SqlErrorCode.PARSING, "Illegal use of dynamic parameter");
+    }
+
+    @Test
+    public void test_parameter_literal() {
+        put(1);
+
+        // Exact numeric literal
+        check("?", "1", RES_NULL, new Object[] { null });
+
+        check("?", "1", RES_LT, (byte) 0);
+        check("?", "1", RES_EQ, (byte) 1);
+        check("?", "1", RES_GT, (byte) 2);
+
+        check("?", "1", RES_LT, (short) 0);
+        check("?", "1", RES_EQ, (short) 1);
+        check("?", "1", RES_GT, (short) 2);
+
+        check("?", "1", RES_LT, 0);
+        check("?", "1", RES_EQ, 1);
+        check("?", "1", RES_GT, 2);
+
+        check("?", "1", RES_LT, 0L);
+        check("?", "1", RES_EQ, 1L);
+        check("?", "1", RES_GT, 2L);
+
+        checkFailure("?", "1", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BIGINT", new BigInteger("1"));
+        checkFailure("?", "1", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BIGINT", new BigDecimal("1"));
+
+        // Inexact numeric literal
+        check("?", "1E0", RES_NULL, new Object[] { null });
+
+        check("?", "1E0", RES_LT, (byte) 0);
+        check("?", "1E0", RES_EQ, (byte) 1);
+        check("?", "1E0", RES_GT, (byte) 2);
+
+        check("?", "1E0", RES_LT, (short) 0);
+        check("?", "1E0", RES_EQ, (short) 1);
+        check("?", "1E0", RES_GT, (short) 2);
+
+        check("?", "1E0", RES_LT, 0);
+        check("?", "1E0", RES_EQ, 1);
+        check("?", "1E0", RES_GT, 2);
+
+        check("?", "1E0", RES_LT, 0L);
+        check("?", "1E0", RES_EQ, 1L);
+        check("?", "1E0", RES_GT, 2L);
+
+        check("?", "1E0", RES_LT, new BigInteger("0"));
+        check("?", "1E0", RES_EQ, new BigInteger("1"));
+        check("?", "1E0", RES_GT, new BigInteger("2"));
+
+        check("?", "1E0", RES_LT, new BigDecimal("0"));
+        check("?", "1E0", RES_EQ, new BigDecimal("1"));
+        check("?", "1E0", RES_GT, new BigDecimal("2"));
+
+        // String literal
+        check("?", "'abc'", RES_NULL, new Object[] { null });
+
+        check("?", "'abc'", RES_LT, "ab");
+        check("?", "'abc'", RES_EQ, "abc");
+        check("?", "'abc'", RES_GT, "abcd");
+
+        checkFailure("?", "'abc'", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from INTEGER to VARCHAR", 1);
+        checkFailure("?", "'1'", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from INTEGER to VARCHAR", 1);
+
+        // Boolean literal
+        check("?", "true", RES_NULL, new Object[] { null });
+
+        check("?", "true", RES_LT, false);
+        check("?", "true", RES_EQ, true);
+
+        checkFailure("?", "true", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from INTEGER to BOOLEAN", 1);
+
+        // Null literal
+        checkFailure("?", "null", SqlErrorCode.PARSING, "Illegal use of dynamic parameter", 1);
+    }
+
+    @Test
+    public void test_literal_literal() {
+        put(1);
+
+        check("1", "0", RES_GT);
+        check("1", "1", RES_EQ);
+        check("1", "2", RES_LT);
+        check("1", "2E0", RES_LT);
+        check("1", "'2'", RES_LT);
+        checkFailure("1", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+        checkFailure("1", "true", SqlErrorCode.PARSING, "Literal 'TRUE' can not be parsed to type 'TINYINT'");
+        check("1", "null", RES_NULL);
+
+        check("1E0", "0E0", RES_GT);
+        check("1E0", "1E0", RES_EQ);
+        check("1E0", "2E0", RES_LT);
+        check("1E0", "'2'", RES_LT);
+        checkFailure("1E0", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'DECIMAL'");
+        checkFailure("1E0", "true", SqlErrorCode.PARSING, "Literal 'TRUE' can not be parsed to type 'DOUBLE'");
+        check("1E0", "null", RES_NULL);
+
+        check("'1'", "'2'", RES_LT);
+        check("'abc'", "'def'", RES_LT);
+        checkFailure("'abc'", "true", SqlErrorCode.PARSING, "Literal ''abc'' can not be parsed to type 'BOOLEAN'");
+        check("'abc'", "null", RES_NULL);
+
+        check("true", "false", RES_GT);
+        check("true", "null", RES_NULL);
+
+        check("null", "null", RES_NULL);
+    }
+
+    private void checkColumnColumn(
+        Class<? extends ExpressionBiValue> clazz,
+        Comparable operand1,
+        Comparable operand2,
+        Integer expectedRes
+    ) {
+        put(createBiValue(clazz, operand1, operand2));
+
+        check("field1", "field2", expectedRes);
+    }
+
+    private void checkColumnColumnFailure(
+        Class<? extends ExpressionBiValue> clazz,
+        Comparable operand1,
+        Comparable operand2,
+        int expectedErrorCode,
+        String expectedErrorMessage
+    ) {
+        put(createBiValue(clazz, operand1, operand2));
+
+        checkFailure("field1", "field2", expectedErrorCode, expectedErrorMessage);
+    }
+
+    private void checkColumnParameter(Object value, Object param, Integer expectedRes) {
+        put(value);
+
+        check("this", "?", expectedRes, param);
+    }
+
+    private void checkColumnParameterFailure(Object value, Object param, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+
+        checkFailure("this", "?", expectedErrorCode, expectedErrorMessage, param);
+    }
+
+    private void checkColumnLiteral(Object value, String literal, Integer expectedRes) {
+        put(value);
+
+        check("this", literal, expectedRes);
+    }
+
+    private void checkColumnLiteralFailure(Object value, String literal, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+
+        checkFailure("this", literal, expectedErrorCode, expectedErrorMessage);
+    }
+
+    private void checkFailure(
+        String operand1,
+        String operand2,
+        int expectedErrorCode,
+        String expectedErrorMessage,
+        Object... params
+    ) {
+        for (String token : mode.tokens) {
+            String sql = sql(token, operand1, operand2);
+
+            checkFailureInternal(sql, expectedErrorCode, expectedErrorMessage, params);
+        }
+    }
+
+    private void check(
+        String operand1,
+        String operand2,
+        Integer expectedRes,
+        Object... params
+    ) {
+        // Test direct
+        Boolean expectedValue = compare(expectedRes);
+
+        for (String token : mode.tokens) {
+            String sql = sql(token, operand1, operand2);
+
+            checkValueInternal(sql, SqlColumnType.BOOLEAN, expectedValue, params);
+
+            Mode inverseMode = mode.inverse();
+
+            for (String inverseToken : inverseMode.tokens) {
+                String inverseSql = sql(inverseToken, operand2, operand1);
+
+                checkValueInternal(inverseSql, SqlColumnType.BOOLEAN, expectedValue, params);
+            }
+        }
+    }
+
+    private String sql(String token, String operand1, String operand2) {
+        return "SELECT " + operand1 + " " + token + " " + operand2 + " FROM map";
+    }
+
+    public Boolean compare(Integer res) {
+        if (res == null) {
+            return null;
+        }
+
+        switch (mode) {
+            case EQ:
+                return res == 0;
+
+            case NEQ:
+                return res != 0;
+
+            case LT:
+                return res < 0;
+
+            case LTE:
+                return res <= 0;
+
+            case GT:
+                return res > 0;
+
+            default:
+                assert mode == Mode.GTE;
+
+                return res >= 0;
+        }
+    }
+
+    private enum Mode {
+        EQ("="),
+        NEQ("!=", "<>"),
+        LT("<"),
+        LTE("<="),
+        GT(">"),
+        GTE(">=");
+
+        private final String[] tokens;
+
+        Mode(String... tokens) {
+            this.tokens = tokens;
+        }
+
+        Mode inverse() {
+            switch (this) {
+                case LT:
+                    return GT;
+
+                case LTE:
+                    return GTE;
+
+                case GT:
+                    return LT;
+
+                case GTE:
+                    return LTE;
+
+                default:
+                    return this;
+            }
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsNullPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsNullPredicateIntegrationTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.predicate;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionType;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BIG_DECIMAL;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BIG_INTEGER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BOOLEAN;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BYTE;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.CHARACTER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.DOUBLE;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.FLOAT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.INTEGER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.LONG;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.OBJECT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.SHORT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.STRING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for IS (NOT) NULL predicates.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class IsNullPredicateIntegrationTest extends SqlExpressionIntegrationTestSupport {
+    @Test
+    public void testLiteral() {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(INTEGER);
+
+        int key = 0;
+        ExpressionValue value = ExpressionValue.create(clazz, 0, 1);
+
+        put(key, value);
+
+        checkLiteral("1", false);
+        checkLiteral("'1'", false);
+
+        checkLiteral("'a'", false);
+
+        checkLiteral("TRUE", false);
+        checkLiteral("true", false);
+        checkLiteral("'TRUE'", false);
+        checkLiteral("'true'", false);
+
+        checkLiteral("FALSE", false);
+        checkLiteral("false", false);
+        checkLiteral("'FALSE'", false);
+        checkLiteral("'false'", false);
+
+        checkLiteral("NULL", true);
+        checkLiteral("null", true);
+        checkLiteral("'NULL'", false);
+        checkLiteral("'null'", false);
+    }
+
+    private void checkLiteral(String literal, boolean expectedResult) {
+        checkLiteral(literal, "IS NULL", expectedResult);
+        checkLiteral(literal, "IS NOT NULL", !expectedResult);
+    }
+
+    private void checkLiteral(String literal, String function, boolean expectedResult) {
+        String expression = literal + " " + function;
+        String sql = "SELECT " + expression + " FROM map WHERE " + expression;
+
+        List<SqlRow> rows = execute(member, sql);
+
+        if (expectedResult) {
+            assertEquals(1, rows.size());
+
+            SqlRow row = rows.get(0);
+
+            assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(0).getType());
+            assertTrue(row.getObject(0));
+        } else {
+            assertEquals(0, rows.size());
+        }
+    }
+
+    @Test
+    public void testColumn() {
+        checkColumn(BOOLEAN);
+
+        checkColumn(BYTE);
+        checkColumn(SHORT);
+        checkColumn(INTEGER);
+        checkColumn(LONG);
+        checkColumn(BIG_INTEGER);
+        checkColumn(BIG_DECIMAL);
+        checkColumn(FLOAT);
+        checkColumn(DOUBLE);
+
+        checkColumn(STRING);
+        checkColumn(CHARACTER);
+
+        checkColumn(OBJECT);
+    }
+
+    private void checkColumn(ExpressionType<?> type) {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(type);
+
+        int keyNull = 0;
+        int keyNotNull = 1;
+
+        Map<Integer, Object> entries = new HashMap<>();
+        entries.put(keyNull, ExpressionValue.create(clazz, keyNull, null));
+        entries.put(keyNotNull, ExpressionValue.create(clazz, keyNotNull, type.valueFrom()));
+        putAll(entries);
+
+        checkColumn("IS NULL", set(keyNull));
+        checkColumn("IS NOT NULL", set(keyNotNull));
+    }
+
+    private void checkColumn(String function, Set<Integer> expectedKeys) {
+        String expression = "field1 " + function;
+        String sql = "SELECT key, " + expression + " FROM map WHERE " + expression;
+
+        List<SqlRow> rows = execute(member, sql);
+
+        assertEquals(expectedKeys.size(), rows.size());
+
+        for (SqlRow row : rows) {
+            assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(1).getType());
+
+            int key = row.getObject(0);
+            boolean value = row.getObject(1);
+
+            assertTrue("Key is not returned: " + key, expectedKeys.contains(key));
+            assertTrue(value);
+        }
+    }
+
+    @Test
+    public void testParameter() {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(INTEGER);
+
+        int key = 0;
+        ExpressionValue value = ExpressionValue.create(clazz, 0, 1);
+
+        put(key, value);
+
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NULL", new Object[] { null }));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT NULL", new Object[] { null }));
+
+        checkNotNullParameter(key, BOOLEAN);
+
+        checkNotNullParameter(key, BYTE);
+        checkNotNullParameter(key, SHORT);
+        checkNotNullParameter(key, INTEGER);
+        checkNotNullParameter(key, LONG);
+        checkNotNullParameter(key, BIG_INTEGER);
+        checkNotNullParameter(key, BIG_DECIMAL);
+        checkNotNullParameter(key, FLOAT);
+        checkNotNullParameter(key, DOUBLE);
+
+        checkNotNullParameter(key, STRING);
+        checkNotNullParameter(key, CHARACTER);
+
+        checkNotNullParameter(key, OBJECT);
+    }
+
+    private void checkNotNullParameter(int key, ExpressionType<?> type) {
+        Object parameter = type.valueFrom();
+
+        assertNotNull(parameter);
+
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NULL", parameter));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT NULL", parameter));
+    }
+
+    private Set<Integer> keys(String sql, Object... params) {
+        List<SqlRow> rows = execute(member, sql, params);
+
+        if (rows.size() == 0) {
+            return Collections.emptySet();
+        }
+
+        assertEquals(1, rows.get(0).getMetadata().getColumnCount());
+
+        Set<Integer> keys = new HashSet<>();
+
+        for (SqlRow row : rows) {
+            int key = row.getObject(0);
+
+            boolean added = keys.add(key);
+
+            assertTrue("Key is not unique: " + key, added);
+        }
+
+        return keys;
+    }
+
+    private static Set<Integer> set(Integer... values) {
+        Set<Integer> res = new HashSet<>();
+
+        if (values != null) {
+            res.addAll(Arrays.asList(values));
+        }
+
+        return res;
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsTrueFalsePredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsTrueFalsePredicateIntegrationTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.predicate;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionType;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BIG_DECIMAL;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BIG_INTEGER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BOOLEAN;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BYTE;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.CHARACTER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.DOUBLE;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.FLOAT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.INTEGER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.LONG;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.OBJECT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.STRING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for IS (NOT) TRUE/FALSE predicates.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class IsTrueFalsePredicateIntegrationTest extends SqlExpressionIntegrationTestSupport {
+    @Test
+    public void testLiteral() {
+        put(ExpressionValue.create(ExpressionValue.createClass(INTEGER), 0, 1));
+
+        // TRUE literal
+        checkLiteral("TRUE", "IS TRUE", true);
+        checkLiteral("true", "IS TRUE", true);
+        checkLiteral("'TRUE'", "IS TRUE", true);
+        checkLiteral("'true'", "IS TRUE", true);
+
+        checkLiteral("TRUE", "IS FALSE", false);
+
+        checkLiteral("true", "IS FALSE", false);
+        checkLiteral("'TRUE'", "IS FALSE", false);
+        checkLiteral("'true'", "IS FALSE", false);
+
+        checkLiteral("TRUE", "IS NOT TRUE", false);
+        checkLiteral("true", "IS NOT TRUE", false);
+        checkLiteral("'TRUE'", "IS NOT TRUE", false);
+        checkLiteral("'true'", "IS NOT TRUE", false);
+
+        checkLiteral("TRUE", "IS NOT FALSE", true);
+        checkLiteral("true", "IS NOT FALSE", true);
+        checkLiteral("'TRUE'", "IS NOT FALSE", true);
+        checkLiteral("'true'", "IS NOT FALSE", true);
+
+        // False literal
+        checkLiteral("FALSE", "IS TRUE", false);
+        checkLiteral("false", "IS TRUE", false);
+        checkLiteral("'FALSE'", "IS TRUE", false);
+        checkLiteral("'false'", "IS TRUE", false);
+
+        checkLiteral("FALSE", "IS FALSE", true);
+        checkLiteral("false", "IS FALSE", true);
+        checkLiteral("'FALSE'", "IS FALSE", true);
+        checkLiteral("'false'", "IS FALSE", true);
+
+        checkLiteral("FALSE", "IS NOT TRUE", true);
+        checkLiteral("false", "IS NOT TRUE", true);
+        checkLiteral("'FALSE'", "IS NOT TRUE", true);
+        checkLiteral("'false'", "IS NOT TRUE", true);
+
+        checkLiteral("FALSE", "IS NOT FALSE", false);
+        checkLiteral("false", "IS NOT FALSE", false);
+        checkLiteral("'FALSE'", "IS NOT FALSE", false);
+        checkLiteral("'false'", "IS NOT FALSE", false);
+
+        // NULL literal
+        checkLiteral("NULL", "IS TRUE", false);
+        checkLiteral("null", "IS TRUE", false);
+
+        checkLiteral("NULL", "IS FALSE", false);
+        checkLiteral("null", "IS FALSE", false);
+
+        checkLiteral("NULL", "IS NOT TRUE", true);
+        checkLiteral("null", "IS NOT TRUE", true);
+
+        checkLiteral("NULL", "IS NOT FALSE", true);
+        checkLiteral("null", "IS NOT FALSE", true);
+
+        // Bad literal
+        checkBadLiteral("IS TRUE");
+        checkBadLiteral("IS FALSE");
+        checkBadLiteral("IS NOT TRUE");
+        checkBadLiteral("IS NOT FALSE");
+    }
+
+    private void checkLiteral(String literal, String function, boolean expectedResult) {
+        String expression = literal + " " + function;
+        String sql = "SELECT " + expression + " FROM map WHERE " + expression;
+
+        List<SqlRow> rows = execute(member, sql);
+
+        if (expectedResult) {
+            assertEquals(1, rows.size());
+
+            SqlRow row = rows.get(0);
+
+            assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(0).getType());
+            assertTrue(row.getObject(0));
+        } else {
+            assertEquals(0, rows.size());
+        }
+    }
+
+    private void checkBadLiteral(String function) {
+        checkFailureInternal("SELECT * FROM map WHERE 'bad' " + function, SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+        checkFailureInternal("SELECT 'bad' " + function + " FROM map", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+    }
+
+    @Test
+    public void testColumn_boolean() {
+        checkColumn(BOOLEAN, true, false);
+    }
+
+    @Test
+    public void testColumn_string() {
+        checkColumn(STRING, "true", "false");
+    }
+
+    private void checkColumn(ExpressionType<?> type, Object trueValue, Object falseValue) {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(type);
+
+        int keyTrue = 0;
+        int keyFalse = 1;
+        int keyNull = 2;
+
+        Map<Integer, Object> entries = new HashMap<>();
+        entries.put(keyTrue, ExpressionValue.create(clazz, keyTrue, trueValue));
+        entries.put(keyFalse, ExpressionValue.create(clazz, keyFalse, falseValue));
+        entries.put(keyNull, ExpressionValue.create(clazz, keyNull, null));
+        putAll(entries);
+
+        checkColumn("IS TRUE", set(keyTrue));
+        checkColumn("IS FALSE", set(keyFalse));
+        checkColumn("IS NOT TRUE", set(keyFalse, keyNull));
+        checkColumn("IS NOT FALSE", set(keyTrue, keyNull));
+    }
+
+    private void checkColumn(String function, Set<Integer> expectedKeys) {
+        String expression = "field1 " + function;
+        String sql = "SELECT key, " + expression + " FROM map WHERE " + expression;
+
+        List<SqlRow> rows = execute(member, sql);
+
+        assertEquals(expectedKeys.size(), rows.size());
+
+        for (SqlRow row : rows) {
+            assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(1).getType());
+
+            int key = row.getObject(0);
+            boolean value = row.getObject(1);
+
+            assertTrue("Key is not returned: " + key, expectedKeys.contains(key));
+            assertTrue(value);
+        }
+    }
+
+    @Test
+    public void testColumnBad_string() {
+        checkColumnBad(STRING, "bad", "VARCHAR");
+    }
+
+    @Test
+    public void testColumnBad_character() {
+        checkColumnBad(CHARACTER, 'a', "VARCHAR");
+    }
+
+    private void checkColumnBad(ExpressionType<?> type, Object value, Object expectedFromType) {
+        put(ExpressionValue.create(ExpressionValue.createClass(type), 1, value));
+
+        checkColumnBad("IS TRUE", expectedFromType);
+        checkColumnBad("IS FALSE", expectedFromType);
+        checkColumnBad("IS NOT TRUE", expectedFromType);
+        checkColumnBad("IS NOT FALSE", expectedFromType);
+    }
+
+    private void checkColumnBad(String function, Object expectedFromType) {
+        checkFailureInternal(
+            "SELECT key FROM map WHERE field1 " + function,
+            SqlErrorCode.DATA_EXCEPTION,
+            "Cannot convert " + expectedFromType + " to BOOLEAN"
+        );
+    }
+
+    @Test
+    public void testColumn_unsupported() {
+        checkUnsupportedColumn(BYTE, "TINYINT");
+        checkUnsupportedColumn(INTEGER, "INTEGER");
+        checkUnsupportedColumn(LONG, "BIGINT");
+        checkUnsupportedColumn(BIG_INTEGER, "DECIMAL(38, 38)");
+        checkUnsupportedColumn(BIG_DECIMAL, "DECIMAL(38, 38)");
+        checkUnsupportedColumn(FLOAT, "REAL");
+        checkUnsupportedColumn(DOUBLE, "DOUBLE");
+        checkUnsupportedColumn(OBJECT, "OBJECT");
+    }
+
+    private void checkUnsupportedColumn(ExpressionType<?> type, String expectedTypeNameInErrorMessage) {
+        checkUnsupportedColumn(type, "IS TRUE", expectedTypeNameInErrorMessage);
+        checkUnsupportedColumn(type, "IS FALSE", expectedTypeNameInErrorMessage);
+        checkUnsupportedColumn(type, "IS NOT FALSE", expectedTypeNameInErrorMessage);
+        checkUnsupportedColumn(type, "IS NOT TRUE", expectedTypeNameInErrorMessage);
+    }
+
+    private void checkUnsupportedColumn(ExpressionType<?> type, String function, String expectedTypeNameInErrorMessage) {
+        String expectedErrorMessage = "Cannot apply '" + function + "' to arguments of type '<"
+            + expectedTypeNameInErrorMessage + "> " + function + "'. Supported form(s): '<BOOLEAN> " + function + "'";
+
+        int key = 0;
+        put(key, ExpressionValue.create(ExpressionValue.createClass(type), key, type.valueFrom()));
+
+        // Function in the condition
+        checkFailureInternal(
+            "SELECT key FROM map WHERE field1 " + function,
+            SqlErrorCode.PARSING,
+            expectedErrorMessage
+        );
+
+        // Function in the column
+        checkFailureInternal(
+            "SELECT field1 " + function + " FROM map",
+            SqlErrorCode.PARSING,
+            expectedErrorMessage
+        );
+    }
+
+    @Test
+    public void testParameter() {
+        int key = 0;
+        put(key, ExpressionValue.create(ExpressionValue.createClass(INTEGER), 0, 1));
+
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS TRUE", true));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS TRUE", false));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS TRUE", "true"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS TRUE", "false"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS TRUE", new Object[] { null }));
+
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS FALSE", true));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS FALSE", false));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS FALSE", "true"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS FALSE", "false"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS FALSE", new Object[] { null }));
+
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT TRUE", true));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT TRUE", false));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT TRUE", "true"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT TRUE", "false"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT TRUE", new Object[] { null }));
+
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT FALSE", true));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT FALSE", false));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT FALSE", "true"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT FALSE", "false"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT FALSE", new Object[] { null }));
+
+        checkUnsupportedParameter((byte) 1, "TINYINT");
+        checkUnsupportedParameter((short) 1, "SMALLINT");
+        checkUnsupportedParameter(1, "INTEGER");
+        checkUnsupportedParameter((long) 1, "BIGINT");
+        checkUnsupportedParameter(BigInteger.ONE, "DECIMAL");
+        checkUnsupportedParameter(BigDecimal.ONE, "DECIMAL");
+        checkUnsupportedParameter(1f, "REAL");
+        checkUnsupportedParameter(1d, "DOUBLE");
+    }
+
+    private void checkUnsupportedParameter(Object param, String expectedTypeInErrorMessage) {
+        checkUnsupportedParameter("IS TRUE", param, expectedTypeInErrorMessage);
+        checkUnsupportedParameter("IS FALSE", param, expectedTypeInErrorMessage);
+        checkUnsupportedParameter("IS NOT TRUE", param, expectedTypeInErrorMessage);
+        checkUnsupportedParameter("IS NOT FALSE", param, expectedTypeInErrorMessage);
+    }
+
+    private void checkUnsupportedParameter(String function, Object param, String expectedTypeInErrorMessage) {
+        String sql = "SELECT * FROM map WHERE ? " + function;
+
+        checkFailureInternal(
+            sql,
+            SqlErrorCode.DATA_EXCEPTION,
+            "Cannot implicitly convert parameter at position 0 from " + expectedTypeInErrorMessage + " to BOOLEAN",
+            param
+        );
+    }
+
+    private Set<Integer> keys(String sql, Object... params) {
+        List<SqlRow> rows = execute(member, sql, params);
+
+        if (rows.size() == 0) {
+            return Collections.emptySet();
+        }
+
+        assertEquals(1, rows.get(0).getMetadata().getColumnCount());
+
+        Set<Integer> keys = new HashSet<>();
+
+        for (SqlRow row : rows) {
+            int key = row.getObject(0);
+
+            boolean added = keys.add(key);
+
+            assertTrue("Key is not unique: " + key, added);
+        }
+
+        return keys;
+    }
+
+    private static Set<Integer> set(Integer... values) {
+        Set<Integer> res = new HashSet<>();
+
+        if (values != null) {
+            res.addAll(Arrays.asList(values));
+        }
+
+        return res;
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/NotPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/NotPredicateIntegrationTest.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.predicate;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionType;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BIG_DECIMAL;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BIG_INTEGER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BOOLEAN;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.BYTE;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.CHARACTER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.DOUBLE;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.FLOAT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.INTEGER;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.LONG;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.OBJECT;
+import static com.hazelcast.sql.support.expressions.ExpressionTypes.STRING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for NOT predicate.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class NotPredicateIntegrationTest extends SqlExpressionIntegrationTestSupport {
+    @Test
+    public void test_column() {
+        // Check boolean values
+        checkColumn(true, false);
+        checkColumn(false, true);
+
+        // Check null
+        put(new ExpressionValue.BooleanVal());
+        check("field1", null);
+
+        // Check string
+        checkColumn("true", false);
+        checkColumn("false", true);
+
+        checkColumnFailure("bad", SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+        checkColumnFailure('b', SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+
+        // Check unsupported values
+        checkColumnFailure((byte) 1, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<TINYINT>'");
+        checkColumnFailure((short) 1, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<SMALLINT>'");
+        checkColumnFailure(1, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<INTEGER>'");
+        checkColumnFailure(1L, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<BIGINT>'");
+        checkColumnFailure(BigInteger.ONE, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<DECIMAL(38, 38)>'");
+        checkColumnFailure(BigDecimal.ONE, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<DECIMAL(38, 38)>'");
+        checkColumnFailure(1f, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<REAL>'");
+        checkColumnFailure(1d, SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<DOUBLE>'");
+
+        put(new ExpressionValue.ObjectVal());
+        checkFailure("field1", SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<OBJECT>'");
+    }
+
+    @Test
+    public void test_parameter() {
+        put(1);
+
+        check("?", null, new Object[] { null });
+
+        check("?", false, true);
+        check("?", true, false);
+
+        check("?", true, "false");
+        check("?", false, "true");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BOOLEAN", "bad");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BOOLEAN", 'b');
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from TINYINT to BOOLEAN", (byte) 0);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from SMALLINT to BOOLEAN", (short) 0);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from INTEGER to BOOLEAN", 0);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from BIGINT to BOOLEAN", 0L);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BOOLEAN", BigInteger.ZERO);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DECIMAL to BOOLEAN", BigDecimal.ZERO);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from REAL to BOOLEAN", 0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from DOUBLE to BOOLEAN", 0d);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 0 from OBJECT to BOOLEAN", new ExpressionValue.ObjectVal());
+    }
+
+    @Test
+    public void test_literal() {
+        put(1);
+
+        check("true", false);
+        check("false", true);
+        check("null", null);
+
+        check("'true'", false);
+        check("'false'", true);
+        checkFailure("'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+
+        checkFailure("1", SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<TINYINT>'");
+        checkFailure("1E0", SqlErrorCode.PARSING, "Cannot apply 'NOT' to arguments of type 'NOT<DOUBLE>'");
+    }
+
+    private void checkColumn(Object value, Boolean expectedResult) {
+        put(value);
+
+        check("this", expectedResult);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    private void checkFailure(String operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT NOT " + operand + " FROM map";
+
+        try {
+            execute(member, sql, params);
+
+            fail("Must fail!");
+        } catch (SqlException e) {
+            assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
+            assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
+            assertEquals(expectedErrorCode, e.getCode());
+        }
+    }
+
+    private void check(String operand, Boolean expectedResult, Object... params) {
+        String sql = "SELECT NOT " + operand + " FROM map";
+
+        List<SqlRow> rows = execute(member, sql, params);
+        assertEquals(1, rows.size());
+
+        SqlRow row = rows.get(0);
+        assertEquals(1, row.getMetadata().getColumnCount());
+        assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(0).getType());
+        assertEquals(expectedResult, row.getObject(0));
+    }
+
+    @Test
+    public void testLiteral() {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(INTEGER);
+
+        int key = 0;
+        ExpressionValue value = ExpressionValue.create(clazz, 0, 1);
+
+        put(key, value);
+
+        // TRUE literal
+        checkLiteral("TRUE", "IS TRUE", true);
+        checkLiteral("true", "IS TRUE", true);
+        checkLiteral("'TRUE'", "IS TRUE", true);
+        checkLiteral("'true'", "IS TRUE", true);
+
+        checkLiteral("TRUE", "IS FALSE", false);
+
+        checkLiteral("true", "IS FALSE", false);
+        checkLiteral("'TRUE'", "IS FALSE", false);
+        checkLiteral("'true'", "IS FALSE", false);
+
+        checkLiteral("TRUE", "IS NOT TRUE", false);
+        checkLiteral("true", "IS NOT TRUE", false);
+        checkLiteral("'TRUE'", "IS NOT TRUE", false);
+        checkLiteral("'true'", "IS NOT TRUE", false);
+
+        checkLiteral("TRUE", "IS NOT FALSE", true);
+        checkLiteral("true", "IS NOT FALSE", true);
+        checkLiteral("'TRUE'", "IS NOT FALSE", true);
+        checkLiteral("'true'", "IS NOT FALSE", true);
+
+        // False literal
+        checkLiteral("FALSE", "IS TRUE", false);
+        checkLiteral("false", "IS TRUE", false);
+        checkLiteral("'FALSE'", "IS TRUE", false);
+        checkLiteral("'false'", "IS TRUE", false);
+
+        checkLiteral("FALSE", "IS FALSE", true);
+        checkLiteral("false", "IS FALSE", true);
+        checkLiteral("'FALSE'", "IS FALSE", true);
+        checkLiteral("'false'", "IS FALSE", true);
+
+        checkLiteral("FALSE", "IS NOT TRUE", true);
+        checkLiteral("false", "IS NOT TRUE", true);
+        checkLiteral("'FALSE'", "IS NOT TRUE", true);
+        checkLiteral("'false'", "IS NOT TRUE", true);
+
+        checkLiteral("FALSE", "IS NOT FALSE", false);
+        checkLiteral("false", "IS NOT FALSE", false);
+        checkLiteral("'FALSE'", "IS NOT FALSE", false);
+        checkLiteral("'false'", "IS NOT FALSE", false);
+
+        // NULL literal
+        checkLiteral("NULL", "IS TRUE", false);
+        checkLiteral("null", "IS TRUE", false);
+
+        checkLiteral("NULL", "IS FALSE", false);
+        checkLiteral("null", "IS FALSE", false);
+
+        checkLiteral("NULL", "IS NOT TRUE", true);
+        checkLiteral("null", "IS NOT TRUE", true);
+
+        checkLiteral("NULL", "IS NOT FALSE", true);
+        checkLiteral("null", "IS NOT FALSE", true);
+
+        // Bad literal
+        checkBadLiteral("IS TRUE");
+        checkBadLiteral("IS FALSE");
+        checkBadLiteral("IS NOT TRUE");
+        checkBadLiteral("IS NOT FALSE");
+    }
+
+    private void checkLiteral(String literal, String function, boolean expectedResult) {
+        String expression = literal + " " + function;
+        String sql = "SELECT " + expression + " FROM map WHERE " + expression;
+
+        List<SqlRow> rows = execute(member, sql);
+
+        if (expectedResult) {
+            assertEquals(1, rows.size());
+
+            SqlRow row = rows.get(0);
+
+            assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(0).getType());
+            assertTrue(row.getObject(0));
+        } else {
+            assertEquals(0, rows.size());
+        }
+    }
+
+    private void checkBadLiteral(String function) {
+        checkFailureInternal(
+            "SELECT * FROM map WHERE 'bad' " + function,
+            SqlErrorCode.PARSING,
+            "Literal ''bad'' can not be parsed to type 'BOOLEAN'"
+        );
+
+        checkFailureInternal(
+            "SELECT 'bad' " + function + " FROM map",
+            SqlErrorCode.PARSING,
+            "Literal ''bad'' can not be parsed to type 'BOOLEAN'"
+        );
+    }
+
+    @Test
+    public void testColumn_boolean() {
+        checkColumn(BOOLEAN, true, false);
+    }
+
+    @Test
+    public void testColumn_string() {
+        checkColumn(STRING, "true", "false");
+    }
+
+    private void checkColumn(ExpressionType<?> type, Object trueValue, Object falseValue) {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(type);
+
+        int keyTrue = 0;
+        int keyFalse = 1;
+        int keyNull = 2;
+
+        Map<Integer, Object> entries = new HashMap<>();
+        entries.put(keyTrue, ExpressionValue.create(clazz, keyTrue, trueValue));
+        entries.put(keyFalse, ExpressionValue.create(clazz, keyFalse, falseValue));
+        entries.put(keyNull, ExpressionValue.create(clazz, keyNull, null));
+        putAll(entries);
+
+        checkColumn("IS TRUE", set(keyTrue));
+        checkColumn("IS FALSE", set(keyFalse));
+        checkColumn("IS NOT TRUE", set(keyFalse, keyNull));
+        checkColumn("IS NOT FALSE", set(keyTrue, keyNull));
+    }
+
+    private void checkColumn(String function, Set<Integer> expectedKeys) {
+        String expression = "field1 " + function;
+        String sql = "SELECT key, " + expression + " FROM map WHERE " + expression;
+
+        List<SqlRow> rows = execute(member, sql);
+
+        assertEquals(expectedKeys.size(), rows.size());
+
+        for (SqlRow row : rows) {
+            assertEquals(SqlColumnType.BOOLEAN, row.getMetadata().getColumn(1).getType());
+
+            int key = row.getObject(0);
+            boolean value = row.getObject(1);
+
+            assertTrue("Key is not returned: " + key, expectedKeys.contains(key));
+            assertTrue(value);
+        }
+    }
+
+    @Test
+    public void testColumnBad_string() {
+        checkColumnBad(STRING, "bad", "VARCHAR");
+    }
+
+    @Test
+    public void testColumnBad_character() {
+        checkColumnBad(CHARACTER, 'a', "VARCHAR");
+    }
+
+    private void checkColumnBad(ExpressionType<?> type, Object value, Object expectedFromType) {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(type);
+
+        put(1, ExpressionValue.create(clazz, 1, value));
+
+        checkColumnBad("IS TRUE", expectedFromType);
+        checkColumnBad("IS FALSE", expectedFromType);
+        checkColumnBad("IS NOT TRUE", expectedFromType);
+        checkColumnBad("IS NOT FALSE", expectedFromType);
+    }
+
+    private void checkColumnBad(String function, Object expectedFromType) {
+        checkFailureInternal(
+            "SELECT key FROM map WHERE field1 " + function,
+            SqlErrorCode.DATA_EXCEPTION,
+            "Cannot convert " + expectedFromType + " to BOOLEAN"
+        );
+    }
+
+    @Test
+    public void testColumn_unsupported() {
+        checkUnsupportedColumn(BYTE, "TINYINT");
+        checkUnsupportedColumn(INTEGER, "INTEGER");
+        checkUnsupportedColumn(LONG, "BIGINT");
+        checkUnsupportedColumn(BIG_INTEGER, "DECIMAL(38, 38)");
+        checkUnsupportedColumn(BIG_DECIMAL, "DECIMAL(38, 38)");
+        checkUnsupportedColumn(FLOAT, "REAL");
+        checkUnsupportedColumn(DOUBLE, "DOUBLE");
+        checkUnsupportedColumn(OBJECT, "OBJECT");
+    }
+
+    private void checkUnsupportedColumn(ExpressionType<?> type, String expectedTypeNameInErrorMessage) {
+        checkUnsupportedColumn(type, "IS TRUE", expectedTypeNameInErrorMessage);
+        checkUnsupportedColumn(type, "IS FALSE", expectedTypeNameInErrorMessage);
+        checkUnsupportedColumn(type, "IS NOT FALSE", expectedTypeNameInErrorMessage);
+        checkUnsupportedColumn(type, "IS NOT TRUE", expectedTypeNameInErrorMessage);
+    }
+
+    private void checkUnsupportedColumn(ExpressionType<?> type, String function, String expectedTypeNameInErrorMessage) {
+        String expectedErrorMessage = "Cannot apply '" + function + "' to arguments of type '<"
+            + expectedTypeNameInErrorMessage + "> " + function + "'. Supported form(s): '<BOOLEAN> " + function + "'";
+
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(type);
+
+        int key = 0;
+        ExpressionValue value = ExpressionValue.create(clazz, key, type.valueFrom());
+
+        put(key, value);
+
+        // Function in the condition
+        checkFailureInternal(
+            "SELECT key FROM map WHERE field1 " + function,
+            SqlErrorCode.PARSING,
+            expectedErrorMessage
+        );
+
+        // Function in the column
+        checkFailureInternal(
+            "SELECT field1 " + function + " FROM map",
+            SqlErrorCode.PARSING,
+            expectedErrorMessage
+        );
+    }
+
+    @Test
+    public void testParameter() {
+        Class<? extends ExpressionValue> clazz = ExpressionValue.createClass(INTEGER);
+
+        int key = 0;
+        ExpressionValue value = ExpressionValue.create(clazz, 0, 1);
+
+        put(key, value);
+
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS TRUE", true));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS TRUE", false));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS TRUE", "true"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS TRUE", "false"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS TRUE", new Object[] { null }));
+
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS FALSE", true));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS FALSE", false));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS FALSE", "true"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS FALSE", "false"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS FALSE", new Object[] { null }));
+
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT TRUE", true));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT TRUE", false));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT TRUE", "true"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT TRUE", "false"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT TRUE", new Object[] { null }));
+
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT FALSE", true));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT FALSE", false));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT FALSE", "true"));
+        assertEquals(set(), keys("SELECT key FROM map WHERE ? IS NOT FALSE", "false"));
+        assertEquals(set(key), keys("SELECT key FROM map WHERE ? IS NOT FALSE", new Object[] { null }));
+
+        checkUnsupportedParameter((byte) 1, "TINYINT");
+        checkUnsupportedParameter((short) 1, "SMALLINT");
+        checkUnsupportedParameter(1, "INTEGER");
+        checkUnsupportedParameter((long) 1, "BIGINT");
+        checkUnsupportedParameter(BigInteger.ONE, "DECIMAL");
+        checkUnsupportedParameter(BigDecimal.ONE, "DECIMAL");
+        checkUnsupportedParameter(1f, "REAL");
+        checkUnsupportedParameter(1d, "DOUBLE");
+    }
+
+    private void checkUnsupportedParameter(Object param, String expectedTypeInErrorMessage) {
+        checkUnsupportedParameter("IS TRUE", param, expectedTypeInErrorMessage);
+        checkUnsupportedParameter("IS FALSE", param, expectedTypeInErrorMessage);
+        checkUnsupportedParameter("IS NOT TRUE", param, expectedTypeInErrorMessage);
+        checkUnsupportedParameter("IS NOT FALSE", param, expectedTypeInErrorMessage);
+    }
+
+    private void checkUnsupportedParameter(String function, Object param, String expectedTypeInErrorMessage) {
+        checkFailureInternal(
+            "SELECT * FROM map WHERE ? " + function,
+            SqlErrorCode.DATA_EXCEPTION,
+            "Cannot implicitly convert parameter at position 0 from " + expectedTypeInErrorMessage + " to BOOLEAN",
+            param
+        );
+    }
+
+    private Set<Integer> keys(String sql, Object... params) {
+        List<SqlRow> rows = execute(member, sql, params);
+
+        if (rows.size() == 0) {
+            return Collections.emptySet();
+        }
+
+        assertEquals(1, rows.get(0).getMetadata().getColumnCount());
+
+        Set<Integer> keys = new HashSet<>();
+
+        for (SqlRow row : rows) {
+            int key = row.getObject(0);
+
+            boolean added = keys.add(key);
+
+            assertTrue("Key is not unique: " + key, added);
+        }
+
+        return keys;
+    }
+
+    private static Set<Integer> set(Integer... values) {
+        Set<Integer> res = new HashSet<>();
+
+        if (values != null) {
+            res.addAll(Arrays.asList(values));
+        }
+
+        return res;
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/OrPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/OrPredicateIntegrationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.predicate;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBigDecimalVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBigIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBooleanVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanByteVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanDoubleVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanLongVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanObjectVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanShortVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.CharacterBooleanVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringBigDecimalVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringBigIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringBooleanVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringByteVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringDoubleVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringFloatVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringIntegerVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringLongVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringObjectVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringShortVal;
+import com.hazelcast.sql.support.expressions.ExpressionBiValue.StringStringVal;
+import com.hazelcast.sql.support.expressions.ExpressionValue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanFloatVal;
+import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanIntegerVal;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class OrPredicateIntegrationTest extends SqlExpressionIntegrationTestSupport {
+
+    private static final Boolean RES_TRUE = true;
+    private static final Boolean RES_FALSE = false;
+    private static final Boolean RES_NULL = null;
+
+    @Test
+    public void test_three_operands() {
+        put(0);
+
+        String sql = sql("?", "?", "?");
+
+        checkValue(sql, true, null, true, false);
+    }
+
+    @Test
+    public void test_column() {
+        // BOOLEAN/BOOLEAN
+        checkColumnColumn(new BooleanBooleanVal().fields(true, true), RES_TRUE);
+        checkColumnColumn(new BooleanBooleanVal().fields(true, false), RES_TRUE);
+        checkColumnColumn(new BooleanBooleanVal().fields(true, null), RES_TRUE);
+        checkColumnColumn(new BooleanBooleanVal().fields(false, false), RES_FALSE);
+        checkColumnColumn(new BooleanBooleanVal().fields(false, null), RES_NULL);
+        checkColumnColumn(new BooleanBooleanVal().fields(null, null), RES_NULL);
+
+        // BOOLEAN/VARCHAR
+        checkColumnColumn(new StringBooleanVal().fields("true", true), RES_TRUE);
+        checkColumnColumn(new StringBooleanVal().fields("false", true), RES_TRUE);
+        checkColumnColumn(new StringBooleanVal().fields("false", false), RES_FALSE);
+        checkColumnColumnFailure(new StringBooleanVal().fields("bad", null), SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+        checkColumnColumnFailure(new CharacterBooleanVal().fields('b', null), SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+
+        // VARCHAR/VARCHAR
+        checkColumnColumn(new StringStringVal().fields("true", "true"), RES_TRUE);
+        checkColumnColumn(new StringStringVal().fields("false", "true"), RES_TRUE);
+        checkColumnColumn(new StringStringVal().fields("false", "false"), RES_FALSE);
+        checkColumnColumnFailure(new StringStringVal().fields("bad", null), SqlErrorCode.DATA_EXCEPTION, "Cannot convert VARCHAR to BOOLEAN");
+
+        // BOOLEAN/unsupported
+        checkColumnColumnFailure(new BooleanByteVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <TINYINT>'");
+        checkColumnColumnFailure(new BooleanShortVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <SMALLINT>'");
+        checkColumnColumnFailure(new BooleanIntegerVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <INTEGER>'");
+        checkColumnColumnFailure(new BooleanLongVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <BIGINT>'");
+        checkColumnColumnFailure(new BooleanBigIntegerVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new BooleanBigDecimalVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new BooleanFloatVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <REAL>'");
+        checkColumnColumnFailure(new BooleanDoubleVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <DOUBLE>'");
+        checkColumnColumnFailure(new BooleanObjectVal().fields(true, null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <OBJECT>'");
+
+        // VARCHAR/unsupported
+        checkColumnColumnFailure(new StringByteVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <TINYINT>'");
+        checkColumnColumnFailure(new StringShortVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <SMALLINT>'");
+        checkColumnColumnFailure(new StringIntegerVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <INTEGER>'");
+        checkColumnColumnFailure(new StringLongVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <BIGINT>'");
+        checkColumnColumnFailure(new StringBigIntegerVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new StringBigDecimalVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <DECIMAL(38, 38)>'");
+        checkColumnColumnFailure(new StringFloatVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <REAL>'");
+        checkColumnColumnFailure(new StringDoubleVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <DOUBLE>'");
+        checkColumnColumnFailure(new StringObjectVal().fields("true", null), SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<VARCHAR> OR <OBJECT>'");
+
+        // COLUMN/PARAMETER
+        put(false);
+        checkValue("this", "?", RES_TRUE, true);
+        checkValue("this", "?", RES_FALSE, false);
+        checkValue("this", "?", RES_NULL, new Object[] { null });
+        checkFailure("this", "?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 0 from VARCHAR to BOOLEAN", "bad");
+
+        // COLUMN/LITERAL
+        checkValue("this", "true", RES_TRUE);
+        checkValue("this", "false", RES_FALSE);
+        checkValue("this", "null", RES_NULL);
+        checkValue("this", "'true'", RES_TRUE);
+        checkValue("this", "'false'", RES_FALSE);
+        checkFailure("this", "1", SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <TINYINT>'");
+        checkFailure("this", "1E0", SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <DOUBLE>'");
+        checkFailure("this", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+    }
+
+    @Test
+    public void test_parameter() {
+        put(1);
+
+        checkValue("?", "?", RES_TRUE, true, true);
+        checkValue("?", "?", RES_TRUE, true, false);
+        checkValue("?", "?", RES_TRUE, true, null);
+        checkValue("?", "?", RES_FALSE, false, false);
+        checkValue("?", "?", RES_NULL, false, null);
+        checkValue("?", "?", RES_NULL, null, null);
+
+        checkValue("?", "?", RES_TRUE, true, "true");
+        checkValue("?", "?", RES_TRUE, true, "false");
+        checkValue("?", "?", RES_TRUE, "true", "true");
+        checkValue("?", "?", RES_TRUE, "true", "false");
+
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Failed to convert parameter at position 1 from VARCHAR to BOOLEAN", true, "bad");
+
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from TINYINT to BOOLEAN", true, (byte) 1);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from SMALLINT to BOOLEAN", true, (short) 1);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from INTEGER to BOOLEAN", true, 1);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from BIGINT to BOOLEAN", true, 1L);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from DECIMAL to BOOLEAN", true, BigInteger.ONE);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from DECIMAL to BOOLEAN", true, BigDecimal.ONE);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from REAL to BOOLEAN", true, 1f);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from DOUBLE to BOOLEAN", true, 1d);
+        checkFailure("?", "?", SqlErrorCode.DATA_EXCEPTION, "Cannot implicitly convert parameter at position 1 from OBJECT to BOOLEAN", true, new ExpressionValue.ObjectVal());
+
+        checkValue("?", "true", RES_TRUE, true);
+        checkValue("?", "true", RES_TRUE, false);
+        checkValue("?", "false", RES_TRUE, true);
+        checkValue("?", "false", RES_FALSE, false);
+        checkValue("?", "null", RES_TRUE, true);
+        checkValue("?", "null", RES_NULL, false);
+
+        checkValue("?", "'true'", RES_TRUE, true);
+        checkValue("?", "'true'", RES_TRUE, false);
+        checkValue("?", "'false'", RES_TRUE, true);
+        checkValue("?", "'false'", RES_FALSE, false);
+
+        checkFailure("?", "1", SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <TINYINT>'", true);
+        checkFailure("?", "1E0", SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <DOUBLE>'", true);
+        checkFailure("?", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'", true);
+    }
+
+    @Test
+    public void test_literal() {
+        put(1);
+
+        checkValue("true", "true", RES_TRUE);
+        checkValue("true", "false", RES_TRUE);
+        checkValue("true", "null", RES_TRUE);
+        checkValue("false", "false", RES_FALSE);
+        checkValue("false", "null", RES_NULL);
+        checkValue("null", "null", RES_NULL);
+
+        checkValue("true", "'false'", RES_TRUE);
+
+        checkFailure("true", "1", SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <TINYINT>'");
+        checkFailure("true", "1E0", SqlErrorCode.PARSING, "Cannot apply 'OR' to arguments of type '<BOOLEAN> OR <DOUBLE>'");
+        checkFailure("true", "'bad'", SqlErrorCode.PARSING, "Literal ''bad'' can not be parsed to type 'BOOLEAN'");
+    }
+
+    private void checkColumnColumn(ExpressionBiValue value, Boolean expectedValue) {
+        put(value);
+
+        checkValue("field1", "field2", expectedValue);
+    }
+
+    private void checkColumnColumnFailure(ExpressionBiValue value, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+
+        checkFailure("field1", "field2", expectedErrorCode, expectedErrorMessage);
+    }
+
+    private void checkValue(String operand1, String operand2, Boolean expectedResult, Object... params) {
+        checkValue(sql(operand1, operand2), expectedResult, params);
+        checkValue(sql(operand2, operand1), expectedResult, params);
+    }
+
+    private void checkValue(String sql, Boolean expectedValue, Object... params) {
+        checkValueInternal(sql, SqlColumnType.BOOLEAN, expectedValue, params);
+    }
+
+    private void checkFailure(
+        String operand1,
+        String operand2,
+        int expectedErrorCode,
+        String expectedErrorMessage,
+        Object... params
+    ) {
+        checkFailureInternal(sql(operand1, operand2), expectedErrorCode, expectedErrorMessage, params);
+    }
+
+    private String sql(Object... operands) {
+        assert operands != null;
+        assert operands.length > 1;
+
+        StringBuilder condition = new StringBuilder();
+        condition.append(operands[0]);
+
+        for (int i = 1; i < operands.length; i++) {
+            condition.append(" OR ");
+            condition.append(operands[i]);
+        }
+
+        return "SELECT " + condition.toString() + " FROM map";
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionBiValue.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/support/expressions/ExpressionBiValue.java
@@ -48,6 +48,14 @@ public abstract class ExpressionBiValue extends ExpressionValue {
 
     public static <T extends ExpressionBiValue> T createBiValue(
         Class<? extends ExpressionBiValue> clazz,
+        Object field1,
+        Object field2
+    ) {
+        return createBiValue(clazz, 0, field1, field2);
+    }
+
+    public static <T extends ExpressionBiValue> T createBiValue(
+        Class<? extends ExpressionBiValue> clazz,
         int key,
         Object field1,
         Object field2

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -109,7 +109,7 @@ public final class QueryUtils {
 
                 break;
 
-            case INT:
+            case INTEGER:
                 type = SqlColumnType.INTEGER;
 
                 break;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
@@ -56,6 +56,7 @@ import com.hazelcast.sql.impl.operation.QueryCheckResponseOperation;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperation;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperationFragment;
 import com.hazelcast.sql.impl.operation.QueryFlowControlExchangeOperation;
+import com.hazelcast.sql.impl.plan.node.EmptyPlanNode;
 import com.hazelcast.sql.impl.plan.node.FilterPlanNode;
 import com.hazelcast.sql.impl.plan.node.MapScanPlanNode;
 import com.hazelcast.sql.impl.plan.node.ProjectPlanNode;
@@ -136,7 +137,9 @@ public class SqlDataSerializerHook implements DataSerializerHook {
     public static final int EXPRESSION_FLOOR_CEIL = 45;
     public static final int EXPRESSION_ROUND_TRUNCATE = 46;
 
-    public static final int LEN = EXPRESSION_ROUND_TRUNCATE + 1;
+    public static final int NODE_EMPTY = 47;
+
+    public static final int LEN = NODE_EMPTY + 1;
 
     @Override
     public int getFactoryId() {
@@ -204,6 +207,8 @@ public class SqlDataSerializerHook implements DataSerializerHook {
         constructors[EXPRESSION_DOUBLE] = arg -> new DoubleFunction();
         constructors[EXPRESSION_FLOOR_CEIL] = arg -> new FloorCeilFunction<>();
         constructors[EXPRESSION_ROUND_TRUNCATE] = arg -> new RoundTruncateFunction<>();
+
+        constructors[NODE_EMPTY] = arg -> new EmptyPlanNode();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/CreateExecPlanNodeVisitor.java
@@ -34,6 +34,7 @@ import com.hazelcast.sql.impl.operation.QueryExecuteOperation;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperationFragment;
 import com.hazelcast.sql.impl.operation.QueryExecuteOperationFragmentMapping;
 import com.hazelcast.sql.impl.operation.QueryOperationHandler;
+import com.hazelcast.sql.impl.plan.node.EmptyPlanNode;
 import com.hazelcast.sql.impl.plan.node.MapScanPlanNode;
 import com.hazelcast.sql.impl.plan.node.FilterPlanNode;
 import com.hazelcast.sql.impl.plan.node.PlanNode;
@@ -223,6 +224,15 @@ public class CreateExecPlanNodeVisitor implements PlanNodeVisitor {
             node.getId(),
             pop(),
             node.getFilter()
+        );
+
+        push(res);
+    }
+
+    @Override
+    public void onEmptyNode(EmptyPlanNode node) {
+        Exec res = new EmptyExec(
+            node.getId()
         );
 
         push(res);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/AbsFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/AbsFunction.java
@@ -65,7 +65,7 @@ public class AbsFunction<T> extends UniExpressionWithType<T> implements Identifi
             case SMALLINT:
                 return (short) Math.abs(operandConverter.asSmallint(operand));
 
-            case INT:
+            case INTEGER:
                 return Math.abs(operandConverter.asInt(operand));
 
             case BIGINT:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DivideFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DivideFunction.java
@@ -86,7 +86,7 @@ public final class DivideFunction<T> extends BiExpressionWithType<T> implements 
                     return (byte) (left.byteValue() / right.longValue());
                 case SMALLINT:
                     return (short) (left.shortValue() / right.longValue());
-                case INT:
+                case INTEGER:
                     return (int) (left.intValue() / right.longValue());
                 case BIGINT:
                     return ExpressionMath.divideExact(left.longValue(), right.longValue());

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MathFunctionUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MathFunctionUtils.java
@@ -30,7 +30,7 @@ public final class MathFunctionUtils {
         switch (type.getTypeFamily()) {
             case TINYINT:
             case SMALLINT:
-            case INT:
+            case INTEGER:
             case BIGINT:
                 return true;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MinusFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MinusFunction.java
@@ -85,7 +85,7 @@ public final class MinusFunction<T> extends BiExpressionWithType<T> implements I
                 return (byte) (left.byteValue() - right.byteValue());
             case SMALLINT:
                 return (short) (left.shortValue() - right.shortValue());
-            case INT:
+            case INTEGER:
                 return left.intValue() - right.intValue();
             case BIGINT:
                 try {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MultiplyFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MultiplyFunction.java
@@ -85,7 +85,7 @@ public final class MultiplyFunction<T> extends BiExpressionWithType<T> implement
                 return (byte) (left.byteValue() * right.byteValue());
             case SMALLINT:
                 return (short) (left.shortValue() * right.shortValue());
-            case INT:
+            case INTEGER:
                 return left.intValue() * right.intValue();
             case BIGINT:
                 try {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/PlusFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/PlusFunction.java
@@ -83,7 +83,7 @@ public final class PlusFunction<T> extends BiExpressionWithType<T> implements Id
                 return (byte) (left.byteValue() + right.byteValue());
             case SMALLINT:
                 return (short) (left.shortValue() + right.shortValue());
-            case INT:
+            case INTEGER:
                 return left.intValue() + right.intValue();
             case BIGINT:
                 try {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/RoundTruncateFunction.java
@@ -92,14 +92,14 @@ public class RoundTruncateFunction<T> extends BiExpressionWithType<T> implements
                 try {
                     return (T) (Short) execute(operand1Value, len).shortValueExact();
                 } catch (ArithmeticException e) {
-                    throw overflow(QueryDataTypeFamily.SMALLINT, QueryDataTypeFamily.INT, e);
+                    throw overflow(QueryDataTypeFamily.SMALLINT, QueryDataTypeFamily.INTEGER, e);
                 }
 
-            case INT:
+            case INTEGER:
                 try {
                     return (T) (Integer) execute(operand1Value, len).intValueExact();
                 } catch (ArithmeticException e) {
-                    throw overflow(QueryDataTypeFamily.INT, QueryDataTypeFamily.BIGINT, e);
+                    throw overflow(QueryDataTypeFamily.INTEGER, QueryDataTypeFamily.BIGINT, e);
                 }
 
             case BIGINT:
@@ -142,7 +142,7 @@ public class RoundTruncateFunction<T> extends BiExpressionWithType<T> implements
             return operand2Value != null ? operand2Value : 0;
         } catch (Exception e) {
             throw QueryException.dataException("Cannot convert the second operand of " + getFunctionName() + " function to "
-                + QueryDataTypeFamily.INT + ": " + e.getMessage(), e);
+                + QueryDataTypeFamily.INTEGER + ": " + e.getMessage(), e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/SignFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/SignFunction.java
@@ -66,7 +66,7 @@ public class SignFunction<T> extends UniExpressionWithType<T> implements Identif
             case SMALLINT:
                 return (short) Integer.signum(operandConverter.asInt(operandValue));
 
-            case INT:
+            case INTEGER:
                 return Integer.signum(operandConverter.asInt(operandValue));
 
             case BIGINT:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/UnaryMinusFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/UnaryMinusFunction.java
@@ -78,7 +78,7 @@ public final class UnaryMinusFunction<T> extends UniExpressionWithType<T> implem
             case SMALLINT:
                 return (short) -number.shortValue();
 
-            case INT:
+            case INTEGER:
                 return -number.intValue();
 
             case BIGINT:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/AndPredicate.java
@@ -60,5 +60,4 @@ public final class AndPredicate extends VariExpression<Boolean> implements Ident
     public QueryDataType getType() {
         return QueryDataType.BOOLEAN;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/EmptyPlanNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/EmptyPlanNode.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.plan.node;
+
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EmptyPlanNode extends AbstractPlanNode implements IdentifiedDataSerializable {
+
+    private List<QueryDataType> fieldTypes;
+
+    public EmptyPlanNode() {
+        // No-op.
+    }
+
+    public EmptyPlanNode(int id, List<QueryDataType> fieldTypes) {
+        super(id);
+
+        this.fieldTypes = fieldTypes;
+    }
+
+    @Override
+    protected PlanNodeSchema getSchema0() {
+        return new PlanNodeSchema(fieldTypes);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.NODE_EMPTY;
+    }
+
+    @Override
+    protected void writeData0(ObjectDataOutput out) throws IOException {
+        SerializationUtil.writeList(fieldTypes, out);
+    }
+
+    @Override
+    protected void readData0(ObjectDataInput in) throws IOException {
+        fieldTypes = SerializationUtil.readList(in);
+    }
+
+    @Override
+    public void visit(PlanNodeVisitor visitor) {
+        visitor.onEmptyNode(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EmptyPlanNode planNode = (EmptyPlanNode) o;
+
+        return id == planNode.id && fieldTypes.equals(planNode.fieldTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * id + fieldTypes.hashCode();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/PlanNodeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/PlanNodeVisitor.java
@@ -36,6 +36,7 @@ public interface PlanNodeVisitor {
     void onRootSendNode(RootSendPlanNode node);
     void onProjectNode(ProjectPlanNode node);
     void onFilterNode(FilterPlanNode node);
+    void onEmptyNode(EmptyPlanNode node);
     void onMapScanNode(MapScanPlanNode node);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeFamily.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeFamily.java
@@ -16,40 +16,57 @@
 
 package com.hazelcast.sql.impl.type;
 
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_BIGINT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_BOOLEAN;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_DATE;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_DECIMAL;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_DOUBLE;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_INTEGER;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_NULL;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_OBJECT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_REAL;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_SMALLINT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_TIME;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_TIMESTAMP;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_TIMESTAMP_WITH_TIME_ZONE;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_TINYINT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.PRECEDENCE_VARCHAR;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_DATE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_NULL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_TIMESTAMP;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_OBJECT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_TIME;
-import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_TIMESTAMP_WITH_OFFSET;
+import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeUtils.TYPE_LEN_VARCHAR;
 
 public enum QueryDataTypeFamily {
-    NULL(false, TYPE_LEN_NULL),
-    VARCHAR(false, TYPE_LEN_VARCHAR),
-    BOOLEAN(false, 1),
-    TINYINT(false, 1),
-    SMALLINT(false, 2),
-    INT(false, 4),
-    BIGINT(false, 8),
-    DECIMAL(false, TYPE_LEN_DECIMAL),
-    REAL(false, 4),
-    DOUBLE(false, 8),
-    TIME(true, TYPE_LEN_TIME),
-    DATE(true, TYPE_LEN_DATE),
-    TIMESTAMP(true, TYPE_LEN_TIMESTAMP),
-    TIMESTAMP_WITH_TIME_ZONE(true, TYPE_LEN_TIMESTAMP_WITH_OFFSET),
-    OBJECT(false, TYPE_LEN_OBJECT);
+    NULL(false, TYPE_LEN_NULL, PRECEDENCE_NULL),
+    VARCHAR(false, TYPE_LEN_VARCHAR, PRECEDENCE_VARCHAR),
+    BOOLEAN(false, 1, PRECEDENCE_BOOLEAN),
+    TINYINT(false, 1, PRECEDENCE_TINYINT),
+    SMALLINT(false, 2, PRECEDENCE_SMALLINT),
+    INTEGER(false, 4, PRECEDENCE_INTEGER),
+    BIGINT(false, 8, PRECEDENCE_BIGINT),
+    DECIMAL(false, TYPE_LEN_DECIMAL, PRECEDENCE_DECIMAL),
+    REAL(false, 4, PRECEDENCE_REAL),
+    DOUBLE(false, 8, PRECEDENCE_DOUBLE),
+    TIME(true, TYPE_LEN_TIME, PRECEDENCE_TIME),
+    DATE(true, TYPE_LEN_DATE, PRECEDENCE_DATE),
+    TIMESTAMP(true, TYPE_LEN_TIMESTAMP, PRECEDENCE_TIMESTAMP),
+    TIMESTAMP_WITH_TIME_ZONE(true, TYPE_LEN_TIMESTAMP_WITH_TIME_ZONE, PRECEDENCE_TIMESTAMP_WITH_TIME_ZONE),
+    OBJECT(false, TYPE_LEN_OBJECT, PRECEDENCE_OBJECT);
 
     private final boolean temporal;
     private final int estimatedSize;
+    private final int precedence;
 
-    QueryDataTypeFamily(boolean temporal, int estimatedSize) {
+    QueryDataTypeFamily(boolean temporal, int estimatedSize, int precedence) {
         assert estimatedSize > 0;
 
         this.temporal = temporal;
         this.estimatedSize = estimatedSize;
+        this.precedence = precedence;
     }
 
     public boolean isTemporal() {
@@ -58,5 +75,9 @@ public enum QueryDataTypeFamily {
 
     public int getEstimatedSize() {
         return estimatedSize;
+    }
+
+    public int getPrecedence() {
+        return precedence;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeUtils.java
@@ -70,7 +70,7 @@ public final class QueryDataTypeUtils {
     public static final int TYPE_LEN_TIMESTAMP = 12 + 20 + TYPE_LEN_TIME + TYPE_LEN_DATE;
 
     /** 12 (hdr) + 20 (fields + padding) + timestamp + 12 (offset hdr) + 12 (offset fields). */
-    public static final int TYPE_LEN_TIMESTAMP_WITH_OFFSET = 12 + 20 + TYPE_LEN_TIMESTAMP + 12 + 12;
+    public static final int TYPE_LEN_TIMESTAMP_WITH_TIME_ZONE = 12 + 20 + TYPE_LEN_TIMESTAMP + 12 + 12;
 
     /** 12 (hdr) + 36 (arbitrary content). */
     public static final int TYPE_LEN_OBJECT = 12 + 36;
@@ -79,6 +79,22 @@ public final class QueryDataTypeUtils {
     // still costs a single reference now, but reference cost is not taken into
     // account as of now.
     public static final int TYPE_LEN_NULL = 1;
+
+    public static final int PRECEDENCE_NULL = 0;
+    public static final int PRECEDENCE_VARCHAR = 100;
+    public static final int PRECEDENCE_BOOLEAN = 200;
+    public static final int PRECEDENCE_TINYINT = 300;
+    public static final int PRECEDENCE_SMALLINT = 400;
+    public static final int PRECEDENCE_INTEGER = 500;
+    public static final int PRECEDENCE_BIGINT = 600;
+    public static final int PRECEDENCE_DECIMAL = 700;
+    public static final int PRECEDENCE_REAL = 800;
+    public static final int PRECEDENCE_DOUBLE = 900;
+    public static final int PRECEDENCE_TIME = 1000;
+    public static final int PRECEDENCE_DATE = 1100;
+    public static final int PRECEDENCE_TIMESTAMP = 1200;
+    public static final int PRECEDENCE_TIMESTAMP_WITH_TIME_ZONE = 1300;
+    public static final int PRECEDENCE_OBJECT = 1400;
 
     private QueryDataTypeUtils() {
         // No-op.
@@ -109,7 +125,7 @@ public final class QueryDataTypeUtils {
             case SMALLINT:
                 return SMALLINT;
 
-            case INT:
+            case INTEGER:
                 return INT;
 
             case BIGINT:
@@ -180,7 +196,7 @@ public final class QueryDataTypeUtils {
             case SMALLINT:
                 return SMALLINT;
 
-            case INT:
+            case INTEGER:
                 return INT;
 
             case BIGINT:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -76,7 +76,7 @@ public abstract class AbstractStringConverter extends Converter {
         try {
             return Integer.parseInt(cast(val));
         } catch (NumberFormatException e) {
-            throw cannotConvert(QueryDataTypeFamily.INT, val);
+            throw cannotConvert(QueryDataTypeFamily.INTEGER, val);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/BigDecimalConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/BigDecimalConverter.java
@@ -62,7 +62,7 @@ public final class BigDecimalConverter extends AbstractDecimalConverter {
         try {
             return casted.setScale(0, BigDecimal.ROUND_DOWN).intValueExact();
         } catch (ArithmeticException e) {
-            throw numericOverflow(QueryDataTypeFamily.INT, val);
+            throw numericOverflow(QueryDataTypeFamily.INTEGER, val);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/BigIntegerConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/BigIntegerConverter.java
@@ -65,7 +65,7 @@ public final class BigIntegerConverter extends AbstractDecimalConverter {
         try {
             return casted.intValueExact();
         } catch (ArithmeticException e) {
-            throw numericOverflow(QueryDataTypeFamily.INT, val);
+            throw numericOverflow(QueryDataTypeFamily.INTEGER, val);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
@@ -140,7 +140,7 @@ public abstract class Converter {
 
     @NotConvertible
     public int asInt(Object val) {
-        throw cannotConvert(QueryDataTypeFamily.INT, val);
+        throw cannotConvert(QueryDataTypeFamily.INTEGER, val);
     }
 
     @NotConvertible
@@ -260,7 +260,7 @@ public abstract class Converter {
             case SMALLINT:
                 return canConvertToSmallint();
 
-            case INT:
+            case INTEGER:
                 return canConvertToInt();
 
             case BIGINT:

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/DoubleConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/DoubleConverter.java
@@ -81,14 +81,14 @@ public final class DoubleConverter extends Converter {
     public int asInt(Object val) {
         double casted = cast(val);
         if (!Double.isFinite(casted)) {
-            throw cannotConvert(QueryDataTypeFamily.INT, val);
+            throw cannotConvert(QueryDataTypeFamily.INTEGER, val);
         }
 
         int converted = (int) casted;
 
         // casts from double to long are saturating
         if (converted != (long) casted) {
-            throw numericOverflow(QueryDataTypeFamily.INT, val);
+            throw numericOverflow(QueryDataTypeFamily.INTEGER, val);
         }
 
         return converted;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/FloatConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/FloatConverter.java
@@ -81,7 +81,7 @@ public final class FloatConverter extends Converter {
     public int asInt(Object val) {
         float casted = cast(val);
         if (!Float.isFinite(casted)) {
-            throw cannotConvert(QueryDataTypeFamily.INT, val);
+            throw cannotConvert(QueryDataTypeFamily.INTEGER, val);
         }
 
         // casts from float to int are saturating
@@ -89,7 +89,7 @@ public final class FloatConverter extends Converter {
 
         // casts from float to long are saturating
         if (converted != (long) casted) {
-            throw numericOverflow(QueryDataTypeFamily.INT, val);
+            throw numericOverflow(QueryDataTypeFamily.INTEGER, val);
         }
 
         return converted;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/IntegerConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/IntegerConverter.java
@@ -30,7 +30,7 @@ public final class IntegerConverter extends Converter {
     public static final IntegerConverter INSTANCE = new IntegerConverter();
 
     private IntegerConverter() {
-        super(ID_INTEGER, QueryDataTypeFamily.INT);
+        super(ID_INTEGER, QueryDataTypeFamily.INTEGER);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/LongConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/LongConverter.java
@@ -68,7 +68,7 @@ public final class LongConverter extends Converter {
         int converted = (int) casted;
 
         if (converted != casted) {
-            throw numericOverflow(QueryDataTypeFamily.INT, val);
+            throw numericOverflow(QueryDataTypeFamily.INTEGER, val);
         }
 
         return converted;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/ObjectConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/ObjectConverter.java
@@ -57,7 +57,7 @@ public final class ObjectConverter extends Converter {
 
     @Override
     public int asInt(Object val) {
-        return resolveConverter(val, QueryDataTypeFamily.INT).asInt(val);
+        return resolveConverter(val, QueryDataTypeFamily.INTEGER).asInt(val);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/AbstractPlanNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/AbstractPlanNodesTest.java
@@ -174,6 +174,11 @@ public class AbstractPlanNodesTest {
         }
 
         @Override
+        public void onEmptyNode(EmptyPlanNode node) {
+            nodes.add(node);
+        }
+
+        @Override
         public void onOtherNode(PlanNode node) {
             nodes.add(node);
         }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/EmptyPlanNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/EmptyPlanNodeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.plan.node;
+
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class EmptyPlanNodeTest extends SqlTestSupport {
+    @Test
+    public void testState() {
+        List<QueryDataType> fieldTypes = Collections.singletonList(QueryDataType.INT);
+        EmptyPlanNode node = new EmptyPlanNode(1, fieldTypes);
+
+        assertEquals(1, node.getId());
+        assertEquals(new PlanNodeSchema(fieldTypes), node.getSchema());
+    }
+
+    @Test
+    public void testEquality() {
+        int id1 = 1;
+        int id2 = 2;
+
+        List<QueryDataType> fieldTypes1 = Collections.singletonList(QueryDataType.INT);
+        List<QueryDataType> fieldTypes2 = Collections.singletonList(QueryDataType.BIGINT);
+
+        checkEquals(new EmptyPlanNode(id1, fieldTypes1), new EmptyPlanNode(id1, fieldTypes1), true);
+        checkEquals(new EmptyPlanNode(id1, fieldTypes1), new EmptyPlanNode(id2, fieldTypes1), false);
+        checkEquals(new EmptyPlanNode(id1, fieldTypes1), new EmptyPlanNode(id1, fieldTypes2), false);
+    }
+
+    @Test
+    public void testSerialization() {
+        EmptyPlanNode original = new EmptyPlanNode(1, Collections.singletonList(QueryDataType.INT));
+        EmptyPlanNode restored = serializeAndCheck(original, SqlDataSerializerHook.NODE_EMPTY);
+
+        checkEquals(original, restored, true);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
@@ -132,7 +132,7 @@ public class QueryDataTypeTest extends SqlTestSupport {
         checkResolvedTypeForTypeFamily(QueryDataType.BOOLEAN, QueryDataTypeFamily.BOOLEAN);
         checkResolvedTypeForTypeFamily(QueryDataType.TINYINT, QueryDataTypeFamily.TINYINT);
         checkResolvedTypeForTypeFamily(QueryDataType.SMALLINT, QueryDataTypeFamily.SMALLINT);
-        checkResolvedTypeForTypeFamily(QueryDataType.INT, QueryDataTypeFamily.INT);
+        checkResolvedTypeForTypeFamily(QueryDataType.INT, QueryDataTypeFamily.INTEGER);
         checkResolvedTypeForTypeFamily(QueryDataType.BIGINT, QueryDataTypeFamily.BIGINT);
         checkResolvedTypeForTypeFamily(QueryDataType.DECIMAL, QueryDataTypeFamily.DECIMAL);
         checkResolvedTypeForTypeFamily(QueryDataType.REAL, QueryDataTypeFamily.REAL);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
@@ -50,7 +50,7 @@ import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DATE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DOUBLE;
-import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INT;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INTEGER;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.NULL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.OBJECT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.REAL;
@@ -148,7 +148,7 @@ public class ConvertersTest {
         ByteConverter converter = ByteConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_BYTE, TINYINT, Byte.class);
-        checkConverterConversions(converter, VARCHAR, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE, OBJECT);
 
         assertEquals("1", converter.asVarchar((byte) 1));
 
@@ -171,7 +171,7 @@ public class ConvertersTest {
         ShortConverter converter = ShortConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_SHORT, SMALLINT, Short.class);
-        checkConverterConversions(converter, VARCHAR, TINYINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TINYINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE, OBJECT);
 
         assertEquals("1", converter.asVarchar((short) 1));
 
@@ -194,7 +194,7 @@ public class ConvertersTest {
     public void testIntConverter() {
         IntegerConverter converter = IntegerConverter.INSTANCE;
 
-        checkConverter(converter, Converter.ID_INTEGER, INT, Integer.class);
+        checkConverter(converter, Converter.ID_INTEGER, INTEGER, Integer.class);
         checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, BIGINT, DECIMAL, REAL, DOUBLE, OBJECT);
 
         assertEquals("1", converter.asVarchar(1));
@@ -220,7 +220,7 @@ public class ConvertersTest {
         LongConverter converter = LongConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_LONG, BIGINT, Long.class);
-        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INT, DECIMAL, REAL, DOUBLE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INTEGER, DECIMAL, REAL, DOUBLE, OBJECT);
 
         assertEquals("1", converter.asVarchar(1L));
 
@@ -246,7 +246,7 @@ public class ConvertersTest {
         BigIntegerConverter converter = BigIntegerConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_BIG_INTEGER, DECIMAL, BigInteger.class);
-        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INT, BIGINT, REAL, DOUBLE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, OBJECT);
 
         BigInteger bigValue = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
 
@@ -275,7 +275,7 @@ public class ConvertersTest {
         BigDecimalConverter converter = BigDecimalConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_BIG_DECIMAL, DECIMAL, BigDecimal.class);
-        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INT, BIGINT, REAL, DOUBLE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, OBJECT);
 
         BigDecimal val = BigDecimal.valueOf(11, 1);
         BigDecimal bigValue = BigDecimal.valueOf(Long.MAX_VALUE).add(new BigDecimal("1.1"));
@@ -305,7 +305,7 @@ public class ConvertersTest {
         FloatConverter converter = FloatConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_FLOAT, REAL, Float.class);
-        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, DOUBLE, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL, DOUBLE, OBJECT);
 
         float val = 1.1f;
         float bigValue = Long.MAX_VALUE * 2.5f;
@@ -355,7 +355,7 @@ public class ConvertersTest {
         DoubleConverter converter = DoubleConverter.INSTANCE;
 
         checkConverter(converter, Converter.ID_DOUBLE, DOUBLE, Double.class);
-        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, OBJECT);
+        checkConverterConversions(converter, VARCHAR, TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, OBJECT);
 
         double val = 1.1d;
         double bigValue = Long.MAX_VALUE * 2.5d;
@@ -541,7 +541,7 @@ public class ConvertersTest {
             BOOLEAN,
             TINYINT,
             SMALLINT,
-            INT,
+            INTEGER,
             BIGINT,
             DECIMAL,
             REAL,
@@ -640,7 +640,7 @@ public class ConvertersTest {
             BOOLEAN,
             TINYINT,
             SMALLINT,
-            INT,
+            INTEGER,
             BIGINT,
             DECIMAL,
             REAL,
@@ -690,7 +690,7 @@ public class ConvertersTest {
             BOOLEAN,
             TINYINT,
             SMALLINT,
-            INT,
+            INTEGER,
             BIGINT,
             DECIMAL,
             REAL,
@@ -711,7 +711,7 @@ public class ConvertersTest {
     public void testNullConverter() {
         NullConverter c = NullConverter.INSTANCE;
         checkConverter(c, Converter.ID_NULL, NULL, Void.class);
-        checkConverterConversions(c, BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP,
+        checkConverterConversions(c, BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE, TIME, DATE, TIMESTAMP,
                 TIMESTAMP_WITH_TIME_ZONE, VARCHAR, OBJECT);
 
         checkUnsupportedException(() -> c.asBoolean(null));
@@ -905,7 +905,7 @@ public class ConvertersTest {
 
                 break;
 
-            case INT:
+            case INTEGER:
                 assertEquals(expected, converter.canConvertToInt());
 
                 break;
@@ -986,7 +986,7 @@ public class ConvertersTest {
 
                     break;
 
-                case INT:
+                case INTEGER:
                     converter.asInt(val);
 
                     break;
@@ -1091,7 +1091,7 @@ public class ConvertersTest {
 
         @Override
         public int asInt(Object val) {
-            invoked = INT;
+            invoked = INTEGER;
 
             return 0;
         }


### PR DESCRIPTION
This PR adds integration tests for existing predicated expressions and fixes a couple of issues revealed during testing:
1. Added handling for empty `Values` relational node that is important for expressions that could be simplified to no-op (e.g. `... WHERE TRUE IS FALSE`)
1. Renamed `QueryDataTypeFamiliy.INT` to `QueryDataTypeFamily.INTEGER` to make sure that error messages show `INTEGER` type in a consistent way
1. Disallowed implicit conversions from types with higher precedence to types with lower precedence for parameters (e.g. `BIGINT` to `INT`). This makes the engine closer to the type system explained in the design docs. However, this is not a complete fix. For some conversions, we have inconsistent error messages. E.g. for BIGINT->INT we have one error message, but for BOOLEAN->INT it is completely different. This complete fix is out of the scope of this PR and will be implemented separately.

Closes #17356