### PR TITLE
Cleanup cache tests with statistics

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheEventListenerSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheEventListenerSplitBrainTest.java
@@ -97,7 +97,6 @@ public class CacheEventListenerSplitBrainTest extends SplitBrainTestSupport {
         if (inMemoryFormat == NATIVE) {
             cacheConfig.getEvictionConfig().setMaxSizePolicy(USED_NATIVE_MEMORY_SIZE);
         }
-        cacheConfig.setStatisticsEnabled(true);
         cacheConfig.getMergePolicyConfig().setPolicy(mergePolicyClass.getName());
 
         if (updatedListener != null) {
@@ -170,12 +169,7 @@ public class CacheEventListenerSplitBrainTest extends SplitBrainTestSupport {
     }
 
     private void assert_update_event_generated_on_merge_of_not_equal_entries() {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                assertEquals(1, cacheBUpdatedListener.updated.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, cacheBUpdatedListener.updated.get()));
     }
 
     static class TestCacheEntryUpdatedListener<K, V> implements CacheEntryUpdatedListener<K, V>, Serializable {

--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -751,9 +751,14 @@ public class CacheStatsTest extends CacheTestSupport {
         // this put must trigger eviction
         cache1.put(key, "foo");
 
-        // number of evictions on primary and backup must be 1
-        assertEquals(1, cache1.getLocalCacheStatistics().getCacheEvictions()
-                + cache2.getLocalCacheStatistics().getCacheEvictions());
+        try {
+            // number of evictions on primary and backup must be 1
+            assertEquals(1, cache1.getLocalCacheStatistics().getCacheEvictions()
+                    + cache2.getLocalCacheStatistics().getCacheEvictions());
+        } finally {
+            cache1.destroy();
+            cache2.destroy();
+        }
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
These tests leave leftover cache stats mbeans
registered and cause failures in unrelated
tests in subsequent test executions.

Fixes #17461 

