### PR TITLE
Locate config files using a thread's context classloader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
@@ -124,10 +124,12 @@ public abstract class AbstractConfigLocator {
         return locateInWorkDir() || locateOnClasspath();
     }
 
+
     protected void loadDefaultConfigurationFromClasspath(String defaultConfigFile) {
         try {
             LOGGER.info(String.format("Loading '%s' from the classpath.", defaultConfigFile));
 
+            // default files should be always located in the same jar as Config class
             configurationUrl = Config.class.getClassLoader().getResource(defaultConfigFile);
 
             if (configurationUrl == null) {
@@ -146,7 +148,8 @@ public abstract class AbstractConfigLocator {
 
     protected boolean loadConfigurationFromClasspath(String configFileName) {
         try {
-            URL url = Thread.currentThread().getContextClassLoader().getResource(configFileName);
+            // Config.class classloader is looked up first to maximize backward compatibility
+            URL url = resolveResourceUrl(configFileName);
             if (url == null) {
                 LOGGER.finest(String.format("Could not find '%s' in the classpath.", configFileName));
                 return false;
@@ -155,7 +158,7 @@ public abstract class AbstractConfigLocator {
             LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
-            in = Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
+            in = resolveResourceAsStream(configFileName);
             if (in == null) {
                 throw new HazelcastException(String.format("Could not load '%s' from the classpath", configFileName));
             }
@@ -295,10 +298,24 @@ public abstract class AbstractConfigLocator {
             throw new HazelcastException("classpath resource can't be empty");
         }
 
-        in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        in = resolveResourceAsStream(resource);
         if (in == null) {
             throw new HazelcastException(String.format("Could not load classpath resource: %s", resource));
         }
-        configurationUrl = Thread.currentThread().getContextClassLoader().getResource(resource);
+        configurationUrl = resolveResourceUrl(resource);
+    }
+
+    private URL resolveResourceUrl(String configFileName) {
+        URL resource = Config.class.getClassLoader().getResource(configFileName);
+        return resource != null
+          ? resource
+          : Thread.currentThread().getContextClassLoader().getResource(configFileName);
+    }
+
+    private InputStream resolveResourceAsStream(String configFileName) {
+        InputStream resource = Config.class.getClassLoader().getResourceAsStream(configFileName);
+        return resource != null
+          ? resource
+          : Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
@@ -146,7 +146,7 @@ public abstract class AbstractConfigLocator {
 
     protected boolean loadConfigurationFromClasspath(String configFileName) {
         try {
-            URL url = Config.class.getClassLoader().getResource(configFileName);
+            URL url = Thread.currentThread().getContextClassLoader().getResource(configFileName);
             if (url == null) {
                 LOGGER.finest(String.format("Could not find '%s' in the classpath.", configFileName));
                 return false;
@@ -155,7 +155,7 @@ public abstract class AbstractConfigLocator {
             LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
-            in = Config.class.getClassLoader().getResourceAsStream(configFileName);
+            in = Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
             if (in == null) {
                 throw new HazelcastException(String.format("Could not load '%s' from the classpath", configFileName));
             }
@@ -295,10 +295,10 @@ public abstract class AbstractConfigLocator {
             throw new HazelcastException("classpath resource can't be empty");
         }
 
-        in = Config.class.getClassLoader().getResourceAsStream(resource);
+        in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
         if (in == null) {
             throw new HazelcastException(String.format("Could not load classpath resource: %s", resource));
         }
-        configurationUrl = Config.class.getClassLoader().getResource(resource);
+        configurationUrl = Thread.currentThread().getContextClassLoader().getResource(resource);
     }
 }


### PR DESCRIPTION
Aligns with other places that rely on context classloader for resource loading, and makes the feature suitable to use with modern frameworks that employ classloader magic to use with hot reloading. 

For example, when running Quarkus with hot reload on, Hazelcast is not able to discover any config files except the default one, although they are discoverable without the hot-reload on.

Other usages of thread context classloader when dealing with config loading:

https://github.com/hazelcast/hazelcast/blob/7d63cfd165e3febe53d961c8618d305db3baebc5/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java#L130

https://github.com/hazelcast/hazelcast/blob/97ff57ba92dc1fbfa77720885e7db40757999080/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java#L61


I'm not fully sure if this is not a breaking change. Considering reworking it into TCCL fallback instead. 

This should be backported to _4.0.z_