### PR TITLE
SQL public API polishing (#17354)

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.parse;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.calcite.SqlBackend;
 import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlConformance;

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/SqlNodeUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/SqlNodeUtil.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.validate;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.converter.StringConverter;
 import org.apache.calcite.runtime.CalciteContextException;

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeSystem.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeSystem.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.validate.types;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.calcite.SqlToQueryType;
 import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlValidator;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -338,10 +338,10 @@ public class SqlBasicTest extends SqlTestSupport {
     private SqlResult query() {
         String sql = sql();
 
-        if (cursorBufferSize == SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE) {
-            return getTarget().getSql().query(sql);
+        if (cursorBufferSize == SqlStatement.DEFAULT_CURSOR_BUFFER_SIZE) {
+            return getTarget().getSql().execute(sql);
         } else {
-            return getTarget().getSql().query(new SqlQuery(sql).setCursorBufferSize(cursorBufferSize));
+            return getTarget().getSql().execute(new SqlStatement(sql).setCursorBufferSize(cursorBufferSize));
         }
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.exec.BlockingExec;
 import com.hazelcast.sql.impl.exec.scan.MapScanExec;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -95,7 +96,7 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
         }).start();
 
         // Start query
-        SqlException error = assertSqlException(instance1, query());
+        HazelcastSqlException error = assertSqlException(instance1, query());
         assertEquals(SqlErrorCode.CONNECTION_PROBLEM, error.getCode());
         assertEquals(instance1.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());
     }
@@ -115,7 +116,7 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
         populate(liteMember);
 
         // Try query from the lite member.
-        SqlException error = assertSqlException(liteMember, query());
+        HazelcastSqlException error = assertSqlException(liteMember, query());
         assertEquals(SqlErrorCode.GENERIC, error.getCode());
         assertEquals("SQL queries cannot be executed on lite members", error.getMessage());
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/JetSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/JetSqlTest.java
@@ -108,7 +108,7 @@ public class JetSqlTest extends SqlTestSupport {
         HazelcastInstance member = newHazelcastInstance(new Config(), randomName(), nodeContext(jetSqlService));
 
         // when
-        SqlResult result = member.getSql().query("SELECT * FROM t");
+        SqlResult result = member.getSql().execute("SELECT * FROM t");
 
         // then
         assertEquals(sqlResult, result);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserNameResolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserNameResolutionTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.parse;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryUtils;
 import com.hazelcast.sql.impl.calcite.HazelcastSqlBackend;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.calcite.parse;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryUtils;
 import com.hazelcast.sql.impl.calcite.HazelcastSqlBackend;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.expression;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.calcite.SqlToQueryType;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ColumnEndToEndTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ColumnEndToEndTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression;
 
 import com.hazelcast.map.IMap;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionEndToEndTestBase.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionEndToEndTestBase.java
@@ -27,8 +27,8 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.impl.SqlErrorCode;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.impl.SqlTestSupport;
@@ -114,7 +114,7 @@ public abstract class ExpressionEndToEndTestBase extends SqlTestSupport {
     protected void assertRow(String expression, String mapName, String expectedColumnName, SqlColumnType expectedType,
                              Object expectedValue, Object... args) {
         boolean done = false;
-        for (SqlRow row : sql.query("select " + expression + " from " + mapName, args)) {
+        for (SqlRow row : sql.execute("select " + expression + " from " + mapName, args)) {
             if (done) {
                 fail("one row expected");
             }
@@ -142,10 +142,10 @@ public abstract class ExpressionEndToEndTestBase extends SqlTestSupport {
     protected void assertError(String expression, String mapName, int errorCode, String message, Object... args) {
         try {
             //noinspection StatementWithEmptyBody
-            for (SqlRow ignore : sql.query("select " + expression + " from " + mapName, args)) {
+            for (SqlRow ignore : sql.execute("select " + expression + " from " + mapName, args)) {
                 // do nothing
             }
-        } catch (SqlException e) {
+        } catch (HazelcastSqlException e) {
             assertEquals(errorCode, e.getCode());
             assertTrue("expected message '" + message + "', got '" + e.getMessage() + "'",
                     e.getMessage().toLowerCase().contains(message.toLowerCase()));

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestBase.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestBase.java
@@ -20,8 +20,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.IMap;
-import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.impl.SqlErrorCode;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlService;
@@ -1159,7 +1159,7 @@ public abstract class ExpressionTestBase extends SqlTestSupport {
     }
 
     protected SqlResult query(SqlService sql, String query, Object... args) {
-        return sql.query(query, args);
+        return sql.execute(query, args);
     }
 
     public static class Record implements Serializable {
@@ -1229,7 +1229,7 @@ public abstract class ExpressionTestBase extends SqlTestSupport {
     }
 
     protected void assertQueryThrows(SqlService sql, String query, String message, Object... args) {
-        SqlException exception = assertThrows(SqlException.class, () -> query(sql, query, args).forEach(r -> {
+        HazelcastSqlException exception = assertThrows(HazelcastSqlException.class, () -> query(sql, query, args).forEach(r -> {
             // do nothing, just drain all the rows
         }));
         assertTrue(exception.getMessage(), exception.getMessage().toLowerCase().contains(message.toLowerCase()));

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ParameterEndToEndTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ParameterEndToEndTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.expression;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/SqlExpressionIntegrationTestSupport.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.expression;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -122,7 +122,7 @@ public abstract class SqlExpressionIntegrationTestSupport extends SqlTestSupport
             execute(member, sql, params);
 
             fail("Must fail");
-        } catch (SqlException e) {
+        } catch (HazelcastSqlException e) {
             assertTrue(expectedErrorMessage.length() != 0);
             assertNotNull(e.getMessage());
             assertTrue(e.getMessage(),  e.getMessage().contains(expectedErrorMessage));

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/CeilFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DivideTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DivideTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.expression.math;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastReturnTypes;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.ByteIntegerVal;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/AndPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/AndPredicateIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.predicate;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBigDecimalVal;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.predicate;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionTypes;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsTrueFalsePredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsTrueFalsePredicateIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.predicate;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionType;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/NotPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/NotPredicateIntegrationTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.sql.impl.expression.predicate;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.impl.SqlErrorCode;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionType;
@@ -152,7 +152,7 @@ public class NotPredicateIntegrationTest extends SqlExpressionIntegrationTestSup
             execute(member, sql, params);
 
             fail("Must fail!");
-        } catch (SqlException e) {
+        } catch (HazelcastSqlException e) {
             assertTrue(expectedErrorMessage != null && !expectedErrorMessage.isEmpty());
             assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
             assertEquals(expectedErrorCode, e.getCode());

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/OrPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/OrPredicateIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.predicate;
 
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.SqlExpressionIntegrationTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanBigDecimalVal;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/plan/cache/PlanCacheIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/plan/cache/PlanCacheIntegrationTest.java
@@ -173,7 +173,7 @@ public class PlanCacheIntegrationTest extends PlanCacheTestSupport {
     }
 
     private Plan getPlan(HazelcastInstance instance, String sql) {
-        try (SqlResult result = instance.getSql().query(sql)) {
+        try (SqlResult result = instance.getSql().execute(sql)) {
             SqlResultImpl result0 = (SqlResultImpl) result;
 
             return result0.getPlan();
@@ -182,7 +182,7 @@ public class PlanCacheIntegrationTest extends PlanCacheTestSupport {
 
     @SuppressWarnings("StatementWithEmptyBody")
     private void executeWithException(HazelcastInstance instance, String sql) {
-        try (SqlResult result = instance.getSql().query(sql)) {
+        try (SqlResult result = instance.getSql().execute(sql)) {
             for (SqlRow ignore : result) {
                 // No-op.
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/SqlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SqlConfig.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.SqlStatement;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
@@ -131,14 +131,14 @@ public class SqlConfig {
     /**
      * Sets the timeout in milliseconds that is applied to queries without an explicit timeout.
      * <p>
-     * It is possible to set a query timeout through the {@link SqlQuery#setTimeoutMillis(long)} method. If the query timeout is
-     * not set, then the value of this parameter will be used.
+     * It is possible to set a query timeout through the {@link SqlStatement#setTimeoutMillis(long)} method. If the query
+     * timeout is not set, then the value of this parameter will be used.
      * <p>
      * Zero value means no timeout. Negative values are prohibited.
      * <p>
      * Defaults to {@link #DEFAULT_QUERY_TIMEOUT}.
      *
-     * @see SqlQuery#setTimeoutMillis(long)
+     * @see SqlStatement#setTimeoutMillis(long)
      * @param queryTimeout Timeout in milliseconds.
      * @return This instance for chaining.
      */

--- a/hazelcast/src/main/java/com/hazelcast/sql/HazelcastSqlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/HazelcastSqlException.java
@@ -25,13 +25,13 @@ import java.util.UUID;
 /**
  * An exception occurred during SQL query execution.
  */
-public class SqlException extends HazelcastException {
+public class HazelcastSqlException extends HazelcastException {
 
     private final UUID originatingMemberId;
     private final int code;
 
     @PrivateApi
-    public SqlException(@Nonnull UUID originatingMemberId, int code, String message, Throwable cause) {
+    public HazelcastSqlException(@Nonnull UUID originatingMemberId, int code, String message, Throwable cause) {
         super(message, cause);
 
         this.originatingMemberId = originatingMemberId;
@@ -49,14 +49,11 @@ public class SqlException extends HazelcastException {
     }
 
     /**
-     * Gets the error code associated with the exception.
-     * <p>
-     * The returned value is one of the constants defined in the {@link SqlErrorCode} class.
+     * Gets the internal error code associated with the exception.
      *
-     * @return the error code associated with the exception
-     *
-     * @see SqlErrorCode
+     * @return the internal error code associated with the exception
      */
+    @PrivateApi
     public int getCode() {
         return code;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlResult.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
  * <p>
  * Code example:
  * <pre>
- * try (SqlResult result = hazelcastInstance.getSql().query("SELECT ...")) {
+ * try (SqlResult result = hazelcastInstance.getSql().execute("SELECT ...")) {
  *     for (SqlRow row : result) {
  *         // Process the row.
  *     }
@@ -45,7 +45,7 @@ import java.util.Iterator;
  * <h4>Usage for update count</h4>
  *
  * <pre>
- *     long updated = hazelcastInstance.getSql().query("UPDATE ...").updateCount();
+ *     long updated = hazelcastInstance.getSql().execute("UPDATE ...").updateCount();
  * </pre>
  *
  * You don't need to call {@link #close()} in this case.
@@ -81,7 +81,7 @@ public interface SqlResult extends Iterable<SqlRow>, AutoCloseable {
      * @throws IllegalStateException if the method is invoked more than once or
      *    if this result doesn't have rows (i.e. when {@link #isUpdateCount()}
      *    returns {@code true})
-     * @throws SqlException in case of an SQL-related error condition
+     * @throws HazelcastSqlException in case of an SQL-related error condition
      */
     @Nonnull
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -96,7 +96,7 @@ import java.util.List;
  * <pre>
  *     HazelcastInstance instance = ...;
  *
- *     try (SqlResult result = instance.sql().query("SELECT * FROM person")) {
+ *     try (SqlResult result = instance.sql().execute("SELECT * FROM person")) {
  *         for (SqlRow row : result) {
  *             long personId = row.getObject("personId");
  *             String name = row.getObject("name");
@@ -110,22 +110,22 @@ public interface SqlService {
     /**
      * Convenient method to execute a distributed query with the given parameters.
      * <p>
-     * Converts passed SQL string and parameters into an {@link SqlQuery} object and invokes {@link #query(SqlQuery)}.
+     * Converts passed SQL string and parameters into an {@link SqlStatement} object and invokes {@link #execute(SqlStatement)}.
      *
      * @param sql SQL string
-     * @param params query parameters that will be passed to {@link SqlQuery#setParameters(List)}
+     * @param params query parameters that will be passed to {@link SqlStatement#setParameters(List)}
      * @return result
      * @throws NullPointerException if the SQL string is null
      * @throws IllegalArgumentException if the SQL string is empty
-     * @throws SqlException in case of execution error
+     * @throws HazelcastSqlException in case of execution error
      *
      * @see SqlService
-     * @see SqlQuery
-     * @see #query(SqlQuery)
+     * @see SqlStatement
+     * @see #execute(SqlStatement)
      */
     @Nonnull
-    default SqlResult query(@Nonnull String sql, Object... params) {
-        SqlQuery query = new SqlQuery(sql);
+    default SqlResult execute(@Nonnull String sql, Object... params) {
+        SqlStatement query = new SqlStatement(sql);
 
         if (params != null) {
             for (Object param : params) {
@@ -133,7 +133,7 @@ public interface SqlService {
             }
         }
 
-        return query(query);
+        return execute(query);
     }
 
     /**
@@ -142,10 +142,10 @@ public interface SqlService {
      * @param query query to be executed
      * @return result
      * @throws NullPointerException if the query is null
-     * @throws SqlException in case of execution error
+     * @throws HazelcastSqlException in case of execution error
      *
      * @see SqlService
      */
     @Nonnull
-    SqlResult query(@Nonnull SqlQuery query);
+    SqlResult execute(@Nonnull SqlStatement query);
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * This object is mutable. Properties are read once before the execution is started.
  * Changes to properties do not affect the behavior of already running queries.
  */
-public final class SqlQuery {
+public final class SqlStatement {
     /** Value for the timeout that is not set. */
     public static final long TIMEOUT_NOT_SET = -1;
 
@@ -48,14 +48,14 @@ public final class SqlQuery {
     private long timeout = DEFAULT_TIMEOUT;
     private int cursorBufferSize = DEFAULT_CURSOR_BUFFER_SIZE;
 
-    public SqlQuery(@Nonnull String sql) {
+    public SqlStatement(@Nonnull String sql) {
         setSql(sql);
     }
 
     /**
      * Copying constructor.
      */
-    private SqlQuery(String sql, List<Object> parameters, long timeout, int cursorBufferSize) {
+    private SqlStatement(String sql, List<Object> parameters, long timeout, int cursorBufferSize) {
         this.sql = sql;
         this.parameters = parameters;
         this.timeout = timeout;
@@ -83,7 +83,7 @@ public final class SqlQuery {
      * @throws IllegalArgumentException if passed SQL query is empty
      */
     @Nonnull
-    public SqlQuery setSql(@Nonnull String sql) {
+    public SqlStatement setSql(@Nonnull String sql) {
         Preconditions.checkNotNull(sql, "SQL cannot be null");
 
         if (sql.length() == 0) {
@@ -121,7 +121,7 @@ public final class SqlQuery {
      * @see #clearParameters()
      */
     @Nonnull
-    public SqlQuery setParameters(List<Object> parameters) {
+    public SqlStatement setParameters(List<Object> parameters) {
         if (parameters == null || parameters.isEmpty()) {
             this.parameters = new ArrayList<>();
         } else {
@@ -141,7 +141,7 @@ public final class SqlQuery {
      * @see #clearParameters()
      */
     @Nonnull
-    public SqlQuery addParameter(Object parameter) {
+    public SqlStatement addParameter(Object parameter) {
         parameters.add(parameter);
 
         return this;
@@ -156,7 +156,7 @@ public final class SqlQuery {
      * @see #addParameter(Object)
      */
     @Nonnull
-    public SqlQuery clearParameters() {
+    public SqlStatement clearParameters() {
         this.parameters = new ArrayList<>();
 
         return this;
@@ -187,7 +187,7 @@ public final class SqlQuery {
      * @see SqlConfig#getQueryTimeoutMillis()
      */
     @Nonnull
-    public SqlQuery setTimeoutMillis(long timeout) {
+    public SqlStatement setTimeoutMillis(long timeout) {
         if (timeout < 0 && timeout != TIMEOUT_NOT_SET) {
             throw new IllegalArgumentException("Timeout should be non-negative or -1: " + timeout);
         }
@@ -224,11 +224,11 @@ public final class SqlQuery {
      * @param cursorBufferSize cursor buffer size (measured in the number of rows)
      * @return this instance for chaining
      *
-     * @see SqlService#query(SqlQuery)
+     * @see SqlService#execute(SqlStatement)
      * @see SqlResult
      */
     @Nonnull
-    public SqlQuery setCursorBufferSize(int cursorBufferSize) {
+    public SqlStatement setCursorBufferSize(int cursorBufferSize) {
         if (cursorBufferSize <= 0) {
             throw new IllegalArgumentException("Cursor buffer size should be positive: " + cursorBufferSize);
         }
@@ -244,8 +244,8 @@ public final class SqlQuery {
      * @return Copy of this instance
      */
     @Nonnull
-    public SqlQuery copy() {
-        return new SqlQuery(sql, new ArrayList<>(parameters), timeout, cursorBufferSize);
+    public SqlStatement copy() {
+        return new SqlStatement(sql, new ArrayList<>(parameters), timeout, cursorBufferSize);
     }
 
     @Override
@@ -258,7 +258,7 @@ public final class SqlQuery {
             return false;
         }
 
-        SqlQuery sqlQuery = (SqlQuery) o;
+        SqlStatement sqlQuery = (SqlStatement) o;
 
         return Objects.equals(sql, sqlQuery.sql)
             && Objects.equals(parameters, sqlQuery.parameters)

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryException.java
@@ -18,7 +18,6 @@ package com.hazelcast.sql.impl;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.sql.SqlErrorCode;
 
 import java.util.Collection;
 import java.util.UUID;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -21,8 +21,7 @@ import com.hazelcast.partition.Partition;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.SqlColumnMetadata;
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.impl.schema.TableResolver;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
@@ -58,9 +57,9 @@ public final class QueryUtils {
         return instanceName + "-" + workerType + "-" + index;
     }
 
-    public static SqlException toPublicException(Exception e, UUID localMemberId) {
-        if (e instanceof SqlException) {
-            return (SqlException) e;
+    public static HazelcastSqlException toPublicException(Exception e, UUID localMemberId) {
+        if (e instanceof HazelcastSqlException) {
+            return (HazelcastSqlException) e;
         }
 
         if (e instanceof QueryException) {
@@ -72,9 +71,9 @@ public final class QueryUtils {
                 originatingMemberId = localMemberId;
             }
 
-            return new SqlException(originatingMemberId, e0.getCode(), e0.getMessage(), e);
+            return new HazelcastSqlException(originatingMemberId, e0.getCode(), e0.getMessage(), e);
         } else {
-            return new SqlException(localMemberId, SqlErrorCode.GENERIC, e.getMessage(), e);
+            return new HazelcastSqlException(localMemberId, SqlErrorCode.GENERIC, e.getMessage(), e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlErrorCode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlErrorCode.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.sql;
+package com.hazelcast.sql.impl;
 
 /**
  * Error codes used in Hazelcast SQL.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
@@ -18,7 +18,6 @@ package com.hazelcast.sql.impl;
 
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.sql.SqlErrorCode;
 import com.hazelcast.sql.impl.exec.io.flowcontrol.FlowControlFactory;
 import com.hazelcast.sql.impl.exec.io.flowcontrol.simple.SimpleFlowControlFactory;
 import com.hazelcast.sql.impl.exec.root.BlockingRootResultConsumer;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -25,7 +25,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.ServiceNotFoundException;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.SqlStatement;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.impl.optimizer.DisabledSqlOptimizer;
@@ -183,7 +183,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
 
     @Nonnull
     @Override
-    public SqlResult query(@Nonnull SqlQuery query) {
+    public SqlResult execute(@Nonnull SqlStatement query) {
         Preconditions.checkNotNull(query, "Query cannot be null");
 
         try {
@@ -193,7 +193,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
 
             long timeout = query.getTimeoutMillis();
 
-            if (timeout == SqlQuery.TIMEOUT_NOT_SET) {
+            if (timeout == SqlStatement.TIMEOUT_NOT_SET) {
                 timeout = queryTimeout;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientService.java
@@ -27,9 +27,9 @@ import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.UuidUtil;
-import com.hazelcast.sql.SqlErrorCode;
-import com.hazelcast.sql.SqlException;
-import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.impl.SqlErrorCode;
+import com.hazelcast.sql.HazelcastSqlException;
+import com.hazelcast.sql.SqlStatement;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.SqlService;
@@ -67,7 +67,7 @@ public class SqlClientService implements SqlService {
 
     @Nonnull
     @Override
-    public SqlResult query(@Nonnull SqlQuery query) {
+    public SqlResult execute(@Nonnull SqlStatement query) {
         Connection connection = client.getConnectionManager().getRandomConnection(true);
 
         if (connection == null) {
@@ -218,7 +218,7 @@ public class SqlClientService implements SqlService {
 
     private static void handleResponseError(SqlError error) {
         if (error != null) {
-            throw new SqlException(error.getOriginatingMemberId(), error.getCode(), error.getMessage(), null);
+            throw new HazelcastSqlException(error.getOriginatingMemberId(), error.getCode(), error.getMessage(), null);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientUtils.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.client;
 
-import com.hazelcast.sql.SqlException;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.impl.QueryUtils;
 
 import java.util.UUID;
@@ -30,7 +30,7 @@ public final class SqlClientUtils {
     }
 
     public static SqlError exceptionToClientError(Exception exception, UUID localMemberId) {
-        SqlException sqlException = QueryUtils.toPublicException(exception, localMemberId);
+        HazelcastSqlException sqlException = QueryUtils.toPublicException(exception, localMemberId);
 
         return new SqlError(
             sqlException.getCode(),

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlExecuteMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlExecuteMessageTask.java
@@ -22,7 +22,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.security.permission.SqlPermission;
-import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.SqlStatement;
 import com.hazelcast.sql.impl.AbstractSqlResult;
 import com.hazelcast.sql.impl.SqlInternalService;
 import com.hazelcast.sql.impl.SqlServiceImpl;
@@ -42,7 +42,7 @@ public class SqlExecuteMessageTask extends SqlAbstractMessageTask<SqlExecuteCode
     @Override
     protected Object call() throws Exception {
         try {
-            SqlQuery query = new SqlQuery(parameters.sql);
+            SqlStatement query = new SqlStatement(parameters.sql);
 
             for (Data param : parameters.parameters) {
                 query.addParameter(serializationService.toObject(param));
@@ -53,7 +53,7 @@ public class SqlExecuteMessageTask extends SqlAbstractMessageTask<SqlExecuteCode
 
             SqlServiceImpl sqlService = nodeEngine.getSqlService();
 
-            AbstractSqlResult result = (AbstractSqlResult) sqlService.query(query);
+            AbstractSqlResult result = (AbstractSqlResult) sqlService.execute(query);
 
             if (result.isUpdateCount()) {
                 return SqlExecuteResponse.updateCountResponse(result.updateCount());

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -18,7 +18,7 @@ package com.hazelcast.sql.impl.exec.scan;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.exec.AbstractExec;
 import com.hazelcast.sql.impl.exec.IterationResult;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -22,7 +22,7 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 
 import java.util.Iterator;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/AbsFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/AbsFunction.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.Expression;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DivideFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/DivideFunction.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpressionWithType;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/ExpressionMath.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/ExpressionMath.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.expression.math;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MinusFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MinusFunction.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpressionWithType;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MultiplyFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/MultiplyFunction.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpressionWithType;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/PlusFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/PlusFunction.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpressionWithType;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/UnaryMinusFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/math/UnaryMinusFunction.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.Expression;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerImpl.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.NodeServiceProvider;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.exec.CreateExecPlanNodeVisitor;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.state;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.ClockProvider;
 import com.hazelcast.sql.impl.QueryException;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converter.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.type.converter;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/HazelcastSqlExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/HazelcastSqlExceptionTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql;
 
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -29,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlExceptionTest {
+public class HazelcastSqlExceptionTest {
     @Test
     public void testFields() {
         UUID memberId = UUID.randomUUID();
@@ -37,7 +38,7 @@ public class SqlExceptionTest {
         String errorMessage = "error";
         Exception cause = new IllegalArgumentException();
 
-        SqlException exception = new SqlException(memberId, errorCode, errorMessage, cause);
+        HazelcastSqlException exception = new HazelcastSqlException(memberId, errorCode, errorMessage, cause);
 
         assertEquals(memberId, exception.getOriginatingMemberId());
         assertEquals(errorCode, exception.getCode());

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlStatementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlStatementTest.java
@@ -31,28 +31,28 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlQueryTest extends SqlTestSupport {
+public class SqlStatementTest extends SqlTestSupport {
 
     private static final String SQL = "sql";
 
     @Test
     public void testDefaults() {
-        SqlQuery query = create();
+        SqlStatement query = create();
 
         assertEquals(SQL, query.getSql());
         assertEquals(0, query.getParameters().size());
-        assertEquals(SqlQuery.DEFAULT_TIMEOUT, query.getTimeoutMillis());
-        assertEquals(SqlQuery.DEFAULT_CURSOR_BUFFER_SIZE, query.getCursorBufferSize());
+        assertEquals(SqlStatement.DEFAULT_TIMEOUT, query.getTimeoutMillis());
+        assertEquals(SqlStatement.DEFAULT_CURSOR_BUFFER_SIZE, query.getCursorBufferSize());
     }
 
     @Test(expected = NullPointerException.class)
     public void testSql_null() {
-        new SqlQuery(null);
+        new SqlStatement(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testSql_empty() {
-        new SqlQuery("");
+        new SqlStatement("");
     }
 
     @Test
@@ -61,7 +61,7 @@ public class SqlQueryTest extends SqlTestSupport {
         Object param1 = new Object();
         Object param2 = new Object();
 
-        SqlQuery query = create();
+        SqlStatement query = create();
         assertEquals(0, query.getParameters().size());
 
         query.setParameters(Arrays.asList(param0, param1));
@@ -85,14 +85,14 @@ public class SqlQueryTest extends SqlTestSupport {
 
     @Test
     public void testTimeout() {
-        SqlQuery query = create().setTimeoutMillis(1);
+        SqlStatement query = create().setTimeoutMillis(1);
         assertEquals(1, query.getTimeoutMillis());
 
         query.setTimeoutMillis(0);
         assertEquals(0, query.getTimeoutMillis());
 
-        query.setTimeoutMillis(SqlQuery.TIMEOUT_NOT_SET);
-        assertEquals(SqlQuery.TIMEOUT_NOT_SET, query.getTimeoutMillis());
+        query.setTimeoutMillis(SqlStatement.TIMEOUT_NOT_SET);
+        assertEquals(SqlStatement.TIMEOUT_NOT_SET, query.getTimeoutMillis());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -102,7 +102,7 @@ public class SqlQueryTest extends SqlTestSupport {
 
     @Test
     public void testCursorBufferSize() {
-        SqlQuery query = create().setCursorBufferSize(1);
+        SqlStatement query = create().setCursorBufferSize(1);
         assertEquals(1, query.getCursorBufferSize());
     }
 
@@ -118,7 +118,7 @@ public class SqlQueryTest extends SqlTestSupport {
 
     @Test
     public void testCopy() {
-        SqlQuery original = create();
+        SqlStatement original = create();
         checkEquals(original, original.copy(), true);
 
         original.setParameters(Arrays.asList(1, 2)).setTimeoutMillis(3L).setCursorBufferSize(4);
@@ -127,8 +127,8 @@ public class SqlQueryTest extends SqlTestSupport {
 
     @Test
     public void testEquals() {
-        SqlQuery query = create();
-        SqlQuery another = create();
+        SqlStatement query = create();
+        SqlStatement another = create();
         checkEquals(query, another, true);
 
         query.setParameters(Arrays.asList(1, 2)).setTimeoutMillis(10L).setCursorBufferSize(20);
@@ -150,7 +150,7 @@ public class SqlQueryTest extends SqlTestSupport {
 
     @Test
     public void testToString() {
-        SqlQuery query = create().setParameters(Arrays.asList(1, 2)).setTimeoutMillis(3L).setCursorBufferSize(4);
+        SqlStatement query = create().setParameters(Arrays.asList(1, 2)).setTimeoutMillis(3L).setCursorBufferSize(4);
 
         String string = query.toString();
 
@@ -160,7 +160,7 @@ public class SqlQueryTest extends SqlTestSupport {
         assertTrue(string.contains("cursorBufferSize="));
     }
 
-    private static SqlQuery create() {
-        return new SqlQuery(SQL);
+    private static SqlStatement create() {
+        return new SqlStatement(SQL);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
@@ -25,7 +25,7 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.sql.SqlQuery;
+import com.hazelcast.sql.SqlStatement;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.exec.CreateExecPlanNodeVisitorHook;
@@ -199,7 +199,7 @@ public class SqlTestSupport extends HazelcastTestSupport {
     }
 
     public static List<SqlRow> execute(HazelcastInstance member, String sql, Object... params) {
-        SqlQuery query = new SqlQuery(sql);
+        SqlStatement query = new SqlStatement(sql);
 
         if (params != null) {
             query.setParameters(Arrays.asList(params));
@@ -207,7 +207,7 @@ public class SqlTestSupport extends HazelcastTestSupport {
 
         List<SqlRow> rows = new ArrayList<>();
 
-        try (SqlResult result = member.getSql().query(query)) {
+        try (SqlResult result = member.getSql().execute(query)) {
             for (SqlRow row : result) {
                 rows.add(row);
             }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/AbstractExecTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.exec;
 
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.row.EmptyRowBatch;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/io/OutboxTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/io/OutboxTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.exec.io;
 
 import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.FaultyQueryOperationHandler;
 import com.hazelcast.sql.impl.LoggingQueryOperationHandler;
 import com.hazelcast.sql.impl.QueryId;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/io/flowcontrol/simple/SimpleFlowControlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/io/flowcontrol/simple/SimpleFlowControlTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.exec.io.flowcontrol.simple;
 
 import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.FaultyQueryOperationHandler;
 import com.hazelcast.sql.impl.LoggingQueryOperationHandler;
 import com.hazelcast.sql.impl.QueryId;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
@@ -32,7 +32,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.partition.PartitionService;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.exec.IterationResult;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.SqlTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.instance.impl.HazelcastInstanceProxy;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.NodeServiceProviderImpl;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.QueryParameterMetadata;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolverTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.partition.Partition;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryUtils;
 import com.hazelcast.sql.impl.schema.Table;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.extract.GenericQueryTargetDescriptor;
 import com.hazelcast.sql.impl.schema.TableField;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.type.converter;
 
 import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.SqlCustomClass;
 import com.hazelcast.sql.impl.expression.math.ExpressionMath;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryOperationWorkerPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/worker/QueryOperationWorkerPoolTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.logging.NoLogFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.sql.SqlErrorCode;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.LocalMemberIdProvider;
 import com.hazelcast.sql.impl.LoggingQueryOperationHandler;
 import com.hazelcast.sql.impl.QueryId;


### PR DESCRIPTION
This PR introduces the following changes to public API:
1. Renamed `SqlException` to `HazelcastSqlException`
1. `SqlErrorCode` is moved to a private package. `HazelcastSqlException.getCode` is marked as a private API. The motivation for this change - users do no need error codes at the moment. Codes are mostly needed by future JDBC integration. No need to increase the public API surface for now
1. `SqlQuery` renamed to `SqlStatement` to reflect the fact that it could be not only query, but also DDL/DML
1. `SqlService.query` renamed to `SqlService.execute`