### PR TITLE
Add logging for test: testPostJoinMapOperation_mapWithIndex

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -59,10 +59,13 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
     protected final MapServiceContext mapServiceContext;
     protected final SerializationService serializationService;
 
+    private final ILogger logger;
+
     MapMigrationAwareService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.serializationService = mapServiceContext.getNodeEngine().getSerializationService();
         this.containers = mapServiceContext.getPartitionContainers();
+        this.logger = mapServiceContext.getNodeEngine().getLogger(getClass());
     }
 
     @Override
@@ -294,8 +297,6 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
             Indexes.markPartitionAsIndexed(event.getPartitionId(), indexesSnapshot);
         }
 
-        Class<? extends MapMigrationAwareService> aClass = getClass();
-        ILogger logger = mapServiceContext.getNodeEngine().getLogger(aClass);
         if (logger.isFinestEnabled()) {
             logger.finest(String.format("Populated indexes at step `%s`:[%s]", stepName, event));
         }
@@ -331,7 +332,6 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
             Indexes.markPartitionAsUnindexed(event.getPartitionId(), indexesSnapshot);
         }
 
-        ILogger logger = mapServiceContext.getNodeEngine().getLogger(getClass());
         if (logger.isFinestEnabled()) {
             logger.finest(String.format("Depopulated indexes at step `%s`:[%s]", stepName, event));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
@@ -86,7 +87,7 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
             clearNonGlobalIndexes(event);
 
             // 2. Populate non-global partitioned indexes.
-            populateIndexes(event, TargetIndexes.NON_GLOBAL);
+            populateIndexes(event, TargetIndexes.NON_GLOBAL, "beforeMigration");
         }
 
         flushAndRemoveQueryCaches(event);
@@ -144,9 +145,9 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
     @Override
     public void commitMigration(PartitionMigrationEvent event) {
         if (event.getMigrationEndpoint() == DESTINATION) {
-            populateIndexes(event, TargetIndexes.GLOBAL);
+            populateIndexes(event, TargetIndexes.GLOBAL, "commitMigration");
         } else {
-            depopulateIndexes(event);
+            depopulateIndexes(event, "commitMigration");
         }
 
         if (SOURCE == event.getMigrationEndpoint()) {
@@ -247,7 +248,8 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
         return mapServiceContext.getMapNearCacheManager().getInvalidator().getMetaDataGenerator();
     }
 
-    private void populateIndexes(PartitionMigrationEvent event, TargetIndexes targetIndexes) {
+    private void populateIndexes(PartitionMigrationEvent event,
+                                 TargetIndexes targetIndexes, String stepName) {
         assert event.getMigrationEndpoint() == DESTINATION;
         assert targetIndexes != null;
 
@@ -256,12 +258,12 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
             return;
         }
 
-        final PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
+        PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
         for (RecordStore<Record> recordStore : container.getMaps().values()) {
-            final MapContainer mapContainer = mapServiceContext.getMapContainer(recordStore.getName());
-            final StoreAdapter storeAdapter = new RecordStoreAdapter(recordStore);
+            MapContainer mapContainer = mapServiceContext.getMapContainer(recordStore.getName());
+            StoreAdapter storeAdapter = new RecordStoreAdapter(recordStore);
 
-            final Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
+            Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
             indexes.createIndexesFromRecordedDefinitions(storeAdapter);
             if (!indexes.haveAtLeastOneIndex()) {
                 // no indexes to work with
@@ -291,9 +293,15 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
 
             Indexes.markPartitionAsIndexed(event.getPartitionId(), indexesSnapshot);
         }
+
+        Class<? extends MapMigrationAwareService> aClass = getClass();
+        ILogger logger = mapServiceContext.getNodeEngine().getLogger(aClass);
+        if (logger.isFinestEnabled()) {
+            logger.finest(String.format("Populated indexes at step `%s`:[%s]", stepName, event));
+        }
     }
 
-    private void depopulateIndexes(PartitionMigrationEvent event) {
+    private void depopulateIndexes(PartitionMigrationEvent event, String stepName) {
         assert event.getMigrationEndpoint() == SOURCE;
         assert event.getNewReplicaIndex() != 0 : "Invalid migration event: " + event;
 
@@ -302,11 +310,10 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
             return;
         }
 
-        final PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
+        PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
         for (RecordStore<Record> recordStore : container.getMaps().values()) {
-            final MapContainer mapContainer = mapServiceContext.getMapContainer(recordStore.getName());
-
-            final Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
+            MapContainer mapContainer = mapServiceContext.getMapContainer(recordStore.getName());
+            Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
             if (!indexes.haveAtLeastOneIndex()) {
                 // no indexes to work with
                 continue;
@@ -322,6 +329,11 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
             }, false);
 
             Indexes.markPartitionAsUnindexed(event.getPartitionId(), indexesSnapshot);
+        }
+
+        ILogger logger = mapServiceContext.getNodeEngine().getLogger(getClass());
+        if (logger.isFinestEnabled()) {
+            logger.finest(String.format("Depopulated indexes at step `%s`:[%s]", stepName, event));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -134,12 +134,11 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
 
     RecordStore getExistingRecordStore(int partitionId, String mapName);
 
-    PartitionIdSet getOwnedPartitions();
-
     /**
-     * Reloads the cached collection of partitions owned by this node.
+     * Returns cached cached collection of owned partitions,
+     * When it is null, reloads and caches it again.
      */
-    void reloadOwnedPartitions();
+    PartitionIdSet getOrInitCachedMemberPartitions();
 
     void nullifyOwnedPartitions();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -98,7 +98,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
@@ -149,7 +148,6 @@ class MapServiceContextImpl implements MapServiceContext {
     private final ConstructorFunction<String, MapContainer> mapConstructor;
     private final IndexProvider indexProvider = new DefaultIndexProvider();
     private final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
-    private final AtomicReference<PartitionIdSet> ownedPartitions = new AtomicReference<>();
     private final ConcurrentMap<String, MapContainer> mapContainers = new ConcurrentHashMap<>();
     private final ExecutorStats offloadedExecutorStats = new ExecutorStats();
     /**
@@ -158,6 +156,8 @@ class MapServiceContextImpl implements MapServiceContext {
     private final Semaphore nodeWideLoadedKeyLimiter;
 
     private MapService mapService;
+
+    private volatile PartitionIdSet ownedPartitions;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     MapServiceContextImpl(NodeEngine nodeEngine) {
@@ -485,27 +485,27 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public PartitionIdSet getOrInitCachedMemberPartitions() {
-        PartitionIdSet ownedPartitionIdSet = ownedPartitions.get();
+        PartitionIdSet ownedPartitionIdSet = ownedPartitions;
         if (ownedPartitionIdSet != null) {
             return ownedPartitionIdSet;
         }
 
         synchronized (this) {
-            ownedPartitionIdSet = ownedPartitions.get();
+            ownedPartitionIdSet = ownedPartitions;
             if (ownedPartitionIdSet != null) {
                 return ownedPartitionIdSet;
             }
             IPartitionService partitionService = nodeEngine.getPartitionService();
             Collection<Integer> partitions = partitionService.getMemberPartitions(nodeEngine.getThisAddress());
             ownedPartitionIdSet = immutablePartitionIdSet(partitionService.getPartitionCount(), partitions);
-            ownedPartitions.set(ownedPartitionIdSet);
+            ownedPartitions = ownedPartitionIdSet;
         }
         return ownedPartitionIdSet;
     }
 
     @Override
     public void nullifyOwnedPartitions() {
-        ownedPartitions.set(null);
+        ownedPartitions = null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSizeLimiter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSizeLimiter.java
@@ -122,7 +122,7 @@ public class QueryResultSizeLimiter {
         }
 
         // limit number of local partitions to check to keep runtime constant
-        PartitionIdSet localPartitions = mapServiceContext.getOwnedPartitions();
+        PartitionIdSet localPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
         int partitionsToCheck = min(localPartitions.size(), maxLocalPartitionsLimitForPreCheck);
         if (partitionsToCheck == 0) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -119,7 +119,7 @@ public class QueryRunner {
      */
     public Result runIndexOrPartitionScanQueryOnOwnedPartitions(Query query, boolean doPartitionScan) {
         int migrationStamp = getMigrationStamp();
-        PartitionIdSet initialPartitions = mapServiceContext.getOwnedPartitions();
+        PartitionIdSet initialPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
 
         // to optimize the query we need to get any index instance
@@ -171,7 +171,7 @@ public class QueryRunner {
      */
     public Result runIndexQueryOnOwnedPartitions(Query query) {
         int migrationStamp = getMigrationStamp();
-        PartitionIdSet initialPartitions = mapServiceContext.getOwnedPartitions();
+        PartitionIdSet initialPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
 
         // to optimize the query we need to get any index instance

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -88,7 +88,7 @@ public class MapScanExecIterator implements KeyValueIterator {
                 } else {
                     int nextPart = partsIterator.next();
 
-                    boolean isOwned = map.getMapServiceContext().getOwnedPartitions().contains(nextPart);
+                    boolean isOwned = map.getMapServiceContext().getOrInitCachedMemberPartitions().contains(nextPart);
 
                     if (!isOwned) {
                         throw QueryException.error(

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
@@ -51,7 +51,7 @@ public final class MapTableUtils {
     public static long estimatePartitionedMapRowCount(NodeEngine nodeEngine, MapServiceContext context, String mapName) {
         long entryCount = 0L;
 
-        PartitionIdSet ownerPartitions = context.getOwnedPartitions();
+        PartitionIdSet ownerPartitions = context.getOrInitCachedMemberPartitions();
 
         for (PartitionContainer partitionContainer : context.getPartitionContainers()) {
             if (!ownerPartitions.contains(partitionContainer.getPartitionId())) {

--- a/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
@@ -245,7 +245,7 @@ public class MapIndexJsonTest extends HazelcastTestSupport {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
         List<Index> result = new ArrayList<Index>();
-        for (int partitionId : mapServiceContext.getOwnedPartitions()) {
+        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
             Indexes indexes = mapContainer.getIndexes(partitionId);
             result.add(indexes.getIndex(attribute));
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -57,7 +57,7 @@ public class RecordStoreTest extends HazelcastTestSupport {
     private void clearIndexes(IMap<Object, Object> map) {
         MapServiceContext mapServiceContext = getMapServiceContext((MapProxyImpl) map);
         MapContainer mapContainer = mapServiceContext.getMapContainer(map.getName());
-        for (int partitionId : mapServiceContext.getOwnedPartitions()) {
+        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
             mapContainer.getIndexes(partitionId).destroyIndexes();
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -28,11 +28,13 @@ import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -55,6 +57,10 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PostJoinMapOperationTest extends HazelcastTestSupport {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule
+            = new ChangeLoggingRule("log4j2-debug-map.xml");
 
     @Override
     protected Config getConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
@@ -27,7 +28,6 @@ import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -47,12 +48,112 @@ import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Verify that maps created on a member joining the cluster, do actually include index & interceptors
- * as expected through execution of PostJoinMapOperation on the joining member.
+ * Verify that maps created on a member joining the cluster, do
+ * actually include index & interceptors as expected through
+ * execution of PostJoinMapOperation on the joining member.
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PostJoinMapOperationTest extends HazelcastTestSupport {
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
+    @Test
+    public void testPostJoinMapOperation_mapWithInterceptor() {
+        Config config = getConfig();
+        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
+
+        // Given: A map with an interceptor on single-node Hazelcast
+        HazelcastInstance hz1 = hzFactory.newHazelcastInstance(config);
+        IMap<String, Person> map = hz1.getMap("map");
+        map.put("foo", new Person("foo", 32));
+        map.put("bar", new Person("bar", 35));
+        map.addInterceptor(new FixedReturnInterceptor());
+        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get("foo"));
+
+        // when: new member joins cluster
+        HazelcastInstance hz2 = hzFactory.newHazelcastInstance(config);
+        waitAllForSafeState(hz1, hz2);
+
+        // then: values from map reference obtained from node 2 are returned by interceptor
+        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
+        assertEquals(RETURNED_FROM_INTERCEPTOR, mapOnNode2.get("whatever"));
+
+        // put a value on node 2, then get it and verify it is the one returned by the interceptor
+        String keyOwnedByNode2 = generateKeyOwnedBy(hz2);
+        map.put(keyOwnedByNode2, new Person("not to be returned", 39));
+        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get(keyOwnedByNode2));
+    }
+
+    // This test is meant to verify that a query will be executed *with an index* on the joining node
+    // See also QueryIndexMigrationTest, which tests that results are as expected.
+    @Test
+    public void testPostJoinMapOperation_mapWithIndex() {
+        Config config = getConfig();
+        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
+
+        // given: a map with index on a single-node HazelcastInstance
+        HazelcastInstance hz1 = hzFactory.newHazelcastInstance(config);
+        IMap<String, Person> map = hz1.getMap("map");
+        map.put("foo", new Person("foo", 32));
+        map.put("bar", new Person("bar", 70));
+        map.addIndex(IndexType.SORTED, "age");
+
+        // when: new node joins and original node is terminated
+        HazelcastInstance hz2 = hzFactory.newHazelcastInstance(config);
+        waitAllForSafeState(hz1, hz2);
+
+        hzFactory.terminate(hz1);
+        waitAllForSafeState(hz2);
+
+        // then: once all migrations are committed, the query is executed *with* the index and
+        // returns the expected results.
+        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
+        AtomicInteger invocationCounter = new AtomicInteger(0);
+
+        // eventually index should be created after join
+        assertTrueEventually(() -> {
+            Collection<Person> personsWithAgePredicate = mapOnNode2.values(new AgePredicate(invocationCounter));
+            assertEquals("index should return 1 match", 1, personsWithAgePredicate.size());
+            assertEquals("isIndexed should have located an index", 1, invocationCounter.get());
+        });
+    }
+
+    @Test
+    public void testPostJoinMapOperation_whenMapHasNoData() {
+        Config config = getConfig();
+        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
+
+        // given: a single node HazelcastInstance with a map configured with index and interceptor
+        HazelcastInstance hz1 = hzFactory.newHazelcastInstance(config);
+        IMap<String, Person> map = hz1.getMap("map");
+        map.addIndex(IndexType.SORTED, "age");
+        map.addInterceptor(new FixedReturnInterceptor());
+
+        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get("foo"));
+
+        // when: another member joins the cluster
+        HazelcastInstance hz2 = hzFactory.newHazelcastInstance(config);
+        waitAllForSafeState(hz1, hz2);
+
+        // then: index & interceptor exist on internal MapContainer on node that joined the cluster
+        MapService mapService = getNodeEngineImpl(hz2).getService(MapService.SERVICE_NAME);
+        MapContainer mapContainerOnNode2 = mapService.getMapServiceContext().getMapContainer("map");
+
+        assertEquals(1, mapContainerOnNode2.getIndexes().getIndexes().length);
+        assertEquals(1, mapContainerOnNode2.getInterceptorRegistry().getInterceptors().size());
+        assertEquals(Person.class,
+                mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything").getClass());
+        assertEquals(RETURNED_FROM_INTERCEPTOR.getAge(),
+                ((Person) mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything")).getAge());
+
+        // also verify via user API
+        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
+        assertEquals(RETURNED_FROM_INTERCEPTOR, mapOnNode2.get("whatever"));
+    }
 
     private static class Person implements Serializable {
         private final int age;
@@ -85,7 +186,7 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
             if (age != person.age) {
                 return false;
             }
-            return name != null ? name.equals(person.name) : person.name == null;
+            return Objects.equals(name, person.name);
 
         }
 
@@ -171,106 +272,4 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
             }
         }
     }
-
-    @Test
-    public void testPostJoinMapOperation_mapWithInterceptor() {
-
-        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
-
-        // Given: A map with an interceptor on single-node Hazelcast
-        HazelcastInstance hz1 = hzFactory.newHazelcastInstance();
-        IMap<String, Person> map = hz1.getMap("map");
-        map.put("foo", new Person("foo", 32));
-        map.put("bar", new Person("bar", 35));
-        map.addInterceptor(new FixedReturnInterceptor());
-        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get("foo"));
-
-        // when: new member joins cluster
-        HazelcastInstance hz2 = hzFactory.newHazelcastInstance();
-        waitAllForSafeState(hz1, hz2);
-
-        // then: values from map reference obtained from node 2 are returned by interceptor
-        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
-        assertEquals(RETURNED_FROM_INTERCEPTOR, mapOnNode2.get("whatever"));
-
-        // put a value on node 2, then get it and verify it is the one returned by the interceptor
-        String keyOwnedByNode2 = generateKeyOwnedBy(hz2);
-        map.put(keyOwnedByNode2, new Person("not to be returned", 39));
-        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get(keyOwnedByNode2));
-
-        hzFactory.terminateAll();
-    }
-
-    // This test is meant to verify that a query will be executed *with an index* on the joining node
-    // See also QueryIndexMigrationTest, which tests that results are as expected.
-    @Test
-    public void testPostJoinMapOperation_mapWithIndex() throws InterruptedException {
-        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
-
-        // given: a map with index on a single-node HazelcastInstance
-        HazelcastInstance hz1 = hzFactory.newHazelcastInstance();
-        IMap<String, Person> map = hz1.getMap("map");
-        map.put("foo", new Person("foo", 32));
-        map.put("bar", new Person("bar", 70));
-        map.addIndex(IndexType.SORTED, "age");
-
-        // when: new node joins and original node is terminated
-        HazelcastInstance hz2 = hzFactory.newHazelcastInstance();
-        waitAllForSafeState(hz1, hz2);
-
-        hzFactory.terminate(hz1);
-        waitAllForSafeState(hz2);
-
-        // then: once all migrations are committed, the query is executed *with* the index and
-        // returns the expected results.
-        final IMap<String, Person> mapOnNode2 = hz2.getMap("map");
-        final AtomicInteger invocationCounter = new AtomicInteger(0);
-
-        // eventually index should be created after join
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                Collection<Person> personsWithAgePredicate = mapOnNode2.values(new AgePredicate(invocationCounter));
-                assertEquals("isIndexed should have located an index", 1, invocationCounter.get());
-                assertEquals("index should return 1 match", 1, personsWithAgePredicate.size());
-            }
-        });
-    }
-
-    @Test
-    public void testPostJoinMapOperation_whenMapHasNoData() {
-        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
-
-        // given: a single node HazelcastInstance with a map configured with index and interceptor
-        HazelcastInstance hz1 = hzFactory.newHazelcastInstance();
-        IMap<String, Person> map = hz1.getMap("map");
-        map.addIndex(IndexType.SORTED, "age");
-        map.addInterceptor(new FixedReturnInterceptor());
-
-        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get("foo"));
-
-        // when: another member joins the cluster
-        HazelcastInstance hz2 = hzFactory.newHazelcastInstance();
-        waitAllForSafeState(hz1, hz2);
-
-        // then: index & interceptor exist on internal MapContainer on node that joined the cluster
-        MapService mapService = getNodeEngineImpl(hz2).getService(MapService.SERVICE_NAME);
-        MapContainer mapContainerOnNode2 = mapService.getMapServiceContext().getMapContainer("map");
-
-
-        assertEquals(1, mapContainerOnNode2.getIndexes().getIndexes().length);
-
-        assertEquals(1, mapContainerOnNode2.getInterceptorRegistry().getInterceptors().size());
-        assertEquals(Person.class,
-                mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything").getClass());
-        assertEquals(RETURNED_FROM_INTERCEPTOR.getAge(),
-                ((Person) mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything")).getAge());
-
-        // also verify via user API
-        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
-        assertEquals(RETURNED_FROM_INTERCEPTOR, mapOnNode2.get("whatever"));
-
-        hzFactory.terminateAll();
-    }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeLimiterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeLimiterTest.java
@@ -253,7 +253,7 @@ public class QueryResultSizeLimiterTest {
         MapServiceContext mapServiceContext = mock(MapServiceContext.class);
         when(mapServiceContext.getNodeEngine()).thenReturn(nodeEngine);
         when(mapServiceContext.getRecordStore(anyInt(), anyString())).thenReturn(recordStore);
-        when(mapServiceContext.getOwnedPartitions()).thenReturn(new PartitionIdSet(PARTITION_COUNT, localPartitions.keySet()));
+        when(mapServiceContext.getOrInitCachedMemberPartitions()).thenReturn(new PartitionIdSet(PARTITION_COUNT, localPartitions.keySet()));
 
         limiter = new QueryResultSizeLimiter(mapServiceContext, Logger.getLogger(QueryResultSizeLimiterTest.class));
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -94,7 +94,7 @@ public class QueryRunnerTest extends HazelcastTestSupport {
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
-        assertArrayEquals(result.getPartitionIds().toArray(), mapService.getMapServiceContext().getOwnedPartitions().toArray());
+        assertArrayEquals(result.getPartitionIds().toArray(), mapService.getMapServiceContext().getOrInitCachedMemberPartitions().toArray());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
@@ -225,7 +225,7 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
         List<Index> result = new ArrayList<>();
-        for (int partitionId : mapServiceContext.getOwnedPartitions()) {
+        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
             Indexes indexes = mapContainer.getIndexes(partitionId);
 
             for (InternalIndex index : indexes.getIndexes()) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -203,7 +203,7 @@ public class JsonIndexIntegrationTest extends HazelcastTestSupport {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
         List<Index> result = new ArrayList<Index>();
-        for (int partitionId : mapServiceContext.getOwnedPartitions()) {
+        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
             Indexes indexes = mapContainer.getIndexes(partitionId);
 
             for (InternalIndex index : indexes.getIndexes()) {

--- a/hazelcast/src/test/resources/log4j2-debug-map.xml
+++ b/hazelcast/src/test/resources/log4j2-debug-map.xml
@@ -18,14 +18,15 @@
 <Configuration status="ERROR">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+            <PatternLayout
+                    pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="com.hazelcast.map" level="trace"/>
+        <Logger name="com.hazelcast.map.impl" level="trace"/>
         <Logger name="com.hazelcast.instance" level="debug"/>
         <Logger name="com.hazelcast.cluster" level="debug"/>
         <Logger name="com.hazelcast.internal.cluster" level="debug"/>


### PR DESCRIPTION
__Modifications:__
- Makes test available for HD extensions.
see https://github.com/hazelcast/hazelcast-enterprise/pull/3772
- Rewrite owned-partitions caching logic by using sync blocks, this is  to prevent unneeded garbage in case of multiple concurrent accesses.
- Add trace logging to MapMigrationAwareService. These logs are enabled in PostJoinMapOperationTest.