### PR TITLE
Assert that no leftover MBeans in JsrTestUtil.cleanup

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -63,6 +63,7 @@ public final class JsrTestUtil {
 
         Hazelcast.shutdownAll();
         HazelcastInstanceFactory.terminateAll();
+        assertNoMBeanLeftovers();
     }
 
     /**


### PR DESCRIPTION
Adding assertion to `JsrTestUtil.cleanup()` to make sure the test calling it not leaking MXBeans behind, so if there is one doing it, we can easily find it.