### PR TITLE
Recover exceptions wrapped in same class correctly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -709,7 +709,11 @@ public class ClientExceptionFactory {
         if (exceptionFactory == null) {
             throwable = new UndefinedErrorCodeException(errorHolder.getMessage(), errorHolder.getClassName());
         } else {
-            throwable = exceptionFactory.createException(errorHolder.getMessage(), createException(iterator));
+            Throwable cause = createException(iterator);
+            throwable = exceptionFactory.createException(errorHolder.getMessage(), cause);
+            if (throwable.getCause() == null && cause != null) {
+                throwable.initCause(cause);
+            }
         }
         throwable.setStackTrace(errorHolder.getStackTraceElements().toArray(new StackTraceElement[0]));
         return throwable;

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -34,6 +34,7 @@ import com.hazelcast.crdt.MutationDisallowedException;
 import com.hazelcast.crdt.TargetNotReplicaException;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
@@ -272,7 +273,8 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new IndeterminateOperationStateException(randomString())},
                 new Object[]{new TargetNotReplicaException(randomString())},
                 new Object[]{new MutationDisallowedException(randomString())},
-                new Object[]{new ConsistencyLostException(randomString())}
+                new Object[]{new ConsistencyLostException(randomString())},
+                new Object[]{ExceptionUtil.tryWrapInSameClass(new NullPointerException())}
         );
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/hazelcast/hazelcast/pull/17212

We have added exceptions created by ExceptionUtil.tryWrapInSameClass
methods to the client.

ClientExceptionFactory.createException method was not handling these
exceptions correctly. More specifically, the cause was not set to the
exception if there was no Constructor with cause. This pr adds changes
to mitigate that.

related to https://github.com/hazelcast/hazelcast/issues/17433

(cherry picked from commit 1c224fa9217b16f4184182f50fdec8c49d93e9e9)