### PR TITLE
Example YAML file should use kebab case

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2948,7 +2948,7 @@ hazelcast:
     join:
       multicast:
         enabled: true
-        loopbackModeEnabled: true
+        loopback-mode-enabled: true
         multicast-group: 1.2.3.4
         multicast-port: 12345
         multicast-timeout-seconds: 5


### PR DESCRIPTION
`loopbackModeEnabled` YAML config property should be presented in the kebab case just like other config entries.

Apparently, this was already acknowledged and reflected in the parser code:
https://github.com/hazelcast/hazelcast/blob/b992fa46d74762af832f0b1fede039bc590d13c7/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java#L1378

And now it's time to remove it from the example file.