### PR TITLE
Revert "Add caller stacktrace to rethrown RuntimeException (#17249)"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClientOfflineException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClientOfflineException.java
@@ -24,8 +24,4 @@ public class HazelcastClientOfflineException extends IllegalStateException {
     public HazelcastClientOfflineException() {
         super("No connection found to cluster");
     }
-
-    public HazelcastClientOfflineException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -709,11 +709,7 @@ public class ClientExceptionFactory {
         if (exceptionFactory == null) {
             throwable = new UndefinedErrorCodeException(errorHolder.getMessage(), errorHolder.getClassName());
         } else {
-            Throwable cause = createException(iterator);
-            throwable = exceptionFactory.createException(errorHolder.getMessage(), cause);
-            if (throwable.getCause() == null && cause != null) {
-                throwable.initCause(cause);
-            }
+            throwable = exceptionFactory.createException(errorHolder.getMessage(), createException(iterator));
         }
         throwable.setStackTrace(errorHolder.getStackTraceElements().toArray(new StackTraceElement[0]));
         return throwable;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -17,15 +17,13 @@
 package com.hazelcast.ringbuffer;
 
 import com.hazelcast.spi.exception.SilentException;
-import com.hazelcast.spi.impl.operationservice.WrappableException;
 
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller
  * than the current head sequence and that the ringbuffer store is disabled. This means that the item isn't available in the
  * ringbuffer and it cannot be loaded from the store either, thus being completely unavailable.
  */
-public class StaleSequenceException extends RuntimeException
-        implements SilentException, WrappableException<StaleSequenceException> {
+public class StaleSequenceException extends RuntimeException implements SilentException {
 
     private final long headSeq;
 
@@ -48,12 +46,5 @@ public class StaleSequenceException extends RuntimeException
      */
     public long getHeadSeq() {
         return headSeq;
-    }
-
-    @Override
-    public StaleSequenceException wrap() {
-        StaleSequenceException staleSequenceException = new StaleSequenceException(getMessage(), headSeq);
-        staleSequenceException.initCause(this);
-        return staleSequenceException;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -22,10 +22,15 @@ import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.util.executor.UnblockableThread;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.operationservice.WrappableException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -46,8 +51,6 @@ import java.util.function.Function;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
-import static com.hazelcast.internal.util.ExceptionUtil.wrapError;
-import static com.hazelcast.internal.util.ExceptionUtil.wrapException;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 import static java.util.concurrent.locks.LockSupport.park;
@@ -56,7 +59,6 @@ import static java.util.concurrent.locks.LockSupport.unpark;
 
 /**
  * Custom implementation of {@link java.util.concurrent.CompletableFuture}.
- *
  * @param <V>
  */
 @SuppressFBWarnings(value = "DLS_DEAD_STORE_OF_CLASS_LITERAL", justification = "Recommended way to prevent classloading bug")
@@ -69,6 +71,13 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
             return "UNRESOLVED";
         }
     };
+    private static final Lookup LOOKUP = MethodHandles.publicLookup();
+    // new Throwable(String message, Throwable cause)
+    private static final MethodType MT_INIT_STRING_THROWABLE = MethodType.methodType(void.class, String.class, Throwable.class);
+    // new Throwable(Throwable cause)
+    private static final MethodType MT_INIT_THROWABLE = MethodType.methodType(void.class, Throwable.class);
+    // new Throwable(String message)
+    private static final MethodType MT_INIT_STRING = MethodType.methodType(void.class, String.class);
 
     private static final AtomicReferenceFieldUpdater<AbstractInvocationFuture, Object> STATE_UPDATER =
             newUpdater(AbstractInvocationFuture.class, Object.class, "state");
@@ -1903,7 +1912,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
             return cause;
         }
         if (cause instanceof RuntimeException) {
-            return wrapException((RuntimeException) cause);
+            return wrapRuntimeException((RuntimeException) cause);
         }
         if ((cause instanceof ExecutionException || cause instanceof InvocationTargetException)
                 && cause.getCause() != null) {
@@ -1918,4 +1927,39 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         return new HazelcastException(cause);
     }
 
+    private static RuntimeException wrapRuntimeException(RuntimeException cause) {
+        if (cause instanceof WrappableException) {
+            return  ((WrappableException) cause).wrap();
+        }
+        RuntimeException wrapped = tryWrapInSameClass(cause);
+        return wrapped == null ?  new HazelcastException(cause) : wrapped;
+    }
+
+    private static Error wrapError(Error cause) {
+        Error result = tryWrapInSameClass(cause);
+        return result == null ? cause : result;
+    }
+
+    private static <T extends Throwable> T tryWrapInSameClass(T cause) {
+        Class<? extends Throwable> exceptionClass = cause.getClass();
+        MethodHandle constructor;
+        try {
+            constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING_THROWABLE);
+            return (T) constructor.invokeWithArguments(cause.getMessage(), cause);
+        } catch (Throwable ignored) {
+        }
+        try {
+            constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_THROWABLE);
+            return (T) constructor.invokeWithArguments(cause);
+        } catch (Throwable ignored) {
+        }
+        try {
+            constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING);
+            T result = (T) constructor.invokeWithArguments(cause.getMessage());
+            result.initCause(cause);
+            return result;
+        } catch (Throwable ignored) {
+        }
+        return null;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.crdt.MutationDisallowedException;
 import com.hazelcast.crdt.TargetNotReplicaException;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
-import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
@@ -273,8 +272,7 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new IndeterminateOperationStateException(randomString())},
                 new Object[]{new TargetNotReplicaException(randomString())},
                 new Object[]{new MutationDisallowedException(randomString())},
-                new Object[]{new ConsistencyLostException(randomString())},
-                new Object[]{ExceptionUtil.tryWrapInSameClass(new NullPointerException())}
+                new Object[]{new ConsistencyLostException(randomString())}
         );
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
@@ -54,16 +54,14 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
     public void testPeel_whenThrowableIsRuntimeException_thenReturnOriginal() {
         RuntimeException result = ExceptionUtil.peel(throwable);
 
-        assertEquals(throwable.getMessage(), result.getMessage());
-        assertEquals(throwable.getClass(), result.getClass());
+        assertEquals(throwable, result);
     }
 
     @Test
     public void testPeel_whenThrowableIsExecutionException_thenReturnCause() {
         RuntimeException result = ExceptionUtil.peel(new ExecutionException(throwable));
 
-        assertEquals(throwable.getMessage(), result.getMessage());
-        assertEquals(throwable.getClass(), result.getClass());
+        assertEquals(throwable, result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TransactionsWithWriteBehind_whenNoCoalescingQueueIsFullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TransactionsWithWriteBehind_whenNoCoalescingQueueIsFullTest.java
@@ -55,6 +55,7 @@ import static com.hazelcast.map.impl.mapstore.writebehind.WriteBehindFlushTest.a
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.core.Is.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -68,6 +69,7 @@ public class TransactionsWithWriteBehind_whenNoCoalescingQueueIsFullTest extends
     @Test
     public void prepare_step_throws_reached_max_size_exception_when_two_phase() {
         expectedException.expect(TransactionException.class);
+        expectedException.expectCause(isA(ReachedMaxSizeException.class));
 
         String mapName = "map";
         long maxWbqCapacity = 100;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
@@ -89,7 +89,7 @@ public class DistributedObjectFutureTest {
         try {
             future.get();
         } catch (Exception e) {
-            assertSame(error.getClass(), e.getClass());
+            assertSame(error, e);
         }
     }
 


### PR DESCRIPTION
This reverts commit 318b336b. Reasoning is that it introduces
significant changes in the invocation handling and causes some tests to
start failing (see https://github.com/hazelcast/hazelcast/issues/6383). 
An alternate or augmented solution must be considered.

EDIT: had to revert https://github.com/hazelcast/hazelcast/pull/17438 as well since it relied on a method in `ExceptionUtil` which was introduced by the above commit.