### PR TITLE
Updated to Jackson version to address a Twistlock-reported issue: CVE…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <log4j2.version>2.13.3</log4j2.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.11.2</jackson.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>


### PR DESCRIPTION
Updated `jackson.version` to the latest 2.11.2, in order to address [this](https://nvd.nist.gov/vuln/detail/CVE-2020-24616) CVE.