### PR TITLE
Use hazelcast-hibernate53:2.1.1

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-hibernate53</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Fixes the breaking change introduced by changing `hazelcast-hibernate` to `hazelcast-hibernate53`