### PR TITLE
SQL: Don't wait forever for the first page

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/ResultIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/ResultIterator.java
@@ -17,29 +17,28 @@
 package com.hazelcast.sql.impl;
 
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Java standard {@link Iterator} enhanced with {@link
- * #hasNextImmediately()} to allow for non-blocking iteration.
+ * Java standard {@link Iterator} enhanced with {@link #hasNext(long,
+ * TimeUnit)} to allow for non-blocking iteration.
  */
 public interface ResultIterator<T> extends Iterator<T> {
 
     /**
-     * Checks if a next item is available immediately.
+     * Checks if a next item is available, with a timeout.
      * <p>
-     * The implementation is free to either:<ul>
-     *     <li>block until an item is available or the end is reached
-     *     <li>not block and return {@link HasNextImmediatelyResult#RETRY} if we're
-     *         not done and an item is not immediately available.
-     * </ul>
+     * The implementation is allowed to block until an item is available and
+     * never actually return TIMEOUT response.
      * <p>
      * This can be used to implement either blocking or non-blocking behavior.
      *
-     * @return see {@link HasNextImmediatelyResult}
+     * @return see {@link HasNextResult}
+     * @param timeout the timeout, 0 means check an immediate next item
      */
-    HasNextImmediatelyResult hasNextImmediately();
+    HasNextResult hasNext(long timeout, TimeUnit timeUnit);
 
-    enum HasNextImmediatelyResult {
+    enum HasNextResult {
         /**
          * The next item is available immediately. Subsequent {@link #next()} call
          * is guaranteed to succeed and not block.
@@ -51,7 +50,7 @@ public interface ResultIterator<T> extends Iterator<T> {
          * The caller should check again later. Also there might not be a next
          * item at all.
          */
-        RETRY,
+        TIMEOUT,
 
         /**
          * The last item was already returned. A call to {@link #next()} will fail.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.sql.impl.state.QueryState;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Cursor implementation.
@@ -142,9 +143,9 @@ public final class SqlResultImpl extends AbstractSqlResult {
         }
 
         @Override
-        public HasNextImmediatelyResult hasNextImmediately() {
+        public HasNextResult hasNext(long timeout, TimeUnit timeUnit) {
             try {
-                return delegate.hasNextImmediately();
+                return delegate.hasNext(timeout, timeUnit);
             } catch (Exception e) {
                 throw QueryUtils.toPublicException(e, state.getLocalMemberId());
             }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/root/BlockingRootResultConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/root/BlockingRootResultConsumer.java
@@ -22,9 +22,10 @@ import com.hazelcast.sql.impl.row.Row;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.sql.impl.ResultIterator.HasNextImmediatelyResult.DONE;
-import static com.hazelcast.sql.impl.ResultIterator.HasNextImmediatelyResult.YES;
+import static com.hazelcast.sql.impl.ResultIterator.HasNextResult.DONE;
+import static com.hazelcast.sql.impl.ResultIterator.HasNextResult.YES;
 
 /**
  * Blocking array-based result consumer which delivers the results to API caller.
@@ -176,8 +177,8 @@ public class BlockingRootResultConsumer implements RootResultConsumer {
         }
 
         @Override
-        public HasNextImmediatelyResult hasNextImmediately() {
-            // We never return RETRY, but we block until next item is available or the end is reached.
+        public HasNextResult hasNext(long timeout, TimeUnit timeUnit) {
+            // We never return TIMEOUT, but we block until a next item is available or the end is reached.
             return hasNext() ? YES : DONE;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
@@ -23,7 +23,7 @@ import com.hazelcast.sql.impl.AbstractSqlResult;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.ResultIterator;
-import com.hazelcast.sql.impl.ResultIterator.HasNextImmediatelyResult;
+import com.hazelcast.sql.impl.ResultIterator.HasNextResult;
 import com.hazelcast.sql.impl.client.SqlPage;
 
 import java.util.ArrayList;
@@ -32,8 +32,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.hazelcast.sql.impl.ResultIterator.HasNextImmediatelyResult.DONE;
-import static com.hazelcast.sql.impl.ResultIterator.HasNextImmediatelyResult.YES;
+import static com.hazelcast.sql.impl.ResultIterator.HasNextResult.DONE;
+import static com.hazelcast.sql.impl.ResultIterator.HasNextResult.TIMEOUT;
+import static com.hazelcast.sql.impl.ResultIterator.HasNextResult.YES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Registry of active client cursors.
@@ -50,7 +52,7 @@ public class QueryClientStateRegistry {
     ) {
         QueryClientState clientCursor = new QueryClientState(clientId, result);
 
-        SqlPage page = fetchInternal(clientCursor, cursorBufferSize, serializationService);
+        SqlPage page = fetchInternal(clientCursor, cursorBufferSize, serializationService, true);
 
         if (!page.isLast()) {
             clientCursors.put(result.getQueryId(), clientCursor);
@@ -71,7 +73,7 @@ public class QueryClientStateRegistry {
             throw QueryException.error("Query cursor is not found (closed?): " + queryId);
         }
 
-        SqlPage page = fetchInternal(clientCursor, cursorBufferSize, serializationService);
+        SqlPage page = fetchInternal(clientCursor, cursorBufferSize, serializationService, false);
 
         if (page.isLast()) {
             deleteClientCursor(clientCursor);
@@ -83,12 +85,13 @@ public class QueryClientStateRegistry {
     private SqlPage fetchInternal(
         QueryClientState clientCursor,
         int cursorBufferSize,
-        InternalSerializationService serializationService
+        InternalSerializationService serializationService,
+        boolean isFirstPage
     ) {
         ResultIterator<SqlRow> iterator = clientCursor.getIterator();
 
         List<List<Data>> page = new ArrayList<>(cursorBufferSize);
-        boolean last = fetchPage(iterator, page, cursorBufferSize, serializationService);
+        boolean last = fetchPage(iterator, page, cursorBufferSize, serializationService, isFirstPage);
 
         if (last) {
             deleteClientCursor(clientCursor);
@@ -101,21 +104,35 @@ public class QueryClientStateRegistry {
         ResultIterator<SqlRow> iterator,
         List<List<Data>> page,
         int cursorBufferSize,
-        InternalSerializationService serializationService
+        InternalSerializationService serializationService,
+        boolean isFirstPage
     ) {
         assert cursorBufferSize > 0;
 
-        if (!iterator.hasNext()) {
-            return true;
+        if (isFirstPage) {
+            // Block for up to 1 second to get the row.
+            // Note: the implementation of ResultIterator in IMDG ignores the time limit and blocks
+            // until a next item is available.
+            HasNextResult hasNextResult = iterator.hasNext(1, SECONDS);
+            if (hasNextResult == TIMEOUT) {
+                return false;
+            } else if (hasNextResult == DONE) {
+                return true;
+            }
+        } else {
+            // block without a limit to get a row
+            if (!iterator.hasNext()) {
+                return true;
+            }
         }
 
-        HasNextImmediatelyResult hasNextResult;
+        HasNextResult hasNextResult;
         do {
             SqlRow row = iterator.next();
             List<Data> convertedRow = convertRow(row, serializationService);
 
             page.add(convertedRow);
-            hasNextResult = iterator.hasNextImmediately();
+            hasNextResult = iterator.hasNext(0, SECONDS);
         } while (hasNextResult == YES && page.size() < cursorBufferSize);
 
         return hasNextResult == DONE;


### PR DESCRIPTION
The `SqlExecuteMessageTask` contains the first page or rows. Until this
message returns to the client, the client isn't able to cancel the
query. The current behavior waits for at least one row. In Jet this can
be catastrophic because the user can submit an ad-hoc query such as
`SELECT * FROM my_topic`, but if there are no new messages in that
topic, the call will never return and the user isn't able to cancel the
query at all.

The fix is to wait for up to 1 second for the first row and if there's
no row, return an empty page to the client.

Note that this doesn't affect the IMDG implementation, its
implementation of `ResultIterator` ignores the timeout in the
`hasNext()` method and always blocks, therefore a full page is always
returned to the client.