### PR TITLE
Increase algorithm timeout for test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/graph/BronKerboschCliqueFinderTest.java
@@ -255,7 +255,7 @@ public class BronKerboschCliqueFinderTest {
         }
 
 
-        Collection<Set<String>> maxCliques = new BronKerboschCliqueFinder<>(graph, 30, TimeUnit.SECONDS).computeMaxCliques();
+        Collection<Set<String>> maxCliques = new BronKerboschCliqueFinder<>(graph, 60, TimeUnit.SECONDS).computeMaxCliques();
 
 
         assumeFalse(maxCliques.isEmpty());
@@ -309,7 +309,7 @@ public class BronKerboschCliqueFinderTest {
             }
         }
 
-        Collection<Set<String>> maxCliques = new BronKerboschCliqueFinder<>(graph, 30, TimeUnit.SECONDS).computeMaxCliques();
+        Collection<Set<String>> maxCliques = new BronKerboschCliqueFinder<>(graph, 60, TimeUnit.SECONDS).computeMaxCliques();
 
 
         assumeFalse(maxCliques.isEmpty());


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/17332

From logs we can see 30 seconds timeout is not enough for the failed run.
```
Finished Running Test: test6DisconnectedSubgraphsOfWholeGraph in 30.269 seconds.
```
Increased it to 60 seconds.
