### PR TITLE
Extend reflective extractors with the possibility to return null for non existing properties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -68,9 +68,13 @@ public final class Extractors {
     }
 
     public Object extract(Object target, String attributeName, Object metadata) {
+        return extract(target, attributeName, metadata, true);
+    }
+
+    public Object extract(Object target, String attributeName, Object metadata, boolean failOnMissingReflectiveAttribute) {
         Object targetObject = getTargetObject(target);
         if (targetObject != null) {
-            Getter getter = getGetter(targetObject, attributeName);
+            Getter getter = getGetter(targetObject, attributeName, failOnMissingReflectiveAttribute);
             try {
                 return getter.getValue(targetObject, attributeName, metadata);
             } catch (Exception ex) {
@@ -112,10 +116,10 @@ public final class Extractors {
         return target;
     }
 
-    Getter getGetter(Object targetObject, String attributeName) {
+    Getter getGetter(Object targetObject, String attributeName, boolean failOnMissingReflectiveAttribute) {
         Getter getter = getterCache.getGetter(targetObject.getClass(), attributeName);
         if (getter == null) {
-            getter = instantiateGetter(targetObject, attributeName);
+            getter = instantiateGetter(targetObject, attributeName, failOnMissingReflectiveAttribute);
             if (getter.isCacheable()) {
                 getterCache.putGetter(targetObject.getClass(), attributeName, getter);
             }
@@ -123,7 +127,7 @@ public final class Extractors {
         return getter;
     }
 
-    private Getter instantiateGetter(Object targetObject, String attributeName) {
+    private Getter instantiateGetter(Object targetObject, String attributeName, boolean failOnMissingReflectiveAttribute) {
         String attributeNameWithoutArguments = extractAttributeNameNameWithoutArguments(attributeName);
         ValueExtractor valueExtractor = extractors.get(attributeNameWithoutArguments);
         if (valueExtractor != null) {
@@ -149,7 +153,7 @@ public final class Extractors {
             } else if (targetObject instanceof HazelcastJsonValue) {
                 return JsonGetter.INSTANCE;
             } else {
-                return ReflectionHelper.createGetter(targetObject, attributeName);
+                return ReflectionHelper.createGetter(targetObject, attributeName, failOnMissingReflectiveAttribute);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -85,7 +85,7 @@ public final class ReflectionHelper {
         return null;
     }
 
-    public static Getter createGetter(Object obj, String attribute) {
+    public static Getter createGetter(Object obj, String attribute, boolean failOnMissingAttribute) {
         if (obj == null || obj == NULL) {
             return NULL_GETTER;
         }
@@ -160,8 +160,12 @@ public final class ReflectionHelper {
                     }
                 }
                 if (localGetter == null) {
-                    throw new IllegalArgumentException("There is no suitable accessor for '"
-                            + baseName + "' on class '" + clazz.getName() + "'");
+                    if (failOnMissingAttribute) {
+                        throw new IllegalArgumentException("There is no suitable accessor for '"
+                                + baseName + "' on class '" + clazz.getName() + "'");
+                    } else {
+                        return NULL_GETTER;
+                    }
                 }
                 parent = localGetter;
             }
@@ -172,8 +176,8 @@ public final class ReflectionHelper {
         }
     }
 
-    public static Object extractValue(Object object, String attributeName) throws Exception {
-        return createGetter(object, attributeName).getValue(object);
+    public static Object extractValue(Object object, String attributeName, boolean failOnMissingAttribute) throws Exception {
+        return createGetter(object, attributeName, failOnMissingAttribute).getValue(object);
     }
 
     public static <T> T invokeMethod(Object object, String methodName) throws RuntimeException {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/GenericFieldExtractor.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/GenericFieldExtractor.java
@@ -46,7 +46,7 @@ public class GenericFieldExtractor extends AbstractGenericExtractor {
     public Object get() {
         try {
             Object target = targetAccessor.getTargetForFieldAccess();
-            Object value = extractors.extract(target, path, null);
+            Object value = extractors.extract(target, path, null, false);
             return type.normalize(value);
         } catch (QueryDataTypeMismatchException e) {
             throw QueryException.dataException("Failed to extract map entry " + (key ? "key" : "value") + " field \""

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -75,8 +75,8 @@ public class ExtractorsTest {
         Extractors extractors = createExtractors(null);
 
         // WHEN
-        Getter getterFirstInvocation = extractors.getGetter(bond, "car.power");
-        Getter getterSecondInvocation = extractors.getGetter(bond, "car.power");
+        Getter getterFirstInvocation = extractors.getGetter(bond, "car.power", true);
+        Getter getterSecondInvocation = extractors.getGetter(bond, "car.power", true);
 
         // THEN
         assertThat(getterFirstInvocation, sameInstance(getterSecondInvocation));
@@ -100,8 +100,8 @@ public class ExtractorsTest {
         Extractors extractors = createExtractors(config);
 
         // WHEN
-        Getter getterFirstInvocation = extractors.getGetter(bond, "gimmePower");
-        Getter getterSecondInvocation = extractors.getGetter(bond, "gimmePower");
+        Getter getterFirstInvocation = extractors.getGetter(bond, "gimmePower", true);
+        Getter getterSecondInvocation = extractors.getGetter(bond, "gimmePower", true);
 
         // THEN
         assertThat(getterFirstInvocation, sameInstance(getterSecondInvocation));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
@@ -25,6 +25,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -36,7 +37,7 @@ public class ReflectionHelperTest {
             throws Exception {
         OuterObject object = new OuterObject();
         try {
-            ReflectionHelper.extractValue(object, "emptyInterface.doesNotExist");
+            ReflectionHelper.extractValue(object, "emptyInterface.doesNotExist", true);
             fail("Non-existing field has been ignored");
         } catch (QueryException e) {
             // createGetter() method is catching everything throwable and wraps it in QueryException
@@ -45,6 +46,14 @@ public class ReflectionHelperTest {
             // IllegalArgumentException as expected exception.
             assertEquals(IllegalArgumentException.class, e.getCause().getClass());
         }
+    }
+
+    @Test
+    public void extractValue_whenIntermediateFieldIsInterfaceAndDoesNotContainField_returnsNull()
+            throws Exception {
+        OuterObject object = new OuterObject();
+
+        assertNull(ReflectionHelper.extractValue(object, "emptyInterface.doesNotExist", false));
     }
 
     @SuppressWarnings("unused")

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -55,7 +56,7 @@ public class GenericQueryTargetTest extends SqlTestSupport {
     }
 
     private void checkTarget(GenericQueryTarget target) {
-        TestObject object = new TestObject(1);
+        TestObject object = new TestObject(1, 2);
 
         checkTarget(target, object, object);
         checkTarget(target, object, toData(object));
@@ -69,6 +70,7 @@ public class GenericQueryTargetTest extends SqlTestSupport {
         QueryExtractor targetExtractor = target.createExtractor(null, QueryDataType.OBJECT);
         TestObject extractedObject = (TestObject) targetExtractor.get();
         assertEquals(originalObject.getField(), extractedObject.getField());
+        assertEquals(originalObject.getField2(), extractedObject.getField2());
 
         // Bad top-level extractor.
         QueryExtractor badTargetExtractor = target.createExtractor(null, QueryDataType.INT);
@@ -76,22 +78,20 @@ public class GenericQueryTargetTest extends SqlTestSupport {
         assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
         assertTrue(error.getMessage().startsWith("Failed to extract map entry " + (target.isKey() ? "key" : "value")));
 
-        // Good field executor.
+        // Good field extractor.
         QueryExtractor fieldExtractor = target.createExtractor("field", QueryDataType.OBJECT);
         int extractedField = (Integer) fieldExtractor.get();
         assertEquals(originalObject.getField(), extractedField);
 
         // Bad field extractor (type).
-        QueryExtractor badFieldTypeExtractor = target.createExtractor("field", QueryDataType.DATE);
+        QueryExtractor badFieldTypeExtractor = target.createExtractor("field", QueryDataType.BIGINT);
         error = assertThrows(QueryException.class, badFieldTypeExtractor::get);
         assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
         assertTrue(error.getMessage().startsWith("Failed to extract map entry " + (target.isKey() ? "key" : "value") + " field"));
 
         // Bad field extractor (name).
-        QueryExtractor badFieldNameExtractor = target.createExtractor("field2", QueryDataType.INT);
-        error = assertThrows(QueryException.class, badFieldNameExtractor::get);
-        assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
-        assertTrue(error.getMessage().startsWith("Failed to extract map entry " + (target.isKey() ? "key" : "value") + " field"));
+        QueryExtractor badFieldNameExtractor = target.createExtractor("badField", QueryDataType.INT);
+        assertNull(badFieldNameExtractor.get());
     }
 
     private static Data toData(TestObject object) {
@@ -115,27 +115,35 @@ public class GenericQueryTargetTest extends SqlTestSupport {
     private static class TestObject implements DataSerializable {
 
         private int field;
+        private int field2;
 
         private TestObject() {
             // No-op.
         }
 
-        private TestObject(int field) {
+        private TestObject(int field, int field2) {
             this.field = field;
+            this.field2 = field2;
         }
 
         private int getField() {
             return field;
         }
 
+        public int getField2() {
+            return field2;
+        }
+
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(field);
+            out.writeInt(field2);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             field = in.readInt();
+            field2 = in.readInt();
         }
     }
 }


### PR DESCRIPTION
To support polymorphic maps and to get similar behavior to how Portable & Json payloads treat non existing fields.