### PR TITLE
Add option where to start port scanning (#16859)

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -2007,6 +2007,7 @@
         </xs:sequence>
         <xs:attribute name="enabled" type="xs:string" use="optional" default="false"/>
         <xs:attribute name="connection-timeout-seconds" type="xs:string" use="optional" default="5"/>
+        <xs:attribute name="scan-start-port" type="xs:int" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="multicast">

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1289,8 +1289,18 @@ public class ConfigXmlGenerator {
 
     private static void tcpConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {
         TcpIpConfig c = join.getTcpIpConfig();
-        gen.open("tcp-ip", "enabled", c.isEnabled(), "connection-timeout-seconds", c.getConnectionTimeoutSeconds())
-                .open("member-list");
+        Object[] attributes;
+        if (c.getScanStartPort() == -1) {
+            attributes = new Object[] {
+                    "enabled", c.isEnabled(),
+                    "connection-timeout-seconds", c.getConnectionTimeoutSeconds()};
+        } else {
+            attributes = new Object[] {
+                    "enabled", c.isEnabled(),
+                    "connection-timeout-seconds", c.getConnectionTimeoutSeconds(),
+                    "scan-start-port", c.getScanStartPort()};
+        }
+        gen.open("tcp-ip", attributes).open("member-list");
         for (String m : c.getMembers()) {
             gen.node("member", m);
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
@@ -34,7 +34,11 @@ public class TcpIpConfig {
 
     private static final int CONNECTION_TIMEOUT_SEC = 5;
 
+    private static final int PORT_MAX = 0xFFFF;
+
     private int connectionTimeoutSeconds = CONNECTION_TIMEOUT_SEC;
+
+    private int scanStartPort = -1;
 
     private boolean enabled;
 
@@ -68,6 +72,34 @@ public class TcpIpConfig {
             throw new IllegalArgumentException("connection timeout can't be smaller than 0");
         }
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+        return this;
+    }
+
+    /**
+     * Returns the port where to start port scan for another member.
+     *
+     * @return the scanStartPort
+     * @see #setScanStartPort(int)
+     */
+    public int getScanStartPort() {
+        return scanStartPort;
+    }
+
+    /**
+     * Sets the port where to start port scan for another member. Together with
+     * @{@link com.hazelcast.spi.properties.ClusterProperty#TCP_JOIN_PORT_TRY_COUNT} allows to set the range
+     * of port to be scanned.
+     *
+     * @param scanStartPort the scan start port
+     * @return the updated TcpIpConfig
+     * @see #getScanStartPort()
+     */
+    public TcpIpConfig setScanStartPort(final int scanStartPort) {
+        if (scanStartPort <= 0 || scanStartPort > PORT_MAX) {
+            throw new IllegalArgumentException("Scan start port out of range: " + scanStartPort
+                    + ". Allowed range [1,65535]");
+        }
+        this.scanStartPort = scanStartPort;
         return this;
     }
 
@@ -207,6 +239,9 @@ public class TcpIpConfig {
         if (connectionTimeoutSeconds != that.connectionTimeoutSeconds) {
             return false;
         }
+        if (scanStartPort != that.scanStartPort) {
+            return false;
+        }
         if (enabled != that.enabled) {
             return false;
         }
@@ -219,6 +254,7 @@ public class TcpIpConfig {
     @Override
     public final int hashCode() {
         int result = connectionTimeoutSeconds;
+        result = 31 * result + scanStartPort;
         result = 31 * result + (enabled ? 1 : 0);
         result = 31 * result + (members != null ? members.hashCode() : 0);
         result = 31 * result + (requiredMember != null ? requiredMember.hashCode() : 0);
@@ -231,6 +267,7 @@ public class TcpIpConfig {
                 + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds
                 + ", members=" + members
                 + ", requiredMember=" + requiredMember
+                + ", scanStartPort=" + scanStartPort
                 + "]";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -79,6 +79,11 @@ public class TcpIpJoiner extends AbstractJoiner {
         return joinConfig.getTcpIpConfig().getConnectionTimeoutSeconds();
     }
 
+    private int getScanStartPort() {
+        final int scanStartPort = joinConfig.getTcpIpConfig().getScanStartPort();
+        return scanStartPort == -1 ? getActiveMemberNetworkConfig(config).getPort() : scanStartPort;
+    }
+
     @Override
     public void doJoin() {
         final Address targetAddress = getTargetAddress();
@@ -323,7 +328,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             try {
                 boolean portIsDefined = addressHolder.getPort() != -1 || !networkConfig.isPortAutoIncrement();
                 int count = portIsDefined ? 1 : maxPortTryCount;
-                int port = addressHolder.getPort() != -1 ? addressHolder.getPort() : networkConfig.getPort();
+                int port = addressHolder.getPort() != -1 ? addressHolder.getPort() : getScanStartPort();
                 AddressMatcher addressMatcher = null;
                 try {
                     addressMatcher = AddressUtil.getAddressMatcher(addressHolder.getAddress());

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1422,6 +1422,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 tcpIpConfig.setEnabled(getBooleanValue(value));
             } else if (matches(att.getNodeName(), "connection-timeout-seconds")) {
                 tcpIpConfig.setConnectionTimeoutSeconds(getIntegerValue("connection-timeout-seconds", value));
+            } else if (att.getNodeName().equals("scan-start-port")) {
+                tcpIpConfig.setScanStartPort(getIntegerValue("scan-start-port", value));
             }
         }
         Set<String> memberTags = new HashSet<>(Arrays.asList("interface", "member", "members"));

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -1401,6 +1401,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="scan-start-port" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The initial port where to start port scan for another member.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="port">
         <xs:simpleContent>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -478,6 +478,8 @@
                 slow down because of longer timeouts (e.g. when a well known member is not up). Increasing
                 this value is recommended if you have many IPs listed and the members cannot properly
                 build up the cluster. Its default value is 5.
+            - "scan-start-port":
+                The initial port where to start port scan for another member.
 
             It has the following sub-elements.
             - <required-member>:
@@ -2783,6 +2785,8 @@
                     slow down because of longer timeouts (e.g. when a well known member is not up). Increasing
                     this value is recommended if you have many IPs listed and the members cannot properly
                     build up the cluster. Its default value is 5.
+                - "scan-start-port":
+                    The initial port where to start port scan for another member.
 
                 It has the following sub-elements.
                 - <required-member>:
@@ -3056,7 +3060,7 @@
                     <interface>10.10.2.*</interface>
                 </trusted-interfaces>
             </multicast>
-            <tcp-ip enabled="false" connection-timeout-seconds="123">
+            <tcp-ip enabled="false" connection-timeout-seconds="123" scan-start-port="5801">
                 <required-member>dummy</required-member>
                 <member>dummy1</member>
                 <member>dummy2</member>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -461,6 +461,8 @@ hazelcast:
   #         slow down because of longer timeouts (e.g. when a well known member is not up). Increasing
   #         this value is recommended if you have many IPs listed and the members cannot properly
   #         build up the cluster. Its default value is 5.
+  #     - "scan-start-port":
+  #         The initial port where to start port scan for another member.
   #     - "required-member":
   #         IP address of the required member. Cluster will only be formed if the member with this
   #         IP address is found.
@@ -2959,6 +2961,7 @@ hazelcast:
       tcp-ip:
         enabled: false
         connection-timeout-seconds: 123
+        scan-start-port: 5801
         required-member: dummy
         member: dummy1,dummy2
         interface: 127.0.0.10

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
@@ -50,6 +50,23 @@ public class AbstractJoinTest extends HazelcastTestSupport {
         assertClusterSize(2, h2);
     }
 
+    protected void testJoin(Config config1, Config config2) throws Exception {
+        config1.setProperty(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
+        config2.setProperty(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
+
+        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config1);
+        assertClusterSize(1, h1);
+
+        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config2);
+        assertClusterSize(2, h1, h2);
+
+        h1.shutdown();
+        h1 = Hazelcast.newHazelcastInstance(config1);
+        // when h1 is returned, it's guaranteed that it should see 2 members
+        assertClusterSize(2, h1);
+        assertClusterSize(2, h2);
+    }
+
     protected void testJoinEventually(Config config) throws Exception {
         HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
         assertClusterSize(1, h1);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -61,6 +61,29 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     }
 
     @Test
+    public void test_whenScanStartPortConfigured() throws Exception {
+        Config config1 = new Config();
+        Config config2 = new Config();
+
+        NetworkConfig networkConfig = config1.getNetworkConfig();
+        JoinConfig join = networkConfig.getJoin();
+        TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
+        tcpIpConfig.setEnabled(true);
+        tcpIpConfig.setScanStartPort(5800);
+        tcpIpConfig.addMember("127.0.0.1");
+
+        networkConfig = config2.getNetworkConfig();
+        networkConfig.setPort(5801);
+        join = networkConfig.getJoin();
+        tcpIpConfig = join.getTcpIpConfig();
+        tcpIpConfig.setEnabled(true);
+        tcpIpConfig.setScanStartPort(5700);
+        tcpIpConfig.addMember("127.0.0.1");
+
+        testJoin(config1, config2);
+    }
+
+    @Test
     public void test_whenExplicitPortConfigured() throws Exception {
         Config config = new Config();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -438,6 +438,7 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("10.10.1.10", joinConfig.getTcpIpConfig().getRequiredMember());
         assertContains(joinConfig.getTcpIpConfig().getMembers(), "10.10.1.11");
         assertContains(joinConfig.getTcpIpConfig().getMembers(), "10.10.1.12");
+        assertEquals(joinConfig.getTcpIpConfig().getScanStartPort(), 5801);
         // failure detector config
         assertTrue(fdConfig.isEnabled());
         assertTrue(fdConfig.isParallelMode());

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1218,6 +1218,7 @@ public class ConfigCompatibilityChecker {
             boolean c2Disabled = c2 == null || !c2.isEnabled();
             return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null
                     && nullSafeEqual(c1.getConnectionTimeoutSeconds(), c2.getConnectionTimeoutSeconds())
+                    && nullSafeEqual(c1.getScanStartPort(), c2.getScanStartPort())
                     && nullSafeEqual(c1.getMembers(), c2.getMembers()))
                     && nullSafeEqual(c1.getRequiredMember(), c2.getRequiredMember());
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -2201,6 +2201,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
     private static TcpIpConfig tcpIpConfig() {
         return new TcpIpConfig()
                 .setEnabled(true)
+                .setScanStartPort(5801)
                 .setConnectionTimeoutSeconds(10)
                 .addMember("10.11.12.1,10.11.12.2")
                 .setRequiredMember("10.11.11.2");

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3447,7 +3447,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "<advanced-network enabled=\"true\">"
                 + "  <join>\n"
                 + "      <multicast enabled=\"false\"/>\n"
-                + "      <tcp-ip enabled=\"true\">\n"
+                + "      <tcp-ip enabled=\"true\" scan-start-port=\"5801\">\n"
                 + "        <required-member>10.10.1.10</required-member>\n"
                 + "        <member>10.10.1.11</member>\n"
                 + "        <member>10.10.1.12</member>\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3237,6 +3237,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "        enabled: false\n"
                 + "      tcp-ip:\n"
                 + "        enabled: true\n"
+                + "        scan-start-port: 5801\n"
                 + "        required-member: 10.10.1.10\n"
                 + "        member-list:\n"
                 + "          - 10.10.1.11\n"

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.xml
@@ -53,7 +53,7 @@
                     <interface>10.10.2.*</interface>
                 </trusted-interfaces>
             </multicast>
-            <tcp-ip enabled="false" connection-timeout-seconds="123">
+            <tcp-ip enabled="false" connection-timeout-seconds="123" scan-start-port="5801">
                 <required-member>dummy</required-member>
                 <member>dummy1</member>
                 <member>dummy2</member>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.yaml
@@ -53,6 +53,7 @@ hazelcast:
       tcp-ip:
         enabled: false
         connection-timeout-seconds: 123
+        scan-start-port: 5801
         required-member: dummy
         member: dummy1,dummy2
         interface: 127.0.0.10

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -62,7 +62,7 @@
                     <interface>10.10.2.*</interface>
                 </trusted-interfaces>
             </multicast>
-            <tcp-ip enabled="false" connection-timeout-seconds="123">
+            <tcp-ip enabled="false" connection-timeout-seconds="123" scan-start-port="5801">
                 <required-member>dummy</required-member>
                 <member>dummy1</member>
                 <member>dummy2</member>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
@@ -62,6 +62,7 @@ hazelcast:
       tcp-ip:
         enabled: false
         connection-timeout-seconds: 123
+        scan-start-port: 5801
         required-member: dummy
         member: dummy1,dummy2
         interface: 127.0.0.10


### PR DESCRIPTION
Add option to TcpIpJoner which allows to set port number, where to start
port scanning for another member. Together with cluster property
`hazelcast.tcp.join.port.try.count` it effectively allows to set a port
range to be scanned when searching for a cluster.