### PR TITLE
Fix MigrationCommitTest.shouldCommitMigrationWhenSourceFailsDuringCommit

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
@@ -27,9 +27,11 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,6 +51,9 @@ import static org.junit.Assert.assertEquals;
 public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport {
 
     private static final float BACKUP_BLOCK_RATIO = 0.65f;
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 
     @Parameters(name = "backups:{0},nodes:{1}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -28,12 +28,14 @@ import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.impl.MigrationInterceptorTest.MigrationInterceptorImpl;
 import com.hazelcast.internal.partition.impl.MigrationInterceptorTest.MigrationProgressNotification;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -65,6 +67,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MigrationCommitTest extends HazelcastTestSupport {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 
     private static final int PARTITION_COUNT = 2;
 
@@ -659,7 +664,7 @@ public class MigrationCommitTest extends HazelcastTestSupport {
     private static class TerminateOtherMemberOnMigrationComplete implements MigrationInterceptor, HazelcastInstanceAware {
 
         private final CountDownLatch migrationStartLatch;
-        private final AtomicBoolean terminated = new AtomicBoolean();
+        private final AtomicReference<MigrationInfo> migrationRef = new AtomicReference<>();
 
         private volatile boolean rollback;
         private volatile HazelcastInstance instance;
@@ -684,7 +689,7 @@ public class MigrationCommitTest extends HazelcastTestSupport {
                 return;
             }
 
-            if (!terminated.compareAndSet(false, true)) {
+            if (!migrationRef.compareAndSet(null, migrationInfo)) {
                 return;
             }
 
@@ -700,9 +705,10 @@ public class MigrationCommitTest extends HazelcastTestSupport {
 
         @Override
         public void onMigrationRollback(MigrationParticipant participant, MigrationInfo migrationInfo) {
-            rollback = true;
-
-            resetInternalMigrationListener(instance);
+            if (migrationInfo.equals(migrationRef.get())) {
+                rollback = true;
+                resetInternalMigrationListener(instance);
+            }
         }
 
         @Override


### PR DESCRIPTION
`TerminateOtherMemberOnMigrationComplete` should remember the migration which
is intercepted and mark `rollback` flag only if that specific migration is rolled back.
This was not an issue before, because all migrations were serial.

Also enabled debug logs for some other tests.

Fixes #14492