### PR TITLE
Remove typos in ConfigUtils methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/MatchingPointConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/MatchingPointConfigPatternMatcher.java
@@ -47,7 +47,7 @@ public class MatchingPointConfigPatternMatcher implements ConfigPatternMatcher {
             }
         }
         if (duplicate != null) {
-            throw ConfigUtils.createAmbigiousConfigrationException(itemName, candidate, duplicate);
+            throw ConfigUtils.createAmbiguousConfigurationException(itemName, candidate, duplicate);
         }
         return candidate;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
@@ -45,7 +45,7 @@ public class RegexConfigPatternMatcher implements ConfigPatternMatcher {
         for (String pattern : configPatterns) {
             if (Pattern.compile(pattern, flags).matcher(itemName).find()) {
                 if (candidate != null) {
-                    throw ConfigUtils.createAmbigiousConfigrationException(itemName, candidate, pattern);
+                    throw ConfigUtils.createAmbiguousConfigurationException(itemName, candidate, pattern);
                 }
                 candidate = pattern;
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/WildcardConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/WildcardConfigPatternMatcher.java
@@ -34,7 +34,7 @@ public class WildcardConfigPatternMatcher implements ConfigPatternMatcher {
         for (String pattern : configPatterns) {
             if (matches(pattern, itemName)) {
                 if (candidate != null) {
-                    throw ConfigUtils.createAmbigiousConfigrationException(itemName, candidate, pattern);
+                    throw ConfigUtils.createAmbiguousConfigurationException(itemName, candidate, pattern);
                 }
                 candidate = pattern;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
@@ -129,11 +129,10 @@ public final class ConfigUtils {
         }
     }
 
-    public static InvalidConfigurationException createAmbigiousConfigrationException(
-            String itemName, String candidate, String duplicate) {
+    public static InvalidConfigurationException createAmbiguousConfigurationException(
+      String itemName, String candidate, String duplicate) {
         return new InvalidConfigurationException(
-                format("Found ambiguous configurations for item\"%s\": \"%s\" vs. \"%s\"%n"
-                        + "Please specify your configuration.", itemName, candidate, duplicate));
+          format("Found ambiguous configurations for item\"%s\": \"%s\" vs. \"%s\"%n"
+            + "Please specify your configuration.", itemName, candidate, duplicate));
     }
-
 }


### PR DESCRIPTION
`ConfigUtils.createAmbigiousConfigrationException` -> `ConfigUtils.createAmbiguousConfigurationException`

Deprecated the old one just for the sake of preserving backward compatibility. Would be happy to remove it if you think it's not needed.