### PR TITLE
Build ZIP assembly during Maven package phase

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-root</artifactId>
+        <version>4.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>hazelcast-distribution</name>
+    <artifactId>hazelcast-distribution</artifactId>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>distro-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>../target</outputDirectory>
+                    <finalName>hazelcast-${project.version}</finalName>
+                    <archiveBaseDirectory>..</archiveBaseDirectory>
+                    <descriptors>
+                        <descriptor>../src/main/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-all</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>hazelcast-build-utils</module>
         <module>hazelcast-sql</module>
         <module>hazelcast-all</module>
+        <module>distribution</module>
     </modules>
 
     <properties>
@@ -214,19 +215,6 @@
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven.assembly.plugin.version}</version>
-                <configuration>
-                    <finalName>hazelcast-${project.version}</finalName>
-                    <descriptors>
-                        <descriptor>./src/main/assembly/assembly.xml</descriptor>
-                    </descriptors>
-                    <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This PR introduces a new Maven module responsible for handling the final ZIP assembly. The ZIP is automatically created during the package phase (i.e. no need to call the `assembly:single` manually). The target location of the ZIP file stays unchanged.

The Dependabot update of  the `maven-assembly-plugin` version caused the current `assembly:assembly` approach doesn't work anymore.