### PR TITLE
Remove dependency to one specific port in a client test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -66,7 +66,6 @@ import javax.xml.validation.Validator;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -237,12 +236,14 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     public void testClientCanConnect_afterDiscoveryStrategyThrowsException() {
         Config config = new Config();
         config.getNetworkConfig().setPort(50001);
-        Hazelcast.newHazelcastInstance(config);
+
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Address address = instance.getCluster().getLocalMember().getAddress();
         ClientConfig clientConfig = new ClientConfig();
 
         clientConfig.setProperty(ClusterProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
         DiscoveryConfig discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
-        DiscoveryStrategyFactory factory = new ExceptionThrowingDiscoveryStrategyFactory();
+        DiscoveryStrategyFactory factory = new ExceptionThrowingDiscoveryStrategyFactory(address);
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
@@ -455,6 +456,11 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     private static class FirstCallExceptionThrowingDiscoveryStrategy implements DiscoveryStrategy {
 
         AtomicBoolean firstCall = new AtomicBoolean(true);
+        private final Address address;
+
+        private FirstCallExceptionThrowingDiscoveryStrategy(Address address) {
+            this.address = address;
+        }
 
         @Override
         public void start() {
@@ -465,14 +471,9 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
             if (firstCall.compareAndSet(true, false)) {
                 throw new RuntimeException();
             }
-            try {
-                List<DiscoveryNode> discoveryNodes = new ArrayList<DiscoveryNode>(1);
-                Address privateAddress = new Address("127.0.0.1", 50001);
-                discoveryNodes.add(new SimpleDiscoveryNode(privateAddress));
-                return discoveryNodes;
-            } catch (UnknownHostException e) {
-                throw new RuntimeException(e);
-            }
+            List<DiscoveryNode> discoveryNodes = new ArrayList<DiscoveryNode>(1);
+            discoveryNodes.add(new SimpleDiscoveryNode(address));
+            return discoveryNodes;
         }
 
         @Override
@@ -492,7 +493,11 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
     public static class ExceptionThrowingDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
 
-        public ExceptionThrowingDiscoveryStrategyFactory() {
+        private final Address address;
+
+        public ExceptionThrowingDiscoveryStrategyFactory(Address address) {
+
+            this.address = address;
         }
 
         @Override
@@ -503,7 +508,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         @Override
         public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
                                                       Map<String, Comparable> properties) {
-            return new FirstCallExceptionThrowingDiscoveryStrategy();
+            return new FirstCallExceptionThrowingDiscoveryStrategy(address);
         }
 
         @Override


### PR DESCRIPTION
Related test
ClientDiscoverySpiTest#testClientCanConnect_afterDiscoveryStrategyThrowsException

When the configured port is occupied because of another test, this
test was not working correctly. Made the client config so that it can
adapt to a different port.

fixes https://github.com/hazelcast/hazelcast/issues/17457
(cherry picked from commit 6b38069939238c174847b70d7bfe1255aa915f55)