### PR TITLE
Corrected null checks in merge() to include all args #14913

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -2060,7 +2060,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
                    @Nonnull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
-        checkNotNull(key, NULL_BIFUNCTION_IS_NOT_ALLOWED);
+        checkNotNull(remappingFunction, NULL_BIFUNCTION_IS_NOT_ALLOWED);
 
         return mergeLocally(key, value, remappingFunction);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -1174,7 +1174,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
                    @Nonnull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
-        checkNotNull(key, NULL_BIFUNCTION_IS_NOT_ALLOWED);
+        checkNotNull(remappingFunction, NULL_BIFUNCTION_IS_NOT_ALLOWED);
 
         if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)
                 && isClusterVersionGreaterOrEqual(Versions.V4_1)) {


### PR DESCRIPTION
The `merge()` function did not have a null check on the `remappingFunction` argument. Corrected that.