### PR TITLE
[BACKPORT]  Public classes for member/client CachingProviders

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -40,9 +40,9 @@ import java.util.Properties;
  * This provider implementation delegates to a {@code CachingProvider} backed
  * by either a member- or a client-side {@link HazelcastInstance}:
  * <ul>
- * <li>{@code com.hazelcast.cache.impl.HazelcastServerCachingProvider} is the
+ * <li>{@link com.hazelcast.cache.HazelcastServerCachingProvider} is the
  * member-side {@link CachingProvider} implementation</li>
- * <li>{@code com.hazelcast.client.cache.impl.HazelcastClientCachingProvider} is the
+ * <li>{@link com.hazelcast.client.cache.HazelcastClientCachingProvider} is the
  * client-side {@link CachingProvider} implementation</li>
  * </ul>
  * <h3>Provider Type Selection</h3>

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -63,9 +63,9 @@ import java.util.Properties;
  *     is identical to using {@link Caching#getCachingProvider()}; choice between
  *     member- or client-side caching provider is performed via system property
  *     {@code hazelcast.jcache.provider.type} as described above.</li>
- *     <li>using {@value #SERVER_CACHING_PROVIDER} as
+ *     <li>using {@link #SERVER_CACHING_PROVIDER} as
  *     class name will return a member-side caching provider</li>
- *     <li>using {@value #CLIENT_CACHING_PROVIDER} as
+ *     <li>using {@link #CLIENT_CACHING_PROVIDER} as
  *     class name will return a client-side caching provider</li>
  * </ul>
  * <h3>Creating or reusing HazelcastInstances with CacheManagers</h3>
@@ -161,11 +161,12 @@ public final class HazelcastCachingProvider implements CachingProvider {
     /**
      * Class name of the member-side Caching Provider
      */
-    public static final String SERVER_CACHING_PROVIDER = "com.hazelcast.cache.impl.HazelcastServerCachingProvider";
+    public static final String SERVER_CACHING_PROVIDER = com.hazelcast.cache.HazelcastServerCachingProvider.class.getName();
     /**
      * Class name of the client-side Caching Provider
      */
-    public static final String CLIENT_CACHING_PROVIDER = "com.hazelcast.client.cache.impl.HazelcastClientCachingProvider";
+    public static final String CLIENT_CACHING_PROVIDER =
+            com.hazelcast.client.cache.HazelcastClientCachingProvider.class.getName();
 
     /**
      * Name of default {@link HazelcastInstance} which may be started when

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -40,7 +40,7 @@ import java.util.Properties;
  * This provider implementation delegates to a {@code CachingProvider} backed
  * by either a member- or a client-side {@link HazelcastInstance}:
  * <ul>
- * <li>{@link com.hazelcast.cache.HazelcastServerCachingProvider} is the
+ * <li>{@link com.hazelcast.cache.HazelcastMemberCachingProvider} is the
  * member-side {@link CachingProvider} implementation</li>
  * <li>{@link com.hazelcast.client.cache.HazelcastClientCachingProvider} is the
  * client-side {@link CachingProvider} implementation</li>
@@ -52,9 +52,11 @@ import java.util.Properties;
  * {@code hazelcast.jcache.provider.type}:
  * <ul>
  *     <li>If no value was set, then the client-side caching provider is selected</li>
- *     <li>If a value was set, then value {@code server} selects the member-side caching
- *     provider, while value {@code client} selects the client-side provider. Other values
- *     result in a {@link CacheException} being thrown.</li>
+ *     <li>If a value was set, then value {@code member} selects the member-side caching
+ *     provider, while value {@code client} selects the client-side provider. Legacy value
+ *     {@code server} is also accepted as an alias for {@code member} for backwards compatibility,
+ *     however its usage is discouraged and will be removed in a future version.
+ *     Other values result in a {@link CacheException} being thrown.</li>
  * </ul>
  * <p>When using one of {@code Caching#getCachingProvider} variants with an explicit
  * class name argument, then:
@@ -63,7 +65,7 @@ import java.util.Properties;
  *     is identical to using {@link Caching#getCachingProvider()}; choice between
  *     member- or client-side caching provider is performed via system property
  *     {@code hazelcast.jcache.provider.type} as described above.</li>
- *     <li>using {@link #SERVER_CACHING_PROVIDER} as
+ *     <li>using {@link #MEMBER_CACHING_PROVIDER} as
  *     class name will return a member-side caching provider</li>
  *     <li>using {@link #CLIENT_CACHING_PROVIDER} as
  *     class name will return a client-side caching provider</li>
@@ -106,7 +108,7 @@ import java.util.Properties;
  * <h3>Examples</h3>
  * <p><b>Obtain a member-side caching provider backed by an existing HazelcastInstance.</b>
  * In this example the member-side caching provider is selected by setting the value of
- * system property {@code hazelcast.jcache.provider.type} to value "{@code server}". An existing
+ * system property {@code hazelcast.jcache.provider.type} to value "{@code member}". An existing
  * {@code HazelcastInstance} is referenced by instance name in the {@code Properties} provided as
  * argument to {@link CachingProvider#getCacheManager(URI, ClassLoader, Properties)}.
  * <blockquote><pre>
@@ -114,7 +116,7 @@ import java.util.Properties;
  * config.setInstanceName("hz-jcache");
  * HazelcastInstance member = Hazelcast.newHazelcastInstance(config);
  *
- * System.setProperty("hazelcast.jcache.provider.type", "server");
+ * System.setProperty("hazelcast.jcache.provider.type", "member");
  * CachingProvider provider = Caching.getCachingProvider();
  * CacheManager manager = provider.getCacheManager(null, null, HazelcastCachingProvider.propertiesByInstanceName("hz-jcache"));
  * Cache cache = manager.createCache("sessions", new MutableConfiguration());
@@ -161,7 +163,15 @@ public final class HazelcastCachingProvider implements CachingProvider {
     /**
      * Class name of the member-side Caching Provider
      */
-    public static final String SERVER_CACHING_PROVIDER = com.hazelcast.cache.HazelcastServerCachingProvider.class.getName();
+    public static final String MEMBER_CACHING_PROVIDER = HazelcastMemberCachingProvider.class.getName();
+
+    /**
+     * Same value as {@link #MEMBER_CACHING_PROVIDER}. This field is maintained for backwards compatibility.
+     * Its use is discouraged and will be removed in a future version.
+     */
+    @Deprecated
+    public static final String SERVER_CACHING_PROVIDER = HazelcastMemberCachingProvider.class.getName();
+
     /**
      * Class name of the client-side Caching Provider
      */
@@ -175,7 +185,8 @@ public final class HazelcastCachingProvider implements CachingProvider {
     public static final String SHARED_JCACHE_INSTANCE_NAME = "_hzinstance_jcache_shared";
 
     private static final String PROVIDER_TYPE_CLIENT = "client";
-    private static final String PROVIDER_TYPE_SERVER = "server";
+    private static final String PROVIDER_TYPE_MEMBER = "member";
+    private static final String LEGACY_PROVIDER_TYPE_MEMBER = "server";
 
     private final CachingProvider delegate;
 
@@ -185,11 +196,12 @@ public final class HazelcastCachingProvider implements CachingProvider {
         if (providerType != null) {
             if (PROVIDER_TYPE_CLIENT.equals(providerType)) {
                 cp = new HazelcastClientCachingProvider();
-            } else if (PROVIDER_TYPE_SERVER.equals(providerType)) {
+            } else if (PROVIDER_TYPE_MEMBER.equals(providerType)
+                    || LEGACY_PROVIDER_TYPE_MEMBER.equals(providerType)) {
                 cp = new HazelcastServerCachingProvider();
             } else {
                 throw new CacheException("Unknown CachingProvider type \"" + providerType + "\". Use "
-                        + "\"client\" or \"server\" as provider type.");
+                        + "\"client\" or \"member\" as provider type.");
             }
         } else {
             cp = new HazelcastClientCachingProvider();

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastMemberCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastMemberCachingProvider.java
@@ -31,7 +31,7 @@ import java.util.Properties;
  *         Programmatically, using {@link javax.cache.Caching#getCachingProvider(String)}:
  * <pre>
  * {@code
- * CachingProvider memberSideCachingProvider = Caching.getCachingProvider("com.hazelcast.cache.HazelcastServerCachingProvider");
+ * CachingProvider memberSideCachingProvider = Caching.getCachingProvider("com.hazelcast.cache.HazelcastMemberCachingProvider");
  * }
  * </pre>
  *     </li>
@@ -41,19 +41,19 @@ import java.util.Properties;
  * <pre>
  * {@code
  * // alternatively, set the system property on the java command line:
- * // java -Djavax.cache.spi.CachingProvider=com.hazelcast.cache.HazelcastServerCachingProvider
- * System.setProperty("javax.cache.spi.CachingProvider", "com.hazelcast.cache.HazelcastServerCachingProvider");
+ * // java -Djavax.cache.spi.CachingProvider=com.hazelcast.cache.HazelcastMemberCachingProvider
+ * System.setProperty("javax.cache.spi.CachingProvider", "com.hazelcast.cache.HazelcastMemberCachingProvider");
  * CachingProvider memberSideCachingProvider = Caching.getCachingProvider();
  * }
  * </pre>
  *     </li>
  * </ul>
  */
-public class HazelcastServerCachingProvider implements CachingProvider {
+public class HazelcastMemberCachingProvider implements CachingProvider {
 
     private final CachingProvider delegate;
 
-    public HazelcastServerCachingProvider() {
+    public HazelcastMemberCachingProvider() {
         this.delegate = new com.hazelcast.cache.impl.HazelcastServerCachingProvider();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastServerCachingProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import javax.cache.CacheManager;
+import javax.cache.configuration.OptionalFeature;
+import javax.cache.spi.CachingProvider;
+import java.net.URI;
+import java.util.Properties;
+
+/**
+ * Member-side {@link CachingProvider} implementation. Its fully-qualified
+ * class name can be used to request the member-side {@code CachingProvider}
+ * implementation. Examples:
+ * <ul>
+ *     <li>
+ *         Programmatically, using {@link javax.cache.Caching#getCachingProvider(String)}:
+ * <pre>
+ * {@code
+ * CachingProvider memberSideCachingProvider = Caching.getCachingProvider("com.hazelcast.cache.HazelcastServerCachingProvider");
+ * }
+ * </pre>
+ *     </li>
+ *     <li>
+ *         Declaratively, using the {@code javax.cache.spi.CachingProvider} system property
+ * as specified in {@link javax.cache.Caching}.
+ * <pre>
+ * {@code
+ * // alternatively, set the system property on the java command line:
+ * // java -Djavax.cache.spi.CachingProvider=com.hazelcast.cache.HazelcastServerCachingProvider
+ * System.setProperty("javax.cache.spi.CachingProvider", "com.hazelcast.cache.HazelcastServerCachingProvider");
+ * CachingProvider memberSideCachingProvider = Caching.getCachingProvider();
+ * }
+ * </pre>
+ *     </li>
+ * </ul>
+ */
+public class HazelcastServerCachingProvider implements CachingProvider {
+
+    private final CachingProvider delegate;
+
+    public HazelcastServerCachingProvider() {
+        this.delegate = new com.hazelcast.cache.impl.HazelcastServerCachingProvider();
+    }
+
+    @Override
+    public CacheManager getCacheManager(URI uri, ClassLoader classLoader, Properties properties) {
+        return delegate.getCacheManager(uri, classLoader, properties);
+    }
+
+    @Override
+    public ClassLoader getDefaultClassLoader() {
+        return delegate.getDefaultClassLoader();
+    }
+
+    @Override
+    public URI getDefaultURI() {
+        return delegate.getDefaultURI();
+    }
+
+    @Override
+    public Properties getDefaultProperties() {
+        return delegate.getDefaultProperties();
+    }
+
+    @Override
+    public CacheManager getCacheManager(URI uri, ClassLoader classLoader) {
+        return delegate.getCacheManager(uri, classLoader);
+    }
+
+    @Override
+    public CacheManager getCacheManager() {
+        return delegate.getCacheManager();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public void close(ClassLoader classLoader) {
+        delegate.close(classLoader);
+    }
+
+    @Override
+    public void close(URI uri, ClassLoader classLoader) {
+        delegate.close(uri, classLoader);
+    }
+
+    @Override
+    public boolean isSupported(OptionalFeature optionalFeature) {
+        return delegate.isSupported(optionalFeature);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/HazelcastClientCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/HazelcastClientCachingProvider.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import javax.cache.CacheManager;
+import javax.cache.configuration.OptionalFeature;
+import javax.cache.spi.CachingProvider;
+import java.net.URI;
+import java.util.Properties;
+
+/**
+ * Client-side {@link CachingProvider} implementation. Its fully-qualified
+ * class name can be used to request the client-side {@code CachingProvider}
+ * implementation. Examples:
+ * <ul>
+ *     <li>
+ *         Programmatically, using {@link javax.cache.Caching#getCachingProvider(String)}:
+ * <pre>
+ * {@code
+ * CachingProvider clientSideCachingProvider =
+ *     Caching.getCachingProvider("com.hazelcast.client.cache.HazelcastClientCachingProvider");
+ * }
+ * </pre>
+ *     </li>
+ *     <li>
+ *         Declaratively, using the {@code javax.cache.spi.CachingProvider} system property
+ * as specified in {@link javax.cache.Caching}.
+ * <pre>
+ * {@code
+ * // alternatively, set the system property on the java command line:
+ * // java -Djavax.cache.spi.CachingProvider=com.hazelcast.client.cache.HazelcastClientCachingProvider
+ * System.setProperty("javax.cache.spi.CachingProvider", "com.hazelcast.client.cache.HazelcastClientCachingProvider");
+ * CachingProvider clientSideCachingProvider = Caching.getCachingProvider();
+ * }
+ * </pre>
+ *     </li>
+ * </ul>
+ */
+public class HazelcastClientCachingProvider implements CachingProvider {
+
+    private final CachingProvider delegate;
+
+    public HazelcastClientCachingProvider() {
+        delegate = new com.hazelcast.client.cache.impl.HazelcastClientCachingProvider();
+    }
+
+    @Override
+    public CacheManager getCacheManager(URI uri, ClassLoader classLoader, Properties properties) {
+        return delegate.getCacheManager(uri, classLoader, properties);
+    }
+
+    @Override
+    public ClassLoader getDefaultClassLoader() {
+        return delegate.getDefaultClassLoader();
+    }
+
+    @Override
+    public URI getDefaultURI() {
+        return delegate.getDefaultURI();
+    }
+
+    @Override
+    public Properties getDefaultProperties() {
+        return delegate.getDefaultProperties();
+    }
+
+    @Override
+    public CacheManager getCacheManager(URI uri, ClassLoader classLoader) {
+        return delegate.getCacheManager(uri, classLoader);
+    }
+
+    @Override
+    public CacheManager getCacheManager() {
+        return delegate.getCacheManager();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public void close(ClassLoader classLoader) {
+        delegate.close(classLoader);
+    }
+
+    @Override
+    public void close(URI uri, ClassLoader classLoader) {
+        delegate.close(uri, classLoader);
+    }
+
+    @Override
+    public boolean isSupported(OptionalFeature optionalFeature) {
+        return delegate.isSupported(optionalFeature);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Public API of client-side CachingProvider
+ */
+package com.hazelcast.client.cache;

--- a/hazelcast/src/test/java/com/hazelcast/cache/HazelcastServerCachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/HazelcastServerCachingProviderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.jsr.JsrTestUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastServerCachingProviderTest
+        extends org.jsr107.tck.spi.CachingProviderTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+        System.setProperty("javax.cache.spi.CachingProvider",
+                HazelcastCachingProvider.SERVER_CACHING_PROVIDER);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        JsrTestUtil.cleanup();
+        System.clearProperty("javax.cache.spi.CachingProvider");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/HazelcastClientCachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/HazelcastClientCachingProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.client.cache.jsr.JsrClientTestUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastClientCachingProviderTest
+        extends org.jsr107.tck.spi.CachingProviderTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrClientTestUtil.setupWithHazelcastInstance();
+        System.setProperty("javax.cache.spi.CachingProvider",
+                HazelcastCachingProvider.CLIENT_CACHING_PROVIDER);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        JsrClientTestUtil.cleanup();
+        System.clearProperty("javax.cache.spi.CachingProvider");
+    }
+}


### PR DESCRIPTION
Adding public classes to expose the member- and
client-side caching provider implementations
without referring to internal classes. The new
classes delegate to existing private
implementations in the corresponding `.impl.`
packages.

Also aligns JCache providers terminology to
Hazelcast terms, using "member" instead of "server". 

Clean backport of #17320 