### PR TITLE
Use parallelism=1 in MigrationCommitTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -510,6 +510,7 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         Config config = new Config();
         config.setProperty(ClusterProperty.PARTITION_MAX_PARALLEL_REPLICATIONS.getName(), "0");
         config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT));
+        config.setProperty(ClusterProperty.PARTITION_MAX_PARALLEL_MIGRATIONS.getName(), "1");
         return config;
     }
 


### PR DESCRIPTION
Tests were designed for serial migrations. They are already using
2 partitions on 2 data members. Using `parallelism=1` will make migrations
serial.

Fixes #14492

_Fix in https://github.com/hazelcast/hazelcast/pull/17445 was incomplete._