### PR TITLE
Made diagnostics rendering more robust

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -124,8 +124,8 @@ final class DiagnosticsLogFile implements DiagnosticsLog {
     }
 
     private void renderPlugin(DiagnosticsPlugin plugin) {
+        logWriter.resetSectionLevel();
         logWriter.init(printWriter);
-
         plugin.run(logWriter);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
@@ -213,6 +213,17 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
         write('=');
     }
 
+    /**
+     * Reset the sectionLevel. A proper rendering of a plugin should always
+     * return this value to -1; but in case of an exception while rendering,
+     * the section level isn't reset and subsequent renderings of plugins
+     * will run into an IndexOutOfBoundsException.
+     * https://github.com/hazelcast/hazelcast/issues/14973
+     */
+    public void resetSectionLevel() {
+        sectionLevel = -1;
+    }
+
     public void init(PrintWriter printWriter) {
         this.printWriter = printWriter;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
@@ -67,6 +67,7 @@ final class DiagnosticsLogger implements DiagnosticsLog {
     }
 
     private void renderPlugin(DiagnosticsPlugin plugin) {
+        logWriter.resetSectionLevel();
         plugin.run(logWriter);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsStdout.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsStdout.java
@@ -66,6 +66,7 @@ final class DiagnosticsStdout implements DiagnosticsLog {
     }
 
     private void renderPlugin(DiagnosticsPlugin plugin) {
+        logWriter.resetSectionLevel();
         plugin.run(logWriter);
     }
 


### PR DESCRIPTION
In case of an exception while rendering a plugin, the number of
indents is not restored to its initial value and eventually
plugins will run into an IndexOutOfBoundException.

This PR fixes that by resetting the number of indents before
a plugin is rendered.