### PR TITLE
Summary of the new naming:

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/CalciteSqlOptimizer.java
@@ -18,7 +18,7 @@ package com.hazelcast.sql.impl.calcite;
 
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.sql.impl.JetSqlService;
+import com.hazelcast.sql.impl.JetSqlCoreBackend;
 import com.hazelcast.sql.impl.calcite.opt.HazelcastConventions;
 import com.hazelcast.sql.impl.calcite.parse.QueryParseResult;
 import com.hazelcast.sql.impl.optimizer.OptimizationTask;
@@ -101,12 +101,12 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
 
     public CalciteSqlOptimizer(
         NodeEngine nodeEngine,
-        @Nullable JetSqlService jetSqlService
+        @Nullable JetSqlCoreBackend jetSqlCoreBackend
     ) {
         this.nodeEngine = nodeEngine;
 
         this.sqlBackend = new HazelcastSqlBackend(nodeEngine);
-        this.jetSqlBackend = jetSqlService == null ? null : (SqlBackend) jetSqlService.sqlBackend();
+        this.jetSqlBackend = jetSqlCoreBackend == null ? null : (SqlBackend) jetSqlCoreBackend.sqlBackend();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/JetSqlCoreBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/JetSqlCoreBackend.java
@@ -24,14 +24,16 @@ import com.hazelcast.sql.impl.schema.map.JetMapMetadataResolver;
 import java.util.List;
 
 /**
- * Provides execution support for Jet specific SQL statements.
+ * Provides execution support for running SQL statements on Jet. This is
+ * the part that's on core code, {@link #sqlBackend()} returns the part
+ * that's on the hazelcast-sql module.
  */
-public interface JetSqlService {
+public interface JetSqlCoreBackend {
 
-    String SERVICE_NAME = "hz:impl:jetSqlService";
+    String SERVICE_NAME = "hz:impl:jetSqlCoreBackend";
 
     /**
-     * Return Jet specific {@link TableResolver}s.
+     * Return Jet-specific {@link TableResolver}s.
      */
     List<TableResolver> tableResolvers();
 
@@ -41,7 +43,7 @@ public interface JetSqlService {
     JetMapMetadataResolver mapMetadataResolver();
 
     /**
-     * Return Jet specific <i>com.hazelcast.sql.impl.calcite.SqlBackend</i>.
+     * Return Jet-specific {@code com.hazelcast.sql.impl.calcite.SqlBackend}.
      */
     Object sqlBackend();
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Proxy for SQL service. Backed by either Calcite-based or no-op implementation.
+ * Proxy for SQL service.
  */
 public class SqlInternalService {
 


### PR DESCRIPTION
- `SqlService` is public API for SQL, in `hazelcast` module

- `SqlServiceImpl` and `SqlClientService`: implementations of the above
for member and client, in `hazelcast` module

- `SqlInternalService`: some extension to `SqlServiceImpl`

- `JetSqlService` Jet extension of `SqlService`: adds no features, only
adds more javadoc

_Backend_ classes: These create extension points for Jet:

- `JetSqlCoreBackend`: the core part of the backend, in `hazelcast`
module. No dependencies to Calcite.

- `JetSqlCoreBackendImpl`: implementation of the above in
`hazelcast-jet-core`

- `SqlBackend`: backend, the part in `hazelcast-sql` module. Has
dependencies to Calcite.

- `HazelcastSqlBackend` and `JetSqlBackend`: implementations of the
above in `hazelcast-sql` and `hazelcast-jet-sql` modules