### PR TITLE
Check for leftover JCache MBeans

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerManagementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerManagementTest.java
@@ -20,8 +20,16 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.MutableConfiguration;
+
+import static com.hazelcast.cache.jsr.JsrTestUtil.assertNoMBeanLeftovers;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -35,5 +43,19 @@ public class CacheManagerManagementTest extends org.jsr107.tck.management.CacheM
     @AfterClass
     public static void cleanup() {
         JsrTestUtil.cleanup();
+    }
+
+    @Test
+    public void testMBeansLeftoversAreDetected() throws Exception {
+        CacheManager cacheManager = getCacheManager();
+        MutableConfiguration<Integer, Integer> cacheConfig = new MutableConfiguration<>();
+        cacheConfig.setManagementEnabled(true);
+        Cache<Integer, Integer> cache = cacheManager.createCache("int-cache", cacheConfig);
+        try {
+            assertNoMBeanLeftovers();
+            fail("Should have failed due to mbean leftovers");
+        } catch (AssertionError error) {
+            cache.close();
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -19,10 +19,13 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.test.JmxLeakHelper;
 
 import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
+import javax.management.ObjectInstance;
 import java.lang.reflect.Field;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +54,7 @@ public final class JsrTestUtil {
     public static void setup() {
         assertThatIsNotMultithreadedTest();
         setSystemProperties("server");
+        assertNoMBeanLeftovers();
     }
 
     public static void cleanup() {
@@ -194,5 +198,15 @@ public final class JsrTestUtil {
 
         //noinspection unchecked
         return (Map<ClassLoader, Map<String, CachingProvider>>) providerMapField.get(providerRegistryInstance);
+    }
+
+    public static void assertNoMBeanLeftovers() {
+        Collection<ObjectInstance> leftovers = JmxLeakHelper.getActiveJmxBeansWithPrefix("javax.cache");
+
+        if (leftovers.isEmpty()) {
+            return;
+        }
+        fail("Leftover MBeans are still registered with the platform MBeanServer: "
+                + leftovers);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 
+import static com.hazelcast.cache.jsr.JsrTestUtil.assertNoMBeanLeftovers;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearSystemProperties;
 import static com.hazelcast.cache.jsr.JsrTestUtil.setSystemProperties;
@@ -42,6 +43,7 @@ public final class JsrClientTestUtil {
     public static void setupWithHazelcastInstance() {
         assertThatIsNotMultithreadedTest();
         setSystemProperties("client");
+        assertNoMBeanLeftovers();
 
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);

--- a/hazelcast/src/test/java/com/hazelcast/test/JmxLeakHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/JmxLeakHelper.java
@@ -89,18 +89,26 @@ public final class JmxLeakHelper {
         return res;
     }
 
+    public static Collection<ObjectInstance> getActiveJmxBeansWithPrefix(String prefix) {
+        return getActiveJmxBeans(prefix);
+    }
+
     private static Collection<ObjectInstance> getActiveJmxBeans() {
+        return getActiveJmxBeans("com.hazelcast");
+    }
+
+    private static Collection<ObjectInstance> getActiveJmxBeans(String prefix) {
         try {
             List<ObjectInstance> res = new ArrayList<>();
 
-            ObjectName objectName = new ObjectName("com.hazelcast*:*");
+            ObjectName objectName = new ObjectName(prefix + "*:*");
 
             Set<ObjectInstance> instances = ManagementFactory.getPlatformMBeanServer().queryMBeans(objectName, null);
 
             for (ObjectInstance instance : instances) {
                 String name = instance.getObjectName().getCanonicalName();
 
-                if (name != null && name.startsWith("com.hazelcast")) {
+                if (name != null && name.startsWith(prefix)) {
                     res.add(instance);
                 }
             }


### PR DESCRIPTION
On setup of JSR test, check whether
any `javax.cache*:*` MBeans are found
registered, to avoid leftovers from
previous tests affecting future tests.

Fixes #15969 