### PR TITLE
Align <durable-executor-service> configuration in YAML and XML default config files

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -117,7 +117,7 @@
         <pool-size>16</pool-size>
         <statistics-enabled>true</statistics-enabled>
     </executor-service>
-    <durable-executor-service>
+    <durable-executor-service name="default">
         <capacity>100</capacity>
         <durability>1</durability>
         <pool-size>16</pool-size>


### PR DESCRIPTION
Provide name attribute for <durable-executor-service> element in `hazelcast-default.xml` and align with other executor services configuration as well as its YAML counterparts.