### PR TITLE
Remove potential NPExceptions for clusterService.getMember(uuid)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
@@ -20,28 +20,24 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.operation.CacheGetInvalidationMetaDataOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.client.impl.protocol.task.AbstractTargetMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import java.security.Permission;
+import java.util.UUID;
 
 public class CacheFetchNearCacheInvalidationMetadataTask
-        extends AbstractInvocationMessageTask<CacheFetchNearCacheInvalidationMetadataCodec.RequestParameters> {
+        extends AbstractTargetMessageTask<CacheFetchNearCacheInvalidationMetadataCodec.RequestParameters> {
 
     public CacheFetchNearCacheInvalidationMetadataTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        OperationServiceImpl operationService = nodeEngine.getOperationService();
-        Member member = nodeEngine.getClusterService().getMember(parameters.uuid);
-        return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
+    protected UUID getTargetUuid() {
+        return parameters.uuid;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
@@ -20,16 +20,14 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.operation.CacheListenerRegistrationOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheListenerRegistrationCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.client.impl.protocol.task.AbstractTargetMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import java.security.Permission;
+import java.util.UUID;
 
 /**
  * This client request  specifically calls {@link CacheListenerRegistrationOperation} on the server side.
@@ -37,10 +35,15 @@ import java.security.Permission;
  * @see CacheListenerRegistrationOperation
  */
 public class CacheListenerRegistrationMessageTask
-        extends AbstractInvocationMessageTask<CacheListenerRegistrationCodec.RequestParameters> {
+        extends AbstractTargetMessageTask<CacheListenerRegistrationCodec.RequestParameters> {
 
     public CacheListenerRegistrationMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected UUID getTargetUuid() {
+        return parameters.uuid;
     }
 
     @Override
@@ -57,13 +60,6 @@ public class CacheListenerRegistrationMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CacheListenerRegistrationCodec.encodeResponse();
-    }
-
-    @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        final OperationServiceImpl operationService = nodeEngine.getOperationService();
-        Member member = nodeEngine.getClusterService().getMember(parameters.uuid);
-        return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
@@ -20,15 +20,13 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheManagementConfigCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.client.impl.protocol.task.AbstractTargetMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import java.security.Permission;
+import java.util.UUID;
 
 /**
  * This client request  specifically calls {@link CacheManagementConfigOperation} on the server side.
@@ -36,7 +34,7 @@ import java.security.Permission;
  * @see CacheManagementConfigOperation
  */
 public class CacheManagementConfigMessageTask
-        extends AbstractInvocationMessageTask<CacheManagementConfigCodec.RequestParameters> {
+        extends AbstractTargetMessageTask<CacheManagementConfigCodec.RequestParameters> {
 
     public CacheManagementConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -58,10 +56,8 @@ public class CacheManagementConfigMessageTask
     }
 
     @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        OperationServiceImpl operationService = nodeEngine.getOperationService();
-        Member member = nodeEngine.getClusterService().getMember(parameters.uuid);
-        return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
+    protected UUID getTargetUuid() {
+        return parameters.uuid;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -18,40 +18,30 @@ package com.hazelcast.client.impl.protocol.task.executorservice;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceSubmitToMemberCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.client.impl.protocol.task.AbstractTargetMessageTask;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.executor.impl.operations.MemberCallableTaskOperation;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.security.SecurityContext;
-import com.hazelcast.spi.exception.TargetNotMemberException;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import javax.security.auth.Subject;
 import java.security.Permission;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
-import static java.lang.String.format;
-
 public class ExecutorServiceSubmitToAddressMessageTask
-        extends AbstractInvocationMessageTask<ExecutorServiceSubmitToMemberCodec.RequestParameters> {
+        extends AbstractTargetMessageTask<ExecutorServiceSubmitToMemberCodec.RequestParameters> {
 
     public ExecutorServiceSubmitToAddressMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        final OperationServiceImpl operationService = nodeEngine.getOperationService();
-        Member member = nodeEngine.getClusterService().getMember(parameters.memberUUID);
-        if (member == null) {
-            throw new TargetNotMemberException(format("Member with uuid(%s) is not in member list ", parameters.memberUUID));
-        }
-        return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
+    protected UUID getTargetUuid() {
+        return parameters.memberUUID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
@@ -18,30 +18,26 @@ package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.client.impl.protocol.task.AbstractTargetMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MapGetInvalidationMetaDataOperation;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import java.security.Permission;
+import java.util.UUID;
 
 public class MapFetchNearCacheInvalidationMetadataTask
-        extends AbstractInvocationMessageTask<MapFetchNearCacheInvalidationMetadataCodec.RequestParameters> {
+        extends AbstractTargetMessageTask<MapFetchNearCacheInvalidationMetadataCodec.RequestParameters> {
 
     public MapFetchNearCacheInvalidationMetadataTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        OperationServiceImpl operationService = nodeEngine.getOperationService();
-        Member member = nodeEngine.getClusterService().getMember(parameters.uuid);
-        return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
+    protected UUID getTargetUuid() {
+        return parameters.uuid;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
@@ -18,32 +18,28 @@ package com.hazelcast.client.impl.protocol.task.scheduledexecutor;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ScheduledExecutorShutdownCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
-import com.hazelcast.cluster.Member;
+import com.hazelcast.client.impl.protocol.task.AbstractTargetMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.impl.operations.ShutdownOperation;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.ScheduledExecutorPermission;
-import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import java.security.Permission;
+import java.util.UUID;
 
 public class ScheduledExecutorShutdownMessageTask
-        extends AbstractInvocationMessageTask<ScheduledExecutorShutdownCodec.RequestParameters> {
+        extends AbstractTargetMessageTask<ScheduledExecutorShutdownCodec.RequestParameters> {
 
     public ScheduledExecutorShutdownMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected InvocationBuilder getInvocationBuilder(Operation op) {
-        final OperationServiceImpl operationService = nodeEngine.getOperationService();
-        Member member = nodeEngine.getClusterService().getMember(parameters.memberUuid);
-        return operationService.createInvocationBuilder(getServiceName(), op, member.getAddress());
+    protected UUID getTargetUuid() {
+        return parameters.memberUuid;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToTargetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToTargetMessageTask.java
@@ -92,7 +92,7 @@ public class ScheduledExecutorSubmitToTargetMessageTask
                 parameters.taskName, callable, parameters.initialDelayInMillis, parameters.periodInMillis,
                 TimeUnit.MILLISECONDS, isAutoDisposable());
         Member member = nodeEngine.getClusterService().getMember(parameters.memberUuid);
-        return new Object[]{parameters.schedulerName, member.getAddress(), def};
+        return new Object[]{parameters.schedulerName, member == null ? null : member.getAddress(), def};
     }
 
     private boolean isAutoDisposable() {


### PR DESCRIPTION
Follow up to https://github.com/hazelcast/hazelcast/pull/16404
On 4.0 with the pr above, we have replaced the member usages
with uuid. On a messageTask, if a member is asked via
clusterService.getMember(uuid) it could return null.

This pr addresses these problems.
In most cases, AbstractInvocationMessageTask is replaced with
AbstractMessageTask in which we have a proper null check.