### PR TITLE
Fixed split-brain healing procedure for indexes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -828,8 +828,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             newValue = persistenceEnabledFor(provenance)
                     ? mapDataStore.add(key, newValue, record.getExpirationTime(), now, null) : newValue;
             onStore(record);
-            mutationObserver.onUpdateRecord(key, record, oldValue, newValue, false);
             storage.updateRecordValue(key, record, newValue);
+            mutationObserver.onUpdateRecord(key, record, oldValue, newValue, false);
         }
 
         return newValue != null;


### PR DESCRIPTION
Update indexes after the storage's update. In old code the update
removes the old entry and inserts new one which is exactly the same
because it takes it from the record that is not updated.

This regression was introduced in the
https://github.com/hazelcast/hazelcast/pull/15854

Closes https://github.com/hazelcast/hazelcast/issues/17333