### PR TITLE
[BACKPORT] Update full-example configs for AWS, Azure and GCP

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -319,9 +319,11 @@
             <tag-value>hz-nodes</tag-value>
             <security-group-name>hazelcast-sg</security-group-name>
             <iam-role>dummy</iam-role>
+            <!--
             <cluster>my-cluster</cluster>
             <family>test-family</family>
             <service-name>test-service</service-name>
+            -->
         </aws>
         <gcp enabled="false">
             <private-key-path>key-path</private-key-path>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -305,26 +305,44 @@
                 <property name="keyStoreType">JKS</property>
             </properties>
         </ssl>
-        <aws enabled="true" connection-timeout-seconds="11">
-            <inside-aws>true</inside-aws>
-            <access-key>TEST_ACCESS_KEY</access-key>
-            <secret-key>TEST_SECRET_KEY</secret-key>
-            <region>us-east-1</region>
+        <aws enabled="false">
+            <access-key>my-access-key</access-key>
+            <secret-key>my-secret-key</secret-key>
+            <region>us-west-1</region>
             <host-header>ec2.amazonaws.com</host-header>
-            <security-group-name>hazelcast-sg</security-group-name>
+            <connection-timeout-seconds>7</connection-timeout-seconds>
+            <read-timeout-seconds>7</read-timeout-seconds>
+            <connection-retries>4</connection-retries>
+            <hz-port>5701-5710</hz-port>
+            <use-public-ip>true</use-public-ip>
             <tag-key>type</tag-key>
             <tag-value>hz-nodes</tag-value>
+            <security-group-name>hazelcast-sg</security-group-name>
+            <iam-role>dummy</iam-role>
+            <cluster>my-cluster</cluster>
+            <family>test-family</family>
+            <service-name>test-service</service-name>
         </aws>
         <gcp enabled="false">
-            <zones>us-east1-b,us-east1-c</zones>
+            <private-key-path>key-path</private-key-path>
+            <projects>project-1,project-2</projects>
+            <region>us-central1</region>
+            <zones>us-central1-b,us-central1-c</zones>
+            <label>key=value</label>
+            <hz-port>5701-5710</hz-port>
+            <use-public-ip>true</use-public-ip>
         </gcp>
         <azure enabled="false">
+            <instance-metadata-available>false</instance-metadata-available>
             <client-id>CLIENT_ID</client-id>
             <client-secret>CLIENT_SECRET</client-secret>
             <tenant-id>TENANT_ID</tenant-id>
             <subscription-id>SUB_ID</subscription-id>
-            <cluster-id>HZLCAST001</cluster-id>
-            <group-name>RESOURCE-GROUP-NAME</group-name>
+            <resource-group>RESOURCE-GROUP-NAME</resource-group>
+            <scale-set>SCALE-SET-NAME</scale-set>
+            <tag>TAG-NAME=HZLCAST001</tag>
+            <hz-port>5701-5707</hz-port>
+            <use-public-ip>true</use-public-ip>
         </azure>
         <kubernetes enabled="false">
             <namespace>MY-KUBERNETES-NAMESPACE</namespace>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -286,9 +286,9 @@ hazelcast-client:
       tag-key: type
       tag-value: hz-nodes
       iam-role: dummy
-      cluster: my-cluster
-      family: test-family
-      service-name: test-service
+      # cluster: my-cluster
+      # family: test-family
+      # service-name: test-service
     gcp:
       enabled: false
       private-key-path: key-path

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -272,27 +272,44 @@ hazelcast-client:
         keyStoreType: JKS
 
     aws:
-      enabled: true
-      connection-timeout-seconds: 11
-      inside-aws: true
-      access-key: TEST_ACCESS_KEY
-      secret-key: TEST_SECRET_KEY
-      region: us-east-1
+      enabled: false
+      access-key: my-access-key
+      secret-key: my-secret-key
+      region: us-west-1
       host-header: ec2.amazonaws.com
+      connection-timeout-seconds: 7
+      read-timeout-seconds: 7
+      connection-retries: 4
+      hz-port: 5701-5710
+      use-public-ip: true
       security-group-name: hazelcast-sg
       tag-key: type
       tag-value: hz-nodes
+      iam-role: dummy
+      cluster: my-cluster
+      family: test-family
+      service-name: test-service
     gcp:
       enabled: false
-      zones: us-east1-b,us-east1-c
+      private-key-path: key-path
+      projects: project-1,project-2
+      region: us-central1
+      zones: us-central1-b,us-central1-c
+      label: key=value
+      hz-port: 5701-5710
+      use-public-ip: true
     azure:
       enabled: false
+      instance-metadata-available: false
       client-id: CLIENT_ID
-      client-secret: CLIENT_SECRET
       tenant-id: TENANT_ID
+      client-secret: CLIENT_SECRET
       subscription-id: SUB_ID
-      cluster-id: HZLCAST001
-      group-name: RESOURCE-GROUP-NAME
+      resource-group: RESOURCE-GROUP-NAME
+      scale-set: SCALE-SET-NAME
+      tag: TAG-NAME=HZLCAST001
+      hz-port: 5701-5705
+      use-public-ip: true
     kubernetes:
       enabled: false
       namespace: MY-KUBERNETES-NAMESPACE

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -308,7 +308,7 @@ hazelcast-client:
       resource-group: RESOURCE-GROUP-NAME
       scale-set: SCALE-SET-NAME
       tag: TAG-NAME=HZLCAST001
-      hz-port: 5701-5705
+      hz-port: 5701-5707
       use-public-ip: true
     kubernetes:
       enabled: false

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -665,9 +665,11 @@
                 <tag-value>hz-nodes</tag-value>
                 <security-group-name>hazelcast-sg</security-group-name>
                 <iam-role>dummy</iam-role>
+                <!--
                 <cluster>my-cluster</cluster>
                 <family>test-family</family>
                 <service-name>test-service</service-name>
+                -->
             </aws>
             <gcp enabled="false">
                 <private-key-path>key-path</private-key-path>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -655,23 +655,38 @@
             <aws enabled="false">
                 <access-key>my-access-key</access-key>
                 <secret-key>my-secret-key</secret-key>
-                <iam-role>dummy</iam-role>
                 <region>us-west-1</region>
                 <host-header>ec2.amazonaws.com</host-header>
-                <security-group-name>hazelcast-sg</security-group-name>
+                <connection-timeout-seconds>7</connection-timeout-seconds>
+                <read-timeout-seconds>7</read-timeout-seconds>
+                <connection-retries>4</connection-retries>
+                <hz-port>5701-5710</hz-port>
                 <tag-key>type</tag-key>
                 <tag-value>hz-nodes</tag-value>
+                <security-group-name>hazelcast-sg</security-group-name>
+                <iam-role>dummy</iam-role>
+                <cluster>my-cluster</cluster>
+                <family>test-family</family>
+                <service-name>test-service</service-name>
             </aws>
             <gcp enabled="false">
-                <zones>us-east1-b,us-east1-c</zones>
+                <private-key-path>key-path</private-key-path>
+                <projects>project-1,project-2</projects>
+                <region>us-central1</region>
+                <zones>us-central1-b,us-central1-c</zones>
+                <label>key=value</label>
+                <hz-port>5701-5710</hz-port>
             </gcp>
             <azure enabled="false">
+                <instance-metadata-available>false</instance-metadata-available>
                 <client-id>CLIENT_ID</client-id>
                 <client-secret>CLIENT_SECRET</client-secret>
                 <tenant-id>TENANT_ID</tenant-id>
                 <subscription-id>SUB_ID</subscription-id>
-                <cluster-id>HZLCAST001</cluster-id>
-                <group-name>RESOURCE-GROUP-NAME</group-name>
+                <resource-group>RESOURCE-GROUP-NAME</resource-group>
+                <scale-set>SCALE-SET-NAME</scale-set>
+                <tag>TAG-NAME=HZLCAST001</tag>
+                <hz-port>5701-5707</hz-port>
             </azure>
             <kubernetes enabled="false">
                 <namespace>MY-KUBERNETES-NAMESPACE</namespace>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -628,23 +628,38 @@ hazelcast:
         enabled: false
         access-key: my-access-key
         secret-key: my-secret-key
-        iam-role: dummy
         region: us-west-1
         host-header: ec2.amazonaws.com
+        connection-timeout-seconds: 7
+        read-timeout-seconds: 7
+        connection-retries: 4
+        hz-port: 5701-5710
         security-group-name: hazelcast-sg
         tag-key: type
         tag-value: hz-nodes
+        iam-role: dummy
+        cluster: my-cluster
+        family: test-family
+        service-name: test-service
       gcp:
         enabled: false
-        zones: us-east1-b,us-east1-c
+        private-key-path: key-path
+        projects: project-1,project-2
+        region: us-central1
+        zones: us-central1-b,us-central1-c
+        label: key=value
+        hz-port: 5701-5710
       azure:
         enabled: false
+        instance-metadata-available: false
         client-id: CLIENT_ID
         client-secret: CLIENT_SECRET
         tenant-id: TENANT_ID
         subscription-id: SUB_ID
-        cluster-id: HZLCAST001
-        group-name: RESOURCE-GROUP-NAME
+        resource-group: RESOURCE-GROUP-NAME
+        scale-set: SCALE-SET-NAME
+        tag: TAG-NAME=HZLCAST001
+        hz-port: 5701-5705
       kubernetes:
         enabled: false
         namespace: MY-KUBERNETES-NAMESPACE

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -659,7 +659,7 @@ hazelcast:
         resource-group: RESOURCE-GROUP-NAME
         scale-set: SCALE-SET-NAME
         tag: TAG-NAME=HZLCAST001
-        hz-port: 5701-5705
+        hz-port: 5701-5707
       kubernetes:
         enabled: false
         namespace: MY-KUBERNETES-NAMESPACE

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -638,9 +638,9 @@ hazelcast:
         tag-key: type
         tag-value: hz-nodes
         iam-role: dummy
-        cluster: my-cluster
-        family: test-family
-        service-name: test-service
+        # cluster: my-cluster
+        # family: test-family
+        # service-name: test-service
       gcp:
         enabled: false
         private-key-path: key-path


### PR DESCRIPTION
The Hazelcast full-example configurations for AWS, Azure and GCP were outdated. I updated them by referencing their respective github repos. Also tried them in my local to verify, the properties are now up to date.

backport of https://github.com/hazelcast/hazelcast/pull/17431