### PR TITLE
Made diagnostics rendering more robust

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
@@ -214,6 +214,12 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
     }
 
     public void init(PrintWriter printWriter) {
+        // Reset the sectionLevel. A proper rendering of a plugin should always
+        // return this value to -1; but in case of an exception while rendering,
+        // the section level isn't reset and subsequent renderings of plugins
+        // will run into an IndexOutOfBoundsException.
+        // https://github.com/hazelcast/hazelcast/issues/14973
+        sectionLevel = -1;
         this.printWriter = printWriter;
     }
 


### PR DESCRIPTION
In case of an exception while rendering a plugin, the number of
indents is not restored to its initial value and eventually
plugins will run into an IndexOutOfBoundException.

This PR fixes that by resetting the number of indents before
a plugin is rendered.

Backport of https://github.com/hazelcast/hazelcast/pull/17501