### PR TITLE
custom load balancer declarative configuration

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/InvalidApplicationContextTest.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/InvalidApplicationContextTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class InvalidApplicationContextTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void shouldFailWhenLoadBalancerContainsClassNameAndImplementationAttribute() {
+        expectedException.expect(BeanDefinitionStoreException.class);
+        expectedException.expectMessage("Unexpected exception parsing XML document from class path resource [com/hazelcast/spring/"
+                + "customLoadBalancer-invalidApplicationContext.xml]; nested exception is "
+                + "java.lang.IllegalArgumentException: Exactly one of 'class-name' or 'implementation' attributes is "
+                + "required to create LoadBalancer!");
+
+        new ClassPathXmlApplicationContext("com\\hazelcast\\spring\\customLoadBalancer-invalidApplicationContext.xml");
+    }
+}

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestCustomLoadBalancerContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestCustomLoadBalancerContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spring;
 
 import com.hazelcast.client.HazelcastClient;
@@ -42,11 +58,11 @@ public class TestCustomLoadBalancerContext {
         ClientConfig config1 = client1.getClientConfig();
         LoadBalancer loadBalancer1 = config1.getLoadBalancer();
         assertTrue(loadBalancer1 instanceof CustomLoadBalancer);
-        assertEquals("default-name", ((CustomLoadBalancer)loadBalancer1).getName());
+        assertEquals("default-name", ((CustomLoadBalancer) loadBalancer1).getName());
 
         ClientConfig config2 = client2.getClientConfig();
         LoadBalancer loadBalancer2 = config2.getLoadBalancer();
         assertTrue(loadBalancer2 instanceof CustomLoadBalancer);
-        assertEquals("custom-balancer-name", ((CustomLoadBalancer)loadBalancer2).getName());
+        assertEquals("custom-balancer-name", ((CustomLoadBalancer) loadBalancer2).getName());
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestCustomLoadBalancerContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestCustomLoadBalancerContext.java
@@ -1,0 +1,52 @@
+package com.hazelcast.spring;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.LoadBalancer;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.client.test.CustomLoadBalancer;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"customLoadBalancer-applicationContext.xml"})
+@Category(QuickTest.class)
+public class TestCustomLoadBalancerContext {
+
+    @Resource(name = "client1")
+    private HazelcastClientProxy client1;
+
+    @Resource(name = "client2")
+    private HazelcastClientProxy client2;
+
+    @BeforeClass
+    @AfterClass
+    public static void start() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testCustomLoadBalancer() {
+        ClientConfig config1 = client1.getClientConfig();
+        LoadBalancer loadBalancer1 = config1.getLoadBalancer();
+        assertTrue(loadBalancer1 instanceof CustomLoadBalancer);
+        assertEquals("default-name", ((CustomLoadBalancer)loadBalancer1).getName());
+
+        ClientConfig config2 = client2.getClientConfig();
+        LoadBalancer loadBalancer2 = config2.getLoadBalancer();
+        assertTrue(loadBalancer2 instanceof CustomLoadBalancer);
+        assertEquals("custom-balancer-name", ((CustomLoadBalancer)loadBalancer2).getName());
+    }
+}

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-applicationContext.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-applicationContext.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.1.xsd">
+
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+          p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
+        <property name="locations">
+            <list>
+                <value>classpath:/hazelcast-default.properties</value>
+            </list>
+        </property>
+    </bean>
+
+    <hz:hazelcast id="instance">
+        <hz:config>
+            <hz:cluster-name>${cluster.name}</hz:cluster-name>
+            <hz:properties>
+                <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
+                <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
+            </hz:properties>
+            <hz:network port="${cluster.port}" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"
+                                  multicast-group="224.2.2.3"
+                                  multicast-port="54327"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:members>${cluster.members}</hz:members>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="false">
+                    <hz:interface>10.10.1.*</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client id="client1">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
+        <hz:network connection-timeout="1000"
+                    redo-operation="false"
+                    smart-routing="false">
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+        <hz:load-balancer type="custom" class-name="com.hazelcast.client.test.CustomLoadBalancer"/>
+    </hz:client>
+
+    <hz:client id="client2">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
+        <hz:network connection-timeout="1000"
+                    redo-operation="false"
+                    smart-routing="false">
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+        <hz:load-balancer type="custom" implementation="customLoadBalancer"/>
+    </hz:client>
+
+    <bean id="customLoadBalancer" class="com.hazelcast.client.test.CustomLoadBalancer">
+        <property name="name" value="custom-balancer-name"/>
+    </bean>
+</beans>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-invalidApplicationContext.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-invalidApplicationContext.xml
@@ -24,41 +24,13 @@
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring-4.1.xsd">
 
-    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
-          p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
-        <property name="locations">
-            <list>
-                <value>classpath:/hazelcast-default.properties</value>
-            </list>
-        </property>
-    </bean>
-
-    <hz:hazelcast id="instance">
-        <hz:config>
-            <hz:network port="${cluster.port}" port-auto-increment="false">
-                <hz:join>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
-                </hz:join>
-            </hz:network>
-        </hz:config>
-    </hz:hazelcast>
-
-    <hz:client id="client1">
+    <hz:client id="client">
         <hz:network connection-timeout="1000" smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-        <hz:load-balancer type="custom" class-name="com.hazelcast.client.test.CustomLoadBalancer"/>
-    </hz:client>
-
-    <hz:client id="client2">
-        <hz:network connection-timeout="1000" smart-routing="false">
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
-        </hz:network>
-        <hz:load-balancer type="custom" implementation="customLoadBalancer"/>
+        <hz:load-balancer type="custom" class-name="com.hazelcast.client.test.CustomLoadBalancer"
+            implementation="customLoadBalancer"/>
     </hz:client>
 
     <bean id="customLoadBalancer" class="com.hazelcast.client.test.CustomLoadBalancer">

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -142,6 +142,13 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             return builder;
         }
 
+        protected BeanDefinitionBuilder createBeanBuilder(String className) {
+            BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(className);
+            builder.setScope(configBuilder.getBeanDefinition().getScope());
+            builder.setLazyInit(configBuilder.getBeanDefinition().isLazyInit());
+            return builder;
+        }
+
         protected BeanDefinitionBuilder createAndFillBeanBuilder(Node node, Class clazz, String propertyName,
                                                                  BeanDefinitionBuilder parent, String... exceptPropertyNames) {
             BeanDefinitionBuilder builder = createBeanBuilder(clazz);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -370,7 +370,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                 String className = classNameNode != null ? getTextContent(classNameNode) : null;
                 Node implNode = attributes.getNamedItem("implementation");
                 String implementation = implNode != null ? getTextContent(implNode) : null;
-                isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                isTrue(className != null ^ implementation != null, "Exactly one of 'class-name' or 'implementation'"
                     + " attributes is required to create LoadBalancer!");
                 if (className != null) {
                     BeanDefinitionBuilder loadBalancerBeanDefinition = createBeanBuilder(className);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spring;
 
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.config.ClientCloudConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig;
@@ -35,7 +34,6 @@ import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.CredentialsFactoryConfig;
-import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InstanceTrackingConfig;

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -3092,9 +3092,11 @@
                 <xs:restriction base="non-space-string">
                     <xs:enumeration value="random"/>
                     <xs:enumeration value="round-robin"/>
+                    <xs:enumeration value="custom"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+        <xs:attributeGroup ref="class-or-bean-name"/>
     </xs:complexType>
     <xs:complexType name="near-cache-client">
         <xs:complexContent>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -3092,11 +3092,9 @@
                 <xs:restriction base="non-space-string">
                     <xs:enumeration value="random"/>
                     <xs:enumeration value="round-robin"/>
-                    <xs:enumeration value="custom"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attributeGroup ref="class-or-bean-name"/>
     </xs:complexType>
     <xs:complexType name="near-cache-client">
         <xs:complexContent>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -3174,9 +3174,11 @@
                 <xs:restriction base="non-space-string">
                     <xs:enumeration value="random"/>
                     <xs:enumeration value="round-robin"/>
+                    <xs:enumeration value="custom"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+        <xs:attributeGroup ref="class-or-bean-name"/>
     </xs:complexType>
     <xs:complexType name="near-cache-client">
         <xs:complexContent>

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -54,6 +54,7 @@ import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT_CONFIG;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
+import static com.hazelcast.internal.util.Preconditions.checkHasText;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
@@ -608,7 +609,9 @@ public class ClientConfig {
     }
 
     /**
-     * Sets the {@link LoadBalancer}
+     * Sets the {@link LoadBalancer}.
+     * <p>
+     * If a load balancer class name was set, it will be removed.
      *
      * @param loadBalancer {@link LoadBalancer}
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
@@ -616,6 +619,7 @@ public class ClientConfig {
      */
     public ClientConfig setLoadBalancer(LoadBalancer loadBalancer) {
         this.loadBalancer = loadBalancer;
+        this.loadBalancerClassName = null;
         return this;
     }
 
@@ -630,14 +634,17 @@ public class ClientConfig {
     }
 
     /**
-     * Sets load balancer class name
+     * Sets load balancer class name.
+     * <p>
+     * If a load balancer implementation was set, it will be removed.
      *
      * @param loadBalancerClassName {@link LoadBalancer}
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
      * @see com.hazelcast.client.LoadBalancer
      */
-    public ClientConfig setLoadBalancerClassName(String loadBalancerClassName) {
-        this.loadBalancerClassName = loadBalancerClassName;
+    public ClientConfig setLoadBalancerClassName(@Nonnull String loadBalancerClassName) {
+        this.loadBalancerClassName = checkHasText(loadBalancerClassName, "Load balancer class name must contain text");
+        this.loadBalancer = null;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -86,6 +86,11 @@ public class ClientConfig {
     private LoadBalancer loadBalancer;
 
     /**
+     * Load balancer class name. Used internally with declarative configuration.
+     */
+    private String loadBalancerClassName;
+
+    /**
      * List of listeners that Hazelcast will automatically add as a part of initialization process.
      * Currently only supports {@link com.hazelcast.core.LifecycleListener}.
      */
@@ -130,6 +135,7 @@ public class ClientConfig {
         securityConfig = new ClientSecurityConfig(config.securityConfig);
         networkConfig = new ClientNetworkConfig(config.networkConfig);
         loadBalancer = config.loadBalancer;
+        loadBalancerClassName = config.loadBalancerClassName;
         listenerConfigs = new LinkedList<>();
         for (ListenerConfig listenerConfig : config.listenerConfigs) {
             listenerConfigs.add(new ListenerConfig(listenerConfig));
@@ -614,6 +620,29 @@ public class ClientConfig {
     }
 
     /**
+     * Gets load balancer class name
+     *
+     * @return load balancer class name
+     * @see com.hazelcast.client.LoadBalancer
+     */
+    public String getLoadBalancerClassName() {
+        return loadBalancerClassName;
+    }
+
+    /**
+     * Sets load balancer class name
+     *
+     * @param loadBalancerClassName {@link LoadBalancer}
+     * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
+     * @see com.hazelcast.client.LoadBalancer
+     */
+    public ClientConfig setLoadBalancerClassName(String loadBalancerClassName) {
+        this.loadBalancerClassName = loadBalancerClassName;
+        return this;
+    }
+
+
+    /**
      * Gets the classLoader
      *
      * @return configured classLoader, null if not yet configured
@@ -944,7 +973,7 @@ public class ClientConfig {
     @Override
     public int hashCode() {
         return Objects.hash(backupAckToClientEnabled, classLoader, clusterName, configPatternMatcher, connectionStrategyConfig,
-                flakeIdGeneratorConfigMap, instanceName, labels, listenerConfigs, loadBalancer,
+                flakeIdGeneratorConfigMap, instanceName, labels, listenerConfigs, loadBalancer, loadBalancerClassName,
                 managedContext, metricsConfig, nativeMemoryConfig, nearCacheConfigMap, networkConfig, properties,
                 proxyFactoryConfigs, queryCacheConfigs, reliableTopicConfigMap, securityConfig, serializationConfig,
                 userCodeDeploymentConfig, userContext, instanceTrackingConfig);
@@ -970,6 +999,7 @@ public class ClientConfig {
                 && Objects.equals(flakeIdGeneratorConfigMap, other.flakeIdGeneratorConfigMap)
                 && Objects.equals(instanceName, other.instanceName) && Objects.equals(labels, other.labels)
                 && Objects.equals(listenerConfigs, other.listenerConfigs) && Objects.equals(loadBalancer, other.loadBalancer)
+                && Objects.equals(loadBalancerClassName, other.loadBalancerClassName)
                 && Objects.equals(managedContext, other.managedContext) && Objects.equals(metricsConfig, other.metricsConfig)
                 && Objects.equals(nativeMemoryConfig, other.nativeMemoryConfig)
                 && Objects.equals(nearCacheConfigMap, other.nearCacheConfigMap)
@@ -992,6 +1022,7 @@ public class ClientConfig {
                 + ", securityConfig=" + securityConfig
                 + ", networkConfig=" + networkConfig
                 + ", loadBalancer=" + loadBalancer
+                + ", loadBalancerClassName=" + loadBalancerClassName
                 + ", listenerConfigs=" + listenerConfigs
                 + ", instanceName='" + instanceName + '\''
                 + ", configPatternMatcher=" + configPatternMatcher

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -429,9 +429,14 @@ public final class ClientConfigXmlGenerator {
         } else if (loadBalancer instanceof RoundRobinLB) {
             type = "round-robin";
         } else {
-            throw new IllegalArgumentException("Unknown load-balancer type: " + loadBalancer);
+            type = "custom";
         }
-        gen.node("load-balancer", null, "type", type);
+
+        if ("custom".equals(type)) {
+            gen.node("load-balancer", loadBalancer.getClass().getName(), "type", type);
+        } else {
+            gen.node("load-balancer", null, "type", type);
+        }
     }
 
     private static void nearCaches(XmlGenerator gen, Map<String, NearCacheConfig> nearCacheMap) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -400,7 +400,9 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
                 LoadBalancer loadBalancer = newInstance(null, loadBalancerClassName);
                 clientConfig.setLoadBalancer(loadBalancer);
             } catch (Exception e) {
-                throw new InvalidConfigurationException("Unable to instantiate load balancer class '" + loadBalancerClassName + "' found in the configuration", e);
+                throw new InvalidConfigurationException(
+                        "Unable to instantiate load balancer class '" + loadBalancerClassName
+                        + "' found in the configuration", e);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.config.impl;
 
+import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.config.ClientCloudConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig;
@@ -90,6 +91,7 @@ import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getDoubleValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getLongValue;
+import static com.hazelcast.internal.nio.ClassLoaderUtil.newInstance;
 import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
 
 @SuppressWarnings({
@@ -118,7 +120,7 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     @Override
-    public void buildConfig(Node rootNode) throws Exception {
+    public void buildConfig(Node rootNode) {
         for (Node node : childElements(rootNode)) {
             String nodeName = cleanNodeName(node);
             if (occurrenceSet.contains(nodeName)) {
@@ -391,7 +393,20 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             clientConfig.setLoadBalancer(new RandomLB());
         } else if ("round-robin".equals(type)) {
             clientConfig.setLoadBalancer(new RoundRobinLB());
+        } else if ("custom".equals(type)) {
+            String loadBalancerClassName = parseCustomLoadBalancerClassName(node);
+
+            try {
+                LoadBalancer loadBalancer = newInstance(null, loadBalancerClassName);
+                clientConfig.setLoadBalancer(loadBalancer);
+            } catch (Exception e) {
+                throw new InvalidConfigurationException("Unable to instantiate load balancer class '" + loadBalancerClassName + "' found in the configuration", e);
+            }
         }
+    }
+
+    protected String parseCustomLoadBalancerClassName(Node node) {
+        return getTextContent(node);
     }
 
     private void handleNetwork(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.config.impl;
 
-import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.config.ClientCloudConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig;
@@ -91,7 +90,6 @@ import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getDoubleValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getLongValue;
-import static com.hazelcast.internal.nio.ClassLoaderUtil.newInstance;
 import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
 
 @SuppressWarnings({
@@ -395,15 +393,7 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
             clientConfig.setLoadBalancer(new RoundRobinLB());
         } else if ("custom".equals(type)) {
             String loadBalancerClassName = parseCustomLoadBalancerClassName(node);
-
-            try {
-                LoadBalancer loadBalancer = newInstance(null, loadBalancerClassName);
-                clientConfig.setLoadBalancer(loadBalancer);
-            } catch (Exception e) {
-                throw new InvalidConfigurationException(
-                        "Unable to instantiate load balancer class '" + loadBalancerClassName
-                        + "' found in the configuration", e);
-            }
+            clientConfig.setLoadBalancerClassName(loadBalancerClassName);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
@@ -114,6 +114,11 @@ public class YamlClientDomConfigProcessor extends ClientDomConfigProcessor {
         return serializationConfig;
     }
 
+    @Override
+    protected String parseCustomLoadBalancerClassName(Node node) {
+        return getAttribute(node, "class-name");
+    }
+
     private void fillGlobalSerializer(Node child, SerializationConfig serializationConfig) {
         GlobalSerializerConfig globalSerializerConfig = new GlobalSerializerConfig();
         String attrClassName = getAttribute(child, "class-name");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -131,6 +131,9 @@ public final class FailoverClientConfigSupport {
         if (notEqual(mainConfig.getLoadBalancer(), alternativeConfig.getLoadBalancer())) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "loadBalancer");
         }
+        if (notEqual(mainConfig.getLoadBalancerClassName(), alternativeConfig.getLoadBalancerClassName())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "loadBalancerClassName");
+        }
         if (notEqual(mainConfig.getListenerConfigs(), alternativeConfig.getListenerConfigs())) {
             throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "listeners");
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -314,7 +314,15 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private LoadBalancer initLoadBalancer(ClientConfig config) {
         LoadBalancer lb = config.getLoadBalancer();
         if (lb == null) {
-            lb = new RoundRobinLB();
+            if (config.getLoadBalancerClassName() != null) {
+                try {
+                    return ClassLoaderUtil.newInstance(config.getClassLoader(), config.getLoadBalancerClassName());
+                } catch (Exception e) {
+                    rethrow(e);
+                }
+            } else {
+                lb = new RoundRobinLB();
+            }
         }
         return lb;
     }

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -249,14 +249,19 @@
     </xs:complexType>
 
     <xs:complexType name="load-balancer">
-        <xs:attribute name="type" use="required">
-            <xs:simpleType>
-                <xs:restriction base="non-space-string">
-                    <xs:enumeration value="random"/>
-                    <xs:enumeration value="round-robin"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="type" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="non-space-string">
+                            <xs:enumeration value="random"/>
+                            <xs:enumeration value="round-robin"/>
+                            <xs:enumeration value="custom"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
     <xs:complexType name="near-cache-client">
         <xs:complexContent>

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -249,19 +249,14 @@
     </xs:complexType>
 
     <xs:complexType name="load-balancer">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="type" use="required">
-                    <xs:simpleType>
-                        <xs:restriction base="non-space-string">
-                            <xs:enumeration value="random"/>
-                            <xs:enumeration value="round-robin"/>
-                            <xs:enumeration value="custom"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:attribute>
-            </xs:extension>
-        </xs:simpleContent>
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string">
+                    <xs:enumeration value="random"/>
+                    <xs:enumeration value="round-robin"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="near-cache-client">
         <xs:complexContent>

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -255,14 +255,19 @@
     </xs:complexType>
 
     <xs:complexType name="load-balancer">
-        <xs:attribute name="type" use="required">
-            <xs:simpleType>
-                <xs:restriction base="non-space-string">
-                    <xs:enumeration value="random"/>
-                    <xs:enumeration value="round-robin"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="type" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="non-space-string">
+                            <xs:enumeration value="random"/>
+                            <xs:enumeration value="round-robin"/>
+                            <xs:enumeration value="custom"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
     <xs:complexType name="near-cache-client">
         <xs:complexContent>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -578,6 +578,8 @@
         It has the attribute "type". The valid values for the type of the load balancer are"
         * "random": The member the operations to be sent to is chosen randomly.
         * "round-robin": The member the operations to be sent to is chosen in a round-robin fashion.
+        * "custom": The member the operations to be sent to is chosen by provided load balancer implementation.
+                    The implementation class name is specified as text content.
     -->
     <load-balancer type="random"/>
 

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -525,6 +525,8 @@ hazelcast-client:
   # It has a scalar sub-node called "type". The valid values for the type of the load balancer are:
   # * "random": The member the operations to be sent to is chosen randomly.
   # * "round-robin": The member the operations to be sent to is chosen in a round-robin fashion.
+  # * "custom": The member the operations to be sent to is chosen by provided load balancer implementation.
+  #             The implementation class name is specified in additional "class-name" key.
   #
   load-balancer:
     type: random

--- a/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
@@ -54,16 +54,15 @@ public class FailoverConfigTest {
                 "setNearCacheConfigMap", "getFlakeIdGeneratorConfigMap", "findFlakeIdGeneratorConfig",
                 "getFlakeIdGeneratorConfig", "addFlakeIdGeneratorConfig", "setFlakeIdGeneratorConfigMap",
                 "setReliableTopicConfigMap", "getReliableTopicConfigMap", "getCredentials", "setCredentials", "setClusterName",
-                "getListenerConfigs", "setListenerConfigs", "getLoadBalancer", "setLoadBalancer", "setClassLoader",
-                "getManagedContext", "setManagedContext", "getExecutorPoolSize", "setExecutorPoolSize", "getProxyFactoryConfigs",
-                "setProxyFactoryConfigs", "getSerializationConfig", "setSerializationConfig", "getNativeMemoryConfig",
-                "setNativeMemoryConfig", "getLicenseKey", "setLicenseKey", "addQueryCacheConfig", "getQueryCacheConfigs",
-                "setQueryCacheConfigs", "getInstanceName", "setInstanceName", "getConnectionStrategyConfig",
-                "setConnectionStrategyConfig", "getUserCodeDeploymentConfig", "setUserCodeDeploymentConfig",
-                "getOrCreateQueryCacheConfig", "getOrNullQueryCacheConfig", "addLabel", "setLabels",
-                "setUserContext", "getUserContext", "setMetricsConfig", "load",
-                "setBackupAckToClientEnabled", "isBackupAckToClientEnabled", "getMetricsConfig", "equals", "hashCode", "toString",
-                "setInstanceTrackingConfig", "getInstanceTrackingConfig");
+                "getListenerConfigs", "setListenerConfigs", "getLoadBalancer", "setLoadBalancer", "getLoadBalancerClassName",
+                "setLoadBalancerClassName", "setClassLoader", "getManagedContext", "setManagedContext", "getExecutorPoolSize",
+                "setExecutorPoolSize", "getProxyFactoryConfigs", "setProxyFactoryConfigs", "getSerializationConfig",
+                "setSerializationConfig", "getNativeMemoryConfig", "setNativeMemoryConfig", "getLicenseKey", "setLicenseKey",
+                "addQueryCacheConfig", "getQueryCacheConfigs", "setQueryCacheConfigs", "getInstanceName", "setInstanceName",
+                "getConnectionStrategyConfig", "setConnectionStrategyConfig", "getUserCodeDeploymentConfig", "setUserCodeDeploymentConfig",
+                "getOrCreateQueryCacheConfig", "getOrNullQueryCacheConfig", "addLabel", "setLabels", "setUserContext",
+                "getUserContext", "setMetricsConfig", "load", "setBackupAckToClientEnabled", "isBackupAckToClientEnabled",
+                "getMetricsConfig", "equals", "hashCode", "toString", "setInstanceTrackingConfig", "getInstanceTrackingConfig");
         Method[] declaredMethods = ClientConfig.class.getDeclaredMethods();
         for (Method method : declaredMethods) {
             String methodName = method.getName();

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -466,6 +466,9 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     public abstract void testLoadBalancerRoundRobin();
 
     @Test
+    public abstract void testLoadBalancerCustom();
+
+    @Test
     public abstract void testWhitespaceInNonSpaceStrings();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigLoadBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigLoadBalancerTest.java
@@ -74,23 +74,6 @@ public class ClientConfigLoadBalancerTest {
     }
 
     @Test
-    public void shouldUseConfigClassLoaderInstanceWhenClassNameSpecified() {
-        hazelcastFactory.newHazelcastInstance();
-
-        LoadBalancer loadBalancer = new RandomLB();
-
-        ClientConfig config = new ClientConfig();
-        config.setLoadBalancer(loadBalancer);
-        config.setLoadBalancerClassName("com.hazelcast.client.test.CustomLoadBalancer");
-
-        HazelcastInstance instance = hazelcastFactory.newHazelcastClient(config);
-        HazelcastClientInstanceImpl client = ClientTestUtil.getHazelcastClientInstanceImpl(instance);
-
-        LoadBalancer actual = client.getLoadBalancer();
-        assertSame(loadBalancer, actual);
-    }
-
-    @Test
     public void shouldCreateCustomLoadBalancerWhenConfigInstanceNotProvidedAndClassNameSpecified() {
         hazelcastFactory.newHazelcastInstance();
 

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigLoadBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigLoadBalancerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.client.LoadBalancer;
+import com.hazelcast.client.impl.clientside.ClientTestUtil;
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.test.CustomLoadBalancer;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.client.util.RandomLB;
+import com.hazelcast.client.util.RoundRobinLB;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientConfigLoadBalancerTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void shouldCreateRoundRobinLoadBalancerWhenNoConfigProvided() {
+        hazelcastFactory.newHazelcastInstance();
+
+        HazelcastInstance instance = hazelcastFactory.newHazelcastClient(new ClientConfig());
+        HazelcastClientInstanceImpl client = ClientTestUtil.getHazelcastClientInstanceImpl(instance);
+
+        LoadBalancer actual = client.getLoadBalancer();
+        assertTrue(actual instanceof RoundRobinLB);
+    }
+
+    @Test
+    public void shouldUseConfigClassLoaderInstanceWhenClassNameNotSpecified() {
+        hazelcastFactory.newHazelcastInstance();
+
+        LoadBalancer loadBalancer = new RandomLB();
+
+        ClientConfig config = new ClientConfig();
+        config.setLoadBalancer(loadBalancer);
+
+        HazelcastInstance instance = hazelcastFactory.newHazelcastClient(config);
+        HazelcastClientInstanceImpl client = ClientTestUtil.getHazelcastClientInstanceImpl(instance);
+
+        LoadBalancer actual = client.getLoadBalancer();
+        assertSame(loadBalancer, actual);
+    }
+
+    @Test
+    public void shouldUseConfigClassLoaderInstanceWhenClassNameSpecified() {
+        hazelcastFactory.newHazelcastInstance();
+
+        LoadBalancer loadBalancer = new RandomLB();
+
+        ClientConfig config = new ClientConfig();
+        config.setLoadBalancer(loadBalancer);
+        config.setLoadBalancerClassName("com.hazelcast.client.test.CustomLoadBalancer");
+
+        HazelcastInstance instance = hazelcastFactory.newHazelcastClient(config);
+        HazelcastClientInstanceImpl client = ClientTestUtil.getHazelcastClientInstanceImpl(instance);
+
+        LoadBalancer actual = client.getLoadBalancer();
+        assertSame(loadBalancer, actual);
+    }
+
+    @Test
+    public void shouldCreateCustomLoadBalancerWhenConfigInstanceNotProvidedAndClassNameSpecified() {
+        hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLoadBalancerClassName("com.hazelcast.client.test.CustomLoadBalancer");
+
+        HazelcastInstance instance = hazelcastFactory.newHazelcastClient(clientConfig);
+        HazelcastClientInstanceImpl client = ClientTestUtil.getHazelcastClientInstanceImpl(instance);
+
+        LoadBalancer actual = client.getLoadBalancer();
+        assertTrue(actual instanceof CustomLoadBalancer);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.test.Employee;
 import com.hazelcast.client.test.PortableFactory;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -38,6 +40,8 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -134,5 +138,29 @@ public class ClientConfigTest {
         ClientReliableTopicConfig newConfig = clientConfig.getReliableTopicConfig("newConfig");
 
         assertEquals(100, newConfig.getReadBatchSize());
+    }
+
+    @Test
+    public void testSettingLoaderBalancerShouldClearLoadBalancerClassName() {
+        LoadBalancer loadBalancer = new RandomLB();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLoadBalancerClassName("com.hazelcast.client.test.CustomLoadBalancer");
+        clientConfig.setLoadBalancer(loadBalancer);
+
+        assertNull(clientConfig.getLoadBalancerClassName());
+        assertSame(loadBalancer, clientConfig.getLoadBalancer());
+    }
+
+    @Test
+    public void testSettingLoadBalancerClassNameShouldClearLoadBalancer() {
+        LoadBalancer loadBalancer = new RandomLB();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLoadBalancer(loadBalancer);
+        clientConfig.setLoadBalancerClassName("com.hazelcast.client.test.CustomLoadBalancer");
+
+        assertEquals("com.hazelcast.client.test.CustomLoadBalancer", clientConfig.getLoadBalancerClassName());
+        assertNull(clientConfig.getLoadBalancer());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -86,6 +86,7 @@ import static com.hazelcast.config.MaxSizePolicy.USED_NATIVE_MEMORY_SIZE;
 import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -491,15 +492,21 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
     @Test
     public void loadBalancer() {
         clientConfig.setLoadBalancer(new RandomLB());
-        LoadBalancer actual = newConfigViaGenerator().getLoadBalancer();
+        ClientConfig newClientConfig = newConfigViaGenerator();
+        LoadBalancer actual = newClientConfig.getLoadBalancer();
         assertTrue(actual instanceof RandomLB);
+        String actualClassName = newClientConfig.getLoadBalancerClassName();
+        assertNull(actualClassName);
     }
 
     @Test
     public void loadBalancerCustom() {
         clientConfig.setLoadBalancer(new CustomLoadBalancer());
-        LoadBalancer actual = newConfigViaGenerator().getLoadBalancer();
-        assertTrue(actual instanceof CustomLoadBalancer);
+        ClientConfig newClientConfig = newConfigViaGenerator();
+        LoadBalancer actual = newClientConfig.getLoadBalancer();
+        assertNull(actual);
+        String actualClassName = newClientConfig.getLoadBalancerClassName();
+        assertEquals("com.hazelcast.client.test.CustomLoadBalancer", actualClassName);
     }
 
     private NearCacheConfig createNearCacheConfig(String name) {

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.config;
 
 import com.hazelcast.client.LoadBalancer;
+import com.hazelcast.client.test.CustomLoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.ConfigCompatibilityChecker;
@@ -492,6 +493,13 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         clientConfig.setLoadBalancer(new RandomLB());
         LoadBalancer actual = newConfigViaGenerator().getLoadBalancer();
         assertTrue(actual instanceof RandomLB);
+    }
+
+    @Test
+    public void loadBalancerCustom() {
+        clientConfig.setLoadBalancer(new CustomLoadBalancer());
+        LoadBalancer actual = newConfigViaGenerator().getLoadBalancer();
+        assertTrue(actual instanceof CustomLoadBalancer);
     }
 
     private NearCacheConfig createNearCacheConfig(String name) {

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.client.test.CustomLoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
@@ -355,6 +356,18 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         ClientConfig config = buildConfig(xml);
 
         assertInstanceOf(RoundRobinLB.class, config.getLoadBalancer());
+    }
+
+    @Override
+    @Test
+    public void testLoadBalancerCustom() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                     + "<load-balancer type=\"custom\">com.hazelcast.client.test.CustomLoadBalancer</load-balancer>"
+                     + HAZELCAST_CLIENT_END_TAG;
+
+        ClientConfig config = buildConfig(xml);
+
+        assertInstanceOf(CustomLoadBalancer.class, config.getLoadBalancer());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.client.test.CustomLoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
@@ -62,6 +61,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -344,6 +344,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         ClientConfig config = buildConfig(xml);
 
         assertInstanceOf(RandomLB.class, config.getLoadBalancer());
+        assertNull(config.getLoadBalancerClassName());
     }
 
     @Override
@@ -356,6 +357,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         ClientConfig config = buildConfig(xml);
 
         assertInstanceOf(RoundRobinLB.class, config.getLoadBalancer());
+        assertNull(config.getLoadBalancerClassName());
     }
 
     @Override
@@ -367,7 +369,8 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
 
         ClientConfig config = buildConfig(xml);
 
-        assertInstanceOf(CustomLoadBalancer.class, config.getLoadBalancer());
+        assertNull(config.getLoadBalancer());
+        assertEquals("com.hazelcast.client.test.CustomLoadBalancer", config.getLoadBalancerClassName());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.client.test.CustomLoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
+import com.hazelcast.client.util.StaticLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
@@ -324,6 +326,20 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         ClientConfig config = buildConfig(yaml);
 
         assertInstanceOf(RoundRobinLB.class, config.getLoadBalancer());
+    }
+
+    @Override
+    @Test
+    public void testLoadBalancerCustom() {
+        String yaml = ""
+                      + "hazelcast-client:\n"
+                      + "  load-balancer:\n"
+                      + "    type: custom\n"
+                      + "    class-name: com.hazelcast.client.test.CustomLoadBalancer\n";
+
+        ClientConfig config = buildConfig(yaml);
+
+        assertInstanceOf(CustomLoadBalancer.class, config.getLoadBalancer());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.client.test.CustomLoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
@@ -58,6 +57,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -312,6 +312,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         ClientConfig config = buildConfig(yaml);
 
         assertInstanceOf(RandomLB.class, config.getLoadBalancer());
+        assertNull(config.getLoadBalancerClassName());
     }
 
     @Override
@@ -325,6 +326,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         ClientConfig config = buildConfig(yaml);
 
         assertInstanceOf(RoundRobinLB.class, config.getLoadBalancer());
+        assertNull(config.getLoadBalancerClassName());
     }
 
     @Override
@@ -338,7 +340,8 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
 
         ClientConfig config = buildConfig(yaml);
 
-        assertInstanceOf(CustomLoadBalancer.class, config.getLoadBalancer());
+        assertNull(config.getLoadBalancer());
+        assertEquals("com.hazelcast.client.test.CustomLoadBalancer", config.getLoadBalancerClassName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.config;
 import com.hazelcast.client.test.CustomLoadBalancer;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
-import com.hazelcast.client.util.StaticLB;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;

--- a/hazelcast/src/test/java/com/hazelcast/client/test/CustomLoadBalancer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/CustomLoadBalancer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.test;
 
 import com.hazelcast.client.LoadBalancer;

--- a/hazelcast/src/test/java/com/hazelcast/client/test/CustomLoadBalancer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/CustomLoadBalancer.java
@@ -1,0 +1,34 @@
+package com.hazelcast.client.test;
+
+import com.hazelcast.client.LoadBalancer;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
+
+public class CustomLoadBalancer implements LoadBalancer {
+
+    private static final String DEFAULT_NAME = "default-name";
+
+    private String name;
+
+    public CustomLoadBalancer() {
+        this.name = DEFAULT_NAME;
+    }
+
+    @Override
+    public void init(Cluster cluster, ClientConfig config) {
+    }
+
+    @Override
+    public Member next() {
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/17228

Changes:

- "custom" balancer type was introduced (as suggested)
- XML, YAML config loading supports new balancer type
- Spring bean class name or reference is also supported for "custom" type

I'm aware that there have to be seperate PRs for other branches. Are you guys able to cherry pick this change onto 4.0.z and 4.z branches or do I have to open separate PRs? (this will take some time)

Can you help review this first?