### PR TITLE
Remove misleading default config entries from 'hazelcast-default' files

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -55,15 +55,8 @@
                 </member-list>
             </tcp-ip>
             <aws enabled="false">
-                <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
-                <host-header>ec2.amazonaws.com</host-header>
-                <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
-                <security-group-name>hazelcast-sg</security-group-name>
-                <tag-key>type</tag-key>
-                <tag-value>hz-nodes</tag-value>
             </aws>
             <gcp enabled="false">
-                <zones>us-east1-b,us-east1-c</zones>
             </gcp>
             <azure enabled="false">
             </azure>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -55,10 +55,6 @@
                 </member-list>
             </tcp-ip>
             <aws enabled="false">
-                <access-key>my-access-key</access-key>
-                <secret-key>my-secret-key</secret-key>
-                <!--optional, default is us-east-1 -->
-                <region>us-west-1</region>
                 <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
                 <host-header>ec2.amazonaws.com</host-header>
                 <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
@@ -72,10 +68,6 @@
             <azure enabled="false">
             </azure>
             <kubernetes enabled="false">
-                <namespace>MY-KUBERNETES-NAMESPACE</namespace>
-                <service-name>MY-SERVICE-NAME</service-name>
-                <service-label-name>MY-SERVICE-LABEL-NAME</service-label-name>
-                <service-label-value>MY-SERVICE-LABEL-VALUE</service-label-value>
             </kubernetes>
             <eureka enabled="false">
                 <self-registration>true</self-registration>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -47,10 +47,6 @@ hazelcast:
           - 127.0.0.1
       aws:
         enabled: false
-        access-key: my-access-key
-        secret-key: my-secret-key
-        # optional, default is us-east-1
-        region: us-west-1
         # optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property
         host-header: ec2.amazonaws.com
         # optional, only instances belonging to this group will be discovered, default will try all running instances
@@ -64,10 +60,6 @@ hazelcast:
         enabled: false
       kubernetes:
         enabled: false
-        namespace: MY-KUBERNETES-NAMESPACE
-        service-name: MY-SERVICE-NAME
-        service-label-name: MY-SERVICE-LABEL-NAME
-        service-label-value: MY-SERVICE-LABEL-VALUE
       eureka:
         enabled: false
         self-registration: true

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -47,15 +47,8 @@ hazelcast:
           - 127.0.0.1
       aws:
         enabled: false
-        # optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property
-        host-header: ec2.amazonaws.com
-        # optional, only instances belonging to this group will be discovered, default will try all running instances
-        security-group-name: hazelcast-sg
-        tag-key: type
-        tag-value: hz-nodes
       gcp:
         enabled: false
-        zones: us-east1-b,us-east1-c
       azure:
         enabled: false
       kubernetes:


### PR DESCRIPTION
Invalid config values like:
- `my-access-key`
- `MY-SERVICE-LABEL-NAME`

Shouldn't belong to default config files, but to full/example ones.

```
# optional, default is us-east-1		
region: us-west-1
```

This is double-misleading since the `region` parameter is set based on the region where an application is running.