### PR TITLE
Add the IdentifiedDataSerializable test class  implementing `IFunction` to be used by non-java native tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedFactory.java
@@ -26,6 +26,7 @@ import com.hazelcast.client.test.executor.tasks.SelectAllMembers;
 import com.hazelcast.client.test.executor.tasks.SelectNoMembers;
 import com.hazelcast.client.test.executor.tasks.SerializedCounterCallable;
 import com.hazelcast.client.test.executor.tasks.TaskWithUnserializableResponse;
+import com.hazelcast.client.test.ifunction.Multiplication;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -81,6 +82,9 @@ public class IdentifiedFactory implements DataSerializableFactory {
         }
         if (typeId == CustomCredentials.CLASS_ID) {
             return new CustomCredentials();
+        }
+        if (typeId == Multiplication.CLASS_ID) {
+            return new Multiplication();
         }
         return null;
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ifunction/Multiplication.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ifunction/Multiplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.test.ifunction;
 
 import com.hazelcast.client.test.IdentifiedFactory;

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ifunction/Multiplication.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ifunction/Multiplication.java
@@ -1,0 +1,39 @@
+package com.hazelcast.client.test.ifunction;
+
+import com.hazelcast.client.test.IdentifiedFactory;
+import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+public class Multiplication implements IFunction<Long, Long>, IdentifiedDataSerializable {
+    public static final int CLASS_ID = 16;
+    private long multiplier;
+
+    @Override
+    public Long apply(Long input) {
+        return input * multiplier;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return IdentifiedFactory.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return CLASS_ID;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeLong(multiplier);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        multiplier = in.readLong();
+    }
+}


### PR DESCRIPTION
Added the test class `Multiplication` as an `IFunction` object and `IdentifiedDataSerializable` to be used by non-java native tests (e.g. `AtomicLong.apply` api test).