### PR TITLE
[BACKPORT 4.1-BETA-1] Remove the hazelcast-sql JAR from the ZIP distribution lib folder

### DIFF
--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -29,14 +29,6 @@
         </fileSet>
 
         <fileSet>
-            <directory>hazelcast-sql/target</directory>
-            <outputDirectory>/lib/</outputDirectory>
-            <includes>
-                <include>hazelcast-sql-${project.version}.jar</include>
-            </includes>
-        </fileSet>
-
-        <fileSet>
             <directory>hazelcast/target/</directory>
             <outputDirectory>/lib/</outputDirectory>
             <includes>


### PR DESCRIPTION
Backport of #17494