### PR TITLE
Rewrite getBackupQueue test utility method as read-only fashion

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -49,6 +49,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static com.hazelcast.collection.impl.collection.CollectionContainer.ID_PROMOTION_OFFSET;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
@@ -992,6 +993,16 @@ public class QueueContainer implements IdentifiedDataSerializable {
             }
         }
         return backupMap;
+    }
+
+    // Only used for testing.
+    // This method is like `getBackupMap` method but read-only.
+    public void scanBackupItems(Consumer<QueueItem> consumer) {
+        if (backupMap != null) {
+            backupMap.values().forEach(consumer);
+        } else {
+            itemQueue.forEach(consumer);
+        }
     }
 
     public Data getDataFromMap(long itemId) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -96,8 +96,8 @@ import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValu
  */
 @SuppressWarnings({"checkstyle:classfanoutcomplexity", "checkstyle:methodcount"})
 public class QueueService implements ManagedService, MigrationAwareService, TransactionalService, RemoteService,
-                                     EventPublishingService<QueueEvent, ItemListener>, StatisticsAwareService<LocalQueueStats>,
-                                     SplitBrainProtectionAwareService, SplitBrainHandlerService, DynamicMetricsProvider {
+        EventPublishingService<QueueEvent, ItemListener>, StatisticsAwareService<LocalQueueStats>,
+        SplitBrainProtectionAwareService, SplitBrainHandlerService, DynamicMetricsProvider {
 
     public static final String SERVICE_NAME = "hz:impl:queueService";
 
@@ -106,19 +106,19 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     private final ConcurrentMap<String, QueueContainer> containerMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, LocalQueueStatsImpl> statsMap;
     private final ConstructorFunction<String, LocalQueueStatsImpl> localQueueStatsConstructorFunction =
-        key -> new LocalQueueStatsImpl();
+            key -> new LocalQueueStatsImpl();
 
     private final ConcurrentMap<String, Object> splitBrainProtectionConfigCache = new ConcurrentHashMap<>();
     private final ContextMutexFactory splitBrainProtectionConfigCacheMutexFactory = new ContextMutexFactory();
     private final ConstructorFunction<String, Object> splitBrainProtectionConfigConstructor =
             new ConstructorFunction<String, Object>() {
-        @Override
-        public Object createNew(String name) {
-            QueueConfig queueConfig = nodeEngine.getConfig().findQueueConfig(name);
-            String splitBrainProtectionName = queueConfig.getSplitBrainProtectionName();
-            return splitBrainProtectionName == null ? NULL_OBJECT : splitBrainProtectionName;
-        }
-    };
+                @Override
+                public Object createNew(String name) {
+                    QueueConfig queueConfig = nodeEngine.getConfig().findQueueConfig(name);
+                    String splitBrainProtectionName = queueConfig.getSplitBrainProtectionName();
+                    return splitBrainProtectionName == null ? NULL_OBJECT : splitBrainProtectionName;
+                }
+            };
 
     private final NodeEngine nodeEngine;
     private final SerializationService serializationService;
@@ -179,6 +179,11 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
             container.getStore().instrument(nodeEngine);
         }
         return container;
+    }
+
+    public QueueContainer getExistingContainerOrNull(String name) {
+        QueueContainer container = containerMap.get(name);
+        return container != null ? container : null;
     }
 
     public void addContainer(String name, QueueContainer container) {
@@ -299,7 +304,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         EventService eventService = nodeEngine.getEventService();
         QueueEventFilter filter = new QueueEventFilter(includeValue);
         return eventService.registerListenerAsync(QueueService.SERVICE_NAME, name, filter, listener)
-                           .thenApplyAsync(EventRegistration::getId, CALLER_RUNS);
+                .thenApplyAsync(EventRegistration::getId, CALLER_RUNS);
     }
 
     public boolean removeItemListener(String name, UUID registrationId) {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/17412

Aligned behavior of `getBackupQueue` with other backup item getter methods in class `CollectionTestUtil`.